### PR TITLE
feat: add unifuncs-web-reader skill

### DIFF
--- a/data/skills/unifuncs-web-reader/SKILL.md
+++ b/data/skills/unifuncs-web-reader/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: unifuncs-web-reader
+description: 网页内容提取服务，通过 Unifuncs API 获取网页正文内容。支持微信公众号、知乎、头条等主流平台。
+argument-hint: "[url]"
+user-invocable: true
+allowed-tools: []
+env-variables:
+  - name: UNIFUNCS_API_KEY
+    description: Unifuncs API 密钥
+    required: true
+---
+
+# Unifuncs Web Reader
+
+网页内容提取服务，通过 Unifuncs API 获取网页正文内容。
+
+## 功能特点
+
+- 支持微信公众号文章
+- 支持知乎专栏/问答
+- 支持今日头条
+- 支持其他主流网站
+- 自动提取正文内容
+- 返回结构化数据
+
+## 配置要求
+
+此技能需要以下环境变量（由系统从 `skill_parameters` 表自动注入）：
+
+| 变量名 | 说明 | 必需 |
+|--------|------|------|
+| `UNIFUNCS_API_KEY` | Unifuncs API 密钥 | ✅ |
+
+## 工具清单
+
+### read_web_page
+
+读取网页内容并提取正文。
+
+**参数：**
+- `url` (string, required): 要读取的网页 URL
+- `timeout` (number, optional): 超时时间（毫秒），默认 30000
+
+**调用方式：**
+```
+GET https://api.unifuncs.com/api/web-reader/{path}?apiKey=API_KEY
+```
+
+**注意：** path 需要进行 URL 编码
+
+**示例：**
+```javascript
+// 读取微信公众号文章
+{
+  "url": "https://mp.weixin.qq.com/s/wmoNh44A4ofkawPNVx_g6A"
+}
+
+// 实际请求 URL
+// https://api.unifuncs.com/api/web-reader/https%3A%2F%2Fmp.weixin.qq.com%2Fs%2FwmoNh44A4ofkawPNVx_g6A?apiKey=API_KEY
+```
+
+**返回示例：**
+```json
+{
+  "success": true,
+  "statusCode": 200,
+  "statusMessage": "OK",
+  "headers": {
+    "content-type": "text/markdown; charset=utf-8",
+    "x-unifuncs-status": "0"
+  },
+  "body": "Title: 文章标题\n\nURL Source: https://example.com\n\nMarkdown Content:\n\n正文内容...",
+  "size": 12345,
+  "originalUrl": "https://example.com"
+}
+```
+
+**说明：** `body` 字段返回 Markdown 格式的文本内容，包含标题、来源 URL 和正文。
+
+## 错误处理
+
+| 状态码 | 说明 |
+|--------|------|
+| 200 | 成功 |
+| 400 | URL 格式错误 |
+| 401 | API Key 无效或缺失 |
+| 403 | 无权限访问 |
+| 404 | 网页不存在 |
+| 429 | 请求频率超限 |
+| 500 | 服务器错误 |
+
+## 安全说明
+
+- API Key 从环境变量获取，不在代码中硬编码
+- 使用 HTTPS 加密传输
+- 最大响应大小限制为 5MB
+- 默认超时 30 秒
+
+## 使用场景
+
+1. **内容分析**：提取网页正文用于 AI 分析
+2. **信息收集**：批量获取特定平台的内容
+3. **内容存档**：保存网页内容到本地
+
+## 注意事项
+
+- 请遵守目标网站的使用条款
+- 不要频繁请求同一网站
+- 部分网站可能有反爬机制

