### PR TITLE
#196: fix 修复历史上下文获取逻辑，包含工具调用结果

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -116,29 +116,121 @@ export function createAutonomousTaskExecutor(options = {}) {
   }
 
   /**
-   * 获取任务的历史上下文消息
-   * @param {string} topicId - 话题ID
-   * @param {number} limit - 消息数量限制
+   * 获取任务的历史上下文消息（包含工具调用）
+   *
+   * 逻辑：
+   * 1. 找到最近的 2 个 user 和 2 个 assistant 消息
+   * 2. 获取第一条对话的时间作为开始时间
+   * 3. 获取大于这个时间的所有对话（包括 tool 消息）
+   * 4. 工具调用只显示工具名称和返回结果（适当截断）
+   *
+   * @param {string} expertId - 专家ID
+   * @param {string} userId - 用户ID
    * @returns {Promise<Array>} 历史消息数组
    */
-  async function getContextMessages(topicId, limit = contextMessagesCount) {
-    if (!topicId) return [];
+  async function getContextMessages(expertId, userId) {
+    if (!expertId || !userId) return [];
     
     try {
-      const messages = await models.Message.findAll({
-        where: { topic_id: topicId },
+      // 1. 先获取最近的 2 个 user 和 2 个 assistant 消息
+      const userMessages = await models.Message.findAll({
+        where: {
+          expert_id: expertId,
+          user_id: userId,
+          role: 'user',
+        },
         attributes: ['id', 'role', 'content', 'created_at'],
         order: [['created_at', 'DESC']],
-        limit,
+        limit: 2,
         raw: true,
       });
       
-      // 反转顺序，使最新消息在最后
-      return messages.reverse();
+      const assistantMessages = await models.Message.findAll({
+        where: {
+          expert_id: expertId,
+          user_id: userId,
+          role: 'assistant',
+        },
+        attributes: ['id', 'role', 'content', 'created_at'],
+        order: [['created_at', 'DESC']],
+        limit: 2,
+        raw: true,
+      });
+      
+      // 2. 合并并找到最早的时间
+      const coreMessages = [...userMessages, ...assistantMessages];
+      if (coreMessages.length === 0) return [];
+      
+      const earliestTime = coreMessages.reduce((min, msg) => {
+        const msgTime = new Date(msg.created_at);
+        return msgTime < min ? msgTime : min;
+      }, new Date(coreMessages[0].created_at));
+      
+      // 3. 获取大于这个时间的所有消息（包括 tool 消息）
+      const allMessages = await models.Message.findAll({
+        where: {
+          expert_id: expertId,
+          user_id: userId,
+          created_at: { [Op.gte]: earliestTime },
+        },
+        attributes: ['id', 'role', 'content', 'tool_calls', 'created_at'],
+        order: [['created_at', 'ASC']],
+        raw: true,
+      });
+      
+      // 4. 格式化消息
+      return allMessages.map(msg => {
+        // 对于 tool 消息，提取工具名称和结果
+        if (msg.role === 'tool') {
+          return formatToolMessage(msg);
+        }
+        
+        // 对于 user 和 assistant 消息，截断内容
+        return {
+          role: msg.role,
+          content: truncateContent(msg.content || '(无内容)', 800),
+        };
+      });
     } catch (error) {
       logger.error(`[AutonomousExecutor] 获取历史上下文失败: ${error.message}`);
       return [];
     }
+  }
+
+  /**
+   * 格式化工具消息
+   * @param {Object} msg - 工具消息对象
+   * @returns {Object} 格式化后的消息
+   */
+  function formatToolMessage(msg) {
+    let toolName = '未知工具';
+    let result = msg.content || '(无结果)';
+    
+    // 尝试解析 tool_calls 字段
+    try {
+      const toolCalls = typeof msg.tool_calls === 'string'
+        ? JSON.parse(msg.tool_calls)
+        : msg.tool_calls;
+      
+      if (toolCalls?.name) {
+        toolName = toolCalls.name;
+      }
+      
+      // 检查工具调用是否成功
+      const success = toolCalls?.success !== false;
+      result = success
+        ? truncateContent(result, 500)  // 成功时截断
+        : `❌ 错误: ${truncateContent(result, 300)}`;  // 失败时标注
+    } catch (e) {
+      // 解析失败，使用原始内容
+      result = truncateContent(result, 500);
+    }
+    
+    return {
+      role: 'tool',
+      name: toolName,
+      content: result,
+    };
   }
 
   /**
@@ -188,14 +280,14 @@ export function createAutonomousTaskExecutor(options = {}) {
         );
       }
 
-      // 获取历史上下文消息（仅当话题已存在时）
-      const contextMessages = isNewTopic ? [] : await getContextMessages(topicId);
+      // 获取历史上下文消息（按 expert_id + user_id 查询，新消息的 topic_id 为 NULL）
+      const contextMessages = await getContextMessages(task.expert_id, task.created_by);
       logger.info(`[AutonomousExecutor] 获取到 ${contextMessages.length} 条历史上下文消息`);
 
       // 构建自主执行的提示消息（包含历史上下文）
       const autonomousPrompt = buildAutonomousPrompt(task, contextMessages);
 
-// 使用 ChatService 生成回复（流式调用，支持多轮工具调用）
+      // 使用 ChatService 生成回复（流式调用，支持多轮工具调用）
       // 虽然是后台任务，但使用 streamChat 可以获得更完善的工具调用处理
       let result = { success: false };
       


### PR DESCRIPTION
## 问题背景

Issue #196 的反馈指出历史上下文获取存在问题：

1. `getContextMessages()` 查询条件使用 `topic_id`，但新消息的 `topic_id` 为 NULL（未归档状态）
2. 缺少工具调用结果的获取

## 改动内容

### 修复 `getContextMessages()` 函数

**新的获取逻辑：**
1. 找到最近的 2 个 user 和 2 个 assistant 消息
2. 获取第一条对话的时间作为开始时间
3. 获取大于这个时间的所有对话（包括 tool 消息）
4. 工具调用只显示工具名称和返回结果（适当截断）

### 新增 `formatToolMessage()` 函数

格式化工具消息：
- 提取工具名称（从 `tool_calls` 字段）
- 截断返回结果（成功 500 字符，失败 300 字符）
- 失败时标注 ❌ 错误

### 查询条件修正

- 改为按 `expert_id + user_id` 查询，而非 `topic_id`
- 确保能获取到未归档的消息

## 示例输出

```json
[
  {"role": "user", "content": "请帮我分析这个文件"},
  {"role": "assistant", "content": "我来帮你分析..."},
  {"role": "tool", "name": "file-reader", "content": "文件内容..."},
  {"role": "assistant", "content": "根据分析结果..."},
  {"role": "user", "content": "继续"},
  {"role": "assistant", "content": "好的，继续分析..."}
]
```

## 相关 Issue

Closes #196

## 已关闭的 PR

- #197 (merged) - 初始实现
- #198 (merged) - 添加监理概念
- #199 (closed) - 简化版本
- #200 (merged) - PM 角色设计