### PR TITLE
#161: fix tool_call_id 为空的问题

### DIFF
--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -795,8 +795,9 @@ class LLMClient {
                 if (!toolCallsSent) {
                   const finalToolCalls = Object.values(accumulatedToolCalls)
                     .sort((a, b) => a.index - b.index)
-                    .map(tc => ({
-                      id: tc.id,
+                    .map((tc, i) => ({
+                      // 如果 LLM 没有返回 id，生成一个唯一的 tool_call_id
+                      id: tc.id || `tool_call_${Date.now()}_${i}`,
                       type: tc.type || 'function',
                       function: {
                         name: tc.function?.name || '',
@@ -881,10 +882,11 @@ class LLMClient {
           // 使用 toolCallsSent 标记防止重复发送
           if (!toolCallsSent) {
             const finalToolCalls = Object.values(accumulatedToolCalls)
-              .filter(tc => tc.id && tc.function?.name)  // 确保是完整的工具调用
+              .filter(tc => tc.function?.name)  // 确保有工具名称
               .sort((a, b) => a.index - b.index)
-              .map(tc => ({
-                id: tc.id,
+              .map((tc, i) => ({
+                // 如果 LLM 没有返回 id，生成一个唯一的 tool_call_id
+                id: tc.id || `tool_call_${Date.now()}_${i}`,
                 type: tc.type || 'function',
                 function: {
                   name: tc.function?.name || '',


### PR DESCRIPTION
## 问题描述

Closes #161

在上下文中，部分 tool 消息的 `tool_call_id` 是空的：

```json
{
  "role": "tool",
  "tool_call_id": "",
  "name": "unknown_tool",
  "content": "{\"success\":true,\"data\":{...}}"
}
```

## 问题原因

某些 LLM 提供商（如本地部署的开源模型）在返回工具调用时可能不包含 `id` 字段。

## 修复方案

在 [`llm-client.js`](lib/llm-client.js) 的流式响应处理中，如果 LLM 没有返回 `id`，则生成一个唯一的 `tool_call_id`：

```javascript
.map((tc, i) => ({
  // 如果 LLM 没有返回 id，生成一个唯一的 tool_call_id
  id: tc.id || `tool_call_${Date.now()}_${i}`,
  // ...
}))
```

## 测试验证

- [x] npm run lint 通过
- [ ] 使用不返回 tool_call.id 的模型测试
- [ ] 确认 tool_call_id 正确生成