--- a/data/skills/unifuncs-web-reader/index.js
+++ b/data/skills/unifuncs-web-reader/index.js
@@ -1,0 +1,160 @@
+/**
+ * Unifuncs Web Reader Skill
+ *
+ * 网页内容提取服务，通过 Unifuncs API 获取网页正文内容。
+ * 支持微信公众号、知乎、头条等主流平台。
+ *
+ * @module unifuncs-web-reader
+ */
+
+const https = require('https');
+
+// API 配置
+const API_BASE = 'api.unifuncs.com';
+const API_PATH = '/api/web-reader/';
+
+// 默认超时（30秒）
+const DEFAULT_TIMEOUT = 30000;
+
+// 最大响应大小（5MB）
+const MAX_RESPONSE_SIZE = 5 * 1024 * 1024;
+
+/**
+ * 发起 HTTPS 请求
+ */
+function makeRequest(urlPath, timeout = DEFAULT_TIMEOUT) {
+  return new Promise((resolve, reject) => {
+    const requestOptions = {
+      hostname: API_BASE,
+      port: 443,
+      path: urlPath,
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+      },
+      timeout: timeout,
+    };
+
+    const req = https.request(requestOptions, (res) => {
+      let data = [];
+      let dataSize = 0;
+
+      res.on('data', (chunk) => {
+        dataSize += chunk.length;
+        if (dataSize <= MAX_RESPONSE_SIZE) {
+          data.push(chunk);
+        }
+      });
+
+      res.on('end', () => {
+        const rawData = Buffer.concat(data);
+        const contentType = res.headers['content-type'] || '';
+
+        let body;
+        if (contentType.includes('application/json')) {
+          try {
+            body = JSON.parse(rawData.toString('utf-8'));
+          } catch (e) {
+            body = rawData.toString('utf-8');
+          }
+        } else {
+          body = rawData.toString('utf-8');
+        }
+
+        resolve({
+          success: res.statusCode >= 200 && res.statusCode < 300,
+          statusCode: res.statusCode,
+          statusMessage: res.statusMessage,
+          headers: res.headers,
+          body: body,
+          size: dataSize,
+        });
+      });
+    });
+
+    req.on('error', (e) => {
+      reject(new Error(`Request failed: ${e.message}`));
+    });
+
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Request timeout'));
+    });
+
+    req.end();
+  });
+}
+
+/**
+ * 读取网页内容
+ *
+ * @param {object} params - 参数对象
+ * @param {string} params.url - 要读取的网页 URL（必需）
+ * @param {number} params.timeout - 超时时间（可选，默认 30000ms）
+ * @returns {Promise<object>} 读取结果
+ */
+async function readWebPage(params) {
+  const { url, timeout = DEFAULT_TIMEOUT } = params;
+
+  // 从环境变量获取 API Key（由 skill-loader 从 skill_parameters 表注入）
+  const apiKey = process.env.UNIFUNCS_API_KEY;
+
+  if (!url) {
+    throw new Error('URL is required');
+  }
+
+  if (!apiKey) {
+    throw new Error('UNIFUNCS_API_KEY is not configured. Please add it to skill_parameters table.');
+  }
+
+  try {
+    // URL 编码
+    const encodedUrl = encodeURIComponent(url);
+    const urlPath = `${API_PATH}${encodedUrl}?apiKey=${apiKey}`;
+
+    const result = await makeRequest(urlPath, timeout);
+
+    return {
+      success: result.success,
+      statusCode: result.statusCode,
+      statusMessage: result.statusMessage,
+      headers: result.headers,
+      body: result.body,
+      size: result.size,
+      originalUrl: url,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+      originalUrl: url,
+    };
+  }
+}
+
+/**
+ * Skill execute function - 被 skill-runner 调用
+ *
+ * @param {string} toolName - 工具名称
+ * @param {object} params - 工具参数
+ * @param {object} context - 执行上下文
+ * @returns {Promise<object>} 执行结果
+ */
+async function execute(toolName, params, context = {}) {
+  switch (toolName) {
+    case 'read_web_page':
+    case 'readWebPage':
+    case 'read':
+      return await readWebPage(params);
+
+    default:
+      throw new Error(`Unknown tool: ${toolName}. Available tools: read_web_page`);
+  }
+}
+
+module.exports = {
+  execute,
+  readWebPage,
+  name: 'unifuncs-web-reader',
+  description: '网页内容提取服务，通过 Unifuncs API 获取网页正文内容',
+};


### PR DESCRIPTION
## 功能描述

新增 unifuncs-web-reader 技能，用于通过 Unifuncs API 提取网页正文内容。

## 功能特点

- 支持微信公众号文章
- 支持知乎专栏/问答
- 支持今日头条
- 支持其他主流网站
- 自动提取正文内容并返回 Markdown 格式

## 技术细节

- 工具名称: `read_web_page`
- 环境变量: `UNIFUNCS_API_KEY` (从 skill_parameters 表自动注入)
- 超时控制: 默认 30 秒
- 响应大小限制: 5MB

## 测试

已通过 `tests/run-skill.js` 测试，成功获取知乎页面内容。

## 文件变更

- `data/skills/unifuncs-web-reader/index.js` - 技能实现
- `data/skills/unifuncs-web-reader/SKILL.md` - 技能说明