### PR TITLE
#136: feat 添加 SFTP 文件传输功能

### DIFF
--- a/data/skills/erix-ssh/SKILL.md
+++ b/data/skills/erix-ssh/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ssh
-description: SSH remote server management with synchronous command execution. Use when you need to connect to remote servers via SSH, execute commands, and get results. Features session-based Connection management, automatic reconnection, and message history stored in SQLite.
-argument-hint: "[connect|exec|sudo|output|history|disconnect] --session ID"
+description: SSH remote server management with synchronous command execution and SFTP file transfer. Use when you need to connect to remote servers via SSH, execute commands, and transfer files. Features session-based connection management, automatic reconnection, and message history stored in SQLite.
+argument-hint: "[connect|exec|sudo|sftp_list|sftp_download|sftp_upload|disconnect] --session ID"
 user-invocable: false
 allowed-tools: []
 ---
 
 # SSH Remote Server Management
 
-Session-based SSH client with synchronous execution and SQLite storage.
+Session-based SSH client with synchronous execution, SFTP file transfer, and SQLite storage.
 
 ## Design Architecture
 
@@ -33,7 +33,7 @@ session_manager.js:
 - Lost Session ID = Lost access (no session list feature for security)
 - Never expose full Session ID in public (show first 8 chars only for identification)
 
-## Tools
+## SSH Tools
 
 ### ssh_connect
 
@@ -189,6 +189,86 @@ Get command execution history for a session.
 
 ---
 
