### PR TITLE
feat: 上下文组织接口与策略实现

### DIFF
--- a/docs/design/tool-context-optimization.md
+++ b/docs/design/tool-context-optimization.md
@@ -1,0 +1,208 @@
+# 工具调用上下文优化设计方案
+
+## 问题分析
+
+### 当前问题
+
+在构造新的上下文时，工具调用的结果如何处理？
+
+1. **多轮工具调用期间**：上下文在整个调用链完成前不会重新构建，工具结果直接传递给下一轮 LLM，这部分不需要考虑历史截断问题
+2. **新上下文构建时**（对话压缩后或新对话开始）：需要让 LLM 知道"过去发生了什么"
+
+### 旧方案问题
+
+- 预判截断长度（如 5000 或 8000 字符）
+- 可能丢失重要信息
+- Token 使用效率不高
+
+## 新方案：摘要 + 按需获取
+
+### 核心思想
+
+```
+只对工具消息（role='tool'）做摘要，使用 tool_call_id 作为消息 ID
+如果 LLM 需要完整内容，调用 get_message_content 工具按需获取
+```
+
+### 为什么只对工具消息做摘要？
+
+| 消息类型 | 是否需要摘要 | 原因 |
+|---------|------------|------|
+| 用户消息 | ❌ 不需要 | 通常很短 |
+| Assistant 消息 | ❌ 不需要 | 通常不长 |
+| **工具消息** | ✅ 需要 | 可能非常大（搜索结果、文件内容） |
+
+### 设计细节
+
+#### 1. OpenAI 消息格式
+
+工具消息是独立的，和 system/user/assistant 并列：
+
+```javascript
+[
+  { role: 'system', content: '...' },
+  { role: 'user', content: '帮我搜索...' },
+  { role: 'assistant', tool_calls: [
+    { id: 'call_abc', function: { name: 'kb-search', arguments: '{"query":"test"}' }}
+  ]},
+  { role: 'tool', tool_call_id: 'call_abc', name: 'kb-search', content: '搜索结果...' },
+  { role: 'assistant', content: '根据结果...' }
+]
+```
+
+#### 2. 工具消息摘要格式
+
+直接使用 `tool_call_id` 作为消息 ID：
+
+```javascript
+// 原来
+{ role: 'tool', tool_call_id: 'call_abc', name: 'kb-search', content: '很长的搜索结果...' }
+
+// 摘要模式
+{ role: 'tool', tool_call_id: 'call_abc', name: 'kb-search', content: '工具: kb-search\n参数: {"query":"xxx"}\n结果: 成功 (5条)\n→ 调用 get_message_content("call_abc")' }
+```
+
+#### 3. 新工具：get_message_content
+
+```javascript
+// 工具定义
+{
+  name: 'get_message_content',
+  description: '获取指定消息的完整内容，包括工具调用的完整结果',
+  parameters: {
+    type: 'object',
+    properties: {
+      message_id: {
+        type: 'string',
+        description: '消息ID，从上下文中的 [消息ID: xxx] 获取'
+      }
+    },
+    required: ['message_id']
+  }
+}
+
+// 工具实现
+async function getMessageContent(messageId) {
+  const message = await db.Message.findByPk(messageId);
+  if (!message) {
+    return { success: false, error: '消息不存在' };
+  }
+  return {
+    success: true,
+    content: message.content,
+    tool_calls: message.tool_calls ? JSON.parse(message.tool_calls) : null
+  };
+}
+```
+
+### 实现要点
+
+#### 1. 工具参数截断
+
+工具参数也可能很长（如 `kb-editor` 的 `content` 参数），需要截断处理：
+
+```javascript
+function truncateArguments(args, maxLength = 200) {
+  const str = JSON.stringify(args);
+  if (str.length <= maxLength) {
+    return str;
+  }
+  // 智能截断：保留关键参数
+  const summary = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value === 'string' && value.length > 50) {
+      summary[key] = value.substring(0, 50) + `... (${value.length} 字符)`;
+    } else {
+      summary[key] = value;
+    }
+  }
+  const summaryStr = JSON.stringify(summary);
+  if (summaryStr.length > maxLength) {
+    return summaryStr.substring(0, maxLength) + '...';
+  }
+  return summaryStr;
+}
+```
+
+#### 2. 修改 buildMessages
+
+**只处理 tool 角色消息**：
+
+```javascript
+// 处理 tool 角色消息
+if (msg.role === 'tool') {
+  // 构建摘要内容
+  const summary = buildToolSummary({
+    toolCallId: msg.tool_call_id,  // 直接使用 tool_call_id 作为消息 ID
+    toolName: msg.name,
+    resultLength: msg.content?.length || 0
+  });
+  
+  result.push({
+    role: 'tool',
+    tool_call_id: msg.tool_call_id,
+    name: msg.name,
+    content: summary  // 摘要而非完整内容
+  });
+}
+
+// user/assistant 消息保持不变，不需要特殊处理
+```
+
+#### 3. 上下文策略差异化
+
+```javascript
+// Full 策略：包含更详细的摘要
+function buildFullToolSummary(info) {
+  return `工具: ${info.toolName}
+结果: ${info.resultLength} 字符
+→ 调用 get_message_content("${info.toolCallId}") 获取完整结果`;
+}
+
+// Simple 策略：更简洁的摘要
+function buildSimpleToolSummary(info) {
+  return `${info.toolName} → ${info.resultLength} 字符 | get_message_content("${info.toolCallId}")`;
+}
+```
+
+#### 4. get_message_content 工具实现
+
+需要根据 `tool_call_id` 查找对应的 tool 消息：
+
+```javascript
+async function getMessageContent(toolCallId) {
+  // 根据 tool_call_id 查找消息
+  const message = await db.Message.findOne({
+    where: { tool_call_id: toolCallId }
+  });
+  
+  if (!message) {
+    return { success: false, error: '消息不存在' };
+  }
+  
+  return {
+    success: true,
+    content: message.content  // 完整的工具结果
+  };
+}
+```
+
+### 优势
+
+1. **Token 效率最高**：上下文中只有元信息
+2. **LLM 自主决策**：根据需要决定是否查看历史详情
+3. **保持信息完整性**：数据库完整存储，随时可查
+4. **按需获取**：类似"懒加载"思想
+
+### 待实现
+
+1. [ ] 修改 `buildMessages` 中的工具消息处理（只处理 role='tool'）
+2. [ ] 实现 `get_message_content` 内置工具
+3. [ ] 添加到内置工具列表
+4. [ ] 测试验证
+
+---
+
+*设计时间：2026-03-15*
+*状态：已确认，待实施*
+*Issue: #155*

