### PR TITLE
#159: fix 用户消息在 LLM request 中重复出现

### DIFF
--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -558,9 +558,20 @@ ${guidance}
     }
 
     // 当前消息
+    // 注意：如果历史消息的最后一条已经是当前用户消息（因为消息已保存到数据库），
+    // 则不再重复添加，避免消息重复
     if (currentMessage) {
-      const currentMsg = processSingleMultimodalMessage({ role: 'user', content: currentMessage });
-      result.push(currentMsg);
+      const lastMsg = result[result.length - 1];
+      const isAlreadyIncluded = lastMsg?.role === 'user' &&
+        (lastMsg?.content === currentMessage ||
+         JSON.stringify(lastMsg?.content) === JSON.stringify(currentMessage));
+      
+      if (!isAlreadyIncluded) {
+        const currentMsg = processSingleMultimodalMessage({ role: 'user', content: currentMessage });
+        result.push(currentMsg);
+      } else {
+        logger.debug('[BaseContextOrganizer] 当前消息已存在于历史消息中，跳过重复添加');
+      }
     }
 
     return result;


### PR DESCRIPTION
## 问题描述

Closes #159

在发送给 LLM 的 request 中，最新一条用户消息被拼接了两次。

## 问题原因

消息处理流程：

1. `chat-service.js:166` 先将用户消息保存到数据库
2. `chat-service.js:194` 构建 LLM 上下文时传入 `content` 作为 `currentMessage`
3. `full-organizer.js:77` 调用 `getUnarchivedMessages` 加载未归档消息，包含刚保存的用户消息
4. `base-organizer.js:560-564` 又将 `currentMessage` 添加到消息列表末尾

导致最新用户消息在 messages 数组中出现两次。

## 修复方案

在 `buildMessages` 方法中添加检查逻辑：如果历史消息的最后一条已经是当前用户消息，则跳过重复添加。

## 测试验证

- [x] npm run lint 通过
- [ ] 发送新消息后检查 LLM request 中的 messages 数组
- [ ] 确认用户消息只出现一次