### PR TITLE
[T102] fix: 修复保存和切换操作的错误处理

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -291,6 +291,9 @@ export default {
     deleteModelFailed: 'Failed to delete model',
     deleteProviderFailed: 'Failed to delete provider',
     deleteExpertFailed: 'Failed to delete expert',
+    saveProviderFailed: 'Failed to save provider',
+    saveModelFailed: 'Failed to save model',
+    saveExpertFailed: 'Failed to save expert',
     // User Management
     userManagement: 'User Management',
     addUser: 'Add User',
@@ -623,6 +626,7 @@ export default {
     viewDetail: 'View Details',
     activate: 'Activate',
     deactivate: 'Deactivate',
+    toggleFailed: 'Failed to toggle skill status',
     reanalyze: 'Reanalyze',
     noDescription: 'No description',
     // Source types

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -295,6 +295,9 @@ export default {
     deleteModelFailed: '删除模型失败',
     deleteProviderFailed: '删除提供商失败',
     deleteExpertFailed: '删除专家失败',
+    saveProviderFailed: '保存提供商失败',
+    saveModelFailed: '保存模型失败',
+    saveExpertFailed: '保存专家失败',
     // 用户管理
     userManagement: '用户管理',
     addUser: '添加用户',
@@ -608,6 +611,7 @@ export default {
     viewDetail: '查看详情',
     activate: '启用',
     deactivate: '禁用',
+    toggleFailed: '切换技能状态失败',
     reanalyze: '重新分析',
     noDescription: '暂无描述',
     // 来源类型

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -2133,7 +2133,8 @@ const saveProvider = async () => {
     }
     closeProviderDialog()
   } catch (err) {
-    // 错误已在 store 中处理
+    const errorMsg = err instanceof Error ? err.message : t('settings.saveProviderFailed')
+    alert(errorMsg)
   }
 }
 
@@ -2213,7 +2214,8 @@ const saveModel = async () => {
     }
     closeModelDialog()
   } catch (err) {
-    // 错误已在 store 中处理
+    const errorMsg = err instanceof Error ? err.message : t('settings.saveModelFailed')
+    alert(errorMsg)
   }
 }
 
@@ -2309,7 +2311,8 @@ const saveExpert = async () => {
     }
     closeExpertDialog()
   } catch (err) {
-    // 错误已在 store 中处理
+    const errorMsg = err instanceof Error ? err.message : t('settings.saveExpertFailed')
+    alert(errorMsg)
   }
 }
 

--- a/frontend/src/views/SkillsView.vue
+++ b/frontend/src/views/SkillsView.vue
@@ -267,8 +267,9 @@ const closeDetailDialog = () => {
 const toggleSkillActive = async (skill: Skill) => {
   try {
     await skillStore.toggleSkillActive(skill.id)
-  } catch {
-    // 错误已在 store 中处理
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : t('skills.toggleFailed')
+    alert(errorMsg)
   }
 }
 


### PR DESCRIPTION
## 问题

在之前的 PR #101 中修复了删除操作的错误处理问题，但代码中还存在其他类似的静默吞掉错误的地方。

## 修复内容

### 1. SkillsView.vue - `toggleSkillActive` 函数
**修复前：**
```typescript
} catch {
  // 错误已在 store 中处理
}
```

**修复后：**
```typescript
} catch (err) {
  const errorMsg = err instanceof Error ? err.message : t('skills.toggleFailed')
  alert(errorMsg)
}
```

### 2. SettingsView.vue - `saveProvider` 函数
**修复前：**
```typescript
} catch (err) {
  // 错误已在 store 中处理
}
```

**修复后：**
```typescript
} catch (err) {
  const errorMsg = err instanceof Error ? err.message : t('settings.saveProviderFailed')
  alert(errorMsg)
}
```

### 3. SettingsView.vue - `saveModel` 函数
同上模式，显示错误信息给用户。

### 4. SettingsView.vue - `saveExpert` 函数
同上模式，显示错误信息给用户。

## 新增 i18n 翻译键

| 键名 | 中文 | 英文 |
|------|------|------|
| `skills.toggleFailed` | 切换技能状态失败 | Failed to toggle skill status |
| `settings.saveProviderFailed` | 保存提供商失败 | Failed to save provider |
| `settings.saveModelFailed` | 保存模型失败 | Failed to save model |
| `settings.saveExpertFailed` | 保存专家失败 | Failed to save expert |

## 测试建议

1. 尝试保存提供商/模型/专家时，模拟后端返回错误，验证错误信息是否正确显示
2. 尝试切换技能状态时，模拟后端返回错误，验证错误信息是否正确显示

## 关联

延续 PR #101 的修复工作