### PR TITLE
#196: fix 简化历史上下文提示词，移除不必要的监理概念

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -279,57 +279,45 @@ export function createAutonomousTaskExecutor(options = {}) {
       parts.push(`任务描述: ${task.description}`);
     }
 
-    // 添加历史上下文（如果有）
+    // 添加历史上下文摘要（如果有）
     if (contextMessages.length > 0) {
       parts.push(``);
-      parts.push(`【最近执行历史】`);
-      parts.push(`(以下是另一个 AI 实例之前的执行记录，你需要作为监理者审视并继续执行)`);
-      parts.push(``);
+      parts.push(`【最近执行历史摘要】`);
       
-      for (const msg of contextMessages) {
-        const roleLabel = msg.role === 'user' ? '📥 系统提示' : 
-                          msg.role === 'assistant' ? '🤖 之前 AI 的回复' :
-                          msg.role === 'tool' ? '🔧 工具执行结果' : msg.role;
-        
-        // 截断过长的内容
-        const content = msg.content || '(无内容)';
-        const truncatedContent = content.length > 500 
-          ? content.substring(0, 500) + '...(已截断)' 
-          : content;
-        
-        parts.push(`${roleLabel}:`);
-        parts.push(`${truncatedContent}`);
-        parts.push(``);
+      // 简化历史摘要，只提取关键信息
+      const lastAssistantMsg = [...contextMessages].reverse().find(m => m.role === 'assistant');
+      const lastToolMsg = [...contextMessages].reverse().find(m => m.role === 'tool');
+      
+      if (lastAssistantMsg) {
+        const content = lastAssistantMsg.content || '(无内容)';
+        const truncated = content.length > 300 ? content.substring(0, 300) + '...' : content;
+        parts.push(`上次回复摘要: ${truncated}`);
       }
       
-      // 添加监理指导
-      parts.push(`【监理职责】`);
-      parts.push(`你是本次执行的监理者。请审视上述历史记录：`);
-      parts.push(`1. 检查之前的执行是否正确、完整`);
-      parts.push(`2. 判断是否存在需要纠正的问题`);
-      parts.push(`3. 继续未完成的工作`);
+      if (lastToolMsg) {
+        const content = lastToolMsg.content || '(无内容)';
+        const truncated = content.length > 200 ? content.substring(0, 200) + '...' : content;
+        parts.push(`最近工具结果: ${truncated}`);
+      }
+      
       parts.push(``);
     }
 
     // 添加执行指导
     parts.push(`【执行指导】`);
-    parts.push(``);
     parts.push(`1. 请完整执行任务，不要跳过必要步骤，不要敷衍了事`);
     parts.push(`2. 如果遇到困难，请尝试不同的解决方案，不要轻易放弃`);
-    parts.push(`3. 根据历史上下文判断当前进度，继续未完成的工作`);
-    parts.push(`4. 如果需要使用工具，请直接调用`);
-    parts.push(`5. 任务完成后，请汇报最终结果`);
+    parts.push(`3. 如果需要使用工具，请直接调用`);
+    parts.push(`4. 任务完成后，请汇报最终结果`);
     
     // 检测历史中是否有未回答的问题
     const lastAssistantMessages = contextMessages
       .filter(m => m.role === 'assistant')
-      .slice(-2);  // 检查最近 2 条助手消息
+      .slice(-2);
     
     const hasUnansweredQuestion = lastAssistantMessages.some(msg => {
       const content = msg.content || '';
-      // 检测是否包含问题标记（中文或英文问号）
       const hasQuestion = content.includes('?') || content.includes('？');
-      // 检测是否包含询问性语句
       const isAsking = content.includes('我应该') || 
                        content.includes('我该') ||
                        content.includes('请问') ||
@@ -340,13 +328,11 @@ export function createAutonomousTaskExecutor(options = {}) {
     
     if (hasUnansweredQuestion) {
       parts.push(``);
-      parts.push(`【注意】`);
-      parts.push(`检测到你上次提出了问题。请根据任务描述自行决策并继续执行，不要等待外部输入。`);
-      parts.push(`如果问题不影响任务执行，可以先搁置并继续其他工作。`);
+      parts.push(`【注意】检测到你上次提出了问题。请根据任务描述自行决策并继续执行。`);
     }
 
     parts.push(``);
-    parts.push(`请开始执行任务。`);
+    parts.push(`请继续执行任务。`);
 
     return parts.join('\n');
   }


### PR DESCRIPTION
## 问题修复

修复了 PR #198 中过度设计的监理概念。

### 问题描述

之前的实现引入了"监理职责"的概念，让 LLM 觉得自己是监理者需要审视之前的执行。但实际上：
- 历史消息就是专家自己之前的回复
- 这里只是构造一个消息来推动对话继续
- 发出去就完事，控制权会交还给之前的专家

### 解决方案

简化提示词：
1. **移除监理概念**：不再强调"另一个 AI 实例"和"监理职责"
2. **简化历史摘要**：只提取上次回复和最近工具结果的摘要
3. **保留核心指导**：防止走捷径、鼓励持续努力、检测未回答问题

### 变更内容

```diff
- 【最近执行历史】
- (以下是另一个 AI 实例之前的执行记录，你需要作为监理者审视并继续执行)
+ 【最近执行历史摘要】

- // 遍历所有历史消息
+ // 只提取关键摘要
+ const lastAssistantMsg = [...contextMessages].reverse().find(m => m.role === 'assistant');
+ const lastToolMsg = [...contextMessages].reverse().find(m => m.role === 'tool');

- 【监理职责】
- 你是本次执行的监理者。请审视上述历史记录：
- 1. 检查之前的执行是否正确、完整
- 2. 判断是否存在需要纠正的问题
- 3. 继续未完成的工作
```

## 相关 Issue

Closes #196