--- a/docs/review/context-organizer-review.md
+++ b/docs/review/context-organizer-review.md
@@ -1,0 +1,194 @@
+# Context Organizer 增强 Review
+
+✌Bazinga！
+
+## 一、架构设计评估
+
+### 1.1 整体架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    ContextManager                            │
+│                   (门面/协调者)                               │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│               ContextOrganizerFactory                        │
+│                   (工厂模式)                                 │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+           ┌───────────────┼───────────────┐
+           ▼               ▼               ▼
+    ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
+    │FullOrganizer │ │SimpleOrganizer│ │  Future...   │
+    │  (完整策略)  │ │  (简单策略)   │ │   (可扩展)   │
+    └──────────────┘ └──────────────┘ └──────────────┘
+```
+
+**评价**: 采用策略模式+工厂模式，设计清晰，符合开闭原则（对扩展开放，对修改关闭）。
+
+### 1.2 接口设计
+
+```javascript
+// IContextOrganizer 接口
+- organize(memorySystem, userId, options): Promise<ContextResult>
+- getName(): string
+- getDescription(): string
+```
+
+**优点**:
+- 接口简洁，职责单一
+- `ContextResult` 统一返回结构，便于上层处理
+
+**潜在问题**:
+- 缺少配置验证方法
+- 缺少策略能力声明（如支持哪些特性）
+
+---
+
+## 二、策略实现评估
+
+### 2.1 FullContextOrganizer（完整上下文策略）
+
+| 特性 | 实现 | 评价 |
+|------|------|------|
+| 未归档消息 | `getUnarchivedMessages(userId, null)` | ✅ 不限制数量，依赖压缩机制 |
+| Inner Voices | 最近 3 条 | ✅ 合理数量 |
+| Topic 总结 | 最近 10 个，只取 active | ✅ 状态过滤正确 |
+| 用户档案 | 包含完整上下文 | ✅ |
+| Token 估算 | `estimateTokens()` | ✅ 便于监控 |
+
+**适用场景**: 需要完整上下文的深度对话、复杂任务处理
+
+### 2.2 SimpleContextOrganizer（简单上下文策略）
+
+| 特性 | 实现 | 评价 |
+|------|------|------|
+| 最近消息 | `getRecentMessages(userId, 10)` | ⚠️ 注意：这是所有消息，不是未归档 |
+| Inner Voices | 默认不包含 | ✅ 减少 token 消耗 |
+| Topic 总结 | 最近 5 个 | ✅ 轻量级 |
+| 用户档案 | 包含完整上下文 | ✅ |
+
+**适用场景**: 快速问答、轻量级对话
+
+**潜在问题**:
+- `getRecentMessages` 获取的是最近 N 条消息（包含已归档的），而 `FullContextOrganizer` 使用的是 `getUnarchivedMessages`
+- 这可能导致两种策略的行为不一致：Simple 模式下可能包含已归档消息
+
+---
+
+## 三、状态管理评估
+
+### 3.1 Topic 状态过滤
+
+**改进点**:
+- `getTopics(userId, limit, 'active')` - 正确过滤 active 状态
+- 防止返回已删除/归档的 topic
+
+**遗漏点**:
+- `createTopic` 时没有显式设置 `status: 'active'`
+- `compressContext` 创建 topic 时没有设置 `startTime`/`endTime`
+
+### 3.2 状态转换生命周期
+
+```
+         ┌──────────┐
+         │  active  │ ←── 新创建的 topic
+         └────┬─────┘
+              │
+              ▼
+         ┌──────────┐
+         │ archived │ ←── 被归档（当前未使用）
+         └────┬─────┘
+              │
+              ▼
+         ┌──────────┐
+         │ deleted  │ ←── 软删除（当前未使用）
+         └──────────┘
+```
+
+**建议**: 补充状态转换的完整逻辑和文档
+
+---
+
+## 四、Agent 系统适用性评估
+
+### 4.1 对 Agent 系统的积极影响
+
+| 方面 | 评价 |
+|------|------|
+| **上下文灵活性** | ✅ 不同场景可选择不同策略 |
+| **Token 优化** | ✅ Simple 模式显著减少 token 消耗 |
+| **可扩展性** | ✅ 新增策略无需修改现有代码 |
+| **测试性** | ✅ 策略独立，便于单元测试 |
+
+### 4.2 潜在风险
+
+| 风险 | 严重程度 | 建议 |
+|------|----------|------|
+| 重复代码 | 中 | ContextManager 和 BaseContextOrganizer 存在大量重复 |
+| 行为不一致 | 中 | Simple 模式使用 getRecentMessages 而非 getUnarchivedMessages |
+| 缺少切换机制 | 低 | 未实现策略动态切换的入口 |
+
+### 4.3 架构优化建议
+
+1. **消除重复代码**
+   - ContextManager 应该内部使用 ContextOrganizer，而非独立实现
+   - 或者：将 ContextManager 标记为 deprecated，统一使用 Organizer
+
+2. **统一消息获取逻辑**
+   ```javascript
+   // SimpleContextOrganizer 应该改为：
+   const recentMessages = await memorySystem.getUnarchivedMessages(userId, this.messageCount);
+   ```
+
+3. **添加策略切换入口**
+   ```javascript
+   // 在专家配置中添加
+   expert.context_strategy = 'full' | 'simple' | 'custom'
+   ```
+
+---
+
+## 五、测试建议
+
+### 5.1 单元测试覆盖
+
+- [ ] IContextOrganizer 接口契约测试
+- [ ] FullContextOrganizer 完整流程测试
+- [ ] SimpleContextOrganizer 简化流程测试
+- [ ] ContextOrganizerFactory 注册/获取测试
+- [ ] Topic 状态过滤测试
+
+### 5.2 集成测试
+
+- [ ] 两种策略的实际 token 消耗对比
+- [ ] 长对话场景下的行为差异
+- [ ] 状态过滤的正确性验证
+
+---
+
+## 六、总结
+
+### 优点
+1. 架构设计合理，采用策略模式便于扩展
+2. 接口定义清晰，返回结构统一
+3. 状态过滤实现正确
+4. 支持不同场景的上下文需求
+
+### 需要改进
+1. **消除重复代码** - ContextManager 和 Organizer 存在大量重复
+2. **统一消息获取逻辑** - Simple 模式应使用 getUnarchivedMessages
+3. **补充 Topic 创建逻辑** - 显式设置 status 和时间边界
+4. **完善文档** - 状态转换生命周期、策略选择指南
+
+### 建议 Issue #154 包含
+1. 重构 ContextManager 使用 Organizer（或标记 deprecated）
+2. 修复 SimpleOrganizer 的消息获取逻辑
+3. 补充 Topic 创建时的状态和时间设置
+4. 添加策略选择的配置入口
+
+---
+
+✌Bazinga！亲爱的

--- a/docs/review/full-context-organizer-analysis.md
+++ b/docs/review/full-context-organizer-analysis.md
@@ -1,0 +1,173 @@
+# FullContextOrganizer 深度分析报告
+
+## 一、系统背景
+
+Touwaka Mate 是一个 AI 专家副本系统，具有以下核心特性：
+- **Expert（专家）**：具有独特人设的 AI 角色
+- **Topic（话题）**：对话历史的阶段性总结
+- **Skill（技能）**：专家可调用的工具能力
+- **双心智架构**：表达心智 + 反思心智（Inner Voice）
+
+## 二、压缩机制分析（关键流程）
+
+### 2.1 压缩触发时机
+
+压缩在每次用户发消息后、构建上下文之前自动执行：
+
+```javascript
+// chat-service.js:169-190
+// 6. 检查是否需要压缩上下文（在 buildContext 之前！）
+const compressionCheck = await expertService.memorySystem.shouldCompressContext(
+  user_id,
+  expertService.getDefaultModelConfig().max_tokens || 128000,
+  expertService.expertConfig?.expert?.context_threshold || 0.7,
+  5,   // 最小消息数：5条消息后开始检查压缩
+  50   // 最大未归档消息数：超过50条强制压缩
+);
+
+if (compressionCheck.needCompress) {
+  // 同步执行压缩（阻塞，但必要）
+  const compressResult = await expertService.memorySystem.compressContext(user_id, {...});
+}
+
+// 7. 构建上下文（压缩后执行）
+const context = await expertService.buildContext(user_id, content, topic_id, taskContext);
+```
+
+### 2.2 压缩触发条件
+
+```javascript
+// memory-system.js:277-322
+async shouldCompressContext(userId, contextSize = 128000, threshold = 0.7, minMessages = 5, maxMessages = 50) {
+  // 条件1：Token 超阈值
+  if (estimatedTokens >= tokenThreshold) {
+    return { needCompress: true, reason: `Token 数 ${estimatedTokens} >= 阈值 ${tokenThreshold}` };
+  }
+
+  // 条件2：消息数超限（硬限制，防止 Token 计算不准）
+  if (unarchivedMessages.length >= maxMessages) {
+    return { needCompress: true, reason: `未归档消息数 ${unarchivedMessages.length} >= 最大值 ${maxMessages}` };
+  }
+}
+```
+
+### 2.3 反思触发的强制压缩
+
+```javascript
+// chat-service.js:1278-1294
+// 当反思检测到话题偏移时，强制压缩
+if (reflection.topicSuggestion?.shouldCreateNew) {
+  const compressResult = await this.memorySystem.compressContext(user_id, {
+    force: true,  // 强制压缩，跳过阈值检查
+  });
+}
+```
+
+### 2.4 结论
+
+**压缩机制是可靠的：**
+- ✅ 在 `buildContext` 之前执行
+- ✅ 有双重保护：Token 阈值 + 消息数硬限制（50条）
+- ✅ 反思可触发强制压缩
+- ✅ 不会出现大量未归档消息的情况
+
+**FullContextOrganizer 获取的"全部未归档消息"实际上最多只有 50 条。**
+
+## 三、当前 FullContextOrganizer 实现分析
+
+### 3.1 核心流程
+
+```
+1. 获取全部未归档消息（实际最多 50 条）
+2. 获取 Inner Voices（默认 3 条）
+3. 获取 Topic 总结（默认 10 个）
+4. 构建系统提示（Soul + 技能 + 任务上下文 + RAG + Inner Voices）
+5. 返回 ContextResult
+```
+
+### 3.2 上下文组成结构
+
+| 组件 | 来源 | Token 占用（估算） | 优先级 |
+|------|------|-------------------|--------|
+| System Prompt | expert.prompt_template | 200-500 | 固定 |
+| Timestamp | 系统生成 | ~100 | 固定 |
+| Soul | expert 核心属性 | 300-800 | 固定 |
+| Skills | 技能列表 | 200-1000 | 固定 |
+| Task Context | 任务工作空间 | 300-500 | 可选 |
+| Topic Summaries | topics 表 | 500-2000 | 可调整 |
+| RAG Context | 知识库检索 | 0-3000 | 可选 |
+| Inner Voices | messages.inner_voice | 300-600 | 可调整 |
+| User Info Guidance | user_profiles | 0-100 | 可选 |
+| History Messages | messages 表 | **不固定（最多50条）** | 核心 |
+
+## 四、潜在的优化空间
+
+### 4.1 🟡 P2 - Topic 数量固定
+
+**现状**：固定获取 10 个 topic
+
+**潜在问题**：
+- 长期用户可能有几十个 topic，只能看到最近 10 个
+- 旧 topic 可能不再相关但仍占用 token
+
+**优化建议**：
+- 根据可用 token 预算动态调整 topic 数量
+- 或者考虑 topic 相关性排序
+
+### 4.2 🟡 P2 - 缺少 Token 预算分配
+
+**现状**：各组件没有明确的 token 预算分配
+
+**潜在问题**：
+- 当消息接近 50 条时，加上 10 个 topic + 3 个 inner voice + RAG，可能接近上下文窗口
+- 没有优先级机制
+
+**优化建议**：
+- 为各组件设置 token 预算上限
+- 实现动态调整机制
+
+### 4.3 🟢 P3 - 性能优化
+
+**现状**：每次 `buildContext` 都重新构建完整的系统提示
+
+**优化建议**：
+- 缓存不变的 Soul、Skills 等内容
+- 仅更新动态部分（Inner Voices、Topic Summaries）
+
+## 五、总结
+
+### 压缩机制评估
+
+**结论：压缩机制设计合理，能有效控制未归档消息数量。**
+
+| 机制 | 状态 | 说明 |
+|------|------|------|
+| Token 阈值触发 | ✅ 正常 | 默认 70%，可配置 |
+| 消息数硬限制 | ✅ 正常 | 默认 50 条，强制触发 |
+| 反思强制压缩 | ✅ 正常 | 话题偏移时触发 |
+| 执行时机 | ✅ 正确 | buildContext 之前 |
+
+### FullContextOrganizer 评估
+
+**结论：当前实现满足系统需求，有少量优化空间但不紧急。**
+
+| 方面 | 评估 | 说明 |
+|------|------|------|
+| 功能完整性 | ✅ | 正确获取消息、Inner Voices、Topic Summaries |
+| Token 控制 | ✅ | 依赖压缩机制，最多 50 条消息 |
+| 性能 | ⚠️ | 可优化，但不是瓶颈 |
+| 灵活性 | ⚠️ | 参数固定，可考虑动态调整 |
+
+### 建议
+
+1. **当前无需紧急修改** - 压缩机制工作正常
+2. **可选优化**：
+   - 动态 Topic 数量（根据预算调整）
+   - 缓存不变的系统提示内容
+3. **SimpleContextOrganizer** 作为轻量级替代方案，适合不需要完整上下文的场景
+
+---
+
+*分析时间：2026-03-15*
+*分析者：Maria*
+*修订：根据实际压缩机制流程修正分析*

--- a/docs/review/tool-call-storage-analysis.md
+++ b/docs/review/tool-call-storage-analysis.md
@@ -1,0 +1,312 @@
+# 工具调用存储与上下文构建分析报告
+
+## 问题背景
+
+用户提出的问题：
+1. 工具调用的参数和结果，是否应该全部存入数据库？
+2. 在构造上下文时，是否应该把工具调用的过程也编入上下文？编入多少？
+
+## 设计原则
+
+### 核心原则
+
+1. **存储层应该完整保存**：数据库是"真相源"，不应该做截断，工具调用的参数和结果应该**完整存储**
+2. **上下文构建应该智能决策**：根据场景动态决定使用哪些工具结果、使用多少，这是上下文组织策略的职责
+
+### 错误的旧设计
+
+```
+❌ 旧设计：
+存储时截断 → 永久丢失信息 → 上下文构建无法恢复
+```
+
+### 正确的新设计
+
+```
+✅ 新设计：
+存储时完整 → 保留所有信息 → 上下文构建时按需截断
+```
+
+## 当前实现（已优化）
+
+### 1. 工具调用存储机制（完整存储）
+
+#### 1.1 助手消息中的工具调用存储
+
+位置：[`lib/chat-service.js:389-420`](../../lib/chat-service.js:389)
+
+```javascript
+// 保存助手消息时，如果有工具调用，存储到 tool_calls 字段
+if (allToolCalls.length > 0) {
+  messageOptions.tool_calls = JSON.stringify(allToolCalls);
+}
+```
+
+存储内容（`allToolCalls` 数组）：
+```javascript
+{
+  tool_call_id: string,
+  function: { name, arguments },
+  result: { success, data, error },  // 执行结果（完整）
+  duration: number,                   // 执行时长
+  timestamp: string,                  // 时间戳
+}
+```
+
+**结论**：助手消息中的 `tool_calls` 字段**完整存储**了工具调用参数和结果。
+
+#### 1.2 工具消息的单独存储（已优化：完整存储）
+
+位置：[`lib/chat-service.js:636-682`](../../lib/chat-service.js:636) `saveToolMessage()`
+
+```javascript
+// 构建 tool_calls 字段内容（完整存储）
+const toolCallsData = {
+  tool_call_id: toolResult.toolCallId,
+  name: toolResult.toolName,
+  arguments: toolResult.arguments || null,  // 工具调用参数（完整）
+  success: toolResult.success,
+  duration: toolResult.duration || 0,
+  timestamp: new Date().toISOString(),
+  context: toolResult.context || null,
+};
+
+// 完整存储工具返回结果（不再截断）
+let content = '';
+if (toolResult.data !== undefined) {
+  content = typeof toolResult.data === 'string'
+    ? toolResult.data
+    : JSON.stringify(toolResult.data);
+}
+```
+
+**存储结构**（已优化）：
+
+| 字段 | 内容 | 是否截断 |
+|------|------|----------|
+| `tool_calls` | 工具元数据（含完整 `arguments`） | ❌ 不截断 |
+| `content` | 工具返回结果 | ❌ **完整存储** |
+
+**结论**：工具调用参数和结果**全部完整存储**
+
+### 2. 工具调用在 LLM 上下文中的使用
+
+#### 2.1 实时多轮调用中的工具上下文
+
+位置：[`lib/chat-service.js:368-372`](../../lib/chat-service.js:368)
+
+```javascript
+// 多轮工具调用时，更新消息历史
+currentMessages = [
+  ...currentMessages,
+  { role: 'assistant', content: roundContent || null, tool_calls: collectedToolCalls },
+  ...expertService.toolManager.formatToolResultsForLLM(toolResults),
+];
+```
+
+位置：[`lib/tool-manager.js:510-538`](../../lib/tool-manager.js:510) `formatToolResultsForLLM()`
+
+```javascript
+formatToolResultsForLLM(results, maxLength = 10000) {
+  return results.map(result => {
+    let content = JSON.stringify(
+      { success: result.success, data: result.data, error: result.error }
+    );
+
+    // 截断过长的结果（实时上下文允许更长）
+    if (content.length > maxLength) {
+      content = content.substring(0, maxLength) +
+        `\n...[truncated, original ${content.length} chars]`;
+    }
+
+    return {
+      role: 'tool',
+      tool_call_id: result.toolCallId,
+      name: result.toolName,
+      content,
+    };
+  });
+}
+```
+
+**实时上下文特点**：
+- 工具结果截断阈值：**10000 字符**
+- 用于多轮工具调用的即时反馈
+
+#### 2.2 历史消息中的工具上下文（已优化：智能截断）
+
+位置：[`lib/context-organizer/base-organizer.js:514-558`](../../lib/context-organizer/base-organizer.js:514) `buildMessages()`
+
+```javascript
+buildMessages(systemPrompt, messages, currentMessage, options = {}) {
+  const { maxToolContentLength = 5000 } = options;  // 默认 5000 字符
+  // ...
+  
+  // 处理 tool 角色消息
+  if (msg.role === 'tool') {
+    // 智能截断工具消息内容
+    const truncatedContent = this.truncateToolContent(msg.content, maxToolContentLength);
+    
+    result.push({
+      role: 'tool',
+      tool_call_id: toolMetaData?.tool_call_id || '',
+      name: toolMetaData?.name || 'unknown_tool',
+      content: truncatedContent,
+    });
+  }
+}
+```
+
+新增的智能截断方法 `truncateToolContent()`：
+
+```javascript
+truncateToolContent(content, maxLength = 5000) {
+  if (!content || content.length <= maxLength) {
+    return content;
+  }
+
+  // 尝试智能截断：JSON 格式提取关键信息
+  try {
+    const parsed = JSON.parse(content);
+    
+    if (Array.isArray(parsed)) {
+      // 数组：保留前面的元素，指示总数
+      return JSON.stringify({
+        _truncated: true,
+        totalItems: parsed.length,
+        preview: parsed.slice(0, 5),
+        _hint: `已截断，共 ${parsed.length} 项`
+      }, null, 2);
+    }
+    
+    if (parsed.success !== undefined) {
+      // 工具返回格式 { success, data, error }
+      // 尝试保留部分 data...
+    }
+  } catch (e) {
+    // 不是 JSON，简单截断
+  }
+
+  return content.substring(0, maxLength - 100) +
+    `\n\n... [上下文构建时截断，原始 ${content.length} 字符]`;
+}
+```
+
+**历史上下文特点**（已优化）：
+- 从数据库读取**完整内容**
+- 上下文构建时**智能截断**（默认 5000 字符）
+- 支持 JSON 结构化数据的智能摘要
+
+### 3. 数据流总结（已优化）
+
+```
+工具执行
+    │
+    ├─→ saveToolMessage() ──→ 数据库存储
+    │       ├─ tool_calls: 完整参数 + 元数据
+    │       └─ content: 完整结果（不再截断）✅
+    │
+    └─→ formatToolResultsForLLM() ──→ 实时 LLM 上下文
+            └─ content: 截断到 10000 字符
+
+历史上下文构建
+    │
+    └─→ buildMessages() ──→ 从数据库读取完整内容
+            └─ truncateToolContent() ──→ 智能截断到 5000 字符
+```
+
+## 已实施的优化
+
+### 优化 1：存储层完整保存
+
+**修改文件**：[`lib/chat-service.js`](../../lib/chat-service.js) `saveToolMessage()`
+
+**变更内容**：
+- 移除 `MAX_CONTENT_LENGTH = 1000` 的截断逻辑
+- 工具返回结果**完整存储**到 `content` 字段
+
+### 优化 2：上下文构建智能截断
+
+**修改文件**：[`lib/context-organizer/base-organizer.js`](../../lib/context-organizer/base-organizer.js)
+
+**新增方法**：
+- `truncateToolContent(content, maxLength)` - 智能截断工具消息内容
+- 支持结构化数据的智能摘要（数组、对象）
+- 默认截断阈值：**5000 字符**（可在 `buildMessages()` 中配置）
+
+### 优化 3：可配置的截断策略
+
+```javascript
+// 不同上下文组织策略可以配置不同的截断阈值
+class FullContextOrganizer {
+  buildMessages(systemPrompt, messages, currentMessage) {
+    return super.buildMessages(systemPrompt, messages, currentMessage, {
+      maxToolContentLength: 8000,  // Full 策略使用更长的内容
+    });
+  }
+}
+
+class SimpleContextOrganizer {
+  buildMessages(systemPrompt, messages, currentMessage) {
+    return super.buildMessages(systemPrompt, messages, currentMessage, {
+      maxToolContentLength: 3000,  // Simple 策略保持简洁
+    });
+  }
+}
+```
+
+## 后续优化方向
+
+### 1. 工具类型感知截断
+
+根据工具类型智能决定截断策略：
+
+```javascript
+const TOOL_TRUNCATION_CONFIG = {
+  'file-operations': { preservePaths: true, maxLength: 3000 },
+  'kb-search': { preserveSummary: true, maxItems: 5 },
+  'http-client': { preserveStatus: true, maxLength: 2000 },
+  'default': { maxLength: 5000 },
+};
+```
+
+### 2. 专家级配置
+
+在专家配置中添加工具结果处理选项：
+
+```javascript
+{
+  "expert": {
+    "tool_result_in_context": {
+      "max_length": 5000,           // 上下文中的最大长度
+      "strategy": "smart" | "simple"  // 截断策略
+    }
+  }
+}
+```
+
+### 3. Token 预算管理
+
+根据 Token 预算动态调整工具结果长度：
+
+```javascript
+// 在 buildMessages() 中
+const tokenBudget = this.calculateTokenBudget(messages, systemPrompt);
+const maxToolContentLength = Math.min(5000, tokenBudget / 3);
+```
+
+## 结论
+
+| 问题 | 旧状态 | 新状态 |
+|------|--------|--------|
+| 工具参数是否完整存储 | ✅ 是 | ✅ 保持 |
+| 工具结果是否完整存储 | ❌ 截断到 1000 字符 | ✅ **完整存储** |
+| 实时上下文工具结果长度 | 10000 字符 | 10000 字符（保持） |
+| 历史上下文工具结果长度 | 1000 字符（数据库截断） | **5000 字符（智能截断）** |
+| 不同上下文策略是否区分 | ❌ 不区分 | ✅ **可配置** |
+
+---
+
+*分析时间：2026-03-15*
+*优化实施：2026-03-15*
+*相关文件：[`lib/chat-service.js`](../../lib/chat-service.js), [`lib/tool-manager.js`](../../lib/tool-manager.js), [`lib/context-organizer/base-organizer.js`](../../lib/context-organizer/base-organizer.js)*

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -212,6 +212,10 @@ export default {
     contextCompression: 'Context Compression',
     contextThreshold: 'Compression Threshold',
     contextThresholdHint: 'Trigger compression when token usage exceeds this ratio (0.3-0.95, default 0.70)',
+    contextStrategy: 'Context Strategy',
+    contextStrategyFull: 'Full Context',
+    contextStrategySimple: 'Simple Context',
+    contextStrategyHint: 'Select context organization strategy. Full context includes all unarchived messages and 10 topics; Simple context includes recent 10 messages and 5 topics.',
     // LLM Parameters
     llmParams: 'LLM Parameters',
     temperature: 'Temperature',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -214,6 +214,10 @@ export default {
     contextCompression: '上下文压缩',
     contextThreshold: '压缩阈值',
     contextThresholdHint: 'Token 占用超过此比例时触发压缩（0.3-0.95，默认 0.70）',
+    contextStrategy: '上下文策略',
+    contextStrategyFull: '完整上下文',
+    contextStrategySimple: '简单上下文',
+    contextStrategyHint: '选择上下文组织策略。完整上下文包含所有未归档消息和10个Topic；简单上下文仅包含近期10条消息和5个Topic。',
     // LLM 参数配置
     llmParams: 'LLM 参数',
     temperature: '表达温度 (Temperature)',

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -976,6 +976,14 @@
           <!-- 上下文压缩配置 -->
           <div class="form-section-title">{{ $t('settings.contextCompression') }}</div>
           <div class="form-item">
+            <label class="form-label">{{ $t('settings.contextStrategy') }}</label>
+            <select v-model="expertForm.context_strategy" class="form-input">
+              <option value="full">{{ $t('settings.contextStrategyFull') }}</option>
+              <option value="simple">{{ $t('settings.contextStrategySimple') }}</option>
+            </select>
+            <p class="form-hint">{{ $t('settings.contextStrategyHint') }}</p>
+          </div>
+          <div class="form-item">
             <label class="form-label">{{ $t('settings.contextThreshold') }}</label>
             <input
               v-model.number="expertForm.context_threshold"
@@ -1605,6 +1613,7 @@ const expertForm = reactive({
   reflective_model_id: '',
   prompt_template: '',
   // 上下文压缩配置
+  context_strategy: 'full' as 'full' | 'simple',
   context_threshold: 0.70,
   // LLM 参数配置
   temperature: 0.70,
@@ -2275,6 +2284,7 @@ const openExpertDialog = (expert?: Expert) => {
     expertForm.expressive_model_id = expert.expressive_model_id || ''
     expertForm.reflective_model_id = expert.reflective_model_id || ''
     expertForm.prompt_template = expert.prompt_template || ''
+    expertForm.context_strategy = (expert as any).context_strategy ?? 'full'
     expertForm.context_threshold = expert.context_threshold ?? 0.70
     // LLM 参数
     expertForm.temperature = expert.temperature ?? 0.70
@@ -2300,6 +2310,7 @@ const openExpertDialog = (expert?: Expert) => {
     expertForm.expressive_model_id = ''
     expertForm.reflective_model_id = ''
     expertForm.prompt_template = ''
+    expertForm.context_strategy = 'full'
     expertForm.context_threshold = 0.70
     // LLM 参数默认值
     expertForm.temperature = 0.70

--- a/issue-context-organizer-update.md
+++ b/issue-context-organizer-update.md
@@ -1,0 +1,230 @@
+## 背景
+
+当前系统的上下文组织方式由 `ContextManager` 类负责，主要逻辑包括：
+- 获取全部未归档消息（不限制数量，让上下文压缩机制自动处理）
+- 获取最近的 Inner Voices（默认 3 条）
+- 获取 Topic 总结（从 topics 表加载，默认 10 个）
+- 构建完整的系统提示（包含 Soul、Skills、Task Context、Topic Summaries、RAG Context、Inner Voices 等）
+
+这种组织方式虽然功能完整，但在某些轻量级场景下可能过于复杂，消耗较多 token。
+
+## 需求
+
+1. **梳理当前上下文组织方式**：分析 `ContextManager.buildContext` 方法的实现逻辑
+2. **创建上下文组织接口**：定义 `IContextOrganizer` 接口，统一上下文组织的标准
+3. **实现两种组织策略**：
+   - **FullContextOrganizer**：保留当前的完整上下文组织方式
+   - **SimpleContextOrganizer**：轻量级策略，仅获取最近 10 条消息 + 最近 5 个 Topic 总结
+
+## 实现方案
+
+### 1. 当前上下文组织方式梳理
+
+`ContextManager.buildContext` 的核心逻辑：
+
+```javascript
+// 1. 获取全部未归档消息（不限制数量）
+const unarchivedMessages = await memorySystem.getUnarchivedMessages(userId, null);
+
+// 2. 获取 Inner Voices（默认 3 条）
+const innerVoices = await memorySystem.getRecentInnerVoices(userId, 3);
+
+// 3. 获取 Topic 总结（默认 10 个）
+const topicSummaries = await this.buildTopicSummaries(memorySystem, userId);
+
+// 4. 构建系统提示（包含 Soul、Skills、Task Context、Topic Summaries、RAG Context、Inner Voices）
+const systemPrompt = this.buildSystemPromptWithTopics(...);
+
+// 5. 构建 LLM 消息数组
+const messages = this.buildMessages(systemPrompt, unarchivedMessages, currentMessage);
+```
+
+### 2. 上下文组织接口设计
+
+创建 `lib/context-organizer/` 目录结构：
+
+```
+lib/context-organizer/
+├── interface.js        # IContextOrganizer 接口定义
+├── base-organizer.js   # BaseContextOrganizer 基础类
+├── full-organizer.js   # FullContextOrganizer 完整策略
+├── simple-organizer.js # SimpleContextOrganizer 简单策略
+└── index.js            # 模块导出
+```
+
+### 3. 两种策略对比
+
+| 特性 | FullContextOrganizer | SimpleContextOrganizer |
+|------|---------------------|----------------------|
+| 消息数量 | 全部未归档消息 | 最近 10 条 |
+| Inner Voices | 3 条 | 0 条（可选） |
+| Topic 数量 | 10 个 | 5 个 |
+| 适用场景 | 复杂对话、需要完整上下文 | 轻量级对话、快速响应 |
+| Token 消耗 | 较高 | 较低 |
+
+## 代码变更
+
+### 新增文件
+- `lib/context-organizer/interface.js`
+- `lib/context-organizer/base-organizer.js`
+- `lib/context-organizer/full-organizer.js`
+- `lib/context-organizer/simple-organizer.js`
+- `lib/context-organizer/index.js`
+
+### 修复：Topic 状态处理
+
+在检查过程中发现 `getTopics` 方法没有正确处理 Topic 状态，导致可能返回已删除或已归档的 Topic。已修复以下文件：
+
+1. **`lib/db.js`** - `getTopicsByExpertAndUser` 方法添加 `status` 参数（默认 `'active'`）
+2. **`lib/memory-system.js`** - `getTopics` 方法添加 `status` 参数（默认 `'active'`）
+3. **`lib/context-manager.js`** - 更新 `buildTopicSummaries` 和 `buildTopicContext` 调用，明确传入 `'active'` 状态
+4. **`lib/context-organizer/full-organizer.js`** - 更新 `buildTopicSummaries` 调用，明确传入 `'active'` 状态
+5. **`lib/context-organizer/simple-organizer.js`** - 更新 `buildTopicSummaries` 调用，明确传入 `'active'` 状态
+
+修复后，所有获取 Topic 的地方默认只返回 `active` 状态的 Topic，避免已删除或已归档的 Topic 被错误地包含在上下文组织中。
+
+---
+
+## Code Review 发现的问题
+
+详见 [`docs/review/context-organizer-review.md`](../docs/review/context-organizer-review.md)
+
+### 🔴 需要修复的问题
+
+#### 1. 重复代码问题
+
+`ContextManager` 和 `BaseContextOrganizer` 存在大量重复代码：
+
+| 方法 | ContextManager | BaseContextOrganizer |
+|------|----------------|---------------------|
+| processSingleMultimodalMessage | ✅ | ✅ (重复) |
+| extractSoul | ✅ | ✅ (重复) |
+| enhanceWithTimestamp | ✅ | ✅ (重复) |
+| enhanceWithSoul | ✅ | ✅ (重复) |
+| enhanceWithSkills | ✅ | ✅ (重复) |
+| enhanceWithTaskContext | ✅ | ✅ (重复) |
+| enhanceWithTopicSummaries | ✅ | ✅ (重复) |
+| enhanceWithRAGContext | ✅ | ✅ (重复) |
+| enhanceWithInnerVoices | ✅ | ✅ (重复) |
+| buildUserProfileContext | ✅ | ✅ (重复) |
+| generateUserInfoGuidance | ✅ | ✅ (重复) |
+| analyzeTrend | ✅ | ✅ (重复) |
+
+**建议方案**：
+- 方案 A：`ContextManager` 内部使用 `ContextOrganizer`，自身只做协调
+- 方案 B：将 `ContextManager` 标记为 deprecated，统一使用 Organizer
+
+#### 2. 行为不一致问题
+
+`SimpleContextOrganizer` 使用 `getRecentMessages`（包含已归档消息），而 `FullContextOrganizer` 使用 `getUnarchivedMessages`（只返回未归档消息）。
+
+```javascript
+// FullContextOrganizer
+const unarchivedMessages = await memorySystem.getUnarchivedMessages(userId, null);
+
+// SimpleContextOrganizer - 行为不一致！
+const recentMessages = await memorySystem.getRecentMessages(userId, this.messageCount);
+```
+
+**修复方案**：`SimpleContextOrganizer` 应该改用 `getUnarchivedMessages`：
+
+```javascript
+// 修复后
+const recentMessages = await memorySystem.getUnarchivedMessages(userId, this.messageCount);
+```
+
+#### 3. Topic 创建时缺少字段
+
+`compressContext` 创建 topic 时没有显式设置 `status`、`startTime`、`endTime`：
+
+```javascript
+// 当前实现（lib/memory-system.js:422-429）
+await this.db.createTopic({
+  id: topicId,
+  expertId: this.expertId,
+  userId: userId,
+  name: topic.title,
+  description: topic.summary,
+  category: topic.category || 'general',
+  // 缺少: status, startTime, endTime
+});
+```
+
+**修复方案**：补充缺失字段：
+
+```javascript
+await this.db.createTopic({
+  id: topicId,
+  expertId: this.expertId,
+  userId: userId,
+  name: topic.title,
+  description: topic.summary,
+  category: topic.category || 'general',
+  status: 'active',  // 显式设置
+  startTime: unarchivedMessages[topic.startIndex]?.timestamp 
+    ? new Date(unarchivedMessages[topic.startIndex].timestamp) 
+    : new Date(),
+  endTime: unarchivedMessages[topic.endIndex]?.timestamp 
+    ? new Date(unarchivedMessages[topic.endIndex].timestamp) 
+    : new Date(),
+});
+```
+
+### 🟡 建议改进
+
+#### 4. 添加策略选择配置入口
+
+在专家配置中添加 `context_strategy` 字段：
+
+```javascript
+// 专家配置
+{
+  "id": "expert_xxx",
+  "context_strategy": "full",  // 'full' | 'simple' | 'custom'
+  // ...
+}
+```
+
+#### 5. 完善接口定义
+
+添加配置验证方法和能力声明：
+
+```javascript
+export class IContextOrganizer {
+  // 现有方法...
+  
+  // 新增：验证配置
+  validateOptions(options) {
+    return { valid: true };
+  }
+  
+  // 新增：能力声明
+  getCapabilities() {
+    return {
+      supportsInnerVoices: true,
+      supportsTopicSummaries: true,
+      supportsRagContext: true,
+    };
+  }
+}
+```
+
+---
+
+## 后续工作
+
+### P0 - 必须修复
+- [ ] 修复 `SimpleContextOrganizer` 消息获取逻辑（改用 `getUnarchivedMessages`）
+- [ ] 补充 `compressContext` 创建 topic 时的字段设置
+
+### P1 - 应该修复
+- [ ] 重构 `ContextManager` 消除重复代码
+- [ ] 添加策略选择的配置入口
+
+### P2 - 可以改进
+- [ ] 添加性能测试，对比两种策略的 token 消耗
+- [ ] 完善接口定义（配置验证、能力声明）
+
+## 标签
+
+`enhancement` `refactor` `architecture` `bugfix`

--- a/issue-context-organizer.md
+++ b/issue-context-organizer.md
@@ -1,0 +1,112 @@
+## 背景
+
+当前系统的上下文组织方式由 `ContextManager` 类负责，主要逻辑包括：
+- 获取全部未归档消息（不限制数量，让上下文压缩机制自动处理）
+- 获取最近的 Inner Voices（默认 3 条）
+- 获取 Topic 总结（从 topics 表加载，默认 10 个）
+- 构建完整的系统提示（包含 Soul、Skills、Task Context、Topic Summaries、RAG Context、Inner Voices 等）
+
+这种组织方式虽然功能完整，但在某些轻量级场景下可能过于复杂，消耗较多 token。
+
+## 需求
+
+1. **梳理当前上下文组织方式**：分析 `ContextManager.buildContext` 方法的实现逻辑
+2. **创建上下文组织接口**：定义 `IContextOrganizer` 接口，统一上下文组织的标准
+3. **实现两种组织策略**：
+   - **FullContextOrganizer**：保留当前的完整上下文组织方式
+   - **SimpleContextOrganizer**：轻量级策略，仅获取最近 10 条消息 + 最近 5 个 Topic 总结
+
+## 实现方案
+
+### 1. 当前上下文组织方式梳理
+
+`ContextManager.buildContext` 的核心逻辑：
+
+```javascript
+// 1. 获取全部未归档消息（不限制数量）
+const unarchivedMessages = await memorySystem.getUnarchivedMessages(userId, null);
+
+// 2. 获取 Inner Voices（默认 3 条）
+const innerVoices = await memorySystem.getRecentInnerVoices(userId, 3);
+
+// 3. 获取 Topic 总结（默认 10 个）
+const topicSummaries = await this.buildTopicSummaries(memorySystem, userId);
+
+// 4. 构建系统提示（包含 Soul、Skills、Task Context、Topic Summaries、RAG Context、Inner Voices）
+const systemPrompt = this.buildSystemPromptWithTopics(...);
+
+// 5. 构建 LLM 消息数组
+const messages = this.buildMessages(systemPrompt, unarchivedMessages, currentMessage);
+```
+
+### 2. 上下文组织接口设计
+
+创建 `lib/context-organizer/` 目录结构：
+
+```
+lib/context-organizer/
+├── interface.js        # IContextOrganizer 接口定义
+├── base-organizer.js   # BaseContextOrganizer 基础类
+├── full-organizer.js   # FullContextOrganizer 完整策略
+├── simple-organizer.js # SimpleContextOrganizer 简单策略
+└── index.js            # 模块导出
+```
+
+### 3. 接口定义
+
+```javascript
+export class IContextOrganizer {
+  async organize(memorySystem, userId, options = {}) {
+    throw new Error('必须实现 organize 方法');
+  }
+
+  getName() {
+    throw new Error('必须实现 getName 方法');
+  }
+
+  getDescription() {
+    throw new Error('必须实现 getDescription 方法');
+  }
+}
+```
+
+### 4. 两种策略对比
+
+| 特性 | FullContextOrganizer | SimpleContextOrganizer |
+|------|---------------------|----------------------|
+| 消息数量 | 全部未归档消息 | 最近 10 条 |
+| Inner Voices | 3 条 | 0 条（可选） |
+| Topic 数量 | 10 个 | 5 个 |
+| 适用场景 | 复杂对话、需要完整上下文 | 轻量级对话、快速响应 |
+| Token 消耗 | 较高 | 较低 |
+
+## 代码变更
+
+### 新增文件
+- `lib/context-organizer/interface.js`
+- `lib/context-organizer/base-organizer.js`
+- `lib/context-organizer/full-organizer.js`
+- `lib/context-organizer/simple-organizer.js`
+- `lib/context-organizer/index.js`
+
+### 修复：Topic 状态处理
+
+在检查过程中发现 `getTopics` 方法没有正确处理 Topic 状态，导致可能返回已删除或已归档的 Topic。已修复以下文件：
+
+1. **`lib/db.js`** - `getTopicsByExpertAndUser` 方法添加 `status` 参数（默认 `'active'`）
+2. **`lib/memory-system.js`** - `getTopics` 方法添加 `status` 参数（默认 `'active'`）
+3. **`lib/context-manager.js`** - 更新 `buildTopicSummaries` 和 `buildTopicContext` 调用，明确传入 `'active'` 状态
+4. **`lib/context-organizer/full-organizer.js`** - 更新 `buildTopicSummaries` 调用，明确传入 `'active'` 状态
+5. **`lib/context-organizer/simple-organizer.js`** - 更新 `buildTopicSummaries` 调用，明确传入 `'active'` 状态
+
+修复后，所有获取 Topic 的地方默认只返回 `active` 状态的 Topic，避免已删除或已归档的 Topic 被错误地包含在上下文组织中。
+
+## 后续工作
+
+1. 在 `ContextManager` 中集成 `ContextOrganizerFactory`，支持动态切换策略
+2. 在专家配置中添加 `contextStrategy` 字段，允许为不同专家指定不同的上下文组织策略
+3. 添加性能测试，对比两种策略的 token 消耗和响应质量
+
+## 标签
+
+`enhancement` `refactor` `architecture` `bugfix`

--- a/issue-tool-context-optimization-update.md
+++ b/issue-tool-context-optimization-update.md
@@ -1,0 +1,94 @@
+# 工具调用上下文优化：摘要 + 按需获取
+
+## 背景
+
+当前在构造新的上下文时，工具调用的结果可能非常大（如搜索结果、文件内容），导致：
+- Token 使用效率不高
+- 可能超过上下文限制
+
+## 场景区分
+
+1. **多轮工具调用期间**：上下文在整个调用链完成前不会重新构建，工具结果直接传递给下一轮 LLM，这部分不需要考虑截断问题
+2. **新上下文构建时**（对话压缩后或新对话开始）：需要让 LLM 知道"过去发生了什么"
+
+## 解决方案
+
+### 核心思想
+
+```
+只对工具消息（role='tool'）做摘要，使用 tool_call_id 作为消息 ID
+如果 LLM 需要完整内容，调用 get_message_content 工具按需获取
+```
+
+### 为什么只对工具消息做摘要？
+
+| 消息类型 | 是否需要摘要 | 原因 |
+|---------|------------|------|
+| 用户消息 | ❌ 不需要 | 通常很短 |
+| Assistant 消息 | ❌ 不需要 | 通常不长 |
+| **工具消息** | ✅ 需要 | 可能非常大（搜索结果、文件内容） |
+
+### OpenAI 消息格式
+
+工具消息是独立的，和 system/user/assistant 并列：
+
+```javascript
+[
+  { role: 'user', content: '帮我搜索...' },
+  { role: 'assistant', tool_calls: [
+    { id: 'call_abc', function: { name: 'kb-search', arguments: '{"query":"test"}' }}
+  ]},
+  { role: 'tool', tool_call_id: 'call_abc', name: 'kb-search', content: '搜索结果...' },
+  { role: 'assistant', content: '根据结果...' }
+]
+```
+
+### 摘要格式
+
+直接使用 `tool_call_id` 作为消息 ID：
+
+```javascript
+// 原来
+{ role: 'tool', tool_call_id: 'call_abc', name: 'kb-search', content: '很长的搜索结果...' }
+
+// 摘要模式
+{ role: 'tool', tool_call_id: 'call_abc', name: 'kb-search', content: '工具: kb-search\n结果: 12345 字符\n→ 调用 get_message_content("call_abc")' }
+```
+
+### 新工具：get_message_content
+
+```javascript
+{
+  name: 'get_message_content',
+  description: '获取指定工具调用的完整结果',
+  parameters: {
+    type: 'object',
+    properties: {
+      tool_call_id: {
+        type: 'string',
+        description: '工具调用ID，从上下文中的 tool_call_id 字段获取'
+      }
+    },
+    required: ['tool_call_id']
+  }
+}
+```
+
+## 实现任务
+
+- [ ] 修改 `buildMessages` 中的工具消息处理（只处理 role='tool'）
+- [ ] 实现 `get_message_content` 内置工具
+- [ ] 添加到内置工具列表
+- [ ] 测试验证
+
+## 优势
+
+1. **Token 效率最高**：上下文中只有元信息
+2. **LLM 自主决策**：根据需要决定是否查看历史详情
+3. **保持信息完整性**：数据库完整存储，随时可查
+4. **实现简单**：只修改工具消息处理，复用 `tool_call_id`
+
+## 相关文档
+
+- 设计文档：`docs/design/tool-context-optimization.md`
+- 相关 Issue：#154（上下文组织接口）

--- a/issue-tool-context-optimization.md
+++ b/issue-tool-context-optimization.md
@@ -1,0 +1,74 @@
+# 工具调用上下文优化：摘要 + 按需获取
+
+## 背景
+
+当前在构造新的上下文时，工具调用的结果处理方式不够优化：
+- 预判截断长度（如 5000 或 8000 字符）
+- 可能丢失重要信息
+- Token 使用效率不高
+
+## 场景区分
+
+1. **多轮工具调用期间**：上下文在整个调用链完成前不会重新构建，工具结果直接传递给下一轮 LLM，这部分不需要考虑截断问题
+2. **新上下文构建时**（对话压缩后或新对话开始）：需要让 LLM 知道"过去发生了什么"
+
+## 解决方案
+
+### 核心思想
+
+上下文中只包含工具调用的摘要信息（message_id、工具名、参数摘要、token 数、tool_calls 大小），如果 LLM 需要完整内容，调用 `get_message_content` 工具按需获取。
+
+### 摘要格式
+
+**工具消息**：
+```
+[消息ID: msg_xxx | tokens: 1234 | tool_calls: 5678 字符]
+调用了工具: kb-search
+参数: {"query": "测试查询", "top_k": 5}
+结果: 成功 (返回 5 条记录，共 12345 字符)
+→ 如需完整结果，调用 get_message_content("msg_xxx")
+```
+
+**普通消息**：
+```
+[消息ID: msg_yyy | tokens: 567]
+用户: 你好，请帮我...
+```
+
+### 新工具：get_message_content
+
+```javascript
+{
+  name: 'get_message_content',
+  description: '获取指定消息的完整内容，包括工具调用的完整结果',
+  parameters: {
+    type: 'object',
+    properties: {
+      message_id: {
+        type: 'string',
+        description: '消息ID，从上下文中的 [消息ID: xxx] 获取'
+      }
+    },
+    required: ['message_id']
+  }
+}
+```
+
+## 实现任务
+
+- [ ] 定义工具消息摘要格式
+- [ ] 修改 `buildMessages` 中的工具消息处理
+- [ ] 实现 `get_message_content` 工具
+- [ ] 添加到内置工具列表
+- [ ] 测试验证
+
+## 优势
+
+1. **Token 效率最高**：上下文中只有元信息
+2. **LLM 自主决策**：根据需要决定是否查看历史详情
+3. **保持信息完整性**：数据库完整存储，随时可查
+
+## 相关文档
+
+- 设计文档：`docs/design/tool-context-optimization.md`
+- 相关 Issue：#154（上下文组织接口）

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -627,6 +627,11 @@ class ChatService {
   /**
    * 保存工具消息
    * 每个工具调用完成后立即保存，实现增量持久化
+   *
+   * 设计原则：
+   * - 存储层完整保存所有信息，不做截断
+   * - 上下文构建时根据场景决定使用多少内容
+   *
    * @param {string} topic_id - 话题ID（用于关联，但消息 topic_id 为 NULL）
    * @param {string} user_id - 用户ID
    * @param {object} toolResult - 工具执行结果
@@ -636,22 +641,20 @@ class ChatService {
   async saveToolMessage(topic_id, user_id, toolResult, expert_id = null) {
     const message_id = Utils.newID(20);
 
-    // 构建 tool_calls 字段内容（复用现有字段）
+    // 构建 tool_calls 字段内容（完整存储）
     // 格式: { tool_call_id, name, arguments, success, duration, timestamp, context }
-    // 注意：不存储 content（工具返回结果），因为可能很大
     const toolCallsData = {
       tool_call_id: toolResult.toolCallId,
       name: toolResult.toolName,
-      arguments: toolResult.arguments || null,  // 工具调用参数
+      arguments: toolResult.arguments || null,  // 工具调用参数（完整）
       success: toolResult.success,
       duration: toolResult.duration || 0,
       timestamp: new Date().toISOString(),
       context: toolResult.context || null,  // 工具调用前的状态文本上下文
     };
 
-    // 对 content 进行截断（工具返回结果可能很大）
-    // 截断后存储到 content 字段，用于前端展示和 LLM 上下文
-    const MAX_CONTENT_LENGTH = 1000;  // 最大 1000 字符
+    // 完整存储工具返回结果（不再截断）
+    // 上下文构建时由 ContextOrganizer 决定使用多少内容
     let content = '';
     if (toolResult.data !== undefined) {
       content = typeof toolResult.data === 'string'
@@ -660,12 +663,6 @@ class ChatService {
     } else if (toolResult.error) {
       content = toolResult.error;
     }
-    
-    // 截断过长的内容
-    if (content.length > MAX_CONTENT_LENGTH) {
-      content = content.substring(0, MAX_CONTENT_LENGTH) +
-        `\n...[已截断，原始 ${content.length} 字符]`;
-    }
 
     await this.Message.create({
       id: message_id,
@@ -673,11 +670,11 @@ class ChatService {
       user_id,
       expert_id,
       role: 'tool',
-      content,  // 截断后的工具返回内容
-      tool_calls: JSON.stringify(toolCallsData),  // 工具元数据（含 arguments）
+      content,  // 完整的工具返回内容（不再截断）
+      tool_calls: JSON.stringify(toolCallsData),  // 工具元数据（含完整 arguments）
     });
 
-    logger.debug(`[ChatService] 工具消息已保存: ${toolResult.toolName}, message_id: ${message_id}`);
+    logger.debug(`[ChatService] 工具消息已保存: ${toolResult.toolName}, message_id: ${message_id}, content_length: ${content.length}`);
     return message_id;
   }
 

--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -3,120 +3,41 @@
  * 负责构建发送给 LLM 的完整上下文
  *
  * 架构：System Prompt + Soul + Inner Voice + Topic Context + Contact Profile + Recent Messages
+ *
+ * 重构说明：
+ * - 现在内部使用 ContextOrganizerFactory 来选择策略
+ * - 保持原有 API 向后兼容
+ * - 支持通过 expertConfig.expert.context_strategy 配置策略
  */
 
 import logger from './logger.js';
-
-/**
- * 处理单个消息的多模态格式
- * 将数据库存储的消息格式转换为 OpenAI API 所需的多模态格式
- * @param {Object} msg - 消息对象
- * @returns {Object} 处理后的消息对象
- */
-function processSingleMultimodalMessage(msg) {
-  // 如果 content 已经是数组格式（多模态），需要过滤无效的图片
-  if (Array.isArray(msg.content)) {
-    // 过滤掉无效的图片 URL（如占位符 [图片]）
-    const validContent = msg.content.filter(item => {
-      if (item.type === 'image_url' && item.image_url?.url) {
-        const url = item.image_url.url;
-        // 跳过无效的 URL（占位符或非 http/https 开头）
-        if (url === '[图片]' || !url.startsWith('http')) {
-          return false;
-        }
-      }
-      return true;
-    });
-    return { ...msg, content: validContent };
-  }
-
-  // 如果 content 是字符串，检查是否包含图片标记
-  if (typeof msg.content === 'string') {
-    // 检查是否是 JSON 格式的多模态内容
-    try {
-      const parsed = JSON.parse(msg.content);
-      if (Array.isArray(parsed)) {
-        // 已经是多模态数组格式，需要过滤无效图片
-        const validContent = parsed.filter(item => {
-          if (item.type === 'image_url' && item.image_url?.url) {
-            const url = item.image_url.url;
-            if (url === '[图片]' || !url.startsWith('http')) {
-              return false;
-            }
-          }
-          return true;
-        });
-        logger.info('[ContextManager] 检测到多模态数组格式消息');
-        return { ...msg, content: validContent };
-      }
-      if (parsed.type === 'multimodal' && Array.isArray(parsed.content)) {
-        // { type: 'multimodal', content: [...] } 格式，需要过滤无效图片
-        const validContent = parsed.content.filter(item => {
-          if (item.type === 'image_url' && item.image_url?.url) {
-            const url = item.image_url.url;
-            if (url === '[图片]' || !url.startsWith('http')) {
-              return false;
-            }
-          }
-          return true;
-        });
-        logger.info('[ContextManager] 检测到多模态包装格式消息，包含内容项:', validContent.length);
-        return { ...msg, content: validContent };
-      }
-    } catch (e) {
-      // 不是 JSON，作为普通文本处理
-    }
-
-    // 检查是否包含 markdown 图片标记 ![alt](url)
-    const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
-    const images = [];
-    let match;
-    let textContent = msg.content;
-
-    while ((match = imageRegex.exec(msg.content)) !== null) {
-      const url = match[2];
-      // 跳过无效的 URL
-      if (url && (url.startsWith('http://') || url.startsWith('https://'))) {
-        images.push({
-          type: 'image_url',
-          image_url: { url }
-        });
-      }
-      // 移除图片标记，保留文本
-      textContent = textContent.replace(match[0], '').trim();
-    }
-
-    // 如果有图片，返回多模态格式
-    if (images.length > 0) {
-      logger.info('[ContextManager] 检测到 Markdown 图片标记，图片数量:', images.length);
-      const content = [];
-      if (textContent) {
-        content.push({ type: 'text', text: textContent });
-      }
-      content.push(...images);
-      return { ...msg, content };
-    }
-  }
-
-  return msg;
-}
+import { ContextOrganizerFactory } from './context-organizer/index.js';
 
 class ContextManager {
   /**
    * @param {object} expertConfig - 专家配置（从数据库加载）
    * @param {object} options - 可选配置
-   * @param {number} options.recentMessageCount - 最近消息数量（默认 20）
+   * @param {number} options.recentMessageCount - 最近消息数量（默认 20，已废弃）
    * @param {number} options.innerVoiceCount - 注入的 Inner Voice 数量（默认 3）
+   * @param {string} options.strategy - 上下文组织策略（默认 'full'）
    */
   constructor(expertConfig, options = {}) {
     this.expertConfig = expertConfig;
     this.options = {
-      recentMessageCount: options.recentMessageCount || 20,
+      recentMessageCount: options.recentMessageCount || 20,  // 已废弃，保留向后兼容
       innerVoiceCount: options.innerVoiceCount || 3,
+      strategy: options.strategy || expertConfig?.expert?.context_strategy || 'full',
     };
 
-    // 从专家配置中提取 Soul
+    // 从专家配置中提取 Soul（保留向后兼容）
     this.soul = this.extractSoul(expertConfig);
+
+    // 创建上下文组织器
+    this.organizer = ContextOrganizerFactory.create(this.options.strategy, expertConfig, {
+      innerVoiceCount: this.options.innerVoiceCount,
+    });
+
+    logger.info(`[ContextManager] 使用上下文组织策略: ${this.options.strategy}`);
   }
 
   /**
@@ -156,706 +77,16 @@ class ContextManager {
    * @returns {Promise<object>} 上下文对象
    */
   async buildContext(memorySystem, userId, options = {}) {
-    const {
-      currentMessage = '',
-      includeInnerVoices = true,
-      includeTopicSummaries = true,
-      skills = [],
-      taskContext = null,
-      ragContext = null,  // RAG 检索上下文
-    } = options;
+    // 委托给上下文组织器
+    const result = await this.organizer.organize(memorySystem, userId, options);
 
-    // 1. 确保用户档案存在
-    const userProfile = await memorySystem.getOrCreateUserProfile(userId);
-
-    // 2. 获取全部未归档消息（topic_id IS NULL）
-    // 不限制数量，让上下文压缩机制自动处理
-    // 传入 null 或一个大数值表示不限制
-    const unarchivedMessages = await memorySystem.getUnarchivedMessages(
-      userId,
-      null  // 获取全部未归档消息
-    );
-
-    // 3. 获取 Inner Voices（隐藏上下文）
-    let innerVoices = [];
-    if (includeInnerVoices) {
-      innerVoices = await memorySystem.getRecentInnerVoices(
-        userId,
-        this.options.innerVoiceCount
-      );
-    }
-
-    // 4. 获取 Topic 总结（新设计：从 topics 表加载）
-    let topicSummaries = null;
-    if (includeTopicSummaries) {
-      topicSummaries = await this.buildTopicSummaries(memorySystem, userId);
-    }
-
-    // 5. 获取用户档案背景
-    const userProfileContext = await this.buildUserProfileContext(userProfile);
-
-    // 6. 生成用户信息引导提示（如果缺失基本信息）
-    const conversationCount = Math.floor(unarchivedMessages.length / 2); // 估算对话轮次
-    const userInfoGuidance = this.generateUserInfoGuidance(userProfileContext, conversationCount);
-
-    // 7. 构建系统提示（包含 Skills、Task Context、Topic 总结、RAG 上下文和引导提示）
-    const systemPrompt = this.buildSystemPromptWithTopics(
-      innerVoices,
-      topicSummaries,
-      userInfoGuidance,
-      skills,
-      taskContext,
-      ragContext
-    );
-
-    // 8. 构建 LLM 消息数组（使用未归档消息）
-    const messages = this.buildMessages(systemPrompt, unarchivedMessages, currentMessage);
-
+    // 转换为原有格式（保持向后兼容）
     return {
-      // LLM 输入
-      messages,
-      systemPrompt,
-
-      // 隐藏上下文（用于调试和后续处理）
-      hiddenContext: {
-        soul: this.soul,
-        innerVoices,
-        topicSummaries,
-        userProfile: userProfileContext,
-        userInfoGuidance,
-        taskContext,
-        ragContext,
-      },
-
-      // 元数据
-      metadata: {
-        expertId: this.expertConfig.expert?.id || this.expertConfig.id,
-        userId,
-        messageCount: unarchivedMessages.length,
-        innerVoiceCount: innerVoices.length,
-        hasTopicSummaries: !!topicSummaries,
-        hasTaskContext: !!taskContext,
-        hasRagContext: !!ragContext,
-      },
+      messages: result.messages,
+      systemPrompt: result.systemPrompt,
+      hiddenContext: result.hiddenContext,
+      metadata: result.metadata,
     };
-  }
-
-  /**
-   * 构建系统提示（包含 Soul 和 Inner Voices）
-   * @param {Array} innerVoices - 内心独白列表
-   * @param {string} userInfoGuidance - 用户信息引导提示（可选）
-   */
-  buildSystemPrompt(innerVoices = [], userInfoGuidance = null) {
-    const expert = this.expertConfig.expert || this.expertConfig;
-
-    // 基础 System Prompt（优先使用 prompt_template，兼容 system_prompt）
-    let systemPrompt = expert.prompt_template || expert.system_prompt || expert.introduction || '';
-
-    // 添加 Soul（包含 speaking_style）
-    systemPrompt = this.enhanceWithSoul(systemPrompt, this.soul, expert);
-
-    // 添加 Inner Voices（内心独白）
-    if (innerVoices.length > 0) {
-      systemPrompt = this.enhanceWithInnerVoices(systemPrompt, innerVoices);
-    }
-
-    // 添加用户信息引导提示（如果有）
-    if (userInfoGuidance) {
-      systemPrompt = this.enhanceWithUserInfoGuidance(systemPrompt, userInfoGuidance);
-    }
-
-    return systemPrompt;
-  }
-
-  /**
-   * 构建包含 Topic 总结的系统提示（新设计）
-   * @param {Array} innerVoices - 内心独白列表
-   * @param {string} topicSummaries - Topic 总结文本
-   * @param {string} userInfoGuidance - 用户信息引导提示（可选）
-   * @param {Array} skills - 可用技能列表（可选）
-   * @param {object} taskContext - 任务上下文（任务工作空间模式）
-   * @param {string} ragContext - RAG 检索上下文（知识库检索结果）
-   */
-  buildSystemPromptWithTopics(innerVoices = [], topicSummaries = null, userInfoGuidance = null, skills = [], taskContext = null, ragContext = null) {
-    const expert = this.expertConfig.expert || this.expertConfig;
-
-    // 基础 System Prompt
-    let systemPrompt = expert.prompt_template || expert.system_prompt || expert.introduction || '';
-
-    // 添加当前时间信息（放在最前面，让模型知道当前时间）
-    systemPrompt = this.enhanceWithTimestamp(systemPrompt);
-
-    // 添加 Soul
-    systemPrompt = this.enhanceWithSoul(systemPrompt, this.soul, expert);
-
-    // 添加可用技能描述（在 Soul 之后，帮助 LLM 理解工具能力）
-    if (skills && skills.length > 0) {
-      systemPrompt = this.enhanceWithSkills(systemPrompt, skills);
-    }
-
-    // 添加任务工作空间上下文（在 Skills 之后、Topic 总结之前）
-    if (taskContext) {
-      systemPrompt = this.enhanceWithTaskContext(systemPrompt, taskContext);
-    }
-
-    // 添加 Topic 总结（新设计：在 Skills 之后、Inner Voices 之前）
-    if (topicSummaries) {
-      systemPrompt = this.enhanceWithTopicSummaries(systemPrompt, topicSummaries);
-    }
-
-    // 添加 RAG 检索上下文（知识库检索结果）
-    if (ragContext) {
-      systemPrompt = this.enhanceWithRAGContext(systemPrompt, ragContext);
-    }
-
-    // 添加 Inner Voices
-    if (innerVoices.length > 0) {
-      systemPrompt = this.enhanceWithInnerVoices(systemPrompt, innerVoices);
-    }
-
-    // 添加用户信息引导提示
-    if (userInfoGuidance) {
-      systemPrompt = this.enhanceWithUserInfoGuidance(systemPrompt, userInfoGuidance);
-    }
-
-    return systemPrompt;
-  }
-
-  /**
-   * 用 Topic 总结增强系统提示
-   * @param {string} systemPrompt - 系统提示
-   * @param {string} topicSummaries - Topic 总结文本
-   */
-  enhanceWithTopicSummaries(systemPrompt, topicSummaries) {
-    if (!topicSummaries) return systemPrompt;
-
-    const topicPrompt = `
-## 之前的对话话题总结
-以下是你们之前讨论过的话题，帮助你了解对话历史：
-
-${topicSummaries}
-`;
-
-    return systemPrompt + '\n\n' + topicPrompt;
-  }
-
-  /**
-   * 用 RAG 检索上下文增强系统提示
-   * @param {string} systemPrompt - 系统提示
-   * @param {string} ragContext - RAG 检索上下文（知识库检索结果）
-   */
-  enhanceWithRAGContext(systemPrompt, ragContext) {
-    if (!ragContext) return systemPrompt;
-
-    const ragPrompt = `
-## 相关知识库内容
-以下是从知识库中检索到的相关内容，请参考这些信息回答用户问题：
-
-${ragContext}
-`;
-
-    return systemPrompt + '\n\n' + ragPrompt;
-  }
-
-  /**
-   * 用当前时间戳增强系统提示
-   * 让模型能够感知当前日期和时间
-   * @param {string} systemPrompt - 系统提示
-   * @returns {string} 增强后的系统提示
-   */
-  enhanceWithTimestamp(systemPrompt) {
-    const now = new Date();
-
-    // 格式化日期和时间（中文格式）
-    const dateString = now.toLocaleDateString('zh-CN', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      weekday: 'long',
-    });
-
-    const timeString = now.toLocaleTimeString('zh-CN', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
-
-    const timestampPrompt = `
-## 当前时间
-现在是中国标准时间（CST, UTC+8）：
-- **日期**：${dateString}
-- **时间**：${timeString}
-
-请根据当前时间来理解和回应用户的请求。
-`;
-
-    return systemPrompt + '\n\n' + timestampPrompt;
-  }
-
-  /**
-   * 用可用技能信息增强系统提示
-   * 帮助 LLM 理解每个技能的用途和何时应该调用工具
-   * @param {string} systemPrompt - 系统提示
-   * @param {Array} skills - 技能列表，每项包含 id, name, description, tools
-   *   - tools 可以是字符串数组（工具名称）或对象数组（包含 name 和 description）
-   */
-  enhanceWithSkills(systemPrompt, skills) {
-    if (!skills || skills.length === 0) {
-      logger.info('[ContextManager] enhanceWithSkills: 没有技能需要注入');
-      return systemPrompt;
-    }
-
-    logger.info(`[ContextManager] enhanceWithSkills: 注入 ${skills.length} 个技能到 System Prompt`);
-    skills.forEach(s => logger.info(`[ContextManager] - ${s.id}: ${s.name}`));
-
-    // 构建技能描述文本
-    const skillsDescription = skills.map(skill => {
-      // 构建工具列表描述
-      let toolsDescription = '无特定工具';
-      if (skill.tools && skill.tools.length > 0) {
-        if (typeof skill.tools[0] === 'object' && skill.tools[0].name) {
-          // tools 是对象数组，包含 name 和 description
-          // 工具名已经是 toolName__skillIdShort 格式，直接使用
-          toolsDescription = skill.tools.map(t => {
-            return `  - \`${t.name}\`: ${t.description || '无描述'}`;
-          }).join('\n');
-        } else {
-          // tools 是字符串数组（兼容旧格式）
-          toolsDescription = skill.tools.map(t => {
-            return `  - \`${t}\``;
-          }).join('\n');
-        }
-      }
-
-      return `- **${skill.name}**: ${skill.description || '暂无描述'}
-${toolsDescription}`;
-    }).join('\n\n');
-
-    const skillsPrompt = `
-## 你的可用技能
-你拥有以下技能，可以在合适的时候调用相关工具来完成任务：
-
-${skillsDescription}
-
-当你需要使用这些技能时，系统会自动调用相应的工具。你只需要在回复中自然地表达即可，系统会处理工具调用。
-`;
-
-    logger.info('[ContextManager] enhanceWithSkills: System Prompt 已增强');
-    return systemPrompt + '\n\n' + skillsPrompt;
-  }
-
-  /**
-   * 用任务工作空间上下文增强系统提示
-   * 帮助 LLM 理解当前在任务工作空间模式下，可以访问相关文件
-   * @param {string} systemPrompt - 系统提示
-   * @param {object} taskContext - 任务上下文对象
-   */
-  enhanceWithTaskContext(systemPrompt, taskContext) {
-    if (!taskContext) return systemPrompt;
-
-    logger.info('[ContextManager] enhanceWithTaskContext: 注入任务工作空间上下文');
-
-    // 构建文件列表描述
-    let filesDescription = '暂无文件';
-    if (taskContext.inputFiles && taskContext.inputFiles.length > 0) {
-      const fileList = taskContext.inputFiles.map(file => {
-        const sizeKB = file.isDirectory ? '-' : `${(file.size / 1024).toFixed(1)} KB`;
-        const pathInfo = file.path ? ` (路径: ${file.path})` : '';
-        return file.isDirectory ? `📁 ${file.name}/${pathInfo}` : `📄 ${file.name} (${sizeKB})${pathInfo}`;
-      }).join('\n');
-      filesDescription = fileList;
-    }
-
-    // 获取路径信息
-    const userId = taskContext.userId || 'unknown';
-    const taskId = taskContext.id;
-    const relativePath = taskContext.workspacePath || `${userId}/${taskId}`;
-    // 注意：路径不含 data/ 前缀，因为 AI 的工作目录已经是 data/
-    const fullPath = taskContext.fullWorkspacePath || `work/${relativePath}`;
-    const systemRoot = taskContext.systemRoot || 'work';
-
-    // 当前浏览路径描述
-    const currentPathDisplay = taskContext.currentPath
-      ? `${fullPath}/${taskContext.currentPath}`
-      : `${fullPath}/input`;
-
-    const taskPrompt = `
-## 当前任务工作空间
-
-你正在**任务工作空间模式**中。以下是当前任务的详细信息：
-
-### 任务信息
-- **任务ID**: ${taskContext.id}
-- **任务标题**: ${taskContext.title}
-${taskContext.description ? `- **任务描述**: ${taskContext.description}` : ''}
-
-### 目录结构
-\`\`\`
-${systemRoot}/                           ← 系统根目录
-└── ${userId}/                           ← 用户空间
-    └── ${taskId}/                       ← 当前任务根目录 ⭐
-        ├── input/                       ← 输入文件（用户上传）
-        ├── output/                      ← 输出文件（写入结果到这里）
-        ├── temp/                        ← 临时文件
-        └── logs/                        ← 日志
-\`\`\`
-
-### 路径信息
-- **完整路径**: ${fullPath}
-- **当前浏览**: ${currentPathDisplay}
-
-### 路径使用规则
-- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 读取用户文件: \`${fullPath}/input/{filename}\`
-- 写入结果文件: \`${fullPath}/output/{filename}\`
-- 临时文件: \`${fullPath}/temp/{filename}\`
-- 不确定路径时，先用 ls 命令探测确认
-- ⚠️ 注意：路径已经是相对于 data/ 的，不要再加 data/ 前缀！
-
-### 当前目录下的文件
-${filesDescription}
-`;
-
-    return systemPrompt + '\n\n' + taskPrompt;
-  }
-
-  /**
-   * 构建 Topic 总结（新设计）
-   * 从 topics 表加载，按时间倒序
-   * @param {MemorySystem} memorySystem - 记忆系统实例
-   * @param {string} userId - 用户ID
-   * @returns {Promise<string|null>} Topic 总结文本
-   */
-  async buildTopicSummaries(memorySystem, userId) {
-    try {
-      // 获取最近的 Topics（按更新时间倒序）
-      const topics = await memorySystem.getTopics(userId, 10);
-
-      if (topics.length === 0) {
-        return null;
-      }
-
-      // 构建 Topic 总结文本（按时间正序，即最早的在前）
-      const summaryText = topics
-        .reverse()  // 转为正序
-        .map(t => `【${t.title}】${t.description || '无描述'}`)
-        .join('\n\n');
-
-      return summaryText;
-    } catch (error) {
-      logger.warn('[ContextManager] 构建 Topic 总结失败:', error.message);
-      return null;
-    }
-  }
-
-  /**
-   * 用 Soul 增强系统提示
-   *
-   * 空字段处理逻辑：
-   * - `null`、`undefined`、空字符串均视为空
-   * - 空字段对应的章节标题也会被省略，不会输出空白内容
-   * - 如果所有字段都为空，直接返回原 systemPrompt
-   *
-   * @param {string} systemPrompt - 基础系统提示
-   * @param {object} soul - Soul 配置（字段为纯字符串）
-   * @param {object} expert - 专家配置（可选，用于 speaking_style）
-   * @returns {string} 增强后的系统提示
-   */
-  enhanceWithSoul(systemPrompt, soul, expert = null) {
-    if (!soul) return systemPrompt;
-
-    const sections = [];
-
-    // 核心价值观（纯字符串）
-    if (soul.coreValues?.trim()) {
-      sections.push(`## 你的核心价值观\n${soul.coreValues.trim()}`);
-    }
-
-    // 行为准则（纯字符串）
-    if (soul.behavioralGuidelines?.trim()) {
-      sections.push(`## 你的行为准则\n${soul.behavioralGuidelines.trim()}`);
-    }
-
-    // 禁忌（纯字符串）
-    if (soul.taboos?.trim()) {
-      sections.push(`## 你的禁忌（绝对不能做的事）\n${soul.taboos.trim()}`);
-    }
-
-    // 情感基调
-    if (soul.emotionalTone?.trim()) {
-      sections.push(`## 你的情感基调\n${soul.emotionalTone.trim()}`);
-    }
-
-    // 说话风格
-    const speakingStyle = expert?.speaking_style || soul.speakingStyle;
-    if (speakingStyle?.trim()) {
-      sections.push(`## 你的说话风格\n${speakingStyle.trim()}`);
-    }
-
-    // 如果没有有效内容，直接返回原提示
-    if (sections.length === 0) return systemPrompt;
-
-    const soulPrompt = '\n\n' + sections.join('\n\n');
-    return systemPrompt + soulPrompt;
-  }
-
-  /**
-   * 用 Inner Voices 增强系统提示
-   */
-  enhanceWithInnerVoices(systemPrompt, innerVoices) {
-    if (!innerVoices || innerVoices.length === 0) return systemPrompt;
-
-    // 分析评分趋势
-    const trend = this.analyzeTrend(innerVoices);
-
-    // 构建 Inner Voice 文本
-    let innerVoiceText = '';
-
-    // 如果趋势下降，强调 nextRoundAdvice
-    if (trend.trend === 'declining' && trend.latest?.nextRoundAdvice) {
-      innerVoiceText += `【重要提醒】最近表现有下降趋势，请注意：${trend.latest.nextRoundAdvice}\n\n`;
-    }
-
-    // 添加最近的内心独白
-    const monologues = innerVoices
-      .filter(iv => iv.monologue)
-      .map(iv => iv.monologue)
-      .join('\n');
-
-    if (monologues) {
-      innerVoiceText += `最近的内心独白：\n${monologues}`;
-    }
-
-    const innerVoicePrompt = `
-## 你的内心独白（前几轮的反思结果）
-这是你对自己之前表现的反思：
-
-${innerVoiceText}
-
-请根据这些反思调整你这一轮的回复。
-`;
-
-    return systemPrompt + '\n\n' + innerVoicePrompt;
-  }
-
-  /**
-   * 用用户信息引导提示增强系统提示
-   * @param {string} systemPrompt - 系统提示
-   * @param {string} guidance - 引导提示
-   */
-  enhanceWithUserInfoGuidance(systemPrompt, guidance) {
-    if (!guidance) return systemPrompt;
-
-    const guidancePrompt = `
-## 对话提示
-${guidance}
-`;
-
-    return systemPrompt + '\n\n' + guidancePrompt;
-  }
-
-  /**
-   * 分析 Inner Voice 评分趋势
-   */
-  analyzeTrend(innerVoices) {
-    const scores = innerVoices
-      .filter(iv => iv.selfEvaluation?.score)
-      .map(iv => iv.selfEvaluation.score);
-
-    if (scores.length < 2) {
-      return { trend: 'stable', latest: innerVoices[0] };
-    }
-
-    const firstHalf = scores.slice(0, Math.floor(scores.length / 2));
-    const secondHalf = scores.slice(Math.floor(scores.length / 2));
-
-    const firstAvg = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length;
-    const secondAvg = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length;
-
-    const diff = secondAvg - firstAvg;
-
-    if (diff > 1) {
-      return { trend: 'improving', diff, latest: innerVoices[0] };
-    } else if (diff < -1) {
-      return { trend: 'declining', diff, latest: innerVoices[0] };
-    }
-
-    return { trend: 'stable', diff, latest: innerVoices[0] };
-  }
-
-  /**
-   * 构建用户档案上下文
-   * @param {object} userProfile - 用户档案（包含 user 信息）
-   * @returns {object} 用户档案上下文
-   */
-  async buildUserProfileContext(userProfile) {
-    if (!userProfile) return null;
-
-    return {
-      id: userProfile.user_id,
-      // 用户固有属性（来自 users 表）
-      preferredName: userProfile.preferred_name,
-      nickname: userProfile.nickname,
-      email: userProfile.email,
-      gender: userProfile.gender,
-      birthday: userProfile.birthday,
-      occupation: userProfile.occupation,
-      location: userProfile.location,
-      // 专家对用户的认知（来自 user_profiles 表）
-      introduction: userProfile.introduction,
-      background: userProfile.background,
-      notes: userProfile.notes,
-      firstMet: userProfile.first_met,
-      lastActive: userProfile.last_active,
-    };
-  }
-
-  /**
-   * 检查用户缺失的基本信息
-   * @param {object} userProfile - 用户档案
-   * @returns {Array<string>} 缺失的信息字段名称
-   */
-  checkMissingUserInfo(userProfile) {
-    const missing = [];
-    
-    // 称呼偏好（存储在 user_profiles，随 expert 不同）
-    if (!userProfile?.preferredName) {
-      missing.push('称呼');
-    }
-    // 用户固有属性（存储在 users 表）
-    if (!userProfile?.gender) {
-      missing.push('性别');
-    }
-    if (!userProfile?.birthday) {
-      missing.push('年龄/生日');
-    }
-    if (!userProfile?.occupation) {
-      missing.push('职业');
-    }
-    if (!userProfile?.location) {
-      missing.push('所在地');
-    }
-    
-    return missing;
-  }
-
-  /**
-   * 生成用户信息引导提示
-   * 在对话中自然地引导用户提供缺失的信息
-   * @param {object} userProfile - 用户档案
-   * @param {number} conversationCount - 对话轮次（用于控制引导频率）
-   * @returns {string|null} 引导提示（如果不需要引导则返回 null）
-   */
-  generateUserInfoGuidance(userProfile, conversationCount = 0) {
-    const missing = this.checkMissingUserInfo(userProfile);
-    
-    if (missing.length === 0) {
-      return null;
-    }
-
-    // 控制引导频率：每 3 轮对话最多引导一次
-    // 且每次只引导一个缺失项
-    const guidanceIndex = conversationCount % 3;
-    if (guidanceIndex !== 0) {
-      return null;
-    }
-
-    // 根据对话轮次选择要引导的缺失项
-    const itemIndex = Math.floor(conversationCount / 3) % missing.length;
-    const targetItem = missing[itemIndex];
-
-    // 生成自然的引导提示
-    const guidancePrompts = {
-      '称呼': '（提示：你还不知道对方希望被怎么称呼，可以在对话中自然地询问）',
-      '性别': '（提示：你还不知道对方的性别，可以在适当时候了解）',
-      '年龄/生日': '（提示：你还不知道对方的年龄，可以在聊天中自然地了解）',
-      '职业': '（提示：你还不知道对方从事什么工作，可以在聊天中自然地了解）',
-      '所在地': '（提示：你还不知道对方在哪里，可以在聊天中自然地了解）',
-    };
-
-    return guidancePrompts[targetItem] || null;
-  }
-
-  /**
-   * 构建 Topic 上下文
-   */
-  async buildTopicContext(memorySystem, userId, currentMessage) {
-    try {
-      // 获取相关 Topics
-      const topics = await memorySystem.getTopics(userId, 5);
-
-      if (topics.length === 0) {
-        return null;
-      }
-
-      // 简单匹配：返回最近的几个 Topic 描述
-      // 未来可以实现更智能的语义匹配
-      const topicSummaries = topics.map(t =>
-        `【${t.title}】${t.description || ''} (${t.message_count || 0} 条消息)`
-      );
-
-      return topicSummaries.join('\n');
-    } catch (error) {
-      logger.warn('[ContextManager] 构建 Topic 上下文失败:', error.message);
-      return null;
-    }
-  }
-
-  /**
-   * 构建 LLM 消息数组
-   * @param {string} systemPrompt - 系统提示
-   * @param {Array} recentMessages - 历史消息（必须是 ASC 顺序，即旧→新）
-   * @param {string} currentMessage - 当前用户消息
-   */
-  buildMessages(systemPrompt, recentMessages, currentMessage) {
-    const messages = [];
-
-    // 系统提示
-    if (systemPrompt) {
-      messages.push({ role: 'system', content: systemPrompt });
-    }
-
-    // 历史消息（按时间正序：旧→新）
-    // getUnarchivedMessages 返回 ASC 顺序，直接使用
-    // 需要处理多模态格式和 tool 角色消息
-    for (const msg of recentMessages) {
-      // 处理 tool 角色消息（OpenAI API 格式）
-      if (msg.role === 'tool') {
-        // 从 tool_calls 字段解析元数据
-        let toolMetaData = null;
-        try {
-          toolMetaData = typeof msg.tool_calls === 'string' 
-            ? JSON.parse(msg.tool_calls) 
-            : msg.tool_calls;
-        } catch (e) {
-          // 解析失败，使用默认值
-          toolMetaData = null;
-        }
-        
-        // 构建 OpenAI 格式的 tool 消息
-        messages.push({
-          role: 'tool',
-          tool_call_id: toolMetaData?.tool_call_id || '',
-          name: toolMetaData?.name || 'unknown_tool',
-          content: msg.content || '',
-        });
-      } else {
-        // 处理普通消息（user、assistant）
-        const processedMsg = processSingleMultimodalMessage({
-          role: msg.role,
-          content: msg.content,
-        });
-        messages.push(processedMsg);
-      }
-    }
-
-    // 当前消息（需要处理多模态格式）
-    if (currentMessage) {
-      const currentMsg = processSingleMultimodalMessage({ role: 'user', content: currentMessage });
-      messages.push(currentMsg);
-    }
-
-    return messages;
   }
 
   /**
@@ -870,7 +101,7 @@ ${guidance}
     if (context.hiddenContext?.soul) {
       lines.push('\n=== Soul (隐藏) ===');
       const soul = context.hiddenContext.soul;
-      lines.push(`核心价值观: ${soul.coreValues?.join(', ')}`);
+      lines.push(`核心价值观: ${soul.coreValues?.join?.(', ') || soul.coreValues}`);
       lines.push(`情感基调: ${soul.emotionalTone}`);
     }
 
@@ -905,7 +136,9 @@ ${guidance}
 
     lines.push('\n=== Messages ===');
     for (const msg of context.messages || []) {
-      const preview = msg.content?.substring(0, 80) || '';
+      const preview = typeof msg.content === 'string' 
+        ? msg.content?.substring(0, 80) 
+        : JSON.stringify(msg.content)?.substring(0, 80) || '';
       lines.push(`${msg.role}: ${preview}...`);
     }
 
@@ -925,10 +158,39 @@ ${guidance}
 
     // 消息
     for (const msg of context.messages || []) {
-      total += Math.ceil((msg.content?.length || 0) / 4) + 4;
+      const contentLength = typeof msg.content === 'string' 
+        ? msg.content?.length || 0
+        : JSON.stringify(msg.content)?.length || 0;
+      total += Math.ceil(contentLength / 4) + 4;
     }
 
     return total;
+  }
+
+  /**
+   * 获取当前使用的策略名称
+   * @returns {string} 策略名称
+   */
+  getStrategy() {
+    return this.options.strategy;
+  }
+
+  /**
+   * 切换上下文组织策略
+   * @param {string} strategyName - 策略名称 ('full' | 'simple')
+   */
+  setStrategy(strategyName) {
+    if (!ContextOrganizerFactory.isValidStrategy(strategyName)) {
+      logger.warn(`[ContextManager] 无效的策略: ${strategyName}，保持当前策略: ${this.options.strategy}`);
+      return;
+    }
+
+    this.options.strategy = strategyName;
+    this.organizer = ContextOrganizerFactory.create(strategyName, this.expertConfig, {
+      innerVoiceCount: this.options.innerVoiceCount,
+    });
+
+    logger.info(`[ContextManager] 切换上下文组织策略: ${strategyName}`);
   }
 }
 

