### PR TITLE
[T105] fix: 根据模型类型处理多模态消息中的图片

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -131,8 +131,8 @@ class LLMClient {
    * @returns {Promise<Object>} 包含 content 和 usage 的响应
    */
   async call(model, messages, options = {}) {
-    // 处理多模态消息格式
-    const processedMessages = this.processMultimodalMessages(messages);
+    // 处理多模态消息格式（传入模型配置以判断是否支持多模态）
+    const processedMessages = this.processMultimodalMessages(messages, model);
 
     const requestBody = JSON.stringify({
       model: model.model_name,
@@ -442,12 +442,36 @@ class LLMClient {
    * 处理多模态消息格式
    * 将数据库存储的消息格式转换为 OpenAI API 所需的多模态格式
    * @param {Array} messages - 消息数组
+   * @param {Object} model - 模型配置（可选），用于判断是否支持多模态
    * @returns {Array} 处理后的消息数组
    */
-  processMultimodalMessages(messages) {
+  processMultimodalMessages(messages, model = null) {
+    // 判断模型是否支持多模态
+    const isMultimodalModel = model?.model_type === 'multimodal';
+    
+    if (isMultimodalModel) {
+      logger.info('[LLMClient] 模型支持多模态，将转换图片为多模态格式:', model.model_name);
+    } else if (model) {
+      logger.info('[LLMClient] 模型不支持多模态，将移除图片标记:', model?.model_name || 'unknown');
+    }
+
     const processedMessages = messages.map(msg => {
-      // 如果 content 已经是数组格式（多模态），直接使用
+      // 如果 content 已经是数组格式（多模态），根据模型类型处理
       if (Array.isArray(msg.content)) {
+        // 如果模型不支持多模态，将数组转换为纯文本
+        if (!isMultimodalModel) {
+          const textParts = msg.content
+            .filter(item => item.type === 'text')
+            .map(item => item.text);
+          const imageUrlParts = msg.content
+            .filter(item => item.type === 'image_url')
+            .map(item => item.image_url?.url)
+            .filter(url => url);
+          
+          // 图片 URL 作为文本保留，让 LLM 知道有图片存在
+          const allText = [...textParts, ...imageUrlParts].join('\n');
+          return { ...msg, content: allText || msg.content };
+        }
         return msg;
       }
 
@@ -458,11 +482,35 @@ class LLMClient {
           const parsed = JSON.parse(msg.content);
           if (Array.isArray(parsed)) {
             // 已经是多模态数组格式
+            // 如果模型不支持多模态，转换为纯文本
+            if (!isMultimodalModel) {
+              const textParts = parsed
+                .filter(item => item.type === 'text')
+                .map(item => item.text);
+              const imageUrlParts = parsed
+                .filter(item => item.type === 'image_url')
+                .map(item => item.image_url?.url)
+                .filter(url => url);
+              const allText = [...textParts, ...imageUrlParts].join('\n');
+              return { ...msg, content: allText || msg.content };
+            }
             logger.info('[LLMClient] 检测到多模态数组格式消息');
             return { ...msg, content: parsed };
           }
           if (parsed.type === 'multimodal' && Array.isArray(parsed.content)) {
             // { type: 'multimodal', content: [...] } 格式
+            // 如果模型不支持多模态，转换为纯文本
+            if (!isMultimodalModel) {
+              const textParts = parsed.content
+                .filter(item => item.type === 'text')
+                .map(item => item.text);
+              const imageUrlParts = parsed.content
+                .filter(item => item.type === 'image_url')
+                .map(item => item.image_url?.url)
+                .filter(url => url);
+              const allText = [...textParts, ...imageUrlParts].join('\n');
+              return { ...msg, content: allText || msg.content };
+            }
             logger.info('[LLMClient] 检测到多模态包装格式消息，包含内容项:', parsed.content.length);
             return { ...msg, content: parsed.content };
           }
@@ -478,22 +526,34 @@ class LLMClient {
 
         while ((match = imageRegex.exec(msg.content)) !== null) {
           images.push({
-            type: 'image_url',
-            image_url: { url: match[2] }
+            url: match[2],
+            alt: match[1],
           });
           // 移除图片标记，保留文本
           textContent = textContent.replace(match[0], '').trim();
         }
 
-        // 如果有图片，返回多模态格式
+        // 如果有图片，根据模型类型处理
         if (images.length > 0) {
-          logger.info('[LLMClient] 检测到 Markdown 图片标记，图片数量:', images.length);
-          const content = [];
-          if (textContent) {
-            content.push({ type: 'text', text: textContent });
+          if (isMultimodalModel) {
+            // 多模态模型：转换为多模态格式
+            logger.info('[LLMClient] 检测到 Markdown 图片标记，转换为多模态格式，图片数量:', images.length);
+            const content = [];
+            if (textContent) {
+              content.push({ type: 'text', text: textContent });
+            }
+            content.push(...images.map(img => ({
+              type: 'image_url',
+              image_url: { url: img.url }
+            })));
+            return { ...msg, content };
+          } else {
+            // 非多模态模型：移除图片标记，保留 URL 作为文本
+            logger.info('[LLMClient] 检测到 Markdown 图片标记，模型不支持多模态，保留 URL 作为文本，图片数量:', images.length);
+            const urlList = images.map(img => img.url).join('\n');
+            const newContent = textContent ? `${textContent}\n${urlList}` : urlList;
+            return { ...msg, content: newContent };
           }
-          content.push(...images);
-          return { ...msg, content };
         }
       }
 
@@ -627,8 +687,8 @@ class LLMClient {
   async callStream(model, messages, options = {}) {
     const { tools, onDelta, onToolCall, onUsage } = options;
 
-    // 处理多模态消息格式
-    const processedMessages = this.processMultimodalMessages(messages);
+    // 处理多模态消息格式（传入模型配置以判断是否支持多模态）
+    const processedMessages = this.processMultimodalMessages(messages, model);
 
     // 分析消息构成
     const messageAnalysis = this.analyzeMessages(processedMessages);


### PR DESCRIPTION
## 问题描述

在使用 `unifuncs-web-reader` 技能时，工具返回的内容包含 Markdown 格式的图片标记 `![alt](url)`。当专家使用非多模态模型（如 `glm-4.7`）时，LLM 客户端会将这些图片转换为多模态格式 `{ type: 'image_url', image_url: { url } }`，导致 HTTP 400 错误，因为非多模态模型不支持这种格式。

## 解决方案

根据数据库 `ai_models` 表中的 `model_type` 字段（`text` / `multimodal` / `embedding`），在 LLM 客户端处理消息时：

- **多模态模型** (`model_type === 'multimodal'`)：转换 Markdown 图片为多模态格式
- **非多模态模型**：移除 Markdown 图片标记，保留 URL 作为纯文本

## 变更内容

### `lib/llm-client.js`

1. `processMultimodalMessages()` 方法新增 `model` 参数
2. 根据 `model.model_type` 判断模型是否支持多模态
3. 处理逻辑：
   - 多模态模型：图片转换为 `{ type: 'image_url', image_url: { url } }` 格式
   - 非多模态模型：图片 URL 作为纯文本保留
4. 更新 `call()` 和 `callStream()` 调用，传入 model 参数

## 测试验证

- 非多模态模型（glm-4.7, gpt-4-turbo 等）不再因图片格式报错
- 多模态模型（glm-4.5v, qwen3.5:35b）可以正确接收图片

## 影响范围

- 所有使用工具（Skill）的专家对话
- 特别是返回图片 URL 的工具（如 `unifuncs-web-reader`）

Closes #105