### PR TITLE
#180: feat 创建 InternalLLMService 用于内部 LLM 调用

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -18,6 +18,7 @@ import ReflectiveMind from './reflective-mind.js';
 import ToolManager from './tool-manager.js';
 import TopicDetector from './topic-detector.js';
 import RAGService from './rag-service.js';
+import InternalLLMService from './internal-llm-service.js';
 import logger from './logger.js';
 import Utils from './utils.js';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
@@ -837,7 +838,9 @@ class ChatService {
     }
 
     // 3. 使用 TopicDetector 检测是否需要切换话题
-    const topicDetector = new TopicDetector(expertService.llmClient);
+    // 使用 InternalLLMService 进行检测（不依赖专家人设）
+    const internalLLM = new InternalLLMService(this.db);
+    const topicDetector = new TopicDetector(internalLLM, { expertId: expert_id });
     const detectionResult = await topicDetector.detectTopicShift({
       currentTopicTitle: currentTopic.title,
       currentTopicDescription: currentTopic.description,

--- a/lib/internal-llm-service.js
+++ b/lib/internal-llm-service.js
@@ -1,0 +1,413 @@
+/**
+ * Internal LLM Service
+ * 提供轻量级的 LLM 调用能力，用于内部判断任务
+ * 
+ * 特点：
+ * - 不依赖专家人设
+ * - 使用反思模型配置（低温度，更确定的输出）
+ * - 支持 JSON 输出格式
+ * - 支持 Schema 校验
+ */
+
+import https from 'https';
+import http from 'http';
+import logger from './logger.js';
+
+class InternalLLMService {
+  /**
+   * @param {Database} db - 数据库实例
+   * @param {Object} options - 配置选项
+   * @param {number} options.defaultTemperature - 默认温度（默认 0.3）
+   * @param {number} options.maxRetries - 最大重试次数（默认 3）
+   * @param {number} options.timeout - 请求超时时间（毫秒，默认 90000）
+   */
+  constructor(db, options = {}) {
+    this.db = db;
+    this.defaultTemperature = options.defaultTemperature ?? 0.3;
+    this.maxRetries = options.maxRetries ?? 3;
+    this.timeout = options.timeout ?? 90000;
+    this.modelCache = new Map();
+  }
+
+  /**
+   * 获取模型配置（优先使用反思模型）
+   * @param {string} expertId - 专家ID
+   * @returns {Promise<Object>} 模型配置
+   */
+  async getModelConfig(expertId) {
+    // 检查缓存
+    const cacheKey = `expert:${expertId}`;
+    if (this.modelCache.has(cacheKey)) {
+      return this.modelCache.get(cacheKey);
+    }
+
+    // 从数据库获取专家配置
+    const expert = await this.db.getExpert(expertId);
+    if (!expert) {
+      throw new Error(`Expert not found: ${expertId}`);
+    }
+
+    // 优先使用反思模型，如果没有则使用表达模型
+    const modelId = expert.reflective_model_id || expert.expressive_model_id;
+    if (!modelId) {
+      throw new Error(`No model configured for expert: ${expertId}`);
+    }
+
+    const modelConfig = await this.db.getModelConfig(modelId);
+    if (!modelConfig) {
+      throw new Error(`Model not found: ${modelId}`);
+    }
+
+    // 缓存配置
+    this.modelCache.set(cacheKey, modelConfig);
+    return modelConfig;
+  }
+
+  /**
+   * 直接通过模型ID获取模型配置
+   * @param {string} modelId - 模型ID
+   * @returns {Promise<Object>} 模型配置
+   */
+  async getModelConfigById(modelId) {
+    const cacheKey = `model:${modelId}`;
+    if (this.modelCache.has(cacheKey)) {
+      return this.modelCache.get(cacheKey);
+    }
+
+    const modelConfig = await this.db.getModelConfig(modelId);
+    if (!modelConfig) {
+      throw new Error(`Model not found: ${modelId}`);
+    }
+
+    this.modelCache.set(cacheKey, modelConfig);
+    return modelConfig;
+  }
+
+  /**
+   * 执行判断任务（JSON 输出）
+   * @param {string} systemPrompt - 系统提示词
+   * @param {string} userPrompt - 用户输入
+   * @param {Object} options - 可选配置
+   * @param {string} options.expertId - 专家ID（用于获取模型配置）
+   * @param {string} options.modelId - 模型ID（直接指定模型）
+   * @param {number} options.temperature - 温度（默认 0.3）
+   * @param {Object} options.schema - 输出 Schema（用于文档说明）
+   * @param {*} options.defaultValue - 解析失败时的默认返回值
+   * @returns {Promise<Object>} 解析后的 JSON 结果
+   */
+  async judge(systemPrompt, userPrompt, options = {}) {
+    const { expertId, modelId, temperature = this.defaultTemperature, schema, defaultValue } = options;
+
+    // 获取模型配置
+    let model;
+    if (modelId) {
+      model = await this.getModelConfigById(modelId);
+    } else if (expertId) {
+      model = await this.getModelConfig(expertId);
+    } else {
+      throw new Error('Either expertId or modelId must be provided');
+    }
+
+    // 构建消息
+    const messages = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+
+    try {
+      // 调用 LLM
+      const response = await this.callWithRetry(model, messages, {
+        temperature,
+        response_format: { type: 'json_object' },
+      });
+
+      // 解析 JSON
+      const result = this.parseJSON(response.content);
+
+      // Schema 校验（如果提供）
+      if (schema && result !== null) {
+        this.validateSchema(result, schema);
+      }
+
+      return result;
+    } catch (error) {
+      logger.error('[InternalLLMService] judge 失败:', error.message);
+
+      // 如果有默认值，返回默认值
+      if (defaultValue !== undefined) {
+        logger.warn('[InternalLLMService] 使用默认值:', JSON.stringify(defaultValue));
+        return defaultValue;
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * 执行简单的文本生成任务
+   * @param {string} systemPrompt - 系统提示词
+   * @param {string} userPrompt - 用户输入
+   * @param {Object} options - 可选配置
+   * @returns {Promise<string>} 生成的文本
+   */
+  async generate(systemPrompt, userPrompt, options = {}) {
+    const { expertId, modelId, temperature = this.defaultTemperature } = options;
+
+    // 获取模型配置
+    let model;
+    if (modelId) {
+      model = await this.getModelConfigById(modelId);
+    } else if (expertId) {
+      model = await this.getModelConfig(expertId);
+    } else {
+      throw new Error('Either expertId or modelId must be provided');
+    }
+
+    const messages = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+
+    const response = await this.callWithRetry(model, messages, { temperature });
+    return response.content;
+  }
+
+  /**
+   * 通用 LLM 调用方法
+   * @param {Object} model - 模型配置
+   * @param {Array} messages - 消息数组
+   * @param {Object} options - 可选参数
+   * @returns {Promise<Object>} 包含 content 和 usage 的响应
+   */
+  async call(model, messages, options = {}) {
+    const requestBody = JSON.stringify({
+      model: model.model_name,
+      messages,
+      temperature: options.temperature ?? this.defaultTemperature,
+      max_tokens: options.max_tokens || model.max_output_tokens || 8192,
+      ...(options.response_format && { response_format: options.response_format }),
+    });
+
+    const url = new URL(model.base_url);
+    const isHttps = url.protocol === 'https:';
+    const httpModule = isHttps ? https : http;
+    const timeoutValue = options.timeout || this.timeout;
+
+    const requestOptions = {
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: `${url.pathname}/chat/completions`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${model.api_key}`,
+        'Content-Length': Buffer.byteLength(requestBody),
+        'Connection': 'keep-alive',
+      },
+      timeout: timeoutValue,
+    };
+
+    logger.debug('[InternalLLMService] 开始调用:', {
+      model: model.model_name,
+      base_url: model.base_url,
+      temperature: options.temperature ?? this.defaultTemperature,
+      messages_count: messages.length,
+    });
+
+    return new Promise((resolve, reject) => {
+      const req = httpModule.request(requestOptions, (res) => {
+        let data = '';
+
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+
+        res.on('end', () => {
+          try {
+            if (res.statusCode !== 200) {
+              logger.error('[InternalLLMService] 调用失败:', {
+                status_code: res.statusCode,
+                response: data.substring(0, 500),
+              });
+              reject(new Error(`HTTP ${res.statusCode}: ${data}`));
+              return;
+            }
+
+            const response = JSON.parse(data);
+            const content = response.choices?.[0]?.message?.content;
+
+            resolve({
+              content,
+              usage: response.usage,
+              model: model.model_name,
+            });
+          } catch (error) {
+            logger.error('[InternalLLMService] 解析响应失败:', error.message);
+            reject(error);
+          }
+        });
+      });
+
+      req.on('error', (error) => {
+        logger.error('[InternalLLMService] 请求错误:', error.message);
+        reject(error);
+      });
+
+      req.on('timeout', () => {
+        logger.error('[InternalLLMService] 请求超时');
+        req.destroy();
+        reject(new Error('Request timeout'));
+      });
+
+      req.write(requestBody);
+      req.end();
+    });
+  }
+
+  /**
+   * 带重试机制的 LLM 调用
+   * @param {Object} model - 模型配置
+   * @param {Array} messages - 消息数组
+   * @param {Object} options - 可选参数
+   * @param {number} maxRetries - 最大重试次数
+   * @returns {Promise<Object>} LLM 响应
+   */
+  async callWithRetry(model, messages, options = {}, maxRetries = this.maxRetries) {
+    const errors = [];
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        return await this.call(model, messages, options);
+      } catch (error) {
+        errors.push(error);
+
+        if (!this.isRetryableError(error) || attempt === maxRetries) {
+          const aggregateError = new Error(
+            `LLM call failed after ${attempt} attempts: ${error.message}`
+          );
+          aggregateError.errors = errors;
+          throw aggregateError;
+        }
+
+        // 指数退避: 2s, 4s, 8s
+        const delay = Math.min(2000 * Math.pow(2, attempt - 1), 30000);
+        logger.warn(
+          `[InternalLLMService] 调用失败 (尝试 ${attempt}/${maxRetries}), ` +
+          `${delay / 1000}s 后重试: ${error.message}`
+        );
+
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  /**
+   * 判断错误是否可重试
+   */
+  isRetryableError(error) {
+    if (!error) return false;
+
+    // 网络相关错误
+    if (['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'ENOTFOUND', 'EPIPE'].includes(error.code)) {
+      return true;
+    }
+
+    const message = error.message || '';
+
+    // Socket 相关错误
+    if (message.includes('socket hang up') || message.includes('connection reset')) {
+      return true;
+    }
+
+    // HTTP 状态码相关
+    if (message.includes('429') || message.includes('503') || message.includes('502') || message.includes('504')) {
+      return true;
+    }
+
+    // 超时错误
+    if (message.includes('timeout')) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * 解析 JSON 响应
+   * @param {string} content - LLM 返回的内容
+   * @returns {Object|null} 解析后的对象，解析失败返回 null
+   */
+  parseJSON(content) {
+    if (!content) return null;
+
+    try {
+      // 尝试直接解析
+      return JSON.parse(content);
+    } catch (e) {
+      // 尝试提取 JSON 块
+      const jsonMatch = content.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        try {
+          return JSON.parse(jsonMatch[0]);
+        } catch (e2) {
+          logger.warn('[InternalLLMService] JSON 提取解析失败:', e2.message);
+        }
+      }
+
+      // 尝试提取数组
+      const arrayMatch = content.match(/\[[\s\S]*\]/);
+      if (arrayMatch) {
+        try {
+          return JSON.parse(arrayMatch[0]);
+        } catch (e3) {
+          logger.warn('[InternalLLMService] JSON 数组提取解析失败:', e3.message);
+        }
+      }
+
+      logger.warn('[InternalLLMService] JSON 解析失败，原始内容:', content.substring(0, 200));
+      return null;
+    }
+  }
+
+  /**
+   * 简单的 Schema 校验
+   * @param {Object} result - 解析后的结果
+   * @param {Object} schema - Schema 定义
+   */
+  validateSchema(result, schema) {
+    // 简单校验：检查必需字段是否存在
+    if (schema.required && Array.isArray(schema.required)) {
+      for (const field of schema.required) {
+        if (!(field in result)) {
+          logger.warn(`[InternalLLMService] Schema 校验: 缺少必需字段 ${field}`);
+        }
+      }
+    }
+
+    // 类型校验
+    if (schema.properties) {
+      for (const [field, def] of Object.entries(schema.properties)) {
+        if (field in result && def.type) {
+          const actualType = Array.isArray(result[field]) ? 'array' : typeof result[field];
+          if (actualType !== def.type && !(actualType === 'number' && def.type === 'integer')) {
+            logger.warn(`[InternalLLMService] Schema 校验: 字段 ${field} 类型不匹配，期望 ${def.type}，实际 ${actualType}`);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * 清除模型缓存
+   * @param {string} key - 缓存键（可选，不传则清除所有）
+   */
+  clearCache(key = null) {
+    if (key) {
+      this.modelCache.delete(key);
+    } else {
+      this.modelCache.clear();
+    }
+  }
+}
+
+export default InternalLLMService;

--- a/lib/topic-detector.js
+++ b/lib/topic-detector.js
@@ -1,21 +1,31 @@
 /**
  * Topic Detector - 话题检测器
- * 使用 LLM 实时检测对话中的话题切换
+ * 使用 InternalLLMService 进行话题切换检测
+ * 
+ * 重构说明：
+ * - 使用 InternalLLMService 替代直接使用 LLMClient
+ * - 不再依赖专家人设，使用独立的判断逻辑
+ * - 支持向后兼容，可以接受 LLMClient 或 InternalLLMService
  */
 
 import logger from './logger.js';
 
 class TopicDetector {
   /**
-   * @param {LLMClient} llmClient - LLM客户端
+   * @param {InternalLLMService|LLMClient} llmClient - LLM客户端（支持向后兼容）
    * @param {object} options - 配置选项
+   * @param {string} options.expertId - 专家ID（使用 InternalLLMService 时必需）
    * @param {number} options.confidenceThreshold - 话题切换置信度阈值（默认0.7）
    * @param {number} options.minMessagesForDetection - 触发检测的最小消息数（默认3轮）
    */
   constructor(llmClient, options = {}) {
     this.llmClient = llmClient;
+    this.expertId = options.expertId || null;
     this.confidenceThreshold = options.confidenceThreshold || 0.7;
     this.minMessagesForDetection = options.minMessagesForDetection || 6; // 3轮对话
+    
+    // 检测是否是 InternalLLMService（通过检查方法是否存在）
+    this.isInternalLLMService = typeof llmClient.judge === 'function';
   }
 
   /**
@@ -37,31 +47,12 @@ class TopicDetector {
     }
 
     try {
-      const prompt = this.buildDetectionPrompt({
-        currentTopicTitle,
-        currentTopicDescription,
-        recentMessages,
-        newMessage,
-      });
-
-      const response = await this.llmClient.callExpressive([
-        {
-          role: 'system',
-          content: '你是一个话题分析专家，负责判断对话是否发生了话题切换。请仔细分析对话上下文和用户的新消息，判断用户是在继续当前话题，还是开启了全新的话题。'
-        },
-        { role: 'user', content: prompt },
-      ], { temperature: 0.3, max_tokens: 500 });
-
-      const result = this.parseDetectionResponse(response.content);
-      
-      logger.info('[TopicDetector] 话题检测结果:', {
-        shouldSwitch: result.shouldSwitch,
-        confidence: result.confidence,
-        reason: result.reason,
-        suggestedTitle: result.suggestedTitle,
-      });
-
-      return result;
+      // 根据客户端类型选择调用方式
+      if (this.isInternalLLMService) {
+        return await this.detectWithInternalLLM(params);
+      } else {
+        return await this.detectWithLLMClient(params);
+      }
     } catch (error) {
       logger.error('[TopicDetector] 话题检测失败:', error.message);
       // 检测失败时，默认不切换话题，避免误操作
@@ -70,7 +61,135 @@ class TopicDetector {
   }
 
   /**
-   * 构建检测提示词
+   * 使用 InternalLLMService 进行检测（新方式）
+   */
+  async detectWithInternalLLM(params) {
+    const { currentTopicTitle, currentTopicDescription, recentMessages, newMessage } = params;
+
+    const systemPrompt = this.buildSystemPrompt();
+    const userPrompt = this.buildUserPrompt({
+      currentTopicTitle,
+      currentTopicDescription,
+      recentMessages,
+      newMessage,
+    });
+
+    const result = await this.llmClient.judge(systemPrompt, userPrompt, {
+      expertId: this.expertId,
+      temperature: 0.3,
+      defaultValue: { isNewTopic: false, confidence: 0, reason: 'LLM 调用失败', suggestedTitle: null },
+    });
+
+    if (!result) {
+      return { shouldSwitch: false, confidence: 0, reason: '解析失败', suggestedTitle: null };
+    }
+
+    const confidence = Math.max(0, Math.min(1, parseFloat(result.confidence) || 0));
+    const shouldSwitch = result.isNewTopic === true && confidence >= this.confidenceThreshold;
+
+    logger.info('[TopicDetector] 话题检测结果:', {
+      shouldSwitch,
+      confidence,
+      reason: result.reason,
+      suggestedTitle: result.suggestedTitle,
+    });
+
+    return {
+      shouldSwitch,
+      confidence,
+      reason: result.reason || '未提供理由',
+      suggestedTitle: result.suggestedTitle || null,
+      isNewTopic: result.isNewTopic === true,
+    };
+  }
+
+  /**
+   * 使用 LLMClient 进行检测（旧方式，向后兼容）
+   * @deprecated 请迁移到 InternalLLMService
+   */
+  async detectWithLLMClient(params) {
+    const { currentTopicTitle, currentTopicDescription, recentMessages, newMessage } = params;
+
+    const prompt = this.buildDetectionPrompt({
+      currentTopicTitle,
+      currentTopicDescription,
+      recentMessages,
+      newMessage,
+    });
+
+    const response = await this.llmClient.callExpressive([
+      {
+        role: 'system',
+        content: '你是一个话题分析专家，负责判断对话是否发生了话题切换。请仔细分析对话上下文和用户的新消息，判断用户是在继续当前话题，还是开启了全新的话题。'
+      },
+      { role: 'user', content: prompt },
+    ], { temperature: 0.3, max_tokens: 500 });
+
+    const result = this.parseDetectionResponse(response.content);
+    
+    logger.info('[TopicDetector] 话题检测结果:', {
+      shouldSwitch: result.shouldSwitch,
+      confidence: result.confidence,
+      reason: result.reason,
+      suggestedTitle: result.suggestedTitle,
+    });
+
+    return result;
+  }
+
+  /**
+   * 构建系统提示词（InternalLLMService 版本）
+   */
+  buildSystemPrompt() {
+    return `你是一个话题分析专家，负责判断对话是否发生了话题切换。
+
+## 分析任务
+分析对话上下文和用户的新消息，判断用户是在继续当前话题，还是开启了全新的话题。
+
+## 判断标准
+- **继续当前话题**：用户追问、补充细节、深入讨论、表达相关观点
+- **开启新话题**：提出全新问题、转向完全不同领域、讨论内容无关联
+
+## 输出要求
+返回 JSON 格式的结果，包含以下字段：
+- isNewTopic (boolean): 是否为新话题
+- confidence (number): 判断的置信度，0-1 之间
+- reason (string): 判断理由，简要说明
+- suggestedTitle (string|null): 如果是新话题，建议一个简短的话题标题（8-15字）；否则为 null`;
+  }
+
+  /**
+   * 构建用户提示词（InternalLLMService 版本）
+   */
+  buildUserPrompt(params) {
+    const { currentTopicTitle, currentTopicDescription, recentMessages, newMessage } = params;
+
+    // 格式化最近的消息（最多取10条）
+    const messagesToAnalyze = recentMessages.slice(-10);
+    const conversationHistory = messagesToAnalyze.map(m => {
+      const role = m.role === 'user' ? '用户' : '助手';
+      const content = m.content?.substring(0, 200) || '';
+      return `${role}: ${content}${m.content?.length > 200 ? '...' : ''}`;
+    }).join('\n');
+
+    return `请分析以下对话，判断用户的新消息是否开启了全新的话题。
+
+## 当前话题信息
+- 话题标题：${currentTopicTitle || '未命名话题'}
+- 话题描述：${currentTopicDescription || '暂无描述'}
+
+## 最近对话历史
+${conversationHistory}
+
+## 用户新消息
+${newMessage}
+
+请返回 JSON 格式的判断结果。`;
+  }
+
+  /**
+   * 构建检测提示词（LLMClient 版本）
+   * @deprecated 使用 buildSystemPrompt 和 buildUserPrompt 替代
    */
   buildDetectionPrompt(params) {
     const { currentTopicTitle, currentTopicDescription, recentMessages, newMessage } = params;
@@ -116,7 +235,7 @@ ${newMessage}
   }
 
   /**
-   * 解析检测响应
+   * 解析检测响应（LLMClient 版本）
    */
   parseDetectionResponse(content) {
     try {


### PR DESCRIPTION
## 背景

当前系统中多个场景需要调用 LLM 做内部判断，但不想绑定专家人设：

| 服务 | 用途 | 当前问题 |
|------|------|----------|
| **TopicDetector** | 检测话题切换 | 绑定专家的 expressive model |
| **ReflectiveMind** | 反思评估 | 绑定专家的 reflective model |
| **自主执行** | TODO 预检、状态判断 | 无合适调用方式 |

这些场景的共同特点：
1. **不需要专家人设** - System prompt 内置在代码中
2. **输出 JSON** - 程序解析后做判断（选择题、填空题）
3. **需要模型配置** - API、temperature 等

## 变更内容

### 新增 `lib/internal-llm-service.js`

提供轻量级的 LLM 调用能力：

```javascript
// 使用示例
const internalLLM = new InternalLLMService(db);
const result = await internalLLM.judge(
  '你是一个话题分析专家...',
  '请判断对话是否切换话题...',
  { 
    expertId: 'xxx',
    schema: { shouldSwitch: 'boolean', confidence: 'number' },
    defaultValue: { shouldSwitch: false }
  }
);
```

**核心特性：**
- 不依赖专家人设
- 使用反思模型配置（低温度，更确定的输出）
- 支持 JSON 输出格式
- 支持 Schema 校验
- 支持重试机制和错误处理

### 重构 `lib/topic-detector.js`

- 使用 InternalLLMService 替代直接使用 LLMClient
- 支持向后兼容，可以接受 LLMClient 或 InternalLLMService
- 使用独立的系统提示词，不绑定专家人设

### 更新 `lib/chat-service.js`

- 引入 InternalLLMService
- 更新 TopicDetector 的调用方式

## 交付物

- [x] `lib/internal-llm-service.js` - 核心服务类
- [x] 重构 `TopicDetector` 使用 InternalLLMService
- [ ] 重构 `ReflectiveMind` 使用 InternalLLMService（可选，后续迭代）
- [ ] 自主执行模块集成 InternalLLMService（后续迭代）

## 测试

- 话题检测功能保持向后兼容
- 新的 InternalLLMService 可以独立使用

Closes #180