### PR TITLE
#132: 去掉专家面板与聊天框的间隙，形成一体化效果

### DIFF
--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -764,8 +764,6 @@ onUnmounted(() => {
   border-radius: 12px 12px 0 0;
   border: 1px solid var(--border-color, #e0e0e0);
   border-bottom: none;
-  margin-bottom: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .expert-info {


### PR DESCRIPTION
Closes #132\n\n## 修改内容\n\n- 去掉 `.chat-info-panel` 的 `margin-bottom: 8px`\n- 去掉 `.chat-info-panel` 的 `box-shadow`\n- 保持顶部圆角和底部圆角的配合，形成一体化卡片效果\n\n## 视觉效果\n\n专家面板和聊天框现在融为一体，形成统一的卡片效果。