+## SFTP Tools
+
+### sftp_list
+
+List contents of a remote directory.
+
+**is_resident:** 0 (calls resident process)
+**script_path:** `scripts/ssh_client.js`
+
+**Parameters:**
+- `session_id` (required): Session ID
+- `path` (required): Remote directory path
+
+**Returns:**
+```json
+{
+  "success": true,
+  "path": "/home/user",
+  "entries": [
+    {
+      "filename": "example.txt",
+      "type": "file",
+      "size": 1234,
+      "mode": "0644",
+      "mtime": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### sftp_download
+
+Download a file from the remote server.
+
+**is_resident:** 0
+**script_path:** `scripts/ssh_client.js`
+
+**Parameters:**
+- `session_id` (required): Session ID
+- `remote_path` (required): Remote file path
+- `local_path` (required): Local file path to save
+
+**Returns:**
+```json
+{
+  "success": true,
+  "remote_path": "/remote/file.txt",
+  "local_path": "/local/file.txt",
+  "bytes_transferred": 12345
+}
+```
+
+---
+
+### sftp_upload
+
+Upload a file to the remote server.
+
+**is_resident:** 0
+**script_path:** `scripts/ssh_client.js`
+
+**Parameters:**
+- `session_id` (required): Session ID
+- `local_path` (required): Local file path
+- `remote_path` (required): Remote file path to save
+
+**Returns:**
+```json
+{
+  "success": true,
+  "local_path": "/local/file.txt",
+  "remote_path": "/remote/file.txt",
+  "bytes_transferred": 12345
+}
+```
+
+---
+
 ## Resident Process
 
 ### ssh_manager (internal)
@@ -262,4 +342,4 @@ Events (unsolicited notifications):
 - ssh2 package
 
 ---
-*Updated: 2026-03-13 - Refactored to resident process with stdin/stdout protocol*
+*Updated: 2026-03-14 - Added SFTP file transfer support*

--- a/data/skills/erix-ssh/scripts/session_manager.js
+++ b/data/skills/erix-ssh/scripts/session_manager.js
@@ -27,6 +27,41 @@ const __dirname = path.dirname(__filename);
 // Active SSH connections (sessionId -> Client)
 const connections = new Map();
 
+// SFTP connections cache (sessionId -> SFTP instance)
+const sftpConnections = new Map();
+
+// ============== SFTP Functions ==============
+
+/**
+ * Get or create SFTP connection for a session
+ * @param {string} sessionId - Session ID
+ * @returns {Promise<SFTP>} SFTP instance
+ */
+async function getSftp(sessionId) {
+  // Check cache
+  if (sftpConnections.has(sessionId)) {
+    return sftpConnections.get(sessionId);
+  }
+  
+  // Get SSH connection
+  const conn = connections.get(sessionId);
+  if (!conn) {
+    throw new Error('Session not connected');
+  }
+  
+  // Create SFTP
+  return new Promise((resolve, reject) => {
+    conn.sftp((err, sftp) => {
+      if (err) reject(err);
+      else {
+        sftpConnections.set(sessionId, sftp);
+        log(`SFTP connection created for ${sessionId}`);
+        resolve(sftp);
+      }
+    });
+  });
+}
+
 // ============== Protocol Functions ==============
 
 let buffer = '';
@@ -135,7 +170,8 @@ async function processCommand(command, params, user) {
  */
 async function processActionWithUser(action, params, userId, isAdmin) {
   // Actions that require session ownership check
-  const sessionActions = ['disconnect', 'exec', 'sudo', 'output', 'history', 'delete'];
+  const sessionActions = ['disconnect', 'exec', 'sudo', 'output', 'history', 'delete',
+                          'sftp_list', 'sftp_download', 'sftp_upload'];
   
   if (sessionActions.includes(action) && params.session_id) {
     // Check session ownership (skip for admin)
@@ -170,6 +206,16 @@ async function processActionWithUser(action, params, userId, isAdmin) {
 
     case 'list_sessions':
       return handleListSessions(userId);
+
+    // SFTP actions
+    case 'sftp_list':
+      return await handleSftpList(params);
+
+    case 'sftp_download':
+      return await handleSftpDownload(params);
+
+    case 'sftp_upload':
+      return await handleSftpUpload(params);
 
     case 'exit':
       await shutdown();
@@ -255,6 +301,9 @@ async function handleDisconnect(params) {
     conn.end();
     connections.delete(session_id);
   }
+
+  // Clear SFTP connection cache
+  sftpConnections.delete(session_id);
 
   db.updateSessionStatus(session_id, 'disconnected');
   db.addMessage(session_id, {
@@ -540,10 +589,120 @@ function handleDelete(params) {
     connections.delete(session_id);
   }
 
+  // Clear SFTP connection cache
+  sftpConnections.delete(session_id);
+
   // Delete from database
   db.deleteSession(session_id);
 
   return { message: 'Session deleted' };
+}
+
+// ============== SFTP Action Handlers ==============
+
+/**
+ * List remote directory contents
+ */
+async function handleSftpList(params) {
+  const { session_id, path: remotePath } = params;
+
+  if (!session_id || !remotePath) {
+    throw new Error('session_id and path are required');
+  }
+
+  const sftp = await getSftp(session_id);
+
+  return new Promise((resolve, reject) => {
+    sftp.readdir(remotePath, (err, list) => {
+      if (err) {
+        reject(new Error(`SFTP list failed: ${err.message}`));
+        return;
+      }
+
+      const entries = list.map(entry => ({
+        filename: entry.filename,
+        type: entry.longname[0] === 'd' ? 'directory' : 
+              entry.longname[0] === 'l' ? 'symlink' : 'file',
+        size: entry.attrs.size,
+        mode: (entry.attrs.mode & 0o7777).toString(8).padStart(4, '0'),
+        mtime: new Date(entry.attrs.mtime * 1000).toISOString(),
+        longname: entry.longname
+      }));
+
+      resolve({
+        path: remotePath,
+        entries: entries
+      });
+    });
+  });
+}
+
+/**
+ * Download file from remote server
+ */
+async function handleSftpDownload(params) {
+  const { session_id, remote_path, local_path } = params;
+
+  if (!session_id || !remote_path || !local_path) {
+    throw new Error('session_id, remote_path and local_path are required');
+  }
+
+  const sftp = await getSftp(session_id);
+  const expandedLocalPath = local_path.replace('~', os.homedir());
+
+  return new Promise((resolve, reject) => {
+    sftp.fastGet(remote_path, expandedLocalPath, (err) => {
+      if (err) {
+        reject(new Error(`SFTP download failed: ${err.message}`));
+        return;
+      }
+
+      // Get file stats for response
+      const stats = fs.statSync(expandedLocalPath);
+
+      resolve({
+        remote_path: remote_path,
+        local_path: expandedLocalPath,
+        bytes_transferred: stats.size
+      });
+    });
+  });
+}
+
+/**
+ * Upload file to remote server
+ */
+async function handleSftpUpload(params) {
+  const { session_id, local_path, remote_path } = params;
+
+  if (!session_id || !local_path || !remote_path) {
+    throw new Error('session_id, local_path and remote_path are required');
+  }
+
+  const sftp = await getSftp(session_id);
+  const expandedLocalPath = local_path.replace('~', os.homedir());
+
+  // Check if local file exists
+  if (!fs.existsSync(expandedLocalPath)) {
+    throw new Error(`Local file not found: ${expandedLocalPath}`);
+  }
+
+  const stats = fs.statSync(expandedLocalPath);
+
+  return new Promise((resolve, reject) => {
+    sftp.fastPut(expandedLocalPath, remote_path, (err) => {
+      if (err) {
+        reject(new Error(`SFTP upload failed: ${err.message}`));
+        return;
+      }
+
+      resolve({
+        local_path: expandedLocalPath,
+        remote_path: remote_path,
+        bytes_transferred: stats.size
+      });
+    });
+  });
 }
 
 // ============== SSH Connection Management ==============
@@ -583,6 +742,7 @@ async function setupConnection(sessionId, config) {
 
     conn.on('close', () => {
       connections.delete(sessionId);
+      sftpConnections.delete(sessionId);  // Clear SFTP cache on connection close
       db.updateSessionStatus(sessionId, 'disconnected');
       db.addMessage(sessionId, {
         type: 'system',
@@ -672,6 +832,7 @@ async function shutdown() {
     } catch (err) {}
   }
   connections.clear();
+  sftpConnections.clear();
 
   if (db.close) {
     db.close();

--- a/data/skills/erix-ssh/scripts/ssh_client.js
+++ b/data/skills/erix-ssh/scripts/ssh_client.js
@@ -325,16 +325,114 @@ async function deleteSession(params) {
   }
 }
 
+// ==================== SFTP Actions ====================
+
+/**
+ * List remote directory
+ */
+async function sftpList(params) {
+  const { session_id, path } = params;
+
+  if (!session_id || !path) {
+    return {
+      success: false,
+      error: 'session_id and path are required'
+    };
+  }
+
+  try {
+    const result = await invokeSSHTOol('sftp_list', {
+      session_id,
+      path
+    }, 30000);
+
+    return {
+      success: true,
+      ...result
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: err.message
+    };
+  }
+}
+
+/**
+ * Download file from remote server
+ */
+async function sftpDownload(params) {
+  const { session_id, remote_path, local_path } = params;
+
+  if (!session_id || !remote_path || !local_path) {
+    return {
+      success: false,
+      error: 'session_id, remote_path and local_path are required'
+    };
+  }
+
+  try {
+    const result = await invokeSSHTOol('sftp_download', {
+      session_id,
+      remote_path,
+      local_path
+    }, 120000); // 2 minutes timeout for file transfers
+
+    return {
+      success: true,
+      ...result
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: err.message
+    };
+  }
+}
+
+/**
+ * Upload file to remote server
+ */
+async function sftpUpload(params) {
+  const { session_id, local_path, remote_path } = params;
+
+  if (!session_id || !local_path || !remote_path) {
+    return {
+      success: false,
+      error: 'session_id, local_path and remote_path are required'
+    };
+  }
+
+  try {
+    const result = await invokeSSHTOol('sftp_upload', {
+      session_id,
+      local_path,
+      remote_path
+    }, 120000); // 2 minutes timeout for file transfers
+
+    return {
+      success: true,
+      ...result
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: err.message
+    };
+  }
+}
+
 /**
  * Skill entry point
- * @param {string} toolName - Tool name (ssh_connect, ssh_exec, etc.)
+ * @param {string} toolName - Tool name (ssh_connect, ssh_exec, sftp_list, etc.)
  * @param {Object} params - Tool parameters
  * @param {Object} context - Execution context
  */
 async function execute(toolName, params, context = {}) {
-  // Extract action from tool name (ssh_connect -> connect, etc.)
+  // Extract action from tool name (ssh_connect -> connect, sftp_list -> sftp_list, etc.)
   let action = toolName.replace(/^ssh_/, '').replace(/-/g, '_');
 
+  // SSH actions
   switch (action) {
     case 'connect':
       return connect(params);
@@ -356,6 +454,16 @@ async function execute(toolName, params, context = {}) {
 
     case 'delete':
       return deleteSession(params);
+
+    // SFTP actions
+    case 'sftp_list':
+      return sftpList(params);
+
+    case 'sftp_download':
+      return sftpDownload(params);
+
+    case 'sftp_upload':
+      return sftpUpload(params);
 
     default:
       console.error(`[ssh-client] Unknown action: ${action}`);

--- a/docs/design/ssh-skill-tools-design.md
+++ b/docs/design/ssh-skill-tools-design.md
@@ -1,0 +1,222 @@
+# SSH 技能工具设计文档
+
+## 概述
+
+本文档定义 SSH 技能的完整工具清单，包括远程命令执行（SSH）和文件传输（SFTP）。
+
+基于 Issue #136 的需求，为 SSH 技能添加 SFTP 文件传输功能。
+
+## 设计原则
+
+1. **专注文件传输** - SFTP 只做文件传输，其他操作用 `ssh_exec` 完成
+2. **复用现有架构** - 使用已有的 `resident://` 协议和 session_manager.js
+3. **保持一致性** - 与现有 SSH 工具命名和参数风格一致
+
+## 职责划分
+
+| 操作类型 | 使用工具 | 说明 |
+|----------|----------|------|
+| 文件上传 | `sftp_upload` | 二进制文件传输 |
+| 文件下载 | `sftp_download` | 二进制文件传输 |
+| 列出目录 | `sftp_list` | 格式化输出，便于 LLM 理解 |
+| 创建目录 | `ssh_exec` | `mkdir -p /path` |
+| 删除文件 | `ssh_exec` | `rm /path/file` |
+| 删除目录 | `ssh_exec` | `rm -rf /path` |
+| 重命名 | `ssh_exec` | `mv old new` |
+| 修改权限 | `ssh_exec` | `chmod 755 /path` |
+| 查看文件信息 | `ssh_exec` | `ls -la /path` |
+
+---
+
+## 工具清单
+
+### SSH 工具（现有）
+
+| 工具名 | 功能 | 核心参数 |
+|--------|------|----------|
+| `ssh_connect` | 连接远程服务器 | `host`, `username`, `port`, `password`/`private_key` |
+| `ssh_disconnect` | 断开连接 | `session_id` |
+| `ssh_exec` | 执行远程命令 | `session_id`, `command`, `timeout` |
+| `ssh_sudo` | 执行 sudo 命令 | `session_id`, `command`, `password` |
+| `ssh_output` | 获取任务输出 | `task_id` |
+| `ssh_history` | 获取命令历史 | `session_id`, `limit` |
+
+### SFTP 工具（新增）
+
+| 工具名 | 功能 | ssh2 方法 | 核心参数 |
+|--------|------|-----------|----------|
+| `sftp_list` | 列出远程目录 | `readdir` | `session_id`, `path` |
+| `sftp_download` | 下载文件 | `fastGet` | `session_id`, `remote_path`, `local_path` |
+| `sftp_upload` | 上传文件 | `fastPut` | `session_id`, `local_path`, `remote_path` |
+
+---
+
+## 详细设计
+
+### sftp_list
+
+列出远程目录内容。
+
+**参数：**
+```json
+{
+  "session_id": { "type": "string", "required": true, "description": "SSH 会话 ID" },
+  "path": { "type": "string", "required": true, "description": "远程目录路径" }
+}
+```
+
+**返回：**
+```json
+{
+  "success": true,
+  "entries": [
+    {
+      "filename": "example.txt",
+      "type": "file",
+      "size": 1234,
+      "mode": "0644",
+      "mtime": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### sftp_download
+
+下载远程文件到本地。
+
+**参数：**
+```json
+{
+  "session_id": { "type": "string", "required": true },
+  "remote_path": { "type": "string", "required": true, "description": "远程文件路径" },
+  "local_path": { "type": "string", "required": true, "description": "本地保存路径" }
+}
+```
+
+**返回：**
+```json
+{
+  "success": true,
+  "remote_path": "/remote/file.txt",
+  "local_path": "/local/file.txt",
+  "bytes_transferred": 12345
+}
+```
+
+---
+
+### sftp_upload
+
+上传本地文件到远程服务器。
+
+**参数：**
+```json
+{
+  "session_id": { "type": "string", "required": true },
+  "local_path": { "type": "string", "required": true, "description": "本地文件路径" },
+  "remote_path": { "type": "string", "required": true, "description": "远程保存路径" }
+}
+```
+
+**返回：**
+```json
+{
+  "success": true,
+  "local_path": "/local/file.txt",
+  "remote_path": "/remote/file.txt",
+  "bytes_transferred": 12345
+}
+```
+
+---
+
+## 架构设计
+
+### SFTP 连接管理
+
+在 `session_manager.js` 中添加 SFTP 连接缓存：
+
+```javascript
+// SFTP 连接缓存（sessionId -> SFTP instance）
+const sftpConnections = new Map();
+
+/**
+ * 获取或创建 SFTP 连接
+ */
+async function getSftp(sessionId) {
+  if (sftpConnections.has(sessionId)) {
+    return sftpConnections.get(sessionId);
+  }
+  
+  const conn = connections.get(sessionId);
+  if (!conn) {
+    throw new Error('Session not connected');
+  }
+  
+  return new Promise((resolve, reject) => {
+    conn.sftp((err, sftp) => {
+      if (err) reject(err);
+      else {
+        sftpConnections.set(sessionId, sftp);
+        resolve(sftp);
+      }
+    });
+  });
+}
+```
+
+### 权限验证
+
+复用现有的用户隔离机制：
+
+```javascript
+const sftpActions = ['sftp_list', 'sftp_download', 'sftp_upload'];
+
+if (sftpActions.includes(action) && params.session_id) {
+  if (!isAdmin && userId) {
+    if (!db.isSessionOwnedByUser(params.session_id, userId)) {
+      throw new Error('Session not found or access denied');
+    }
+  }
+}
+```
+
+### 工具注册
+
+在 `skill_tools` 表中注册：
+
+```sql
+INSERT INTO skill_tools (skill_id, name, description, parameters, script_path, is_resident) VALUES
+(ssh_skill_id, 'sftp_list', '列出远程目录', '...', 'resident://sftp_list', 0),
+(ssh_skill_id, 'sftp_download', '下载文件', '...', 'resident://sftp_download', 0),
+(ssh_skill_id, 'sftp_upload', '上传文件', '...', 'resident://sftp_upload', 0);
+```
+
+---
+
+## 实现计划
+
+### Step 1: 核心实现（session_manager.js）
+
+1. 添加 SFTP 连接管理（`getSftp` 函数）
+2. 实现 3 个 SFTP action handler
+3. 添加错误处理和超时控制
+
+### Step 2: 工具注册
+
+1. 数据库迁移：添加 SFTP 工具记录
+2. 更新 SKILL.md 文档
+
+### Step 3: 测试
+
+1. 编写测试用例（使用 `run-skill.js`）
+2. 测试各种边界情况
+
+---
+
+*文档版本: 1.1*
+*创建日期: 2026-03-14*
+*作者: Maria*


### PR DESCRIPTION
## Summary

为 SSH 技能添加 SFTP 文件传输功能。

## Changes

- **新增工具**
  - `sftp_list` - 列出远程目录内容
  - `sftp_download` - 从远程服务器下载文件
  - `sftp_upload` - 上传文件到远程服务器

- **代码修改**
  - `session_manager.js` - 添加 SFTP 连接缓存和操作处理
  - `ssh_client.js` - 添加 SFTP 工具入口函数

- **文档更新**
  - `SKILL.md` - 更新工具文档
  - 新增 `docs/design/ssh-skill-tools-design.md` - SSH 技能工具设计文档

## Technical Details

- SFTP 连接缓存：每个 session 只创建一次 SFTP 实例
- 资源清理：断开连接时自动清理 SFTP 缓存
- 权限检查：SFTP 操作验证会话所有权

## Test Plan

- [ ] 使用实际 SSH 服务器测试 `sftp_list`
- [ ] 测试 `sftp_download` 文件下载
- [ ] 测试 `sftp_upload` 文件上传

Closes #136