### PR TITLE
#196: feat 自主任务执行时提供历史上下文给 LLM

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -7,8 +7,14 @@
  * 工作流程：
  * 1. 查找所有 status='autonomous' 的任务
  * 2. 检查任务是否需要执行（根据 last_executed_at 和执行间隔）
- * 3. 调用 ChatService 生成 AI 回复
- * 4. 更新任务的 last_executed_at 时间戳
+ * 3. 获取任务的历史上下文（最近 N 条消息）
+ * 4. 调用 ChatService 生成 AI 回复
+ * 5. 更新任务的 last_executed_at 时间戳
+ *
+ * 上下文感知提示词：
+ * - 获取最近 N 条历史消息作为上下文
+ * - 防止 LLM 走捷径，鼓励完整执行任务
+ * - 检测 LLM 提出的问题并提供指导
  *
  * 速率限制处理：
  * - 遇到 429 错误时，暂停执行一段时间（默认 60 秒）
@@ -26,10 +32,17 @@ import logger from './logger.js';
  * @param {number} options.batchSize 每批处理的任务数量（默认 5）
  * @param {number} options.minIntervalMinutes 最小执行间隔（分钟，默认 1）
  * @param {number} options.rateLimitCooldownMs 速率限制冷却时间（毫秒，默认 60000）
