### PR TITLE
#125: feat: 添加网页语言切换功能

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -30,6 +30,14 @@
     </nav>
 
     <div class="header-right">
+      <!-- 语言切换 -->
+      <div class="lang-selector">
+        <select v-model="currentLocale" @change="handleLocaleChange" class="lang-select">
+          <option value="zh-CN">中文</option>
+          <option value="en-US">English</option>
+        </select>
+      </div>
+      
       <div class="user-menu" ref="menuRef">
         <button class="btn-user" @click="showUserMenu = !showUserMenu">
           <span class="user-avatar">{{ userInitial }}</span>
@@ -60,13 +68,29 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useUserStore } from '@/stores/user'
+import { useI18n } from 'vue-i18n'
+import type { Locale } from '@/i18n'
 
 const route = useRoute()
 const router = useRouter()
 const userStore = useUserStore()
+const { locale } = useI18n()
 
 const showUserMenu = ref(false)
 const menuRef = ref<HTMLElement | null>(null)
+
+// 当前语言
+const currentLocale = computed({
+  get: () => locale.value as Locale,
+  set: (value: Locale) => {
+    locale.value = value
+  }
+})
+
+// 处理语言切换
+const handleLocaleChange = async () => {
+  await userStore.changeLanguage(currentLocale.value)
+}
 
 const userInitial = computed(() => {
   return userStore.user?.nickname?.charAt(0).toUpperCase() || 'U'
@@ -179,6 +203,33 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+/* 语言选择器 */
+.lang-selector {
+  display: flex;
+  align-items: center;
+}
+
+.lang-select {
+  padding: 6px 12px;
+  background: var(--card-bg, #ffffff);
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text-primary, #333);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.lang-select:hover {
+  border-color: var(--primary-color, #2196f3);
+}
+
+.lang-select:focus {
+  outline: none;
+  border-color: var(--primary-color, #2196f3);
+  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.1);
 }
 
 .user-menu {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -70,6 +70,12 @@ export default {
     timeDaysAgo: '{n} days ago',
     uploadImage: 'Upload image',
     selectModel: 'Select Model',
+    // Task mode
+    exitTaskMode: 'Click to exit task mode',
+    selectDirectory: 'Please select a directory in the right panel to save conversation history',
+    noDirectory: 'No directory selected',
+    commandHint: 'Type / for shortcuts, or describe what you want to do...',
+    connectionLost: 'Connection lost, reconnecting. Please try again later.',
   },
 
   // Debug panel

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -72,6 +72,12 @@ export default {
     timeDaysAgo: '{n}天前',
     uploadImage: '上传图片',
     selectModel: '选择模型',
+    // 任务模式
+    exitTaskMode: '点击退出任务模式',
+    selectDirectory: '请在右侧面板选择目录以保存对话记录',
+    noDirectory: '未选择目录',
+    commandHint: '输入 / 查看快捷指令，或描述你想做什么...',
+    connectionLost: '连接已断开，正在重连中，请稍后重试',
   },
 
   // 调试面板

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1,46 +1,46 @@
 <template>
   <div class="chat-view">
-    <!-- 聊天头部 -->
-    <div class="chat-header">
-      <div class="expert-info">
-        <div
-          class="expert-avatar"
-          :style="currentExpert?.avatar_base64 ? { backgroundImage: `url(${currentExpert.avatar_base64})` } : {}"
-        >
-          <span v-if="!currentExpert?.avatar_base64">🤖</span>
-        </div>
-        <h2 class="expert-name">{{ currentExpert?.name || $t('chat.title') }}</h2>
-        <!-- skill-studio 显示模型选择器 -->
-        <ModelSelector
-          v-if="is_skill_studio"
-          v-model="selected_model_id"
-          class="model-selector"
-        />
-        <span v-else-if="currentModel" class="model-badge">{{ currentModel.name }}</span>
-        <!-- Task 模式状态 -->
-        <span
-          class="task-mode-tag"
-          :class="{ 'in-task': taskStore.currentTask, 'no-task': !taskStore.currentTask }"
-          @click="taskStore.currentTask && handleExitTaskMode()"
-          :title="taskStore.currentTask ? '点击退出任务模式' : '请在右侧面板选择目录以保存对话记录'"
-        >
-          <template v-if="taskStore.currentTask">
-            📁 {{ taskStore.currentTask.title }}
-            <span class="exit-icon">✕</span>
-          </template>
-          <template v-else>
-            ⚠️ 未选择目录
-          </template>
-        </span>
-      </div>
-    </div>
-
     <!-- 聊天主体 + 右侧面板（可拖拽调整） -->
     <div class="chat-body-wrapper">
       <Splitpanes @resize="handlePanelResize">
         <!-- 聊天主体 -->
         <Pane :size="chatPaneSize" class="chat-pane">
           <div class="chat-body">
+            <!-- 专家信息面板（对话 box 顶部） -->
+            <div class="chat-info-panel" v-if="currentExpertId">
+              <div class="expert-info">
+                <div
+                  class="expert-avatar"
+                  :style="currentExpert?.avatar_base64 ? { backgroundImage: `url(${currentExpert.avatar_base64})` } : {}"
+                >
+                  <span v-if="!currentExpert?.avatar_base64">🤖</span>
+                </div>
+                <h2 class="expert-name">{{ currentExpert?.name || $t('chat.title') }}</h2>
+                <!-- skill-studio 显示模型选择器 -->
+                <ModelSelector
+                  v-if="is_skill_studio"
+                  v-model="selected_model_id"
+                  class="model-selector"
+                />
+                <span v-else-if="currentModel" class="model-badge">{{ currentModel.name }}</span>
+                <!-- Task 模式状态 -->
+                <span
+                  class="task-mode-tag"
+                  :class="{ 'in-task': taskStore.currentTask, 'no-task': !taskStore.currentTask }"
+                  @click="taskStore.currentTask && handleExitTaskMode()"
+                  :title="taskStore.currentTask ? $t('chat.exitTaskMode') : $t('chat.selectDirectory')"
+                >
+                  <template v-if="taskStore.currentTask">
+                    📁 {{ taskStore.currentTask.title }}
+                    <span class="exit-icon">✕</span>
+                  </template>
+                  <template v-else>
+                    ⚠️ {{ $t('chat.noDirectory') }}
+                  </template>
+                </span>
+              </div>
+            </div>
+            
             <div class="chat-content" v-if="currentExpertId">
               <ChatWindow
                 ref="chatWindowRef"
@@ -51,7 +51,7 @@
                 :expert-avatar="currentExpert?.avatar_base64"
                 :expert-avatar-large="currentExpert?.avatar_large_base64"
                 :show-command-hints="is_skill_studio"
-                :custom-placeholder="is_skill_studio ? '输入 / 查看快捷指令，或描述你想做什么...' : undefined"
+                :custom-placeholder="is_skill_studio ? $t('chat.commandHint') : undefined"
                 @send="handleSendMessage"
                 @retry="handleRetry"
                 @load-more="loadMoreMessages"
@@ -462,7 +462,7 @@ const handleSendMessage = async (content: string) => {
       chatStore.addLocalMessage({
         expert_id,
         role: 'assistant',
-        content: '连接已断开，正在重连中，请稍后重试',
+        content: t('chat.connectionLost'),
         status: 'error',
       })
       return
@@ -724,10 +724,40 @@ onUnmounted(() => {
   background: var(--main-bg, #fff);
 }
 
-.chat-header {
+.chat-body-wrapper {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex: 1;
+  overflow: hidden;
+}
+
+.chat-pane {
+  height: 100%;
+}
+
+.panel-pane {
+  height: 100%;
+}
+
+.chat-body {
+  height: 100%;
+  overflow: hidden;
+  padding: 16px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+/* 专家信息面板样式 */
+.chat-info-panel {
   padding: 12px 16px;
   border-bottom: 1px solid var(--border-color, #e0e0e0);
   background: var(--header-bg, #fff);
@@ -771,57 +801,6 @@ onUnmounted(() => {
 
 .model-selector {
   margin-left: 8px;
-}
-
-.header-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.btn-toggle-panel {
-  padding: 6px 12px;
-  background: var(--secondary-bg, #f5f5f5);
-  border: 1px solid var(--border-color, #e0e0e0);
-  border-radius: 6px;
-  font-size: 13px;
-  color: var(--text-secondary, #666);
-  cursor: pointer;
-}
-
-.btn-toggle-panel:hover {
-  background: var(--hover-bg, #e8e8e8);
-}
-
-.chat-body-wrapper {
-  display: flex;
-  flex: 1;
-  overflow: hidden;
-}
-
-.chat-pane {
-  height: 100%;
-}
-
-.panel-pane {
-  height: 100%;
-}
-
-.chat-body {
-  height: 100%;
-  overflow: hidden;
-  padding: 16px;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-}
-
-.chat-content {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  height: 100%;
 }
 
 .no-expert-selected {


### PR DESCRIPTION
## 变更内容

在网页顶部导航栏添加语言切换功能。

### 具体变更

1. **AppHeader.vue** - 添加语言选择下拉框
   - 支持中文(zh-CN)和英文(en-US)切换
   - 位置：用户头像左侧

2. **ChatView.vue** - 专家信息面板调整
   - 将专家信息面板从独立位置移到聊天框上方

3. **i18n 翻译文件** - 新增翻译键
   - `chat.exitTaskMode` - 退出任务模式
   - `chat.selectDirectory` - 选择目录
   - `chat.noDirectory` - 未选择目录
   - `chat.commandHint` - 命令提示
   - `chat.connectionLost` - 连接丢失

### 截图

语言选择器位于导航栏右侧，用户头像旁边。

Closes #125