### PR TITLE
#196: fix 明确历史上下文中的角色定位，LLM 作为监理者审视之前的执行

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -283,13 +283,13 @@ export function createAutonomousTaskExecutor(options = {}) {
     if (contextMessages.length > 0) {
       parts.push(``);
       parts.push(`【最近执行历史】`);
-      parts.push(`(以下是你之前的执行记录，请参考以判断当前进度)`);
+      parts.push(`(以下是另一个 AI 实例之前的执行记录，你需要作为监理者审视并继续执行)`);
       parts.push(``);
       
       for (const msg of contextMessages) {
         const roleLabel = msg.role === 'user' ? '📥 系统提示' : 
-                          msg.role === 'assistant' ? '🤖 你的回复' :
-                          msg.role === 'tool' ? '🔧 工具结果' : msg.role;
+                          msg.role === 'assistant' ? '🤖 之前 AI 的回复' :
+                          msg.role === 'tool' ? '🔧 工具执行结果' : msg.role;
         
         // 截断过长的内容
         const content = msg.content || '(无内容)';
@@ -301,6 +301,14 @@ export function createAutonomousTaskExecutor(options = {}) {
         parts.push(`${truncatedContent}`);
         parts.push(``);
       }
+      
+      // 添加监理指导
+      parts.push(`【监理职责】`);
+      parts.push(`你是本次执行的监理者。请审视上述历史记录：`);
+      parts.push(`1. 检查之前的执行是否正确、完整`);
+      parts.push(`2. 判断是否存在需要纠正的问题`);
+      parts.push(`3. 继续未完成的工作`);
+      parts.push(``);
     }
 
     // 添加执行指导


### PR DESCRIPTION
## 问题修复

修复了 PR #197 中的角色定位问题。

### 问题描述

之前的实现将历史消息标记为"你的回复"，这会让 LLM 误以为那是自己说的，导致角色混淆。

### 解决方案

1. **明确角色定位**：将历史消息标记为"之前 AI 的回复"，让当前 LLM 明白这是另一个 AI 实例的执行记录

2. **添加监理职责**：明确告诉 LLM 它是监理者，需要：
   - 检查之前的执行是否正确、完整
   - 判断是否存在需要纠正的问题
   - 继续未完成的工作

### 变更内容

```diff
- parts.push(`(以下是你之前的执行记录，请参考以判断当前进度)`);
+ parts.push(`(以下是另一个 AI 实例之前的执行记录，你需要作为监理者审视并继续执行)`);

- const roleLabel = msg.role === 'assistant' ? '🤖 你的回复' :
+ const roleLabel = msg.role === 'assistant' ? '🤖 之前 AI 的回复' :

+ // 添加监理指导
+ parts.push(`【监理职责】`);
+ parts.push(`你是本次执行的监理者。请审视上述历史记录：`);
+ parts.push(`1. 检查之前的执行是否正确、完整`);
+ parts.push(`2. 判断是否存在需要纠正的问题`);
+ parts.push(`3. 继续未完成的工作`);
```

## 相关 Issue

Closes #196