### PR TITLE
#163: fix 上下文中 tool_call_id 使用消息主键 ID

### DIFF
--- a/data/skills/message-reader/index.js
+++ b/data/skills/message-reader/index.js
@@ -47,25 +47,30 @@ async function get_message_content(params, context) {
   }
 
   try {
-    // 通过 tool_call_id 查询消息
-    // tool_call_id 存储在 tool_calls 字段中（JSON 格式）
+    // tool_call_id 现在是消息主键 ID，直接用 ID 查询
     const messages = await db.query(`
       SELECT id, role, content, tool_calls, created_at
       FROM messages
-      WHERE role = 'tool' 
-        AND JSON_EXTRACT(tool_calls, '$.tool_call_id') = ?
-      ORDER BY created_at DESC
+      WHERE id = ?
       LIMIT 1
     `, [tool_call_id]);
 
     if (!messages || messages.length === 0) {
       return {
         success: false,
-        error: `未找到 tool_call_id="${tool_call_id}" 的消息`,
+        error: `未找到 id="${tool_call_id}" 的消息`,
       };
     }
 
     const message = messages[0];
+
+    // 验证消息角色
+    if (message.role !== 'tool') {
+      return {
+        success: false,
+        error: `消息 id="${tool_call_id}" 不是工具消息 (role=${message.role})`,
+      };
+    }
 
     logger.info(`[message-reader] 检索到消息: id=${message.id}, content_length=${message.content?.length || 0}`);
 

--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -180,7 +180,8 @@ class ContextManager {
           toolMetaData = null;
         }
         
-        const toolCallId = toolMetaData?.tool_call_id || '';
+        // 使用消息主键 ID 作为 tool_call_id（用于 OpenAI API 格式）
+        const toolCallId = msg.id;
         const toolName = toolMetaData?.name || 'unknown_tool';
         
         // 决定是生成摘要还是使用完整内容

--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -543,7 +543,7 @@ ${guidance}
 
         result.push({
           role: 'tool',
-          tool_call_id: toolMetaData?.tool_call_id || '',
+          tool_call_id: msg.id,  // 使用消息主键 ID 作为 tool_call_id
           name: toolMetaData?.name || 'unknown_tool',
           content: truncatedContent,
         });


### PR DESCRIPTION
## 关联 Issue

Closes #163

## 修改内容

### 问题原因
上下文组装时，`tool_call_id` 字段为空，原因是代码试图从 `tool_calls` JSON 字段中解析 `tool_call_id`，但实际应该使用消息表的主键 `id` 字段。

### 解决方案

修改以下文件，使用消息主键 `id` 作为 `tool_call_id`：

1. **`lib/context-organizer/base-organizer.js`** - 上下文组织器
   - 将 `tool_call_id: toolMetaData?.tool_call_id || ''` 改为 `tool_call_id: msg.id`

2. **`lib/context-manager.js`** - 上下文管理器
   - 将 `const toolCallId = toolMetaData?.tool_call_id || ''` 改为 `const toolCallId = msg.id`

3. **`data/skills/message-reader/index.js`** - 消息读取技能
   - 查询方式从 `JSON_EXTRACT(tool_calls, '$.tool_call_id')` 改为直接用主键 `WHERE id = ?`

## 影响范围

- 工具消息的上下文组装
- `get_message_content` 技能的消息检索

## 测试验证

- [ ] 验证工具调用后上下文中 `tool_call_id` 正确填充
- [ ] 验证 `get_message_content` 技能能正确检索消息