### PR TITLE
#127: 优化专家对话界面顶部专家面板的视觉效果

### DIFF
--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -555,7 +555,7 @@ defineExpose({
   height: 100%;
   background: var(--chat-bg, #fff);
   border: 1px solid var(--border-color, #e0e0e0);
-  border-radius: 12px;
+  border-radius: 0 0 12px 12px;
   overflow: hidden;
   position: relative;
 }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -759,9 +759,13 @@ onUnmounted(() => {
 /* 专家信息面板样式 */
 .chat-info-panel {
   padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color, #e0e0e0);
   background: var(--header-bg, #fff);
   flex-shrink: 0;
+  border-radius: 12px 12px 0 0;
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-bottom: none;
+  margin-bottom: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .expert-info {


### PR DESCRIPTION
Closes #127\n\n## 修改内容\n\n### ChatView.vue\n- 专家信息面板添加顶部圆角（`border-radius: 12px 12px 0 0`）\n- 与下方聊天框留出 8px 间隙（`margin-bottom: 8px`）\n- 添加轻微阴影增强层次感\n- 调整边框样式使面板更独立\n\n### ChatWindow.vue\n- 调整圆角为仅底部圆角（`border-radius: 0 0 12px 12px`）\n- 与专家面板形成卡片组合效果\n\n## 视觉效果\n专家面板和聊天框现在形成视觉上的"卡片组合"效果，提升了整体 UI 质感。