### PR TITLE
#141: feat 工具调用状态文本实时更新到对应消息

### DIFF
--- a/docs/design/issue-141-tool-context-design.md
+++ b/docs/design/issue-141-tool-context-design.md
@@ -1,0 +1,216 @@
+# Issue #141 设计方案：工具调用状态文本实时更新到对应消息
+
+> **状态：✅ 已验证可行，可进入开发阶段**
+>
+> **验证结论**：整体方案可行，采用"接受重复显示"简化方案，降低实现复杂度。
+
+## 问题描述
+
+在一次流式调用中，LLM 可能会多次调用工具。在调用工具的过程中，LLM 会输出一些状态更新文本，例如：
+
+- "搜索完成，收获了丰富的官方回应素材！"
+- "正在整理写入文件..."
+- "现在更新 TODO 状态..."
+
+这些内容是流式返回的，但目前这些状态文本会集中在最后一条 assistant message 中显示，缩成一团。
+
+## 期望行为
+
+每个工具调用过程中的状态文本，应该实时更新到对应的 tool message 的 context 字段中，而不是全部堆积在最后的 assistant message 里。
+
+## 数据结构
+
+### 当前 Message 表结构
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | string | 消息ID |
+| role | enum | `user` / `assistant` / `tool` |
+| content | text | 消息内容 |
+| tool_calls | json | 工具调用元数据 |
+| ... | ... | ... |
+
+### Message 类型说明
+
+| Message 类型 | role 字段 | 内容 |
+|-------------|----------|------|
+| 用户消息 | `user` | 用户输入 |
+| 助手消息 | `assistant` | LLM 文本回复 + tool_calls 元数据 |
+| 工具消息 | `tool` | 工具执行结果 |
+
+**它们是独立的 message 记录，不是同一个 message。**
+
+### 新增字段
+
+在 tool message 的 `tool_calls` JSON 字段中新增 `context` 字段：
+
+```json
+{
+  "tool_call_id": "call_xxx",
+  "name": "tool-name",
+  "arguments": {...},
+  "context": "让我打开文件...",  // 新增：LLM 在调用工具前的状态文本
+  "success": true,
+  "duration": 1234,
+  "timestamp": "2024-01-01T00:00:00.000Z"
+}
+```
+
+## 技术方案
+
+### 1. 修改 `lib/llm-client.js` - 捕获每个工具的 context
+
+在流式处理中，当检测到新的 tool_call index 时，立即捕获当前累积的文本作为该工具的 context：
+
+```javascript
+// callStream 方法中
+
+let pendingContent = '';  // 当前累积的文本
+let toolCallContexts = {};  // 按工具 index 存储 context
+
+res.on('data', (chunk) => {
+  // ...
+  if (delta?.content) {
+    pendingContent += delta.content;
+    onDelta?.(delta.content);
+  }
+  
+  if (delta?.tool_calls) {
+    for (const tc of delta.tool_calls) {
+      const idx = tc.index;
+      if (!accumulatedToolCalls[idx]) {
+        // ★ 关键：新的工具调用开始，捕获当前累积的文本作为 context
+        accumulatedToolCalls[idx] = { index: idx, function: {} };
+        toolCallContexts[idx] = pendingContent.trim();
+        pendingContent = '';  // 清空，准备下一个工具的状态文本
+      }
+      // 累积工具调用字段...
+    }
+  }
+});
+
+// 流结束时，将 context 附加到每个工具调用
+const finalToolCalls = Object.values(accumulatedToolCalls)
+  .map(tc => ({
+    ...tc,
+    context: toolCallContexts[tc.index] || '',
+  }));
+onToolCall?.(finalToolCalls);
+```
+
+### 2. 修改 `lib/chat-service.js` - 传递 context 并从 assistant message 中移除
+
+```javascript
+// streamChat 方法中
+
+let roundContent = '';  // 本轮完整输出
+let toolCallContexts = {};  // 每个工具的 context
+
+await expertService.llmClient.callStream(
+  modelConfig,
+  currentMessages,
+  {
+    tools,
+    onDelta: (delta) => {
+      roundContent += delta;
+      onDelta?.({ type: 'delta', content: delta });
+    },
+    onToolCall: (toolCalls) => {
+      // toolCalls 已包含 context（由 llm-client 捕获）
+      toolCalls.forEach(tc => {
+        toolCallContexts[tc.id] = tc.context;
+      });
+      // ... 后续处理
+    },
+  }
+);
+
+// 执行工具时传递 context
+const toolResults = await expertService.handleToolCalls(
+  collectedToolCalls,
+  user_id,
+  access_token,
+  taskContext,
+  async (toolResult) => {
+    // 关联 context
+    toolResult.context = toolCallContexts[toolResult.toolCallId];
+    await this.saveToolMessage(topic_id, user_id, toolResult, expert_id);
+    onDelta?.({ type: 'tool_result', result: toolResult });
+  }
+);
+
+// 简化方案：不从 roundContent 中移除 context
+// 状态文本会同时在 tool message 和 assistant message 中显示
+// 用户确认接受此行为
+fullContent += roundContent;
+```
+
+### 3. 修改 `saveToolMessage()` - 保存 context 字段
+
+```javascript
+async saveToolMessage(topic_id, user_id, toolResult, expert_id = null) {
+  const toolCallsData = {
+    tool_call_id: toolResult.toolCallId,
+    name: toolResult.toolName,
+    arguments: toolResult.arguments || null,
+    context: toolResult.context || null,  // 新增：状态文本
+    success: toolResult.success,
+    duration: toolResult.duration || 0,
+    timestamp: new Date().toISOString(),
+  };
+  // ...
+}
+```
+
+### 4. 前端展示修改
+
+在 `ChatWindow.vue` 的工具消息面板中展示 `context` 字段。
+
+## 数据流示意
+
+```
+时间线:
+chunk 1: delta.content = "让我打开文件..."
+         pendingContent = "让我打开文件..."
+         
+chunk 2: delta.tool_calls = [{index: 0, id: "call_1", function: {name: "toolA"}}]
+         → 新 index 0，捕获 context = "让我打开文件..."
+         → pendingContent 清空
+         
+chunk 3: delta.content = "搜索完成..."
+         pendingContent = "搜索完成..."
+         
+chunk 4: delta.tool_calls = [{index: 1, id: "call_2", function: {name: "toolB"}}]
+         → 新 index 1，捕获 context = "搜索完成..."
+         → pendingContent 清空
+         
+chunk 5: delta.content = "整理完成"
+         pendingContent = "整理完成"
+         
+最终存储:
+  tool message A: context = "让我打开文件..."
+  tool message B: context = "搜索完成..."
+  assistant message: content = "整理完成"
+```
+
+## 边界情况处理
+
+| 场景 | 行为 |
+|------|------|
+| 多个工具同时开始（同一 chunk） | 共享相同的 context（合理，因为 LLM 没有区分） |
+| 工具之间有文本输出 | 每个工具获得各自的状态文本 |
+| 无文本输出直接调用工具 | context 为空字符串 |
+| 纯文本响应无工具调用 | 正常流式输出，全部保存到 assistant message |
+
+## 需要修改的文件
+
+1. **`lib/llm-client.js`**：在流式处理中捕获每个工具的 context
+2. **`lib/chat-service.js`**：传递 context 到 `saveToolMessage()`，从 assistant message 中移除已关联的文本
+3. **前端 `ChatWindow.vue`**：在工具消息面板展示 context
+
+## 注意事项
+
+1. **不影响 LLM 上下文**：状态文本仅保存到数据库用于前端展示，不回传给 LLM
+2. **幂等性**：同一个工具调用不会重复保存
+3. **向后兼容**：`context` 字段可选，旧数据正常显示
+4. **文本匹配**：使用简单的字符串替换，如果 LLM 输出有变化可能匹配失败，需要考虑更健壮的方案

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -46,8 +46,12 @@
                 </svg>
               </span>
             </div>
