### PR TITLE
[T108] fix: 修复任务模式 UI 问题

### DIFF
--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -203,7 +203,7 @@
     </template>
 
     <!-- 创建/编辑任务对话框 -->
-    <div v-if="showTaskDialog" class="dialog-overlay" @click.self="closeTaskDialog">
+    <div v-if="showTaskDialog" class="dialog-overlay">
       <div class="dialog">
         <div class="dialog-header">
           <h3>{{ isEditMode ? ($t('tasks.editTitle') || '编辑任务') : ($t('tasks.createTitle') || '创建任务') }}</h3>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -20,11 +20,11 @@
         <!-- Task 模式状态 -->
         <span
           class="task-mode-tag"
-          :class="{ 'in-task': taskStore.isInTaskMode }"
-          @click="taskStore.isInTaskMode && handleExitTaskMode()"
-          :title="taskStore.isInTaskMode ? '点击退出任务模式' : ''"
+          :class="{ 'in-task': taskStore.currentTask }"
+          @click="taskStore.currentTask && handleExitTaskMode()"
+          :title="taskStore.currentTask ? '点击退出任务模式' : ''"
         >
-          <template v-if="taskStore.isInTaskMode && taskStore.currentTask">
+          <template v-if="taskStore.currentTask">
             📁 {{ taskStore.currentTask.title }}
             <span class="exit-icon">✕</span>
           </template>
@@ -475,7 +475,7 @@ const handleSendMessage = async (content: string) => {
     }
     
     // 如果在任务模式下，添加 task_id 和 task_path
-    if (taskStore.isInTaskMode && taskStore.currentTask) {
+    if (taskStore.currentTask) {
       messageParams.task_id = taskStore.currentTask.id  // 使用数据库主键
       // 添加当前浏览路径
       if (taskStore.currentPath) {


### PR DESCRIPTION
## 问题描述

在任务模式下存在两个 UI 问题：

1. **TasksTab.vue**: 点击对话框背景会意外关闭对话框，导致编辑中的任务丢失
2. **ChatView.vue**: 任务模式标签判断使用 `taskStore.isInTaskMode`，但实际应该使用 `taskStore.currentTask` 的存在性来判断

## 解决方案

### 1. `frontend/src/components/panel/TasksTab.vue`
- 移除对话框背景的 `@click.self="closeTaskDialog"` 事件
- 防止误点击关闭对话框

### 2. `frontend/src/views/ChatView.vue`
- 将 `taskStore.isInTaskMode` 替换为 `taskStore.currentTask`
- 修复任务模式标签显示和退出逻辑

## 测试验证

1. 打开任务创建/编辑对话框，点击背景，确认对话框不会关闭
2. 进入任务模式，确认顶部标签正确显示任务名称
3. 点击标签上的 ✕ 图标，确认能正确退出任务模式

Closes #108