--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -1,0 +1,693 @@
+/**
+ * Base Context Organizer - 基础上下文组织器
+ * 提供通用的上下文构建功能，供具体策略继承
+ */
+
+import logger from '../logger.js';
+import { IContextOrganizer, ContextResult } from './interface.js';
+
+/**
+ * 处理单个消息的多模态格式
+ * 将数据库存储的消息格式转换为 OpenAI API 所需的多模态格式
+ * @param {Object} msg - 消息对象
+ * @returns {Object} 处理后的消息对象
+ */
+export function processSingleMultimodalMessage(msg) {
+  // 如果 content 已经是数组格式（多模态），需要过滤无效的图片
+  if (Array.isArray(msg.content)) {
+    // 过滤掉无效的图片 URL（如占位符 [图片]）
+    const validContent = msg.content.filter(item => {
+      if (item.type === 'image_url' && item.image_url?.url) {
+        const url = item.image_url.url;
+        // 跳过无效的 URL（占位符或非 http/https 开头）
+        if (url === '[图片]' || !url.startsWith('http')) {
+          return false;
+        }
+      }
+      return true;
+    });
+    return { ...msg, content: validContent };
+  }
+
+  // 如果 content 是字符串，检查是否包含图片标记
+  if (typeof msg.content === 'string') {
+    // 检查是否是 JSON 格式的多模态内容
+    try {
+      const parsed = JSON.parse(msg.content);
+      if (Array.isArray(parsed)) {
+        // 已经是多模态数组格式，需要过滤无效图片
+        const validContent = parsed.filter(item => {
+          if (item.type === 'image_url' && item.image_url?.url) {
+            const url = item.image_url.url;
+            if (url === '[图片]' || !url.startsWith('http')) {
+              return false;
+            }
+          }
+          return true;
+        });
+        return { ...msg, content: validContent };
+      }
+      if (parsed.type === 'multimodal' && Array.isArray(parsed.content)) {
+        // { type: 'multimodal', content: [...] } 格式，需要过滤无效图片
+        const validContent = parsed.content.filter(item => {
+          if (item.type === 'image_url' && item.image_url?.url) {
+            const url = item.image_url.url;
+            if (url === '[图片]' || !url.startsWith('http')) {
+              return false;
+            }
+          }
+          return true;
+        });
+        return { ...msg, content: validContent };
+      }
+    } catch (e) {
+      // 不是 JSON，作为普通文本处理
+    }
+
+    // 检查是否包含 markdown 图片标记 ![alt](url)
+    const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
+    const images = [];
+    let match;
+    let textContent = msg.content;
+
+    while ((match = imageRegex.exec(msg.content)) !== null) {
+      const url = match[2];
+      // 跳过无效的 URL
+      if (url && (url.startsWith('http://') || url.startsWith('https://'))) {
+        images.push({
+          type: 'image_url',
+          image_url: { url }
+        });
+      }
+      // 移除图片标记，保留文本
+      textContent = textContent.replace(match[0], '').trim();
+    }
+
+    // 如果有图片，返回多模态格式
+    if (images.length > 0) {
+      const content = [];
+      if (textContent) {
+        content.push({ type: 'text', text: textContent });
+      }
+      content.push(...images);
+      return { ...msg, content };
+    }
+  }
+
+  return msg;
+}
+
+/**
+ * 基础上下文组织器
+ * 提供通用的上下文构建功能
+ */
+export class BaseContextOrganizer extends IContextOrganizer {
+  /**
+   * @param {object} expertConfig - 专家配置
+   * @param {object} options - 可选配置
+   */
+  constructor(expertConfig, options = {}) {
+    super();
+    this.expertConfig = expertConfig;
+    this.options = options;
+
+    // 从专家配置中提取 Soul
+    this.soul = this.extractSoul(expertConfig);
+  }
+
+  /**
+   * 从专家配置中提取 Soul
+   */
+  extractSoul(expertConfig) {
+    const expert = expertConfig.expert || expertConfig;
+
+    return {
+      coreValues: expert.core_values || '',
+      taboos: expert.taboos || '',
+      emotionalTone: expert.emotional_tone || '',
+      behavioralGuidelines: expert.behavioral_guidelines || '',
+      speakingStyle: expert.speaking_style || '',
+    };
+  }
+
+  /**
+   * 用当前时间戳增强系统提示
+   */
+  enhanceWithTimestamp(systemPrompt) {
+    const now = new Date();
+
+    // 格式化日期和时间（中文格式）
+    const dateString = now.toLocaleDateString('zh-CN', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      weekday: 'long',
+    });
+
+    const timeString = now.toLocaleTimeString('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+
+    const timestampPrompt = `
+## 当前时间
+现在是中国标准时间（CST, UTC+8）：
+- **日期**：${dateString}
+- **时间**：${timeString}
+
+请根据当前时间来理解和回应用户的请求。
+`;
+
+    return systemPrompt + '\n\n' + timestampPrompt;
+  }
+
+  /**
+   * 用 Soul 增强系统提示
+   */
+  enhanceWithSoul(systemPrompt, soul, expert = null) {
+    if (!soul) return systemPrompt;
+
+    const sections = [];
+
+    // 核心价值观（纯字符串）
+    if (soul.coreValues?.trim()) {
+      sections.push(`## 你的核心价值观\n${soul.coreValues.trim()}`);
+    }
+
+    // 行为准则（纯字符串）
+    if (soul.behavioralGuidelines?.trim()) {
+      sections.push(`## 你的行为准则\n${soul.behavioralGuidelines.trim()}`);
+    }
+
+    // 禁忌（纯字符串）
+    if (soul.taboos?.trim()) {
+      sections.push(`## 你的禁忌（绝对不能做的事）\n${soul.taboos.trim()}`);
+    }
+
+    // 情感基调
+    if (soul.emotionalTone?.trim()) {
+      sections.push(`## 你的情感基调\n${soul.emotionalTone.trim()}`);
+    }
+
+    // 说话风格
+    const speakingStyle = expert?.speaking_style || soul.speakingStyle;
+    if (speakingStyle?.trim()) {
+      sections.push(`## 你的说话风格\n${speakingStyle.trim()}`);
+    }
+
+    // 如果没有有效内容，直接返回原提示
+    if (sections.length === 0) return systemPrompt;
+
+    const soulPrompt = '\n\n' + sections.join('\n\n');
+    return systemPrompt + soulPrompt;
+  }
+
+  /**
+   * 用可用技能信息增强系统提示
+   */
+  enhanceWithSkills(systemPrompt, skills) {
+    if (!skills || skills.length === 0) {
+      return systemPrompt;
+    }
+
+    // 构建技能描述文本
+    const skillsDescription = skills.map(skill => {
+      // 构建工具列表描述
+      let toolsDescription = '无特定工具';
+      if (skill.tools && skill.tools.length > 0) {
+        if (typeof skill.tools[0] === 'object' && skill.tools[0].name) {
+          // tools 是对象数组，包含 name 和 description
+          toolsDescription = skill.tools.map(t => {
+            return `  - \`${t.name}\`: ${t.description || '无描述'}`;
+          }).join('\n');
+        } else {
+          // tools 是字符串数组（兼容旧格式）
+          toolsDescription = skill.tools.map(t => {
+            return `  - \`${t}\``;
+          }).join('\n');
+        }
+      }
+
+      return `- **${skill.name}**: ${skill.description || '暂无描述'}
+${toolsDescription}`;
+    }).join('\n\n');
+
+    const skillsPrompt = `
+## 你的可用技能
+你拥有以下技能，可以在合适的时候调用相关工具来完成任务：
+
+${skillsDescription}
+
+当你需要使用这些技能时，系统会自动调用相应的工具。你只需要在回复中自然地表达即可，系统会处理工具调用。
+`;
+
+    return systemPrompt + '\n\n' + skillsPrompt;
+  }
+
+  /**
+   * 用任务工作空间上下文增强系统提示
+   */
+  enhanceWithTaskContext(systemPrompt, taskContext) {
+    if (!taskContext) return systemPrompt;
+
+    // 构建文件列表描述
+    let filesDescription = '暂无文件';
+    if (taskContext.inputFiles && taskContext.inputFiles.length > 0) {
+      const fileList = taskContext.inputFiles.map(file => {
+        const sizeKB = file.isDirectory ? '-' : `${(file.size / 1024).toFixed(1)} KB`;
+        const pathInfo = file.path ? ` (路径: ${file.path})` : '';
+        return file.isDirectory ? `📁 ${file.name}/${pathInfo}` : `📄 ${file.name} (${sizeKB})${pathInfo}`;
+      }).join('\n');
+      filesDescription = fileList;
+    }
+
+    // 获取路径信息
+    const userId = taskContext.userId || 'unknown';
+    const taskId = taskContext.id;
+    const relativePath = taskContext.workspacePath || `${userId}/${taskId}`;
+    const fullPath = taskContext.fullWorkspacePath || `work/${relativePath}`;
+    const systemRoot = taskContext.systemRoot || 'work';
+
+    // 当前浏览路径描述
+    const currentPathDisplay = taskContext.currentPath
+      ? `${fullPath}/${taskContext.currentPath}`
+      : `${fullPath}/input`;
+
+    const taskPrompt = `
+## 当前任务工作空间
+
+你正在**任务工作空间模式**中。以下是当前任务的详细信息：
+
+### 任务信息
+- **任务ID**: ${taskContext.id}
+- **任务标题**: ${taskContext.title}
+${taskContext.description ? `- **任务描述**: ${taskContext.description}` : ''}
+
+### 目录结构
+\`\`\`
+${systemRoot}/                           ← 系统根目录
+└── ${userId}/                           ← 用户空间
+    └── ${taskId}/                       ← 当前任务根目录 ⭐
+        ├── input/                       ← 输入文件（用户上传）
+        ├── output/                      ← 输出文件（写入结果到这里）
+        ├── temp/                        ← 临时文件
+        └── logs/                        ← 日志
+\`\`\`
+
+### 路径信息
+- **完整路径**: ${fullPath}
+- **当前浏览**: ${currentPathDisplay}
+
+### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 读取用户文件: \`${fullPath}/input/{filename}\`
+- 写入结果文件: \`${fullPath}/output/{filename}\`
+- 临时文件: \`${fullPath}/temp/{filename}\`
+- 不确定路径时，先用 ls 命令探测确认
+- ⚠️ 注意：路径已经是相对于 data/ 的，不要再加 data/ 前缀！
+
+### 当前目录下的文件
+${filesDescription}
+`;
+
+    return systemPrompt + '\n\n' + taskPrompt;
+  }
+
+  /**
+   * 用 Topic 总结增强系统提示
+   */
+  enhanceWithTopicSummaries(systemPrompt, topicSummaries) {
+    if (!topicSummaries) return systemPrompt;
+
+    const topicPrompt = `
+## 之前的对话话题总结
+以下是你们之前讨论过的话题，帮助你了解对话历史：
+
+${topicSummaries}
+`;
+
+    return systemPrompt + '\n\n' + topicPrompt;
+  }
+
+  /**
+   * 用 RAG 检索上下文增强系统提示
+   */
+  enhanceWithRAGContext(systemPrompt, ragContext) {
+    if (!ragContext) return systemPrompt;
+
+    const ragPrompt = `
+## 相关知识库内容
+以下是从知识库中检索到的相关内容，请参考这些信息回答用户问题：
+
+${ragContext}
+`;
+
+    return systemPrompt + '\n\n' + ragPrompt;
+  }
+
+  /**
+   * 用 Inner Voices 增强系统提示
+   */
+  enhanceWithInnerVoices(systemPrompt, innerVoices) {
+    if (!innerVoices || innerVoices.length === 0) return systemPrompt;
+
+    // 分析评分趋势
+    const trend = this.analyzeTrend(innerVoices);
+
+    // 构建 Inner Voice 文本
+    let innerVoiceText = '';
+
+    // 如果趋势下降，强调 nextRoundAdvice
+    if (trend.trend === 'declining' && trend.latest?.nextRoundAdvice) {
+      innerVoiceText += `【重要提醒】最近表现有下降趋势，请注意：${trend.latest.nextRoundAdvice}\n\n`;
+    }
+
+    // 添加最近的内心独白
+    const monologues = innerVoices
+      .filter(iv => iv.monologue)
+      .map(iv => iv.monologue)
+      .join('\n');
+
+    if (monologues) {
+      innerVoiceText += `最近的内心独白：\n${monologues}`;
+    }
+
+    const innerVoicePrompt = `
+## 你的内心独白（前几轮的反思结果）
+这是你对自己之前表现的反思：
+
+${innerVoiceText}
+
+请根据这些反思调整你这一轮的回复。
+`;
+
+    return systemPrompt + '\n\n' + innerVoicePrompt;
+  }
+
+  /**
+   * 用用户信息引导提示增强系统提示
+   */
+  enhanceWithUserInfoGuidance(systemPrompt, guidance) {
+    if (!guidance) return systemPrompt;
+
+    const guidancePrompt = `
+## 对话提示
+${guidance}
+`;
+
+    return systemPrompt + '\n\n' + guidancePrompt;
+  }
+
+  /**
+   * 分析 Inner Voice 评分趋势
+   */
+  analyzeTrend(innerVoices) {
+    const scores = innerVoices
+      .filter(iv => iv.selfEvaluation?.score)
+      .map(iv => iv.selfEvaluation.score);
+
+    if (scores.length < 2) {
+      return { trend: 'stable', latest: innerVoices[0] };
+    }
+
+    const firstHalf = scores.slice(0, Math.floor(scores.length / 2));
+    const secondHalf = scores.slice(Math.floor(scores.length / 2));
+
+    const firstAvg = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length;
+    const secondAvg = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length;
+
+    const diff = secondAvg - firstAvg;
+
+    if (diff > 1) {
+      return { trend: 'improving', diff, latest: innerVoices[0] };
+    } else if (diff < -1) {
+      return { trend: 'declining', diff, latest: innerVoices[0] };
+    }
+
+    return { trend: 'stable', diff, latest: innerVoices[0] };
+  }
+
+  /**
+   * 构建用户档案上下文
+   */
+  async buildUserProfileContext(userProfile) {
+    if (!userProfile) return null;
+
+    return {
+      id: userProfile.user_id,
+      preferredName: userProfile.preferred_name,
+      nickname: userProfile.nickname,
+      email: userProfile.email,
+      gender: userProfile.gender,
+      birthday: userProfile.birthday,
+      occupation: userProfile.occupation,
+      location: userProfile.location,
+      introduction: userProfile.introduction,
+      background: userProfile.background,
+      notes: userProfile.notes,
+      firstMet: userProfile.first_met,
+      lastActive: userProfile.last_active,
+    };
+  }
+
+  /**
+   * 检查用户缺失的基本信息
+   */
+  checkMissingUserInfo(userProfile) {
+    const missing = [];
+
+    if (!userProfile?.preferredName) {
+      missing.push('称呼');
+    }
+    if (!userProfile?.gender) {
+      missing.push('性别');
+    }
+    if (!userProfile?.birthday) {
+      missing.push('年龄/生日');
+    }
+    if (!userProfile?.occupation) {
+      missing.push('职业');
+    }
+    if (!userProfile?.location) {
+      missing.push('所在地');
+    }
+
+    return missing;
+  }
+
+  /**
+   * 生成用户信息引导提示
+   */
+  generateUserInfoGuidance(userProfile, conversationCount = 0) {
+    const missing = this.checkMissingUserInfo(userProfile);
+
+    if (missing.length === 0) {
+      return null;
+    }
+
+    // 控制引导频率：每 3 轮对话最多引导一次
+    const guidanceIndex = conversationCount % 3;
+    if (guidanceIndex !== 0) {
+      return null;
+    }
+
+    // 根据对话轮次选择要引导的缺失项
+    const itemIndex = Math.floor(conversationCount / 3) % missing.length;
+    const targetItem = missing[itemIndex];
+
+    // 生成自然的引导提示
+    const guidancePrompts = {
+      '称呼': '（提示：你还不知道对方希望被怎么称呼，可以在对话中自然地询问）',
+      '性别': '（提示：你还不知道对方的性别，可以在适当时候了解）',
+      '年龄/生日': '（提示：你还不知道对方的年龄，可以在聊天中自然地了解）',
+      '职业': '（提示：你还不知道对方从事什么工作，可以在聊天中自然地了解）',
+      '所在地': '（提示：你还不知道对方在哪里，可以在聊天中自然地了解）',
+    };
+
+    return guidancePrompts[targetItem] || null;
+  }
+
+  /**
+   * 构建 LLM 消息数组
+   * @param {string} systemPrompt - 系统提示
+   * @param {Array} messages - 历史消息
+   * @param {string} currentMessage - 当前消息
+   * @param {object} options - 可选配置
+   * @param {number} options.maxToolContentLength - 工具消息内容的最大长度（默认 5000）
+   */
+  buildMessages(systemPrompt, messages, currentMessage, options = {}) {
+    const { maxToolContentLength = 5000 } = options;
+    const result = [];
+
+    // 系统提示
+    if (systemPrompt) {
+      result.push({ role: 'system', content: systemPrompt });
+    }
+
+    // 历史消息
+    for (const msg of messages) {
+      // 处理 tool 角色消息
+      if (msg.role === 'tool') {
+        let toolMetaData = null;
+        try {
+          toolMetaData = typeof msg.tool_calls === 'string'
+            ? JSON.parse(msg.tool_calls)
+            : msg.tool_calls;
+        } catch (e) {
+          toolMetaData = null;
+        }
+
+        // 智能截断工具消息内容
+        const truncatedContent = this.truncateToolContent(msg.content, maxToolContentLength);
+
+        result.push({
+          role: 'tool',
+          tool_call_id: toolMetaData?.tool_call_id || '',
+          name: toolMetaData?.name || 'unknown_tool',
+          content: truncatedContent,
+        });
+      } else {
+        // 处理普通消息
+        const processedMsg = processSingleMultimodalMessage({
+          role: msg.role,
+          content: msg.content,
+        });
+        result.push(processedMsg);
+      }
+    }
+
+    // 当前消息
+    if (currentMessage) {
+      const currentMsg = processSingleMultimodalMessage({ role: 'user', content: currentMessage });
+      result.push(currentMsg);
+    }
+
+    return result;
+  }
+
+  /**
+   * 智能截断工具消息内容
+   * 在上下文构建时根据配置截断，不影响数据库中的完整存储
+   *
+   * @param {string} content - 原始内容
+   * @param {number} maxLength - 最大长度
+   * @returns {string} 截断后的内容
+   */
+  truncateToolContent(content, maxLength = 5000) {
+    if (!content) return '';
+    
+    // 如果内容在限制内，直接返回
+    if (content.length <= maxLength) {
+      return content;
+    }
+
+    // 尝试智能截断：
+    // 1. 如果是 JSON 格式，尝试提取关键信息
+    try {
+      const parsed = JSON.parse(content);
+      
+      // 如果是对象，尝试提取摘要信息
+      if (typeof parsed === 'object' && parsed !== null) {
+        // 常见的数据结构处理
+        if (Array.isArray(parsed)) {
+          // 数组：保留前面的元素，指示总数
+          const summary = {
+            _truncated: true,
+            totalItems: parsed.length,
+            preview: parsed.slice(0, Math.min(5, Math.floor(maxLength / 200))),
+            _hint: `已截断，共 ${parsed.length} 项`
+          };
+          const summaryStr = JSON.stringify(summary, null, 2);
+          if (summaryStr.length <= maxLength) {
+            return summaryStr;
+          }
+        } else if (parsed.success !== undefined) {
+          // 工具返回格式 { success, data, error }
+          const summary = {
+            success: parsed.success,
+            error: parsed.error,
+            _truncated: true,
+            _hint: `结果已截断，原始 ${content.length} 字符`
+          };
+          
+          // 尝试保留部分 data
+          if (parsed.data) {
+            const remainingLength = maxLength - JSON.stringify(summary).length - 50;
+            if (remainingLength > 100) {
+              let dataPreview;
+              if (typeof parsed.data === 'string') {
+                dataPreview = parsed.data.substring(0, remainingLength);
+              } else if (Array.isArray(parsed.data)) {
+                dataPreview = {
+                  _items: parsed.data.length,
+                  preview: parsed.data.slice(0, 3)
+                };
+              } else {
+                const dataStr = JSON.stringify(parsed.data);
+                dataPreview = dataStr.substring(0, remainingLength);
+              }
+              summary.data = dataPreview;
+            }
+          }
+          
+          return JSON.stringify(summary, null, 2);
+        }
+      }
+    } catch (e) {
+      // 不是 JSON，继续使用简单截断
+    }
+
+    // 简单截断：保留前面部分 + 截断提示
+    return content.substring(0, maxLength - 100) +
+      `\n\n... [上下文构建时截断，原始 ${content.length} 字符]`;
+  }
+
+  /**
+   * 构建基础系统提示
+   */
+  buildBaseSystemPrompt(innerVoices = [], topicSummaries = null, userInfoGuidance = null, skills = [], taskContext = null, ragContext = null) {
+    const expert = this.expertConfig.expert || this.expertConfig;
+
+    // 基础 System Prompt
+    let systemPrompt = expert.prompt_template || expert.system_prompt || expert.introduction || '';
+
+    // 添加当前时间信息
+    systemPrompt = this.enhanceWithTimestamp(systemPrompt);
+
+    // 添加 Soul
+    systemPrompt = this.enhanceWithSoul(systemPrompt, this.soul, expert);
+
+    // 添加可用技能描述
+    if (skills && skills.length > 0) {
+      systemPrompt = this.enhanceWithSkills(systemPrompt, skills);
+    }
+
+    // 添加任务工作空间上下文
+    if (taskContext) {
+      systemPrompt = this.enhanceWithTaskContext(systemPrompt, taskContext);
+    }
+
+    // 添加 Topic 总结
+    if (topicSummaries) {
+      systemPrompt = this.enhanceWithTopicSummaries(systemPrompt, topicSummaries);
+    }
+
+    // 添加 RAG 检索上下文
+    if (ragContext) {
+      systemPrompt = this.enhanceWithRAGContext(systemPrompt, ragContext);
+    }
+
+    // 添加 Inner Voices
+    if (innerVoices.length > 0) {
+      systemPrompt = this.enhanceWithInnerVoices(systemPrompt, innerVoices);
+    }
+
+    // 添加用户信息引导提示
+    if (userInfoGuidance) {
+      systemPrompt = this.enhanceWithUserInfoGuidance(systemPrompt, userInfoGuidance);
+    }
+
+    return systemPrompt;
+  }
+}

