### PR TITLE
[T107] feat: 增强技能调试能力

### DIFF
--- a/data/skills/unifuncs-web-reader/index.js
+++ b/data/skills/unifuncs-web-reader/index.js
@@ -97,14 +97,25 @@ async function readWebPage(params) {
   const { url, timeout = DEFAULT_TIMEOUT } = params;
 
   // 从环境变量获取 API Key（由 skill-loader 从 skill_parameters 表注入）
-  const apiKey = process.env.UNIFUNCS_API_KEY;
+  // 系统会自动添加 SKILL_ 前缀，所以需要检查 SKILL_UNIFUNCS_API_KEY
+  // 同时保留对无前缀版本的支持，方便本地测试
+  const apiKey = process.env.SKILL_UNIFUNCS_API_KEY || process.env.UNIFUNCS_API_KEY;
+
+  // 🔍 调试日志：输出环境变量和参数信息
+  console.log('[unifuncs-web-reader] ========== DEBUG INFO ==========');
+  console.log('[unifuncs-web-reader] params:', JSON.stringify(params, null, 2));
+  console.log('[unifuncs-web-reader] SKILL_UNIFUNCS_API_KEY:', process.env.SKILL_UNIFUNCS_API_KEY ? `${process.env.SKILL_UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
+  console.log('[unifuncs-web-reader] UNIFUNCS_API_KEY:', process.env.UNIFUNCS_API_KEY ? `${process.env.UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
+  console.log('[unifuncs-web-reader] resolved apiKey:', apiKey ? `${apiKey.substring(0, 8)}...` : '(not set)');
+  console.log('[unifuncs-web-reader] ==============================');
 
   if (!url) {
     throw new Error('URL is required');
   }
 
   if (!apiKey) {
-    throw new Error('UNIFUNCS_API_KEY is not configured. Please add it to skill_parameters table.');
+    throw new Error('UNIFUNCS_API_KEY is not configured. Please add it to skill_parameters table. ' +
+      'Note: System will auto-add SKILL_ prefix, looking for SKILL_UNIFUNCS_API_KEY in env.');
   }
 
   try {
@@ -112,7 +123,18 @@ async function readWebPage(params) {
     const encodedUrl = encodeURIComponent(url);
     const urlPath = `${API_PATH}${encodedUrl}?apiKey=${apiKey}`;
 
+    // 🔍 调试日志：输出请求信息（隐藏完整 API Key）
+    console.log('[unifuncs-web-reader] Request URL:', `https://${API_BASE}${API_PATH}${encodedUrl}?apiKey=${apiKey.substring(0, 8)}...`);
+    console.log('[unifuncs-web-reader] Timeout:', timeout);
+
     const result = await makeRequest(urlPath, timeout);
+
+    // 🔍 调试日志：输出响应信息
+    console.log('[unifuncs-web-reader] Response status:', result.statusCode, result.statusMessage);
+    console.log('[unifuncs-web-reader] Response size:', result.size, 'bytes');
+    if (!result.success) {
+      console.log('[unifuncs-web-reader] Response body:', JSON.stringify(result.body).substring(0, 500));
+    }
 
     return {
       success: result.success,
@@ -124,6 +146,7 @@ async function readWebPage(params) {
       originalUrl: url,
     };
   } catch (error) {
+    console.log('[unifuncs-web-reader] Error:', error.message);
     return {
       success: false,
       error: error.message,

--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -344,7 +344,8 @@ class SkillLoader {
         const duration = Date.now() - startTime;
         
         if (stderr) {
-          logger.debug(`[SkillLoader] ${skillId} stderr:`, stderr);
+          // 技能的 console.log 输出到 stderr，使用 info 级别确保可见
+          logger.info(`[SkillLoader] ${skillId} stderr:\n${stderr}`);
         }
 
         // 尝试解析 stdout（即使 exit code 非 0，错误详情也在 stdout 的 JSON 中）

--- a/tests/run-skill.js
+++ b/tests/run-skill.js
@@ -37,6 +37,7 @@ import string_decoder from 'string_decoder';
 import querystring from 'querystring';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
+import mysql from 'mysql2/promise';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -129,6 +130,64 @@ function generateAdminToken() {
   const adminUserId = 'c464d6d1e06b5d5d05c4';  // admin 用户的真实 ID
   const adminRole = 'admin';
   return jwt.sign({ userId: adminUserId, role: adminRole }, JWT_SECRET, { expiresIn: '1h' });
+}
+
+/**
+ * 从数据库加载技能参数并注入环境变量
+ * 与 skill-loader.js 的 buildSkillEnvironment 保持一致：
+ * - 参数名会被转换为 SKILL_{PARAM_NAME} 格式的环境变量
+ * - 例如：UNIFUNCS_API_KEY -> SKILL_UNIFUNCS_API_KEY
+ * @param {string} skillName - 技能名称
+ */
+async function loadSkillParameters(skillName) {
+  const dbConfig = {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '3306'),
+    database: process.env.DB_NAME || 'touwaka_mate',
+    user: process.env.DB_USER || 'root',
+    password: process.env.DB_PASSWORD || '',
+  };
+  
+  let connection;
+  try {
+    connection = await mysql.createConnection(dbConfig);
+    
+    // 查询技能参数 - 支持两种方式：
+    // 1. skill_id 为技能名称（如 'unifuncs-web-reader'）
+    // 2. skill_id 为技能 ID（如 'mmoasyw4iar2f9qi4z96'）
+    const [rows] = await connection.query(`
+      SELECT param_name, param_value 
+      FROM skill_parameters 
+      WHERE skill_id = ? OR skill_id IN (SELECT id FROM skills WHERE name = ?)
+    `, [skillName, skillName]);
+    
+    if (rows.length > 0) {
+      console.log(`📦 从数据库加载 ${rows.length} 个技能参数`);
+      for (const row of rows) {
+        // 替换环境变量引用
+        let value = row.param_value;
+        if (value && value.startsWith('${') && value.endsWith('}')) {
+          const envKey = value.slice(2, -1);
+          value = process.env[envKey] || '';
+        }
+        
+        // 与 skill-loader.js 保持一致：添加 SKILL_ 前缀
+        const envVarName = `SKILL_${row.param_name.toUpperCase()}`;
+        process.env[envVarName] = value;
+        
+        // 同时设置无前缀版本（方便本地测试和向后兼容）
+        process.env[row.param_name] = value;
+        
+        console.log(`   - ${envVarName}: ${value ? '✅' : '❌'}`);
+      }
+    }
+  } catch (error) {
+    console.warn(`⚠️  加载技能参数失败: ${error.message}`);
+  } finally {
+    if (connection) {
+      await connection.end();
+    }
+  }
 }
 
 /**
@@ -246,6 +305,9 @@ async function main() {
       USER_ACCESS_TOKEN = generateAdminToken();
       console.log('   ✅ 已生成管理员令牌');
     }
+    
+    // 从数据库加载技能参数并注入环境变量
+    await loadSkillParameters(skillName);
     
     // 设置环境变量（技能模块会读取这些）
     process.env.API_BASE = API_BASE;


### PR DESCRIPTION
## 问题描述

在调试 `unifuncs-web-reader` 技能时，发现几个问题：
1. 技能参数环境变量命名不一致（`UNIFUNCS_API_KEY` vs `SKILL_UNIFUNCS_API_KEY`）
2. `tests/run-skill.js` 无法从数据库加载技能参数
3. 技能的 `console.log` 输出到 stderr，但日志级别为 `debug`，在生产环境不可见

## 解决方案

### 1. `data/skills/unifuncs-web-reader/index.js`
- 支持 `SKILL_UNIFUNCS_API_KEY` 和 `UNIFUNCS_API_KEY` 两种环境变量名
- 添加详细的调试日志，方便排查问题
- 改进错误提示信息

### 2. `lib/skill-loader.js`
- 将 stderr 输出日志级别从 `debug` 改为 `info`
- 技能的 `console.log` 输出到 stderr，使用 info 级别确保可见

### 3. `tests/run-skill.js`
- 新增 `loadSkillParameters()` 函数，从数据库加载技能参数
- 与 `skill-loader.js` 的 `buildSkillEnvironment` 保持一致：
  - 参数名转换为 `SKILL_{PARAM_NAME}` 格式
  - 同时设置无前缀版本（向后兼容）
  - 支持环境变量引用替换

## 测试验证

```bash
# 测试技能执行
node tests/run-skill.js unifuncs-web-reader read --url="https://example.com"

# 验证日志输出
# [unifuncs-web-reader] ========== DEBUG INFO ==========
# 📦 从数据库加载 1 个技能参数
#    - SKILL_UNIFUNCS_API_KEY: ✅
```

Closes #107