+ * @param {number} options.contextMessagesCount 历史上下文消息数量（默认 6）
  * @returns {Function} 任务处理函数
  */
 export function createAutonomousTaskExecutor(options = {}) {
-  const { chatService, batchSize = 5, minIntervalMinutes = 1, rateLimitCooldownMs = 60000 } = options;
+  const { 
+    chatService, 
+    batchSize = 5, 
+    minIntervalMinutes = 1, 
+    rateLimitCooldownMs = 60000,
+    contextMessagesCount = 6,  // 默认获取最近 6 条消息（约 3 轮对话）
+  } = options;
 
   // 速率限制状态
   let rateLimitedUntil = 0;  // 速率限制解除的时间戳（毫秒）
@@ -103,6 +116,32 @@ export function createAutonomousTaskExecutor(options = {}) {
   }
 
   /**
+   * 获取任务的历史上下文消息
+   * @param {string} topicId - 话题ID
+   * @param {number} limit - 消息数量限制
+   * @returns {Promise<Array>} 历史消息数组
+   */
+  async function getContextMessages(topicId, limit = contextMessagesCount) {
+    if (!topicId) return [];
+    
+    try {
+      const messages = await models.Message.findAll({
+        where: { topic_id: topicId },
+        attributes: ['id', 'role', 'content', 'created_at'],
+        order: [['created_at', 'DESC']],
+        limit,
+        raw: true,
+      });
+      
+      // 反转顺序，使最新消息在最后
+      return messages.reverse();
+    } catch (error) {
+      logger.error(`[AutonomousExecutor] 获取历史上下文失败: ${error.message}`);
+      return [];
+    }
+  }
+
+  /**
    * 执行单个自主任务
    * @param {Object} task 任务对象
    * @param {Object} db 数据库实例
@@ -129,11 +168,9 @@ export function createAutonomousTaskExecutor(options = {}) {
         return { success: false };
       }
 
-      // 构建自主执行的提示消息
-      const autonomousPrompt = buildAutonomousPrompt(task);
-
       // 获取或创建任务关联的话题
       let topicId = task.topic_id;
+      let isNewTopic = false;
       if (!topicId) {
         // 创建新话题
         topicId = await chatService.createNewTopic(
@@ -142,6 +179,7 @@ export function createAutonomousTaskExecutor(options = {}) {
           `自主任务: ${task.title}`,
           task.id
         );
+        isNewTopic = true;
 
         // 更新任务的 topic_id
         await models.Task.update(
@@ -149,6 +187,13 @@ export function createAutonomousTaskExecutor(options = {}) {
           { where: { id: task.id } }
         );
       }
+
+      // 获取历史上下文消息（仅当话题已存在时）
+      const contextMessages = isNewTopic ? [] : await getContextMessages(topicId);
+      logger.info(`[AutonomousExecutor] 获取到 ${contextMessages.length} 条历史上下文消息`);
+
+      // 构建自主执行的提示消息（包含历史上下文）
+      const autonomousPrompt = buildAutonomousPrompt(task, contextMessages);
 
 // 使用 ChatService 生成回复（流式调用，支持多轮工具调用）
       // 虽然是后台任务，但使用 streamChat 可以获得更完善的工具调用处理
@@ -220,9 +265,10 @@ export function createAutonomousTaskExecutor(options = {}) {
   /**
    * 构建自主执行的提示消息
    * @param {Object} task 任务对象
+   * @param {Array} contextMessages 历史上下文消息
    * @returns {string} 提示消息
    */
-  function buildAutonomousPrompt(task) {
+  function buildAutonomousPrompt(task, contextMessages = []) {
     const parts = [
       `【自主任务执行】`,
       ``,
@@ -233,8 +279,66 @@ export function createAutonomousTaskExecutor(options = {}) {
       parts.push(`任务描述: ${task.description}`);
     }
 
+    // 添加历史上下文（如果有）
+    if (contextMessages.length > 0) {
+      parts.push(``);
+      parts.push(`【最近执行历史】`);
+      parts.push(`(以下是你之前的执行记录，请参考以判断当前进度)`);
+      parts.push(``);
+      
+      for (const msg of contextMessages) {
+        const roleLabel = msg.role === 'user' ? '📥 系统提示' : 
+                          msg.role === 'assistant' ? '🤖 你的回复' :
+                          msg.role === 'tool' ? '🔧 工具结果' : msg.role;
+        
+        // 截断过长的内容
+        const content = msg.content || '(无内容)';
+        const truncatedContent = content.length > 500 
+          ? content.substring(0, 500) + '...(已截断)' 
+          : content;
+        
+        parts.push(`${roleLabel}:`);
+        parts.push(`${truncatedContent}`);
+        parts.push(``);
+      }
+    }
+
+    // 添加执行指导
+    parts.push(`【执行指导】`);
     parts.push(``);
-    parts.push(`请继续执行此任务。如果需要使用工具，请直接调用。执行完成后请汇报结果。`);
+    parts.push(`1. 请完整执行任务，不要跳过必要步骤，不要敷衍了事`);
+    parts.push(`2. 如果遇到困难，请尝试不同的解决方案，不要轻易放弃`);
+    parts.push(`3. 根据历史上下文判断当前进度，继续未完成的工作`);
+    parts.push(`4. 如果需要使用工具，请直接调用`);
+    parts.push(`5. 任务完成后，请汇报最终结果`);
+    
+    // 检测历史中是否有未回答的问题
+    const lastAssistantMessages = contextMessages
+      .filter(m => m.role === 'assistant')
+      .slice(-2);  // 检查最近 2 条助手消息
+    
+    const hasUnansweredQuestion = lastAssistantMessages.some(msg => {
+      const content = msg.content || '';
+      // 检测是否包含问题标记（中文或英文问号）
+      const hasQuestion = content.includes('?') || content.includes('？');
+      // 检测是否包含询问性语句
+      const isAsking = content.includes('我应该') || 
+                       content.includes('我该') ||
+                       content.includes('请问') ||
+                       content.includes('如何') ||
+                       content.includes('怎么');
+      return hasQuestion && isAsking;
+    });
+    
+    if (hasUnansweredQuestion) {
+      parts.push(``);
+      parts.push(`【注意】`);
+      parts.push(`检测到你上次提出了问题。请根据任务描述自行决策并继续执行，不要等待外部输入。`);
+      parts.push(`如果问题不影响任务执行，可以先搁置并继续其他工作。`);
+    }
+
+    parts.push(``);
+    parts.push(`请开始执行任务。`);
 
     return parts.join('\n');
   }


### PR DESCRIPTION
## 变更概述

解决了自主任务执行时提示词固定的问题，现在会提供历史上下文给 LLM，使其能够智能判断任务进度并继续执行。

## 主要变更

### 1. 新增 `getContextMessages` 函数
- 获取任务关联 Topic 的最近 N 条消息（默认 6 条）
- 按时间正序排列，便于 LLM 理解执行历史

### 2. 改进 `buildAutonomousPrompt` 函数

**历史上下文注入：**
- 将最近 N 条消息作为上下文注入提示词
- 区分不同角色：系统提示、AI 回复、工具结果
- 自动截断过长内容（500 字符）

**执行指导原则：**
1. 防止 LLM 走捷径：明确要求完整执行任务，不要敷衍了事
2. 鼓励持续努力：遇到困难时尝试不同解决方案
3. 进度判断：根据历史上下文判断当前进度
4. 工具使用：支持直接调用工具

**智能问题检测：**
- 检测历史中是否有未回答的问题
- 如果检测到 LLM 之前的提问，提示其自行决策
- 避免任务因等待输入而卡住

## 测试验证

- [x] 代码语法正确
- [x] 逻辑符合 Issue #196 的需求

## 相关 Issue

Closes #196