### PR TITLE
[T94] refactor: 缩短工具名 skill_id 前缀 + 移除 _meta 节省 token

### DIFF
--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -397,6 +397,7 @@ ${ragContext}
    * 帮助 LLM 理解每个技能的用途和何时应该调用工具
    * @param {string} systemPrompt - 系统提示
    * @param {Array} skills - 技能列表，每项包含 id, name, description, tools
+   *   - tools 可以是字符串数组（工具名称）或对象数组（包含 name 和 description）
    */
   enhanceWithSkills(systemPrompt, skills) {
     if (!skills || skills.length === 0) {
@@ -409,14 +410,26 @@ ${ragContext}
 
     // 构建技能描述文本
     const skillsDescription = skills.map(skill => {
-      // 提取工具名称列表
-      const toolNames = skill.tools && skill.tools.length > 0
-        ? skill.tools.join(', ')
-        : '无特定工具';
+      // 构建工具列表描述
+      let toolsDescription = '无特定工具';
+      if (skill.tools && skill.tools.length > 0) {
+        if (typeof skill.tools[0] === 'object' && skill.tools[0].name) {
+          // tools 是对象数组，包含 name 和 description
+          // 工具名已经是 skillIdShort_toolName 格式（6字符前缀），直接使用
+          toolsDescription = skill.tools.map(t => {
+            return `  - \`${t.name}\`: ${t.description || '无描述'}`;
+          }).join('\n');
+        } else {
+          // tools 是字符串数组（兼容旧格式）
+          toolsDescription = skill.tools.map(t => {
+            return `  - \`${t}\``;
+          }).join('\n');
+        }
+      }
 
-      return `- **${skill.name}** (${skill.id}): ${skill.description || '暂无描述'}
-    - 可用工具: ${toolNames}`;
-    }).join('\n');
+      return `- **${skill.name}**: ${skill.description || '暂无描述'}
+${toolsDescription}`;
+    }).join('\n\n');
 
     const skillsPrompt = `
 ## 你的可用技能

--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -203,9 +203,10 @@ class SkillLoader {
       }
     }
 
-    // 使用 skillId_toolName 格式作为工具名称（人类可读且唯一）
+    // 使用 skillId后6位_toolName 格式作为工具名称（缩短长度，保持唯一性）
     const toolId = toolRow.id;  // 保留数据库 ID 用于内部引用
-    const toolFunctionName = `${skill.id}_${toolRow.name}`;  // 如 "compression_zip"
+    const skillIdShort = skill.id.slice(-6);  // 取后6位，保证唯一性
+    const toolFunctionName = `${skillIdShort}_${toolRow.name}`;  // 如 "8h9i0_zip"
 
     return {
       type: 'function',
@@ -217,7 +218,7 @@ class SkillLoader {
       // 保留原始信息用于执行和显示
       _meta: {
         toolId: toolId,              // 工具 ID（skill_tools.id）- 用于数据库查询
-        toolFunctionName,            // 完整工具函数名（skillId_toolName）
+        toolFunctionName,            // 完整工具函数名（skillIdShort_toolName）
         skillId: skill.id,           // 所属技能 ID
         skillName: skill.name,       // 技能名称（用于显示）
         toolName: toolRow.name,      // 工具名称（用于执行）
@@ -666,13 +667,14 @@ class SkillLoader {
       // 解析参数（从描述中提取）
       const parameters = this.parseParametersFromDescription(toolDesc);
       
-      // 从 Markdown 解析的工具没有数据库 ID，使用 skillId_toolName 格式
-      const toolId = `${skill.id}_${toolName}`;
+      // 从 Markdown 解析的工具使用缩短的 skillId 格式（与 convertToolToOpenAIFormat 一致）
+      const skillIdShort = skill.id.slice(-6);  // 取后6位，保证唯一性
+      const toolFunctionName = `${skillIdShort}_${toolName}`;
       
       tools.push({
         type: 'function',
         function: {
-          name: toolId,
+          name: toolFunctionName,
           description: this.extractFirstSentence(toolDesc),
           parameters: {
             type: 'object',
@@ -682,7 +684,8 @@ class SkillLoader {
         },
         // 保留原始信息用于执行和显示
         _meta: {
-          toolId: toolId,
+          toolId: null,  // Markdown 解析的工具没有数据库 ID
+          toolFunctionName,
           skillId: skill.id,
           skillName: skill.name,
           toolName: toolName,

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -151,7 +151,7 @@ class ToolManager {
 
   /**
    * 获取所有工具定义（供 LLM 使用）
-   * @returns {Array} OpenAI 格式的工具定义数组
+   * @returns {Array} OpenAI 格式的工具定义数组（不含 _meta，节省 token）
    */
   getToolDefinitions() {
     const definitions = [];
@@ -159,7 +159,11 @@ class ToolManager {
     // 添加所有技能工具
     for (const skill of this.skills.values()) {
       const tools = this.skillLoader.getToolDefinitions(skill);
-      definitions.push(...tools);
+      // 移除 _meta 字段，不发送给 LLM（节省 token）
+      for (const tool of tools) {
+        const { _meta, ...llmTool } = tool;
+        definitions.push(llmTool);
+      }
     }
 
     return definitions;


### PR DESCRIPTION
## 任务目录

- **Task Dir**: `docs/tasks/active/task-94-shorten-skill-id-prefix/`
- **Issue**: #94

## 问题描述

当前工具名称使用完整的 skill_id（20字符）作为前缀，且 `_meta` 字段被发送给 LLM，浪费上下文 token。

## 解决方案

### 1. 缩短 skill_id 前缀（取后6位）

- **唯一性保证**: 36^6 ≈ 21.7亿种可能，1000个技能碰撞概率 ≈ 0.00002%
- 工具名从 `lz1a2b3c4d5e6f7g8h9i0_zip` 变为 `7g8h9i_zip`

### 2. 移除发送给 LLM 的 _meta 字段

- `_meta` 用于内部执行路由，不应发送给 LLM
- 每个工具节省约 200-300 字符

## 修改文件

| 文件 | 修改内容 |
|------|---------|
| `lib/skill-loader.js` | 工具名使用 `skill.id.slice(-6)` |
| `lib/context-manager.js` | System Prompt 显示缩短后的工具名 |
| `lib/tool-manager.js` | `getToolDefinitions()` 移除 `_meta` 字段 |

## 节省估算

- 工具名缩短: 每个工具名节省约 14 字符
- 移除 _meta: 每个工具节省约 200-300 字符
- **总计**: 10 个工具约节省 500-750 tokens

## 测试

- [ ] 启动服务验证工具调用正常
- [ ] 检查 System Prompt 中工具名显示正确

✌Bazinga！