### PR TITLE
#196 feat: 实现两步调用流程 - PM生成指导建议后发给专家

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -24,6 +24,7 @@
 
 import { Op } from 'sequelize';
 import logger from './logger.js';
+import InternalLLMService from './internal-llm-service.js';
 
 /**
  * 创建自主任务执行器
@@ -284,11 +285,25 @@ export function createAutonomousTaskExecutor(options = {}) {
       const contextMessages = await getContextMessages(task.expert_id, task.created_by);
       logger.info(`[AutonomousExecutor] 获取到 ${contextMessages.length} 条历史上下文消息`);
 
-      // 构建自主执行的提示消息（包含历史上下文）
-      const autonomousPrompt = buildAutonomousPrompt(task, contextMessages);
+      // 【两步调用流程】
+      // 步骤 1: 用 InternalLLMService 生成 PM 指导建议
+      const internalLLM = new InternalLLMService(db);
+      const pmPrompt = buildPMPrompt(task, contextMessages);
+      
+      let guidanceMessage;
+      try {
+        guidanceMessage = await internalLLM.generate(
+          '你是一个项目管理助手（PM），负责监督 AI 专家的工作进展。你的任务是给出简洁、具体的指导建议，帮助专家继续推进任务。',
+          pmPrompt,
+          { expertId: task.expert_id }
+        );
+        logger.info(`[AutonomousExecutor] PM 生成指导建议: ${guidanceMessage.substring(0, 100)}...`);
+      } catch (error) {
+        logger.warn(`[AutonomousExecutor] PM 生成失败，使用默认指导: ${error.message}`);
+        guidanceMessage = buildDefaultGuidance(task);
+      }
 
-      // 使用 ChatService 生成回复（流式调用，支持多轮工具调用）
-      // 虽然是后台任务，但使用 streamChat 可以获得更完善的工具调用处理
+      // 步骤 2: 把指导建议发给专家继续工作
       let result = { success: false };
       
       await new Promise((resolve) => {
@@ -297,7 +312,7 @@ export function createAutonomousTaskExecutor(options = {}) {
             topic_id: topicId,
             user_id: task.created_by,
             expert_id: task.expert_id,
-            content: autonomousPrompt,
+            content: guidanceMessage,
             task_id: task.id,
           },
           // onDelta - 忽略流式事件（后台任务不需要实时反馈）
@@ -400,6 +415,82 @@ ${historySection}
 请根据上述项目进展，给出你的指导建议，帮助专家继续推进任务。`;
 
     return prompt;
+  }
+
+  /**
+   * 构建 PM 提示词（用于 InternalLLMService）
+   *
+   * PM 角色说明：
+   * - PM 是项目管理助手，监督专家的工作进展
+   * - PM 根据历史对话了解项目状态
+   * - PM 给出简洁、具体的指导建议
+   *
+   * @param {Object} task 任务对象
+   * @param {Array} contextMessages 历史上下文消息
+   * @returns {string} PM 提示词
+   */
+  function buildPMPrompt(task, contextMessages = []) {
+    // 构建任务描述
+    const taskDescription = task.description
+      ? `${task.title}\n任务详情: ${task.description}`
+      : task.title;
+
+    // 构建历史上下文
+    let historySection = '';
+    if (contextMessages.length > 0) {
+      const formattedHistory = contextMessages.map(msg => {
+        if (msg.role === 'tool') {
+          return `【工具调用】${msg.name}: ${msg.content}`;
+        }
+        const roleLabel = msg.role === 'user' ? '用户' : '专家';
+        return `【${roleLabel}】${msg.content}`;
+      }).join('\n\n');
+      
+      historySection = `
+--------
+【最近对话记录】
+${formattedHistory}
+`;
+    } else {
+      historySection = `
+--------
+【最近对话记录】
+（暂无对话记录，这是任务的第一次执行）
+`;
+    }
+
+    const prompt = `你是一个项目管理助手（PM），负责监督 AI 专家的工作进展。
+
+当前任务：${taskDescription}
+${historySection}
+--------
+请根据上述任务要求和专家的工作进展，给出简洁、具体的指导建议（不超过 200 字），帮助专家继续推进任务。
+
+注意：
+1. 如果专家刚完成某个步骤，指导下一步该做什么
+2. 如果专家遇到困难，建议尝试其他方案
+3. 如果专家跳过了必要步骤，要求其补充
+4. 不要重复专家已经完成的工作`;
+
+    return prompt;
+  }
+
+  /**
+   * 构建默认指导消息（当 PM 生成失败时的后备方案）
+   *
+   * @param {Object} task 任务对象
+   * @returns {string} 默认指导消息
+   */
+  function buildDefaultGuidance(task) {
+    const taskDescription = task.description
+      ? `${task.title}: ${task.description}`
+      : task.title;
+
+    return `请继续推进任务「${taskDescription}」。
+
+如果你刚完成某个步骤，请继续下一步。
+如果遇到问题，请尝试不同的解决方案。
+请确保完成所有必要的工作，不要跳过关键步骤。`;
   }
 
   /**


### PR DESCRIPTION
## 📋 变更概述

实现两步调用流程，解决自主任务执行时每次发送相同提示词的问题。

### 🔄 两步调用流程

```
步骤1: InternalLLMService.generate()
        ↓ PM 提示词 + 历史上下文
        ↓ 生成指导建议
        
步骤2: ChatService.streamChat()
        ↓ 把指导建议发给专家
        ↓ 专家继续推进任务
```

### 📝 具体实现

1. **[`buildPMPrompt()`](lib/autonomous-task-executor.js:421)** - 构建 PM 提示词
   - 包含任务描述
   - 包含最近对话记录（user/assistant/tool）
   - 要求 PM 给出简洁、具体的指导建议

2. **[`buildDefaultGuidance()`](lib/autonomous-task-executor.js:474)** - 默认指导消息
   - 当 PM 生成失败时的后备方案
   - 通用指导语，确保专家继续推进任务

3. **修改 [`executeTask()`](lib/autonomous-task-executor.js:243)** 
   - 步骤1: 调用 `InternalLLMService.generate()` 获取 PM 指导
   - 步骤2: 把指导发给专家继续工作

### ✅ 测试验证

- [x] 语法检查通过 `node --check lib/autonomous-task-executor.js`

---

Closes #196