### PR TITLE
#129: feat SSH驻留进程用户认证机制

### DIFF
--- a/data/skills/erix-ssh/scripts/db.js
+++ b/data/skills/erix-ssh/scripts/db.js
@@ -4,9 +4,13 @@
  * Provides persistent storage for sessions, tasks, and messages using SQLite.
  */
 
-const Database = require('better-sqlite3');
-const path = require('path');
-const fs = require('fs');
+import Database from 'better-sqlite3';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Use project directory for data storage
 const DATA_DIR = path.join(__dirname, '..', 'data');
@@ -33,6 +37,7 @@ db.exec(`
     username TEXT NOT NULL,
     status TEXT DEFAULT 'connecting',
     config TEXT,  -- JSON blob
+    user_id TEXT,  -- 用户ID，用于session隔离
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     last_read_at TEXT
@@ -73,6 +78,7 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
   CREATE INDEX IF NOT EXISTS idx_messages_read ON messages(read);
   CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id);
+  CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);
 `);
 
 /**
@@ -90,12 +96,15 @@ function generateId(prefix = 'sess') {
 
 /**
  * Create a new session
+ * @param {string} sessionId - Session ID
+ * @param {object} config - Session config (host, port, username, etc.)
+ * @param {string} userId - User ID for session isolation
  */