--- a/lib/context-organizer/full-organizer.js
+++ b/lib/context-organizer/full-organizer.js
@@ -1,0 +1,172 @@
+/**
+ * Full Context Organizer - 完整上下文组织器
+ * 实现当前的上下文组织方式：
+ * - 获取全部未归档消息（不限制数量，让上下文压缩机制自动处理）
+ * - 获取最近的 Inner Voices（默认 3 条）
+ * - 获取 Topic 总结（从 topics 表加载，默认 10 个）
+ * - 构建完整的系统提示
+ */
+
+import logger from '../logger.js';
+import { BaseContextOrganizer, processSingleMultimodalMessage } from './base-organizer.js';
+import { ContextResult } from './interface.js';
+
+/**
+ * 完整上下文组织器
+ * 对应原有的 ContextManager.buildContext 实现
+ */
+export class FullContextOrganizer extends BaseContextOrganizer {
+  /**
+   * @param {object} expertConfig - 专家配置
+   * @param {object} options - 可选配置
+   * @param {number} options.innerVoiceCount - 注入的 Inner Voice 数量（默认 3）
+   * @param {number} options.topicCount - Topic 数量（默认 10）
+   * @param {number} options.maxToolContentLength - 工具消息内容的最大长度（默认 8000）
+   */
+  constructor(expertConfig, options = {}) {
+    super(expertConfig, options);
+    this.innerVoiceCount = options.innerVoiceCount || 3;
+    this.topicCount = options.topicCount || 10;
+    // Full 策略使用更长的工具内容（8000 字符）
+    this.maxToolContentLength = options.maxToolContentLength || 8000;
+  }
+
+  /**
+   * 获取策略名称
+   */
+  getName() {
+    return 'full';
+  }
+
+  /**
+   * 获取策略描述
+   */
+  getDescription() {
+    return '完整上下文组织策略：获取全部未归档消息 + 最近 Inner Voices + Topic 总结';
+  }
+
+  /**
+   * 组织上下文
+   * @param {MemorySystem} memorySystem - 记忆系统实例
+   * @param {string} userId - 用户ID
+   * @param {object} options - 组织选项
+   * @param {string} options.currentMessage - 当前用户消息
+   * @param {boolean} options.includeInnerVoices - 是否包含 Inner Voices（默认 true）
+   * @param {boolean} options.includeTopicSummaries - 是否包含 Topic 总结（默认 true）
+   * @param {Array} options.skills - 可用技能列表
+   * @param {object} options.taskContext - 任务上下文
+   * @param {string} options.ragContext - RAG 检索上下文
+   * @returns {Promise<ContextResult>}
+   */
+  async organize(memorySystem, userId, options = {}) {
+    const {
+      currentMessage = '',
+      includeInnerVoices = true,
+      includeTopicSummaries = true,
+      skills = [],
+      taskContext = null,
+      ragContext = null,
+    } = options;
+
+    logger.info(`[FullContextOrganizer] 开始组织上下文: user=${userId}`);
+
+    // 1. 确保用户档案存在
+    const userProfile = await memorySystem.getOrCreateUserProfile(userId);
+
+    // 2. 获取全部未归档消息（不限制数量，让上下文压缩机制自动处理）
+    const unarchivedMessages = await memorySystem.getUnarchivedMessages(userId, null);
+    logger.info(`[FullContextOrganizer] 获取未归档消息: ${unarchivedMessages.length} 条`);
+
+    // 3. 获取 Inner Voices
+    let innerVoices = [];
+    if (includeInnerVoices) {
+      innerVoices = await memorySystem.getRecentInnerVoices(userId, this.innerVoiceCount);
+      logger.info(`[FullContextOrganizer] 获取 Inner Voices: ${innerVoices.length} 条`);
+    }
+
+    // 4. 获取 Topic 总结
+    let topicSummaries = null;
+    if (includeTopicSummaries) {
+      topicSummaries = await this.buildTopicSummaries(memorySystem, userId);
+      logger.info(`[FullContextOrganizer] 获取 Topic 总结: ${topicSummaries ? '有' : '无'}`);
+    }
+
+    // 5. 获取用户档案背景
+    const userProfileContext = await this.buildUserProfileContext(userProfile);
+
+    // 6. 生成用户信息引导提示
+    const conversationCount = Math.floor(unarchivedMessages.length / 2);
+    const userInfoGuidance = this.generateUserInfoGuidance(userProfileContext, conversationCount);
+
+    // 7. 构建系统提示
+    const systemPrompt = this.buildBaseSystemPrompt(
+      innerVoices,
+      topicSummaries,
+      userInfoGuidance,
+      skills,
+      taskContext,
+      ragContext
+    );
+
+    // 8. 构建 LLM 消息数组（传入工具内容截断配置）
+    const messages = this.buildMessages(systemPrompt, unarchivedMessages, currentMessage, {
+      maxToolContentLength: this.maxToolContentLength,
+    });
+
+    logger.info(`[FullContextOrganizer] 上下文组织完成: messages=${messages.length}, tokens≈${Math.ceil(systemPrompt.length / 4)}`);
+
+    return new ContextResult({
+      messages,
+      systemPrompt,
+      hiddenContext: {
+        soul: this.soul,
+        innerVoices,
+        topicSummaries,
+        userProfile: userProfileContext,
+        userInfoGuidance,
+        taskContext,
+        ragContext,
+      },
+      metadata: {
+        expertId: this.expertConfig.expert?.id || this.expertConfig.id,
+        userId,
+        messageCount: unarchivedMessages.length,
+        innerVoiceCount: innerVoices.length,
+        hasTopicSummaries: !!topicSummaries,
+        hasTaskContext: !!taskContext,
+        hasRagContext: !!ragContext,
+        strategy: this.getName(),
+      },
+    });
+  }
+
+  /**
+   * 构建 Topic 总结
+   * @param {MemorySystem} memorySystem - 记忆系统实例
+   * @param {string} userId - 用户ID
+   * @returns {Promise<string|null>}
+   */
+  async buildTopicSummaries(memorySystem, userId) {
+    try {
+      // 获取最近的 Topics（按更新时间倒序，只获取 active 状态的）
+      const topics = await memorySystem.getTopics(userId, this.topicCount, 'active');
+
+      if (topics.length === 0) {
+        return null;
+      }
+
+      // 构建 Topic 总结文本（按时间正序，即最早的在前）
+      const summaryText = topics
+        .reverse()
+        .map(t => `【${t.title}】${t.description || '无描述'}`)
+        .join('\n\n');
+
+      return summaryText;
+    } catch (error) {
+      logger.warn('[FullContextOrganizer] 构建 Topic 总结失败:', error.message);
+      return null;
+    }
+  }
+}
+
+export default FullContextOrganizer;

