### PR TITLE
#130: fix 修复专家技能更新时复合主键查询错误

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -783,14 +783,14 @@ class Database {
       });
 
       if (existing) {
-        // 更新现有关联
+        // 更新现有关联（使用复合主键 expert_id + skill_id）
         await this.models.expert_skill.update(
           {
             is_enabled,
             config: skillConfig !== undefined ? skillConfig : existing.config,
           },
           {
-            where: { id: existing.id },
+            where: { expert_id: expertId, skill_id },
           }
         );
       } else if (is_enabled) {


### PR DESCRIPTION
## 描述

修复专家技能更新接口 500 错误

## 变更内容

- 修复 [`lib/db.js`](lib/db.js:793) 中 `batchUpdateExpertSkills` 方法的 WHERE 条件错误
- 将 `where: { id: existing.id }` 改为 `where: { expert_id: expertId, skill_id }`
- `expert_skills` 表使用复合主键 `(expert_id, skill_id)`，没有独立的 `id` 字段

## 测试

- [x] 调用 `POST /api/experts/:id/skills` 接口应正常返回

Closes #130