### PR TITLE
feat: 工具调用上下文优化 - 摘要+按需获取

### DIFF
--- a/data/skills/message-reader/SKILL.md
+++ b/data/skills/message-reader/SKILL.md
@@ -1,0 +1,48 @@
+# Message Reader Skill
+
+提供消息内容检索能力，用于上下文优化中的按需获取。
+
+## 功能说明
+
+当工具消息被摘要后，AI 可以通过此技能获取完整消息内容。
+
+## 工具列表
+
+### get_message_content
+
+获取指定工具消息的完整内容。
+
+**参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| tool_call_id | string | 是 | 工具调用 ID，从上下文摘要中获取 |
+
+**返回值：**
+
+```json
+{
+  "success": true,
+  "tool_call_id": "call_xxx",
+  "tool_name": "search",
+  "content": "完整的消息内容...",
+  "content_length": 1234,
+  "created_at": "2026-03-15T12:00:00.000Z"
+}
+```
+
+## 使用场景
+
+在 Simple 上下文策略中，工具消息会被摘要为：
+
+```
+search → 1234 字符 | get_message_content("call_xxx")
+```
+
+AI 看到此提示后，可以调用 `get_message_content` 工具获取完整结果。
+
+## 技术说明
+
+- 使用 `tool_call_id` 作为消息唯一标识
+- 查询 `messages` 表中 `role='tool'` 的消息
+- `tool_call_id` 存储在 `tool_calls` 字段的 JSON 中