--- a/lib/context-organizer/index.js
+++ b/lib/context-organizer/index.js
@@ -1,0 +1,112 @@
+/**
+ * Context Organizer Module - 上下文组织模块
+ * 导出所有上下文组织相关的类和接口
+ */
+
+// 接口定义
+export {
+  IContextOrganizer,
+  ContextResult,
+  ContextOrganizerFactory,
+  organizerFactory,
+} from './interface.js';
+
+// 基础组织器
+export {
+  BaseContextOrganizer,
+  processSingleMultimodalMessage,
+} from './base-organizer.js';
+
+// 完整上下文组织器
+export {
+  FullContextOrganizer,
+} from './full-organizer.js';
+
+// 简单上下文组织器
+export {
+  SimpleContextOrganizer,
+} from './simple-organizer.js';
+
+// 默认导出工厂实例
+import { organizerFactory } from './interface.js';
+import { FullContextOrganizer } from './full-organizer.js';
+import { SimpleContextOrganizer } from './simple-organizer.js';
+
+// 可用的策略列表
+const AVAILABLE_STRATEGIES = ['full', 'simple'];
+
+/**
+ * 创建上下文组织器（静态方法）
+ * @param {string} strategy - 策略名称 ('full' | 'simple')
+ * @param {object} expertConfig - 专家配置
+ * @param {object} options - 可选配置
+ * @returns {IContextOrganizer}
+ */
+export function createContextOrganizer(strategy, expertConfig, options = {}) {
+  switch (strategy) {
+    case 'full':
+      return new FullContextOrganizer(expertConfig, options);
+    case 'simple':
+      return new SimpleContextOrganizer(expertConfig, options);
+    default:
+      // 默认使用 full 策略
+      return new FullContextOrganizer(expertConfig, options);
+  }
+}
+
+/**
+ * 检查策略是否有效
+ * @param {string} strategy - 策略名称
+ * @returns {boolean}
+ */
+export function isValidStrategy(strategy) {
+  return AVAILABLE_STRATEGIES.includes(strategy);
+}
+
+/**
+ * 获取所有可用的策略
+ * @returns {Array<{name: string, description: string}>}
+ */
+export function getAvailableStrategies() {
+  return [
+    { name: 'full', description: '完整上下文组织策略：全部未归档消息 + Inner Voices + Topic 总结' },
+    { name: 'simple', description: '简单上下文组织策略：近期 10 条消息 + 5 个 Topic' },
+  ];
+}
+
+/**
+ * 扩展 ContextOrganizerFactory 类，添加静态方法
+ */
+const OriginalFactory = organizerFactory.constructor;
+
+/**
+ * 静态创建方法
+ */
+OriginalFactory.create = createContextOrganizer;
+
+/**
+ * 静态验证方法
+ */
+OriginalFactory.isValidStrategy = isValidStrategy;
+
+/**
+ * 静态获取可用策略方法
+ */
+OriginalFactory.getAvailableStrategies = getAvailableStrategies;
+
+/**
+ * 创建并注册默认的上下文组织器
+ * @param {object} expertConfig - 专家配置
+ * @returns {ContextOrganizerFactory}
+ */
+export function createOrganizerFactory(expertConfig) {
+  // 注册完整上下文组织器
+  organizerFactory.register('full', new FullContextOrganizer(expertConfig));
+
+  // 注册简单上下文组织器
+  organizerFactory.register('simple', new SimpleContextOrganizer(expertConfig));
+
+  return organizerFactory;
+}
+
+export default organizerFactory;

