### PR TITLE
#196: feat 重构自主任务提示词为 PM 角色设计

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -264,91 +264,63 @@ export function createAutonomousTaskExecutor(options = {}) {
 
   /**
    * 构建自主执行的提示消息
+   *
+   * 设计思路：
+   * - LLM 扮演 PM 角色，监督专家的工作
+   * - 提供最近 2 轮对话历史，让 PM 了解项目进展
+   * - PM 根据进展指导专家推进项目
+   *
    * @param {Object} task 任务对象
    * @param {Array} contextMessages 历史上下文消息
    * @returns {string} 提示消息
    */
   function buildAutonomousPrompt(task, contextMessages = []) {
-    const parts = [
-      `【自主任务执行】`,
-      ``,
-      `任务标题: ${task.title}`,
-    ];
+    // 构建任务描述
+    const taskDescription = task.description
+      ? `${task.title}\n任务详情: ${task.description}`
+      : task.title;
 
-    if (task.description) {
-      parts.push(`任务描述: ${task.description}`);
-    }
-
-    // 添加历史上下文（如果有）
+    // 构建历史上下文（最近 2 轮对话）
+    let historySection = '';
     if (contextMessages.length > 0) {
-      parts.push(``);
-      parts.push(`【最近执行历史】`);
-      parts.push(`(以下是另一个 AI 实例之前的执行记录，你需要作为监理者审视并继续执行)`);
-      parts.push(``);
+      // 格式化为 JSON 结构，便于 LLM 理解
+      const formattedHistory = contextMessages.map(msg => ({
+        role: msg.role,
+        content: truncateContent(msg.content || '(无内容)', 800),
+        timestamp: msg.created_at,
+      }));
       
-      for (const msg of contextMessages) {
-        const roleLabel = msg.role === 'user' ? '📥 系统提示' : 
-                          msg.role === 'assistant' ? '🤖 之前 AI 的回复' :
-                          msg.role === 'tool' ? '🔧 工具执行结果' : msg.role;
-        
-        // 截断过长的内容
-        const content = msg.content || '(无内容)';
-        const truncatedContent = content.length > 500 
-          ? content.substring(0, 500) + '...(已截断)' 
-          : content;
-        
-        parts.push(`${roleLabel}:`);
-        parts.push(`${truncatedContent}`);
-        parts.push(``);
-      }
-      
-      // 添加监理指导
-      parts.push(`【监理职责】`);
-      parts.push(`你是本次执行的监理者。请审视上述历史记录：`);
-      parts.push(`1. 检查之前的执行是否正确、完整`);
-      parts.push(`2. 判断是否存在需要纠正的问题`);
-      parts.push(`3. 继续未完成的工作`);
-      parts.push(``);
+      historySection = `
+--------
+【最近对话记录】
+\`\`\`json
+${JSON.stringify(formattedHistory, null, 2)}
+\`\`\`
+`;
     }
 
-    // 添加执行指导
-    parts.push(`【执行指导】`);
-    parts.push(``);
-    parts.push(`1. 请完整执行任务，不要跳过必要步骤，不要敷衍了事`);
-    parts.push(`2. 如果遇到困难，请尝试不同的解决方案，不要轻易放弃`);
-    parts.push(`3. 根据历史上下文判断当前进度，继续未完成的工作`);
-    parts.push(`4. 如果需要使用工具，请直接调用`);
-    parts.push(`5. 任务完成后，请汇报最终结果`);
-    
-    // 检测历史中是否有未回答的问题
-    const lastAssistantMessages = contextMessages
-      .filter(m => m.role === 'assistant')
-      .slice(-2);  // 检查最近 2 条助手消息
-    
-    const hasUnansweredQuestion = lastAssistantMessages.some(msg => {
-      const content = msg.content || '';
-      // 检测是否包含问题标记（中文或英文问号）
-      const hasQuestion = content.includes('?') || content.includes('？');
-      // 检测是否包含询问性语句
-      const isAsking = content.includes('我应该') || 
-                       content.includes('我该') ||
-                       content.includes('请问') ||
-                       content.includes('如何') ||
-                       content.includes('怎么');
-      return hasQuestion && isAsking;
-    });
-    
-    if (hasUnansweredQuestion) {
-      parts.push(``);
-      parts.push(`【注意】`);
-      parts.push(`检测到你上次提出了问题。请根据任务描述自行决策并继续执行，不要等待外部输入。`);
-      parts.push(`如果问题不影响任务执行，可以先搁置并继续其他工作。`);
+    // PM 角色的提示词
+    const prompt = `当前项目是「${taskDescription}」，你是当前项目的 PM，负责监督专家的工作。
+以下是项目的进展，请根据项目要求和专家的进展，指导专家推进项目。
+注意：要求专家不能跳过必要步骤，遇到困难要尝试不同解决方案，不要轻易放弃。
+${historySection}
+--------
+请根据上述项目进展，给出你的指导建议，帮助专家继续推进任务。`;
+
+    return prompt;
+  }
+
+  /**
+   * 截断过长的内容
+   * @param {string} content 原始内容
+   * @param {number} maxLength 最大长度
+   * @returns {string} 截断后的内容
+   */
+  function truncateContent(content, maxLength = 800) {
+    if (content.length <= maxLength) {
+      return content;
     }
-
-    parts.push(``);
-    parts.push(`请开始执行任务。`);
-
-    return parts.join('\n');
+    return content.substring(0, maxLength) + '...(内容已截断)';
   }
 
   return async function autonomousTaskHandler(db) {


### PR DESCRIPTION
## 问题背景

Issue #196 的反馈指出：之前的设计误解了场景。正确的理解是：

**LLM 应该扮演 PM 角色，监督专家的工作进展，并给出指导建议。**

## 改动内容

### 重构 `buildAutonomousPrompt()` 函数

**新的提示词结构：**
```
当前项目是「xxx任务」，你是当前项目的 PM，负责监督专家的工作。
以下是项目的进展，请根据项目要求和专家的进展，指导专家推进项目。
注意：要求专家不能跳过必要步骤，遇到困难要尝试不同解决方案，不要轻易放弃。
--------
【最近对话记录】
```json
[历史消息JSON]
```
--------
请根据上述项目进展，给出你的指导建议，帮助专家继续推进任务。
```

### 主要变更

1. **PM 角色定位**：LLM 作为项目 PM，监督专家工作
2. **历史格式化**：对话历史以 JSON 格式呈现，便于 LLM 理解
3. **明确指令**：要求 PM 给出指导建议，而非直接执行任务

### 新增辅助函数

- `truncateContent()`: 截断过长内容，防止上下文过长

## 相关 Issue

Closes #196

## 已关闭的 PR

- #197 (merged) - 初始实现
- #198 (merged) - 添加监理概念（后证实理解有误）
- #199 (closed) - 简化版本（本 PR 取代）