### PR TITLE
#203 fix: 修复 fixArticleStatus 函数无法正确更新文章状态的 bug

### DIFF
--- a/lib/embedding-worker.js
+++ b/lib/embedding-worker.js
@@ -413,23 +413,21 @@ export function createEmbeddingTask(options = {}) {
         console.log('[EmbeddingTask] 🔄 Updating article status based on vectorization progress...');
         const affectedArticleIds = articleIds;
 
-        // 统计每个文章的段落总数
-        const totalParagraphsStats = await models.KbParagraph.findAll({
-          attributes: [
-            'section_id',
-            [db.sequelize.fn('COUNT', db.sequelize.col('kb_paragraph.id')), 'total']
-          ],
-          include: [{
-            model: models.KbSection,
-            as: 'section',
-            attributes: [],
-            where: { article_id: affectedArticleIds },
-          }],
-          group: ['section.article_id'],
-          raw: true,
-        });
+        // 统计每个文章的段落总数（使用原始 SQL，避免 Sequelize raw 模式下 group 字段丢失问题）
+        const totalStats = await db.sequelize.query(
+          `SELECT a.id as article_id, COUNT(p.id) as total
+           FROM kb_articles a
+           JOIN kb_sections s ON s.article_id = a.id
+           JOIN kb_paragraphs p ON p.section_id = s.id
+           WHERE a.id IN (?)
+           GROUP BY a.id`,
+          {
+            replacements: [affectedArticleIds],
+            type: db.sequelize.QueryTypes.SELECT,
+          }
+        );
 
-        // 统计每个文章的已向量化段落数（使用原始 SQL）
+        // 统计每个文章的已向量化段落数
         const vectorizedStats = await db.sequelize.query(
           `SELECT a.id as article_id, COUNT(p.id) as vectorized
            FROM kb_articles a
@@ -444,7 +442,7 @@ export function createEmbeddingTask(options = {}) {
         );
 
         // 构建统计 Map
-        const totalMap = new Map(totalParagraphsStats.map(s => [s.section?.article_id, parseInt(s.total) || 0]));
+        const totalMap = new Map(totalStats.map(s => [s.article_id, parseInt(s.total) || 0]));
         const vectorizedMap = new Map(vectorizedStats.map(s => [s.article_id, parseInt(s.vectorized) || 0]));
 
         // 批量更新状态
@@ -497,23 +495,21 @@ async function fixArticleStatus(db, models) {
 
     console.log(`[EmbeddingTask] 🔧 Checking ${pendingArticles.length} pending articles for status fix...`);
 
-    // 统计每个文章的段落总数
-    const totalParagraphsStats = await models.KbParagraph.findAll({
-      attributes: [
-        'section_id',
-        [db.sequelize.fn('COUNT', db.sequelize.col('kb_paragraph.id')), 'total']
-      ],
-      include: [{
-        model: models.KbSection,
-        as: 'section',
-        attributes: [],
-        where: { article_id: pendingArticleIds },
-      }],
-      group: ['section.article_id'],
-      raw: true,
-    });
+    // 统计每个文章的段落总数（使用原始 SQL，避免 Sequelize raw 模式下 group 字段丢失问题）
+    const totalStats = await db.sequelize.query(
+      `SELECT a.id as article_id, COUNT(p.id) as total
+       FROM kb_articles a
+       JOIN kb_sections s ON s.article_id = a.id
+       JOIN kb_paragraphs p ON p.section_id = s.id
+       WHERE a.id IN (?)
+       GROUP BY a.id`,
+      {
+        replacements: [pendingArticleIds],
+        type: db.sequelize.QueryTypes.SELECT,
+      }
+    );
 
-    // 统计每个文章的已向量化段落数（使用原始 SQL）
+    // 统计每个文章的已向量化段落数
     const vectorizedStats = await db.sequelize.query(
       `SELECT a.id as article_id, COUNT(p.id) as vectorized
        FROM kb_articles a
@@ -528,7 +524,7 @@ async function fixArticleStatus(db, models) {
     );
 
     // 构建统计 Map
-    const totalMap = new Map(totalParagraphsStats.map(s => [s.section?.article_id, parseInt(s.total) || 0]));
+    const totalMap = new Map(totalStats.map(s => [s.article_id, parseInt(s.total) || 0]));
     const vectorizedMap = new Map(vectorizedStats.map(s => [s.article_id, parseInt(s.vectorized) || 0]));
 
     // 检查并更新状态


### PR DESCRIPTION
## 问题描述

`fixArticleStatus` 函数中的 Sequelize 查询存在 bug，导致已完全向量化的文章无法自动从 `processing` 状态更新为 `ready`。

## 根本原因

在 `lib/embedding-worker.js` 中，Sequelize 查询使用 `raw: true` 模式配合 `group: ['section.article_id']`，但结果中不会包含 `article_id` 字段，导致所有文章 ID 都映射到了 `undefined`。

## 修复内容

将 Sequelize 查询改为原始 SQL 查询，确保 `article_id` 正确返回：

```javascript
// 修复前（Sequelize raw 模式下 group 字段丢失）
const totalParagraphsStats = await models.KbParagraph.findAll({
  attributes: ['section_id', [db.sequelize.fn('COUNT', ...), 'total']],
  include: [{ model: models.KbSection, as: 'section', ... }],
  group: ['section.article_id'],
  raw: true,
});
const totalMap = new Map(totalParagraphsStats.map(s => [s.section?.article_id, ...]));
// 结果: { undefined: 12 }

// 修复后（使用原始 SQL）
const totalStats = await db.sequelize.query(
  `SELECT a.id as article_id, COUNT(p.id) as total FROM ... GROUP BY a.id`,
  { replacements: [pendingArticleIds], type: db.sequelize.QueryTypes.SELECT }
);
const totalMap = new Map(totalStats.map(s => [s.article_id, ...]));
// 结果: { 'mmi8cgdbmvkl2kap8ubu': 16, ... }
```

## 验证结果

修复后，4 篇 `processing` 状态的文章已成功更新为 `ready`：

```
mmi8cgdbmvkl2kap8ubu | ready
mmi8eoikcytt5up2sn09 | ready
mmlmn8kbuuezkbmdo7co | ready
mmlmnadwc9whme9rgr70 | ready
```

Closes #203