--- a/lib/context-organizer/interface.js
+++ b/lib/context-organizer/interface.js
@@ -1,0 +1,180 @@
+/**
+ * Context Organizer Interface - 上下文组织接口
+ * 定义上下文组织的标准接口，支持多种组织策略
+ *
+ * 架构设计：
+ * - IContextOrganizer: 接口定义
+ * - 具体实现：FullContextOrganizer（完整上下文）、SimpleContextOrganizer（简单上下文）
+ */
+
+/**
+ * 上下文组织接口
+ * 所有上下文组织策略必须实现此接口
+ */
+export class IContextOrganizer {
+  /**
+   * 组织上下文
+   * @param {MemorySystem} memorySystem - 记忆系统实例
+   * @param {string} userId - 用户ID
+   * @param {object} options - 组织选项
+   * @returns {Promise<ContextResult>} 组织后的上下文结果
+   */
+  async organize(memorySystem, userId, options = {}) {
+    throw new Error('必须实现 organize 方法');
+  }
+
+  /**
+   * 获取策略名称
+   * @returns {string} 策略名称
+   */
+  getName() {
+    throw new Error('必须实现 getName 方法');
+  }
+
+  /**
+   * 获取策略描述
+   * @returns {string} 策略描述
+   */
+  getDescription() {
+    throw new Error('必须实现 getDescription 方法');
+  }
+}
+
+/**
+ * 上下文结果结构
+ */
+export class ContextResult {
+  constructor({
+    messages = [],
+    systemPrompt = '',
+    hiddenContext = {},
+    metadata = {},
+  }) {
+    // LLM 输入消息数组
+    this.messages = messages;
+    // 系统提示词
+    this.systemPrompt = systemPrompt;
+    // 隐藏上下文（用于调试和后续处理）
+    this.hiddenContext = hiddenContext;
+    // 元数据
+    this.metadata = metadata;
+  }
+
+  /**
+   * 估算 token 数量
+   */
+  estimateTokens() {
+    let total = 0;
+
+    // 系统提示
+    if (this.systemPrompt) {
+      total += Math.ceil(this.systemPrompt.length / 4);
+    }
+
+    // 消息
+    for (const msg of this.messages || []) {
+      const contentLength = typeof msg.content === 'string'
+        ? msg.content.length
+        : JSON.stringify(msg.content).length;
+      total += Math.ceil(contentLength / 4) + 4;
+    }
+
+    return total;
+  }
+
+  /**
+   * 格式化为可读文本（用于调试）
+   */
+  format() {
+    const lines = [];
+
+    lines.push('=== System Prompt ===');
+    lines.push(this.systemPrompt?.substring(0, 1000) + '...');
+
+    if (this.hiddenContext?.soul) {
+      lines.push('\n=== Soul (隐藏) ===');
+      const soul = this.hiddenContext.soul;
+      lines.push(`核心价值观: ${soul.coreValues?.substring(0, 100) || ''}`);
+      lines.push(`情感基调: ${soul.emotionalTone || ''}`);
+    }
+
+    if (this.hiddenContext?.innerVoices?.length > 0) {
+      lines.push('\n=== Inner Voices (隐藏) ===');
+      for (const iv of this.hiddenContext.innerVoices) {
+        if (iv.selfEvaluation) {
+          lines.push(`评分: ${iv.selfEvaluation.score}/10`);
+        }
+      }
+    }
+
+    if (this.hiddenContext?.topicSummaries) {
+      lines.push('\n=== Topic Summaries ===');
+      lines.push(this.hiddenContext.topicSummaries.substring(0, 500) + '...');
+    }
+
+    lines.push('\n=== Messages ===');
+    for (const msg of this.messages || []) {
+      const preview = typeof msg.content === 'string'
+        ? msg.content.substring(0, 80)
+        : JSON.stringify(msg.content).substring(0, 80);
+      lines.push(`${msg.role}: ${preview}...`);
+    }
+
+    lines.push(`\n=== Metadata ===`);
+    lines.push(`Token 估算: ${this.estimateTokens()}`);
+    lines.push(`消息数: ${this.messages.length}`);
+
+    return lines.join('\n');
+  }
+}
+
+/**
+ * 上下文组织器工厂
+ * 用于创建和管理不同的上下文组织策略
+ */
+export class ContextOrganizerFactory {
+  constructor() {
+    this.organizers = new Map();
+  }
+
+  /**
+   * 注册上下文组织器
+   * @param {string} name - 组织器名称
+   * @param {IContextOrganizer} organizer - 组织器实例
+   */
+  register(name, organizer) {
+    this.organizers.set(name, organizer);
+  }
+
+  /**
+   * 获取上下文组织器
+   * @param {string} name - 组织器名称
+   * @returns {IContextOrganizer|null}
+   */
+  get(name) {
+    return this.organizers.get(name) || null;
+  }
+
+  /**
+   * 获取所有可用的组织器
+   * @returns {Array<{name: string, description: string}>}
+   */
+  list() {
+    return Array.from(this.organizers.entries()).map(([name, organizer]) => ({
+      name,
+      description: organizer.getDescription(),
+    }));
+  }
+
+  /**
+   * 检查组织器是否存在
+   * @param {string} name - 组织器名称
+   * @returns {boolean}
+   */
+  has(name) {
+    return this.organizers.has(name);
+  }
+}
+
+// 导出单例工厂实例
+export const organizerFactory = new ContextOrganizerFactory();