-function createSession(sessionId, config) {
+function createSession(sessionId, config, userId = null) {
   const now = new Date().toISOString();
   const stmt = db.prepare(`
-    INSERT INTO sessions (id, host, port, username, status, config, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO sessions (id, host, port, username, status, config, user_id, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   
   stmt.run(
@@ -105,6 +114,7 @@ function createSession(sessionId, config) {
     config.username,
     'connecting',
     JSON.stringify(config),
+    userId,
     now,
     now
   );
@@ -142,6 +152,18 @@ function updateSessionStatus(sessionId, status) {
 }
 
 /**
+ * Update session config
+ */
+function updateSessionConfig(sessionId, config) {
+  const now = new Date().toISOString();
+  const stmt = db.prepare(`
+    UPDATE sessions SET config = ?, updated_at = ? WHERE id = ?
+  `);
+  stmt.run(JSON.stringify(config), now, sessionId);
+  return getSession(sessionId);
+}
+
+/**
  * Update last read timestamp
  */
 function updateLastRead(sessionId) {
@@ -174,12 +196,38 @@ function getSessionSummary(sessionId) {
 }
 
 /**
- * List all sessions
+ * List all sessions (optionally filtered by user)
+ * @param {string} userId - Optional user ID to filter sessions
  */
-function listSessions() {
-  const stmt = db.prepare('SELECT id FROM sessions ORDER BY updated_at DESC');
-  const rows = stmt.all();
-  return rows.map(row => getSessionSummary(row.id)).filter(s => s !== null);
+function listSessions(userId = null) {
+  let stmt;
+  if (userId) {
+    stmt = db.prepare('SELECT id FROM sessions WHERE user_id = ? ORDER BY updated_at DESC');
+    const rows = stmt.all(userId);
+    return rows.map(row => getSessionSummary(row.id)).filter(s => s !== null);
+  } else {
+    stmt = db.prepare('SELECT id FROM sessions ORDER BY updated_at DESC');
+    const rows = stmt.all();
+    return rows.map(row => getSessionSummary(row.id)).filter(s => s !== null);
+  }
+}
+
+/**
+ * Check if session belongs to user
+ * @param {string} sessionId - Session ID
+ * @param {string} userId - User ID
+ * @returns {boolean} True if session belongs to user
+ */
+function isSessionOwnedByUser(sessionId, userId) {
+  const stmt = db.prepare('SELECT user_id FROM sessions WHERE id = ?');
+  const row = stmt.get(sessionId);
+  
+  if (!row) return false;
+  
+  // If session has no user_id, it's accessible by anyone (backward compatibility)
+  // If session has user_id, it must match
+  if (row.user_id === null) return true;
+  return row.user_id === userId;
 }
 
 /**
@@ -452,8 +500,21 @@ function getUnreadMessages(sessionId) {
 /**
  * Get messages by task
  */
-function getMessagesByTask(sessionId, taskId) {
-  return queryMessages(sessionId, { taskId });
+function getMessagesByTask(taskId) {
+  const stmt = db.prepare('SELECT * FROM messages WHERE task_id = ?');
+  const rows = stmt.all(taskId);
+  
+  return rows.map(row => ({
+    ...row,
+    read: row.read === 1
+  }));
+}
+
+/**
+ * Get messages for a session
+ */
+function getMessages(sessionId, options = {}) {
+  return queryMessages(sessionId, options);
 }
 
 /**
@@ -614,15 +675,17 @@ function close() {
   db.close();
 }
 
-module.exports = {
+export {
   // Session operations
   generateId,
   createSession,
   getSession,
   updateSessionStatus,
+  updateSessionConfig,
   getSessionSummary,
   listSessions,
   deleteSession,
+  isSessionOwnedByUser,
   
   // Task operations
   createTask,
@@ -640,6 +703,7 @@ module.exports = {
   queryMessages,
   getUnreadMessages,
   getMessagesByTask,
+  getMessages,
   markAsRead,
   getCommandHistory,
   searchMessages,

--- a/data/skills/erix-ssh/scripts/session_manager.js
+++ b/data/skills/erix-ssh/scripts/session_manager.js
@@ -9,13 +9,20 @@
  *
  * This process is automatically started by the main program and
  * binds its stdio to an internal API endpoint.
+ *
+ * 注意：此文件作为独立子进程运行，使用 ES Module 格式（继承项目 "type": "module"）
  */
 
-const { Client } = require('ssh2');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const db = require('./db');
+import { Client } from 'ssh2';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+import * as db from './db.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Active SSH connections (sessionId -> Client)
 const connections = new Map();
@@ -44,6 +51,7 @@ function log(message, ...args) {
 
 /**
  * Process a single JSON command line
+ * Supports both old format (action-based) and new format (command-based)
  */
 async function processCommandLine(line) {
   let cmd;
@@ -51,13 +59,35 @@ async function processCommandLine(line) {
     cmd = JSON.parse(line);
   } catch (err) {
     sendResponse({
-      id: null,
+      task_id: null,
       error: `Invalid JSON: ${err.message}`,
       success: false
     });
     return;
   }
 
+  // New format: { command, task_id, params, user }
+  if (cmd.command) {
+    const { command, task_id, params, user } = cmd;
+    
+    try {
+      const result = await processCommand(command, params || {}, user || {});
+      sendResponse({
+        task_id: task_id,
+        result: result,
+        success: true
+      });
+    } catch (err) {
+      sendResponse({
+        task_id: task_id,
+        error: err.message,
+        success: false
+      });
+    }
+    return;
+  }
+
+  // Old format: { id, action, ...params } - for backward compatibility
   const { id, action, ...params } = cmd;
 
   try {
@@ -77,15 +107,48 @@ async function processCommandLine(line) {
 }
 
 /**
- * Process an action and return result
+ * Process a command (new format with user context)
+ * @param {string} command - Command name
+ * @param {object} params - Command parameters
+ * @param {object} user - User context { userId, accessToken, expertId, isAdmin }
  */
-async function processAction(action, params) {
-  switch (action) {
+async function processCommand(command, params, user) {
+  const userId = user.userId || null;
+  const isAdmin = user.isAdmin || false;
+  
+  switch (command) {
+    case 'invoke':
+      // Invoke is a wrapper for various actions
+      const action = params.action || params.command || 'connect';
+      return await processActionWithUser(action, params, userId, isAdmin);
+
     case 'ping':
       return { type: 'pong', timestamp: Date.now() };
 
+    default:
+      return await processActionWithUser(command, params, userId, isAdmin);
+  }
+}
+
+/**
+ * Process an action with user context for permission checking
+ */
+async function processActionWithUser(action, params, userId, isAdmin) {
+  // Actions that require session ownership check
+  const sessionActions = ['disconnect', 'exec', 'sudo', 'output', 'history', 'delete'];
+  
+  if (sessionActions.includes(action) && params.session_id) {
+    // Check session ownership (skip for admin)
+    if (!isAdmin && userId) {
+      if (!db.isSessionOwnedByUser(params.session_id, userId)) {
+        throw new Error('Session not found or access denied');
+      }
+    }
+  }
+
+  switch (action) {
     case 'connect':
-      return await handleConnect(params);
+      return await handleConnectWithUser(params, userId);
 
     case 'disconnect':
       return await handleDisconnect(params);
@@ -105,8 +168,10 @@ async function processAction(action, params) {
     case 'delete':
       return handleDelete(params);
 
+    case 'list_sessions':
+      return handleListSessions(userId);
+
     case 'exit':
-      // Graceful shutdown
       await shutdown();
       return { message: 'Shutting down' };
 
@@ -115,27 +180,36 @@ async function processAction(action, params) {
   }
 }
 
+/**
+ * Process an action and return result (legacy format)
+ */
+async function processAction(action, params) {
+  return processActionWithUser(action, params, null, false);
+}
+
 // ============== Action Handlers ==============
 
 /**
- * Connect to SSH server
+ * Connect to SSH server (with user isolation)
+ * @param {object} params - Connection parameters
+ * @param {string} userId - User ID for session isolation
  */
-async function handleConnect(params) {
+async function handleConnectWithUser(params, userId = null) {
   const { host, username, port = 22, password, private_key, passphrase } = params;
 
   if (!host || !username) {
     throw new Error('host and username are required');
   }
 
-  const sessionId = 'sess_' + require('crypto').randomBytes(32).toString('hex');
+  const sessionId = 'sess_' + crypto.randomBytes(32).toString('hex');
 
-  // Create session record
+  // Create session record with user_id
   db.createSession(sessionId, {
     host,
     username,
     port,
     created_at: new Date().toISOString()
-  });
+  }, userId);
 
   // Setup connection
   await setupConnection(sessionId, {
@@ -148,6 +222,22 @@ async function handleConnect(params) {
   });
 
   return { session_id: sessionId };
+}
+
+/**
+ * Connect to SSH server (legacy, without user isolation)
+ */
+async function handleConnect(params) {
+  return handleConnectWithUser(params, null);
+}
+
+/**
+ * List sessions for a user
+ * @param {string} userId - User ID (null for all sessions)
+ */
+function handleListSessions(userId = null) {
+  const sessions = db.listSessions(userId);
+  return { sessions };
 }
 
 /**

--- a/lib/resident-skill-manager.js
+++ b/lib/resident-skill-manager.js
@@ -65,8 +65,9 @@ class ResidentProcess {
       const whitelist = await this.getWhitelist();
 
       // 启动子进程
+      // cwd 设置为项目根目录，让 ES Module 能正确解析 node_modules
       this.process = spawn('node', [fullPath], {
-        cwd: path.dirname(fullPath),
+        cwd: process.cwd(),
         env: {
           ...process.env,
           NODE_ENV: process.env.NODE_ENV || 'development',
@@ -151,10 +152,11 @@ class ResidentProcess {
   /**
    * 提交任务
    * @param {Object} params - 任务参数
+   * @param {Object} userContext - 用户上下文 { userId, accessToken, expertId, isAdmin }
    * @param {number} timeout - 超时时间（毫秒）
    * @returns {Promise<Object>} 任务结果
    */
-  async invoke(params, timeout = 60000) {
+  async invoke(params, userContext = {}, timeout = 60000) {
     if (this.state !== ProcessState.RUNNING) {
       throw new Error(`ResidentProcess ${this.tool.name} is not running`);
     }
@@ -171,8 +173,17 @@ class ResidentProcess {
       // 存储待处理任务
       this.pendingTasks.set(taskId, { resolve, reject, timeoutId });
 
-      // 发送任务
-      this.sendCommand('invoke', { task_id: taskId, params });
+      // 发送任务（包含用户上下文）
+      this.sendCommand('invoke', {
+        task_id: taskId,
+        params,
+        user: {
+          userId: userContext.userId || '',
+          accessToken: userContext.accessToken || '',
+          expertId: userContext.expertId || '',
+          isAdmin: userContext.isAdmin || false,
+        },
+      });
     });
   }
 
@@ -322,6 +333,12 @@ class ResidentSkillManager {
 
     // 启动每个驻留进程
     for (const tool of residentTools) {
+      // 检查是否已存在（防止重复启动）
+      if (this.processes.has(tool.id)) {
+        logger.warn(`ResidentProcess ${tool.name} already running, skipping`);
+        continue;
+      }
+
       const skill = skillMap.get(tool.skill_id);
       if (!skill) {
         logger.warn(`Skill not found for tool ${tool.name} (skill_id: ${tool.skill_id})`);
@@ -344,20 +361,26 @@ class ResidentSkillManager {
    * 调用驻留工具
    * @param {string} toolId - 工具ID
    * @param {Object} params - 参数
+   * @param {Object} userContext - 用户上下文 { userId, accessToken, expertId, isAdmin }
    * @param {number} timeout - 超时时间
    */
-  async invoke(toolId, params, timeout = 60000) {
+  async invoke(toolId, params, userContext = {}, timeout = 60000) {
     const proc = this.processes.get(toolId);
     if (!proc) {
       throw new Error(`Resident tool ${toolId} not found or not running`);
     }
-    return proc.invoke(params, timeout);
+    return proc.invoke(params, userContext, timeout);
   }
 
   /**
    * 通过工具名调用
+   * @param {string} skillId - 技能ID
+   * @param {string} toolName - 工具名
+   * @param {Object} params - 参数
+   * @param {Object} userContext - 用户上下文 { userId, accessToken, expertId, isAdmin }
+   * @param {number} timeout - 超时时间
    */
-  async invokeByName(skillId, toolName, params, timeout = 60000) {
+  async invokeByName(skillId, toolName, params, userContext = {}, timeout = 60000) {
     // 查找工具ID
     const tool = await this.Tool.findOne({
       where: { skill_id: skillId, name: toolName },
@@ -368,7 +391,7 @@ class ResidentSkillManager {
       throw new Error(`Tool ${toolName} not found in skill ${skillId}`);
     }
 
-    return this.invoke(tool.id, params, timeout);
+    return this.invoke(tool.id, params, userContext, timeout);
   }
 
   /**

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -214,6 +214,7 @@ class ToolManager {
   /**
    * 执行工具调用
    * 所有技能统一通过 skill-runner 子进程隔离执行
+   * 支持驻留工具（resident:// 协议）直接调用 ResidentSkillManager
    *
    * @param {string} toolId - 工具 ID（toolName__skillIdShort 格式）
    * @param {object} params - 工具参数
@@ -273,6 +274,11 @@ class ToolManager {
     }
 
     const { skillId, toolName, scriptPath } = toolInfo;
+
+    // 检查是否是驻留工具（resident:// 协议）
+    if (scriptPath && scriptPath.startsWith('resident://')) {
+      return await this.executeResidentTool(scriptPath, skillId, params, context, display, toolId);
+    }
 
     // 通过子进程隔离执行
     const skill = this.skills.get(skillId);
@@ -336,6 +342,75 @@ class ToolManager {
     } catch (error) {
       logger.error(`[ToolManager] 工具执行失败: ${display}`, error.message);
 
+      return {
+        success: false,
+        error: error.message,
+        toolId,
+        toolName: display,
+      };
+    }
+  }
+
+  /**
+   * 执行驻留工具（通过 ResidentSkillManager）
+   * @param {string} scriptPath - 脚本路径（resident://toolName 格式）
+   * @param {string} skillId - 技能ID
+   * @param {object} params - 工具参数
+   * @param {object} context - 执行上下文
+   * @param {string} display - 工具显示名称
+   * @param {string} toolId - 工具ID
+   * @returns {Promise<object>} 执行结果
+   */
+  async executeResidentTool(scriptPath, skillId, params, context, display, toolId) {
+    // 解析驻留工具名称
+    const residentToolName = scriptPath.replace('resident://', '');
+    
+    logger.info(`[ToolManager] 执行驻留工具: ${residentToolName} (skill: ${skillId})`);
+
+    // 获取 ResidentSkillManager（从全局或 context）
+    const residentSkillManager = global.residentSkillManager;
+    if (!residentSkillManager) {
+      logger.error('[ToolManager] ResidentSkillManager 未初始化');
+      return {
+        success: false,
+        error: 'ResidentSkillManager not initialized',
+        toolId,
+        toolName: display,
+      };
+    }
+
+    try {
+      const startTime = Date.now();
+
+      // 构建用户上下文
+      const userContext = {
+        userId: context.userId || context.user_id || '',
+        accessToken: context.accessToken || '',
+        expertId: context.expertId || context.expert_id || '',
+        isAdmin: context?.is_admin || false,
+      };
+
+      // 调用驻留工具
+      const result = await residentSkillManager.invokeByName(
+        skillId,
+        residentToolName,
+        params,
+        userContext,
+        60000  // 默认超时 60 秒
+      );
+
+      const duration = Date.now() - startTime;
+      logger.info(`[ToolManager] 驻留工具执行成功: ${display} (${duration}ms)`);
+
+      return {
+        success: true,
+        data: result,
+        toolId,
+        toolName: display,
+        duration,
+      };
+    } catch (error) {
+      logger.error(`[ToolManager] 驻留工具执行失败: ${display}`, error.message);
       return {
         success: false,
         error: error.message,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@xenova/transformers": "^2.17.2",
         "adm-zip": "^0.5.16",
         "bcryptjs": "^2.4.3",
+        "better-sqlite3": "^12.8.0",
         "dotenv": "^16.6.1",
         "jsonwebtoken": "^9.0.3",
         "koa": "^3.1.1",
@@ -24,6 +25,7 @@
         "mysql2": "^3.11.3",
         "sequelize": "^6.37.7",
         "sharp": "^0.34.5",
+        "ssh2": "^1.17.0",
         "tiktoken": "^1.0.22"
       },
       "devDependencies": {
@@ -783,6 +785,15 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
@@ -913,11 +924,43 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -965,6 +1008,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -1206,6 +1258,20 @@
       "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
       "integrity": "sha512-3DdaFaU/Zf1AnpLiFDeNCD4TOWe3Zl2RZaTzUvWiIk5ERzcCodOE20Vqq4fzCbNoHURFHT4/us/Lfq+S2zyY4w==",
       "license": "MIT"
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -1454,6 +1520,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
     "node_modules/flatbuffers": {
@@ -1811,6 +1883,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.2.tgz",
       "integrity": "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~1.0.1",
@@ -2089,6 +2162,7 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
       "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
@@ -2150,6 +2224,13 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -2531,6 +2612,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -2864,6 +2946,23 @@
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3056,6 +3155,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@xenova/transformers": "^2.17.2",
     "adm-zip": "^0.5.16",
     "bcryptjs": "^2.4.3",
+    "better-sqlite3": "^12.8.0",
     "dotenv": "^16.6.1",
     "jsonwebtoken": "^9.0.3",
     "koa": "^3.1.1",
@@ -40,6 +41,7 @@
     "mysql2": "^3.11.3",
     "sequelize": "^6.37.7",
     "sharp": "^0.34.5",
+    "ssh2": "^1.17.0",
     "tiktoken": "^1.0.22"
   },
   "devDependencies": {


### PR DESCRIPTION
## 变更概述

实现 SSH 驻留进程用户认证机制，为后续 SFTP 功能奠定基础。

## 变更内容

### 1. ResidentSkillManager ([`lib/resident-skill-manager.js`](lib/resident-skill-manager.js))

- `invoke()` 接收 `userContext` 参数 `{ userId, accessToken, expertId, isAdmin }`
- stdin 命令携带 `user` 字段
- `initialize()` 添加重复启动保护
- `cwd` 设置为项目根目录（ES Module 依赖解析）

### 2. ToolManager ([`lib/tool-manager.js`](lib/tool-manager.js))

- 新增 `executeResidentTool()` 方法
- 识别 `resident://` 协议路由到驻留进程

### 3. SSH Session Manager ([`data/skills/erix-ssh/scripts/session_manager.js`](data/skills/erix-ssh/scripts/session_manager.js))

- 支持 `invoke` 命令格式（新格式）
- `handleConnectWithUser()` 绑定 `user_id`
- session 操作权限验证（disconnect, exec, sudo, output, history, delete）
- 转换为 ES Module 格式

### 4. SSH DB ([`data/skills/erix-ssh/scripts/db.js`](data/skills/erix-ssh/scripts/db.js))

- `sessions` 表添加 `user_id` 字段
- `createSession()` 支持 `userId` 参数
- `listSessions()` 支持按用户过滤
- `isSessionOwnedByUser()` 权限检查
- 转换为 ES Module 格式

### 5. 依赖

- 添加 `ssh2`, `better-sqlite3`

## 安全性

- SSH 密码、私钥、sudo 密码**不保存**到数据库
- 敏感信息仅在内存中使用，输出中用 `********` 替换

## 测试

- [x] `npm run lint` 通过
- [x] ES 模块导入验证通过
- [x] 驻留进程启动测试通过

Closes #129