### PR TITLE
[T74] refactor: 技能沙箱使用 IS_ADMIN 替代 USER_ROLE

### DIFF
--- a/data/skills/file-operations/index.js
+++ b/data/skills/file-operations/index.js
@@ -11,8 +11,7 @@ const fs = require('fs');
 const path = require('path');
 
 // 用户角色检查（管理员有特殊权限）
-const USER_ROLE = process.env.USER_ROLE || 'user';
-const IS_ADMIN = USER_ROLE === 'admin';
+const IS_ADMIN = process.env.IS_ADMIN === 'true';
 
 // Allowed base directories (from environment or default)
 // 统一使用 DATA_BASE_PATH，技能路径为 DATA_BASE_PATH/skills

--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -552,7 +552,7 @@ class SkillLoader {
       // 用户认证信息（用于 API 调用）
       USER_ACCESS_TOKEN: userContext.accessToken || '',  // 7. 用户 JWT Token
       USER_ID: String(userContext.userId || ''),         // 8. 用户 ID
-      USER_ROLE: userContext.userRole || 'user',         // 9. 用户角色（用于管理员权限）
+      IS_ADMIN: userContext.isAdmin ? 'true' : 'false',   // 9. 是否管理员（便捷属性）
       API_BASE: process.env.API_BASE || 'http://localhost:3000',  // 10. API 基础地址
       WORKING_DIRECTORY: workingDirectory || '',         // 11. 工作目录（相对 DATA_BASE_PATH）
       ...configEnv,               // 12. 展开的配置环境变量

--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -236,9 +236,8 @@ function executeSkill(code, skillId) {
   // 构建安全的 process.env 副本（只包含技能相关的环境变量）
   const safeEnv = { ...process.env };
   
-  // 检查用户角色（管理员有特殊权限）
-  const userRole = process.env.USER_ROLE || 'user';
-  const isAdmin = userRole === 'admin';
+  // 检查是否管理员（直接从环境变量读取）
+  const isAdmin = process.env.IS_ADMIN === 'true';
   
   // 确定工作目录（用于 process.cwd()）
   // 优先使用 WORKING_DIRECTORY，否则回退到 DATA_BASE_PATH

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -214,8 +214,8 @@ class ToolManager {
     logger.info(`[ToolManager] 执行工具: ${display}`, { toolId, params });
 
     // Phase 2 权限检查
-    const userRole = context?.user_role || 'user';
-    const validation = validateSkillAccess(userRole, toolId);
+    const isAdmin = context?.is_admin || false;
+    const validation = validateSkillAccess(isAdmin ? 'admin' : 'user', toolId);
     if (!validation.allowed) {
       logger.warn(`[ToolManager] 权限拒绝: ${display} - ${validation.error}`);
       return {
@@ -281,7 +281,7 @@ class ToolManager {
           expertId,
           accessToken,  // 传递用户 Token
           workingDirectory,  // 传递工作目录
-          userRole,  // 传递用户角色（用于管理员权限）
+          isAdmin: context?.is_admin || false,  // 传递管理员标识
         },
         scriptPath || 'index.js',  // 传递脚本路径
       );


### PR DESCRIPTION
## 变更概述

将技能沙箱的 `USER_ROLE` 环境变量改为 `IS_ADMIN`，与后端 `ctx.state.session.isAdmin` 保持一致。

## 变更对照

| 旧 API | 新 API |
|--------|--------|
| `USER_ROLE: userContext.userRole \|\| 'user'` | `IS_ADMIN: userContext.isAdmin ? 'true' : 'false'` |
| `const isAdmin = userRole === 'admin'` | `const isAdmin = process.env.IS_ADMIN === 'true'` |

## 修改的文件

### lib/skill-loader.js
```javascript
// 旧
USER_ROLE: userContext.userRole || 'user',

// 新
IS_ADMIN: userContext.isAdmin ? 'true' : 'false',
```

### lib/skill-runner.js
```javascript
// 旧
const userRole = process.env.USER_ROLE || 'user';
const isAdmin = userRole === 'admin';

// 新
const isAdmin = process.env.IS_ADMIN === 'true';
```
### lib/tool-manager.js
```javascript
// 旧
const userRole = context?.user_role || 'user';
const validation = validateSkillAccess(userRole, toolId);

// 新
const isAdmin = context?.is_admin || false;
const validation = validateSkillAccess(isAdmin ? 'admin' : 'user', toolId);
```

### data/skills/file-operations/index.js
```javascript
// 旧
const USER_ROLE = process.env.USER_ROLE || 'user';
const IS_ADMIN = USER_ROLE === 'admin';

// 新
const IS_ADMIN = process.env.IS_ADMIN === 'true';
```

## 关联

- Closes #74