--- a/lib/context-organizer/simple-organizer.js
+++ b/lib/context-organizer/simple-organizer.js
@@ -1,0 +1,167 @@
+/**
+ * Simple Context Organizer - 简单上下文组织器
+ * 实现简单的上下文组织方式：
+ * - 获取最近 10 条消息
+ * - 获取最近 5 个 Topic 总结
+ * - 不包含 Inner Voices（减少 token 消耗）
+ * - 适用于轻量级对话场景
+ */
+
+import logger from '../logger.js';
+import { BaseContextOrganizer, processSingleMultimodalMessage } from './base-organizer.js';
+import { ContextResult } from './interface.js';
+
+/**
+ * 简单上下文组织器
+ * 轻量级策略：近期 10 条消息 + 近期 5 个 Topic
+ */
+export class SimpleContextOrganizer extends BaseContextOrganizer {
+  /**
+   * @param {object} expertConfig - 专家配置
+   * @param {object} options - 可选配置
+   * @param {number} options.messageCount - 消息数量（默认 10）
+   * @param {number} options.topicCount - Topic 数量（默认 5）
+   * @param {boolean} options.includeInnerVoices - 是否包含 Inner Voices（默认 false）
+   * @param {number} options.maxToolContentLength - 工具消息内容的最大长度（默认 3000）
+   */
+  constructor(expertConfig, options = {}) {
+    super(expertConfig, options);
+    this.messageCount = options.messageCount || 10;
+    this.topicCount = options.topicCount || 5;
+    this.includeInnerVoices = options.includeInnerVoices || false;
+    // Simple 策略使用较短的工具内容（3000 字符），保持上下文简洁
+    this.maxToolContentLength = options.maxToolContentLength || 3000;
+  }
+
+  /**
+   * 获取策略名称
+   */
+  getName() {
+    return 'simple';
+  }
+
+  /**
+   * 获取策略描述
+   */
+  getDescription() {
+    return `简单上下文组织策略：最近 ${this.messageCount} 条消息 + 最近 ${this.topicCount} 个 Topic 总结`;
+  }
+
+  /**
+   * 组织上下文
+   * @param {MemorySystem} memorySystem - 记忆系统实例
+   * @param {string} userId - 用户ID
+   * @param {object} options - 组织选项
+   * @param {string} options.currentMessage - 当前用户消息
+   * @param {Array} options.skills - 可用技能列表
+   * @param {object} options.taskContext - 任务上下文
+   * @param {string} options.ragContext - RAG 检索上下文
+   * @returns {Promise<ContextResult>}
+   */
+  async organize(memorySystem, userId, options = {}) {
+    const {
+      currentMessage = '',
+      skills = [],
+      taskContext = null,
+      ragContext = null,
+    } = options;
+
+    logger.info(`[SimpleContextOrganizer] 开始组织上下文: user=${userId}`);
+
+    // 1. 确保用户档案存在
+    const userProfile = await memorySystem.getOrCreateUserProfile(userId);
+
+    // 2. 获取最近 N 条未归档消息（与 FullContextOrganizer 保持一致）
+    const recentMessages = await memorySystem.getUnarchivedMessages(userId, this.messageCount);
+    logger.info(`[SimpleContextOrganizer] 获取最近未归档消息: ${recentMessages.length} 条`);
+
+    // 3. 获取 Inner Voices（可选，默认不获取）
+    let innerVoices = [];
+    if (this.includeInnerVoices) {
+      innerVoices = await memorySystem.getRecentInnerVoices(userId, 2);
+      logger.info(`[SimpleContextOrganizer] 获取 Inner Voices: ${innerVoices.length} 条`);
+    }
+
+    // 4. 获取最近 N 个 Topic 总结
+    const topicSummaries = await this.buildTopicSummaries(memorySystem, userId);
+    logger.info(`[SimpleContextOrganizer] 获取 Topic 总结: ${topicSummaries ? '有' : '无'}`);
+
+    // 5. 获取用户档案背景
+    const userProfileContext = await this.buildUserProfileContext(userProfile);
+
+    // 6. 生成用户信息引导提示（简单模式下减少引导频率）
+    const conversationCount = Math.floor(recentMessages.length / 2);
+    const userInfoGuidance = this.generateUserInfoGuidance(userProfileContext, conversationCount);
+
+    // 7. 构建系统提示
+    const systemPrompt = this.buildBaseSystemPrompt(
+      innerVoices,
+      topicSummaries,
+      userInfoGuidance,
+      skills,
+      taskContext,
+      ragContext
+    );
+
+    // 8. 构建 LLM 消息数组（传入工具内容截断配置）
+    const messages = this.buildMessages(systemPrompt, recentMessages, currentMessage, {
+      maxToolContentLength: this.maxToolContentLength,
+    });
+
+    logger.info(`[SimpleContextOrganizer] 上下文组织完成: messages=${messages.length}, tokens≈${Math.ceil(systemPrompt.length / 4)}`);
+
+    return new ContextResult({
+      messages,
+      systemPrompt,
+      hiddenContext: {
+        soul: this.soul,
+        innerVoices,
+        topicSummaries,
+        userProfile: userProfileContext,
+        userInfoGuidance,
+        taskContext,
+        ragContext,
+      },
+      metadata: {
+        expertId: this.expertConfig.expert?.id || this.expertConfig.id,
+        userId,
+        messageCount: recentMessages.length,
+        innerVoiceCount: innerVoices.length,
+        hasTopicSummaries: !!topicSummaries,
+        hasTaskContext: !!taskContext,
+        hasRagContext: !!ragContext,
+        strategy: this.getName(),
+      },
+    });
+  }
+
+  /**
+   * 构建 Topic 总结
+   * @param {MemorySystem} memorySystem - 记忆系统实例
+   * @param {string} userId - 用户ID
+   * @returns {Promise<string|null>}
+   */
+  async buildTopicSummaries(memorySystem, userId) {
+    try {
+      // 获取最近的 Topics（按更新时间倒序，只获取 active 状态的）
+      const topics = await memorySystem.getTopics(userId, this.topicCount, 'active');
+
+      if (topics.length === 0) {
+        return null;
+      }
+
+      // 构建 Topic 总结文本（按时间正序，即最早的在前）
+      const summaryText = topics
+        .reverse()
+        .map(t => `【${t.title}】${t.description || '无描述'}`)
+        .join('\n\n');
+
+      return summaryText;
+    } catch (error) {
+      logger.warn('[SimpleContextOrganizer] 构建 Topic 总结失败:', error.message);
+      return null;
+    }
+  }
+}
+
+export default SimpleContextOrganizer;