-            <!-- 展开状态：显示参数和结果 -->
+            <!-- 展开状态：显示上下文、参数和结果 -->
             <div v-if="isToolExpanded(message.id)" class="tool-details">
+              <div v-if="getToolContext(message)" class="tool-section context-section">
+                <div class="tool-section-title">{{ $t('chat.toolContext') || '上下文' }}</div>
+                <div class="tool-context-text">{{ getToolContext(message) }}</div>
+              </div>
               <div v-if="getToolArguments(message)" class="tool-section">
                 <div class="tool-section-title">{{ $t('chat.toolArguments') || '参数' }}</div>
                 <pre class="tool-section-content">{{ formatToolArguments(message) }}</pre>
@@ -609,6 +613,7 @@ interface ToolCallData {
   timestamp?: string
   arguments?: Record<string, unknown>
   result?: unknown
+  context?: string  // 工具调用前的状态文本上下文
 }
 
 /**
@@ -660,6 +665,14 @@ const getToolDuration = (message: ChatMessage): number | null => {
 const getToolArguments = (message: ChatMessage): Record<string, unknown> | null => {
   const toolData = parseToolCalls(message)
   return toolData?.arguments ?? null
+}
+
+/**
+ * 获取工具上下文（工具调用前的状态文本）
+ */
+const getToolContext = (message: ChatMessage): string | null => {
+  const toolData = parseToolCalls(message)
+  return toolData?.context ?? null
 }
 
 /**
@@ -1443,6 +1456,25 @@ defineExpose({
   letter-spacing: 0.5px;
   margin-bottom: 6px;
   padding: 0 4px;
+}
+
+/* Tool context 样式 */
+.tool-section.context-section {
+  margin-bottom: 12px;
+}
+
+.tool-context-text {
+  background: var(--tool-context-bg, #f0f7ff);
+  border-left: 3px solid var(--primary-color, #2196f3);
+  border-radius: 4px;
+  padding: 8px 12px;
+  color: var(--text-primary, #333);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-height: 150px;
+  overflow-y: auto;
 }
 
 .tool-section-content {

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -71,6 +71,7 @@ export default {
     // Tool messages
     toolArguments: 'Arguments',
     toolResult: 'Result',
+    toolContext: 'Context',
     uploadImage: 'Upload image',
     selectModel: 'Select Model',
     // Task mode

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -73,6 +73,7 @@ export default {
     // Tool 消息
     toolArguments: '参数',
     toolResult: '结果',
+    toolContext: '上下文',
     uploadImage: '上传图片',
     selectModel: '选择模型',
     // 任务模式

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -319,6 +319,14 @@ class ChatService {
 
         logger.info(`[ChatService] 第${round + 1}轮开始执行工具调用:`, collectedToolCalls.length);
         
+        // 构建 toolCallId -> context 映射
+        const toolCallContexts = {};
+        for (const call of collectedToolCalls) {
+          if (call.id && call.context) {
+            toolCallContexts[call.id] = call.context;
+          }
+        }
+        
         // 执行工具（传递任务上下文），每完成一个工具就实时通知前端并保存消息
         const toolResults = await expertService.handleToolCalls(
           collectedToolCalls,
@@ -328,6 +336,11 @@ class ChatService {
           // 实时回调：每执行完一个工具就保存消息并通知前端
           async (toolResult) => {
             logger.info(`[ChatService] 工具执行完成: ${toolResult.toolName}, 成功: ${toolResult.success}`);
+            // 关联 context（从原始 toolCall 中获取）
+            const originalCall = collectedToolCalls.find(c => c.id === toolResult.toolCallId);
+            if (originalCall?.context) {
+              toolResult.context = originalCall.context;
+            }
             // 保存工具消息到数据库
             await this.saveToolMessage(topic_id, user_id, toolResult, expert_id);
             // 通知前端
@@ -624,7 +637,7 @@ class ChatService {
     const message_id = Utils.newID(20);
 
     // 构建 tool_calls 字段内容（复用现有字段）
-    // 格式: { tool_call_id, name, arguments, success, duration, timestamp }
+    // 格式: { tool_call_id, name, arguments, success, duration, timestamp, context }
     // 注意：不存储 content（工具返回结果），因为可能很大
     const toolCallsData = {
       tool_call_id: toolResult.toolCallId,
@@ -633,6 +646,7 @@ class ChatService {
       success: toolResult.success,
       duration: toolResult.duration || 0,
       timestamp: new Date().toISOString(),
+      context: toolResult.context || null,  // 工具调用前的状态文本上下文
     };
 
     // 对 content 进行截断（工具返回结果可能很大）

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -776,6 +776,8 @@ class LLMClient {
         let buffer = '';
         let accumulatedToolCalls = {};  // 累积工具调用（按 index 累积）
         let toolCallsSent = false;  // 标记工具调用是否已发送，防止重复
+        let pendingContent = '';  // 当前累积的文本（用于捕获工具调用的 context）
+        let toolCallContexts = {};  // 按工具 index 存储 context
         
         res.on('data', (chunk) => {
           buffer += chunk.toString();
@@ -800,6 +802,7 @@ class LLMClient {
                         name: tc.function?.name || '',
                         arguments: tc.function?.arguments || '',
                       },
+                      context: toolCallContexts[tc.index] || '',  // 附加 context
                     }));
                   
                   if (finalToolCalls.length > 0) {
@@ -807,6 +810,7 @@ class LLMClient {
                     logger.info('[LLMClient] 流式工具调用完成:', {
                       count: finalToolCalls.length,
                       tools: finalToolCalls.map(tc => tc.function.name),
+                      contexts: finalToolCalls.map(tc => tc.context?.substring(0, 30) || ''),
                     });
                     onToolCall?.(finalToolCalls);
                   }
@@ -828,6 +832,7 @@ class LLMClient {
                 const delta = parsed.choices?.[0]?.delta;
 
                 if (delta?.content) {
+                  pendingContent += delta.content;  // 累积文本用于捕获 context
                   onDelta?.(delta.content);
                 }
 
@@ -841,7 +846,11 @@ class LLMClient {
                   for (const tc of delta.tool_calls) {
                     const idx = tc.index;
                     if (!accumulatedToolCalls[idx]) {
+                      // ★ 关键：新的工具调用开始，捕获当前累积的文本作为 context
                       accumulatedToolCalls[idx] = { index: idx, function: {} };
+                      toolCallContexts[idx] = pendingContent.trim();
+                      pendingContent = '';  // 清空，准备下一个工具的状态文本
+                      logger.debug(`[LLMClient] 捕获工具 #${idx} 的 context:`, toolCallContexts[idx]?.substring(0, 50));
                     }
                     // 累积各个字段
                     if (tc.id) accumulatedToolCalls[idx].id = tc.id;
@@ -881,6 +890,7 @@ class LLMClient {
                   name: tc.function?.name || '',
                   arguments: tc.function?.arguments || '',
                 },
+                context: toolCallContexts[tc.index] || '',  // 附加 context
               }));
             
             if (finalToolCalls.length > 0) {
@@ -888,6 +898,7 @@ class LLMClient {
               logger.info('[LLMClient] 流式结束(res.on end)，处理累积工具调用:', {
                 count: finalToolCalls.length,
                 tools: finalToolCalls.map(tc => tc.function.name),
+                contexts: finalToolCalls.map(tc => tc.context?.substring(0, 30) || ''),
               });
               onToolCall?.(finalToolCalls);
             }


### PR DESCRIPTION
## Summary

实现 Issue #141 - 工具调用状态文本实时更新到对应消息

### 功能描述

在 LLM 流式响应中，当 AI 决定调用工具时，往往会在调用前输出一些状态文本（如"让我搜索一下..."）。这些文本之前会"消失"或与工具调用结果分离，导致用户体验不连贯。

本次实现将工具调用前的文本作为 `context` 捕获并存储，在工具消息卡片展开时显示。

### 实现细节

1. **lib/llm-client.js** - 捕获 context
   - 在流式响应中累积文本内容 (`pendingContent`)
   - 当检测到新工具调用时，捕获当前累积的文本作为该工具的 context
   - 将 context 存储在 toolCalls 对象中

2. **lib/chat-service.js** - 传递 context
   - 在工具执行回调中，从原始 toolCall 获取 context 并传递给 `saveToolMessage()`
   - `saveToolMessage()` 方法将 context 存储在 `tool_calls` JSON 字段中

3. **ChatWindow.vue** - 展示 context
   - 添加 `getToolContext()` 辅助方法
   - 在工具消息卡片展开时，显示"上下文"区域

4. **i18n** - 添加翻译
   - 中文: `toolContext: '上下文'`
   - 英文: `toolContext: 'Context'`

### 技术亮点

- **无需数据库迁移**: context 存储在现有的 `tool_calls` JSON 字段中
- **简化方案**: 接受状态文本在工具消息和助手消息中"重复显示"，避免复杂的文本匹配和移除逻辑
- **向后兼容**: 旧数据没有 context 字段时，UI 会优雅地不显示上下文区域

### 测试

- ✅ 前端构建成功 (`npm run build`)
- ✅ TypeScript 类型检查通过

Closes #141