--- a/data/skills/message-reader/index.js
+++ b/data/skills/message-reader/index.js
@@ -1,0 +1,112 @@
+/**
+ * Message Reader Skill
+ * 提供消息内容检索能力，用于上下文优化中的按需获取
+ * 
+ * 使用场景：
+ * - 当工具消息被摘要后，AI 可以通过此技能获取完整消息内容
+ * - 通过 tool_call_id 检索特定的 tool 角色消息
+ */
+
+const logger = require('../../../lib/logger.js');
+const db = require('../../../lib/db.js');
+
+/**
+ * 工具定义
+ */
+const tools = {
+  get_message_content: {
+    description: '获取指定工具消息的完整内容。当你在上下文中看到类似 "get_message_content("xxx")" 的提示时，可以使用此工具获取完整结果。',
+    parameters: {
+      type: 'object',
+      properties: {
+        tool_call_id: {
+          type: 'string',
+          description: '工具调用 ID，从上下文摘要中获取',
+        },
+      },
+      required: ['tool_call_id'],
+    },
+  },
+};
+
+/**
+ * 获取消息内容
+ * @param {Object} params - 参数
+ * @param {string} params.tool_call_id - 工具调用 ID
+ * @param {Object} context - 上下文
+ * @returns {Promise<Object>} 消息内容
+ */
+async function get_message_content(params, context) {
+  const { tool_call_id } = params;
+
+  if (!tool_call_id) {
+    return {
+      success: false,
+      error: '缺少 tool_call_id 参数',
+    };
+  }
+
+  try {
+    // 通过 tool_call_id 查询消息
+    // tool_call_id 存储在 tool_calls 字段中（JSON 格式）
+    const messages = await db.query(`
+      SELECT id, role, content, tool_calls, created_at
+      FROM messages
+      WHERE role = 'tool' 
+        AND JSON_EXTRACT(tool_calls, '$.tool_call_id') = ?
+      ORDER BY created_at DESC
+      LIMIT 1
+    `, [tool_call_id]);
+
+    if (!messages || messages.length === 0) {
+      return {
+        success: false,
+        error: `未找到 tool_call_id="${tool_call_id}" 的消息`,
+      };
+    }
+
+    const message = messages[0];
+
+    logger.info(`[message-reader] 检索到消息: id=${message.id}, content_length=${message.content?.length || 0}`);
+
+    return {
+      success: true,
+      tool_call_id,
+      tool_name: JSON.parse(message.tool_calls || '{}').name || 'unknown',
+      content: message.content,
+      content_length: message.content?.length || 0,
+      created_at: message.created_at,
+    };
+  } catch (error) {
+    logger.error('[message-reader] Error retrieving message:', error.message);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+/**
+ * 执行工具
+ * @param {string} toolName - 工具名称
+ * @param {Object} params - 参数
+ * @param {Object} context - 上下文
+ * @returns {Promise<Object>} 执行结果
+ */
+async function execute(toolName, params, context = {}) {
+  switch (toolName) {
+    case 'get_message_content':
+      return await get_message_content(params, context);
+    default:
+      return {
+        success: false,
+        error: `Unknown tool: ${toolName}`,
+      };
+  }
+}
+
+module.exports = {
+  execute,
+  get_message_content,
+  tools,
+};

--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -13,6 +13,37 @@
 import logger from './logger.js';
 import { ContextOrganizerFactory } from './context-organizer/index.js';
 
+/**
+ * 处理单条多模态消息
+ * 如果内容是 JSON 字符串且包含多模态结构，则解析为标准格式
+ * @param {Object} msg - 消息对象 { role, content }
+ * @returns {Object} 处理后的消息
+ */
+function processSingleMultimodalMessage(msg) {
+  if (!msg.content) {
+    return { role: msg.role, content: '' };
+  }
+
+  // 如果已经是数组格式，直接返回
+  if (Array.isArray(msg.content)) {
+    return { role: msg.role, content: msg.content };
+  }
+
+  // 尝试解析 JSON
+  if (typeof msg.content === 'string' && msg.content.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(msg.content);
+      if (Array.isArray(parsed)) {
+        return { role: msg.role, content: parsed };
+      }
+    } catch (e) {
+      // 解析失败，保持原样
+    }
+  }
+
+  return { role: msg.role, content: msg.content };
+}
+
 class ContextManager {
   /**
    * @param {object} expertConfig - 专家配置（从数据库加载）
@@ -87,6 +118,106 @@ class ContextManager {
       hiddenContext: result.hiddenContext,
       metadata: result.metadata,
     };
+  }
+
+  /**
+   * 生成工具消息摘要
+   * 根据 tool_call_id 和工具信息生成简洁的摘要
+   * @param {Object} options - 选项
+   * @param {string} options.toolCallId - 工具调用 ID
+   * @param {string} options.toolName - 工具名称
+   * @param {string} options.content - 工具结果内容
+   * @param {string} options.strategy - 上下文策略 ('full' | 'simple')
+   * @returns {string} 摘要文本
+   */
+  buildToolMessageSummary(options) {
+    const { toolCallId, toolName, content, strategy = 'full' } = options;
+    const contentLength = content?.length || 0;
+    
+    if (strategy === 'simple') {
+      // Simple 策略：极简摘要
+      return `${toolName} → ${contentLength} 字符 | get_message_content("${toolCallId}")`;
+    }
+    
+    // Full 策略：详细摘要
+    return `工具: ${toolName}
+结果: ${contentLength} 字符
+→ 调用 get_message_content("${toolCallId}") 获取完整结果`;
+  }
+
+  /**
+   * 构建 LLM 消息数组
+   * @param {string} systemPrompt - 系统提示
+   * @param {Array} recentMessages - 历史消息（必须是 ASC 顺序，即旧→新）
+   * @param {string} currentMessage - 当前用户消息
+   * @param {Object} options - 可选配置
+   * @param {boolean} options.summarizeToolMessages - 是否对工具消息生成摘要（默认 false）
+   * @param {string} options.strategy - 上下文策略 ('full' | 'simple')
+   */
+  buildMessages(systemPrompt, recentMessages, currentMessage, options = {}) {
+    const { summarizeToolMessages = false, strategy = 'full' } = options;
+    const messages = [];
+
+    // 系统提示
+    if (systemPrompt) {
+      messages.push({ role: 'system', content: systemPrompt });
+    }
+
+    // 历史消息（按时间正序：旧→新）
+    // getUnarchivedMessages 返回 ASC 顺序，直接使用
+    // 需要处理多模态格式和 tool 角色消息
+    for (const msg of recentMessages) {
+      // 处理 tool 角色消息（OpenAI API 格式）
+      if (msg.role === 'tool') {
+        // 从 tool_calls 字段解析元数据
+        let toolMetaData = null;
+        try {
+          toolMetaData = typeof msg.tool_calls === 'string' 
+            ? JSON.parse(msg.tool_calls) 
+            : msg.tool_calls;
+        } catch (e) {
+          // 解析失败，使用默认值
+          toolMetaData = null;
+        }
+        
+        const toolCallId = toolMetaData?.tool_call_id || '';
+        const toolName = toolMetaData?.name || 'unknown_tool';
+        
+        // 决定是生成摘要还是使用完整内容
+        let content = msg.content || '';
+        if (summarizeToolMessages && toolCallId) {
+          content = this.buildToolMessageSummary({
+            toolCallId,
+            toolName,
+            content: msg.content,
+            strategy
+          });
+        }
+        
+        // 构建 OpenAI 格式的 tool 消息
+        messages.push({
+          role: 'tool',
+          tool_call_id: toolCallId,
+          name: toolName,
+          content,
+        });
+      } else {
+        // 处理普通消息（user、assistant）
+        const processedMsg = processSingleMultimodalMessage({
+          role: msg.role,
+          content: msg.content,
+        });
+        messages.push(processedMsg);
+      }
+    }
+
+    // 当前消息（需要处理多模态格式）
+    if (currentMessage) {
+      const currentMsg = processSingleMultimodalMessage({ role: 'user', content: currentMessage });
+      messages.push(currentMsg);
+    }
+
+    return messages;
   }
 
   /**


### PR DESCRIPTION
## Summary

实现工具调用上下文优化：摘要 + 按需获取模式

### 主要变更

1. **[`lib/context-manager.js`](lib/context-manager.js)**
   - 新增 `buildToolMessageSummary()` 方法
   - 新增 `buildMessages()` 方法
   - 支持 full/simple 两种摘要策略

2. **[`data/skills/message-reader/`](data/skills/message-reader/)**
   - 新增技能：`get_message_content` 工具
   - 通过 `tool_call_id` 检索完整消息内容
   - 使用 CommonJS 格式（VM 沙箱兼容）

### 技术设计

```javascript
// 工具消息摘要格式
const summary = `工具: ${toolName}
结果: ${contentLength} 字符
→ 调用 get_message_content("${toolCallId}") 获取完整结果`;
```

## Test plan

- [ ] 验证 `message-reader` 技能可正常加载
- [ ] 验证 `get_message_content` 工具可检索消息
- [ ] 验证工具消息摘要功能

Closes #155