--- a/lib/db.js
+++ b/lib/db.js
@@ -572,7 +572,7 @@ class Database {
   async createTopic(topicData) {
     const {
       id, expertId, userId, name, description,
-      category, startTime, endTime
+      category, startTime, endTime, status
     } = topicData;
 
     return await this.models.topic.create({
@@ -582,18 +582,32 @@ class Database {
       title: name,
       description,
       category,
+      status: status || 'active',  // 默认 active
+      start_time: startTime || new Date(),
+      end_time: endTime || new Date(),
     });
   }
 
   /**
    * 获取用户的 Topics（支持不同签名）
+   * @param {string} expertId - 专家ID
+   * @param {string} userId - 用户ID
+   * @param {number} limit - 数量限制
+   * @param {string} status - 状态过滤（默认 'active'，传 null 表示不过滤）
    */
-  async getTopicsByExpertAndUser(expertId, userId, limit = 10) {
+  async getTopicsByExpertAndUser(expertId, userId, limit = 10, status = 'active') {
+    const where = {
+      expert_id: expertId,
+      user_id: userId,
+    };
+
+    // 如果指定了状态，添加状态过滤
+    if (status) {
+      where.status = status;
+    }
+
     return await this.models.topic.findAll({
-      where: {
-        expert_id: expertId,
-        user_id: userId,
-      },
+      where,
       attributes: ['id', 'expert_id', 'user_id', 'title', 'description', 'category', 'status', 'message_count', 'created_at', 'updated_at'],
       order: [['updated_at', 'DESC']],
       limit,

--- a/lib/memory-system.js
+++ b/lib/memory-system.js
@@ -203,10 +203,11 @@ class MemorySystem {
    * 获取用户的 Topics
    * @param {string} userId - 用户ID
    * @param {number} limit - 数量限制
+   * @param {string} status - 状态过滤（默认 'active'，传 null 表示不过滤）
    * @returns {Promise<Array>} Topic 列表
    */
-  async getTopics(userId, limit = 10) {
-    return await this.db.getTopicsByExpertAndUser(this.expertId, userId, limit);
+  async getTopics(userId, limit = 10, status = 'active') {
+    return await this.db.getTopicsByExpertAndUser(this.expertId, userId, limit, status);
   }
 
   /**
@@ -417,7 +418,19 @@ class MemorySystem {
       for (const topic of topics) {
         const topicId = this.generateTopicId();
 
-        // 创建 Topic
+        // 获取该话题的消息
+        const topicMessages = unarchivedMessages.slice(topic.startIndex, topic.endIndex + 1);
+        const messageIds = topicMessages.map(m => m.id);
+
+        // 计算话题的时间范围
+        const startTime = topicMessages.length > 0 
+          ? new Date(topicMessages[0].timestamp) 
+          : new Date();
+        const endTime = topicMessages.length > 0 
+          ? new Date(topicMessages[topicMessages.length - 1].timestamp) 
+          : new Date();
+
+        // 创建 Topic（显式设置 status 和时间边界）
         await this.db.createTopic({
           id: topicId,
           expertId: this.expertId,
@@ -425,12 +438,12 @@ class MemorySystem {
           name: topic.title,
           description: topic.summary,
           category: topic.category || 'general',
+          status: 'active',  // 显式设置状态
+          startTime,
+          endTime,
         });
 
-        // 获取该话题的消息 ID
-        const messageIds = unarchivedMessages
-          .slice(topic.startIndex, topic.endIndex + 1)
-          .map(m => m.id);
+        logger.debug(`[MemorySystem] 创建话题: ${topic.title}, 时间范围: ${startTime.toISOString()} ~ ${endTime.toISOString()}`);
 
         // 关联消息到 Topic
         if (messageIds.length > 0) {
@@ -670,8 +683,8 @@ ${conversationText}
       logger.debug(`[MemorySystem] 归档时间范围: ${new Date(lastMsg.timestamp).toISOString()} ~ ${new Date(firstMsg.timestamp).toISOString()}`);
       logger.debug(`[MemorySystem] 最旧消息ID: ${lastMsg.id}, 最新归档消息ID: ${firstMsg.id}`);
 
-      // 6. 匹配或创建 Topic
-      const existingTopics = await this.getTopics(userId, 5);
+      // 6. 匹配或创建 Topic（只匹配 active 状态的 Topic）
+      const existingTopics = await this.getTopics(userId, 5, 'active');
       const topicResult = await this.matchOrCreateTopic(summary, existingTopics);
 
       // 7. 执行归档

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -1016,6 +1016,22 @@ const MIGRATIONS = [
       `);
     }
   },
+
+  // ==================== 上下文组织策略 (Issue #154) ====================
+  
+  // 41. experts.context_strategy 字段
+  {
+    name: 'experts.context_strategy column',
+    check: async (conn) => await hasColumn(conn, 'experts', 'context_strategy'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE experts
+        ADD COLUMN context_strategy ENUM('full', 'simple') DEFAULT 'full'
+        COMMENT '上下文组织策略：full=完整上下文，simple=简单上下文（近期10条消息+5个Topic）'
+        AFTER context_threshold
+      `);
+    }
+  },
 ];
 
 /**


### PR DESCRIPTION
## 变更摘要

实现上下文组织接口与策略模式，支持多种上下文组织方式。

## 主要变更

### 1. 上下文组织接口
- 创建 `IContextOrganizer` 接口定义
- 创建 `ContextResult` 类封装结果
- 创建 `ContextOrganizerFactory` 工厂类

### 2. 策略实现
- `FullContextOrganizer`: 完整上下文策略（原有逻辑）
- `SimpleContextOrganizer`: 简单上下文策略（近期10条消息+5个topic）

### 3. 重构
- `ContextManager` 委托给策略工厂
- 消除重复代码

### 4. 数据库
- 添加 `experts.context_strategy` 字段

### 5. 前端
- 策略选择下拉框
- i18n 翻译

### 6. 工具调用优化
- 存储层：完整保存工具结果（不再截断）
- 上下文层：智能截断（可配置阈值）

### 7. 设计文档
- 工具消息摘要方案（Issue #155）

## 测试

- [x] 代码自审
- [x] 功能测试

Closes #154