### PR TITLE
#214: Docker部署配置

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Dependencies
+node_modules/
+frontend/node_modules/
+
+# Build outputs (will be built inside Docker)
+frontend/dist/
+
+# Development files
+.git/
+.gitignore
+.vscode/
+.idea/
+*.md
+!README.md
+
+# Environment files (should be mounted or set via docker-compose)
+.env
+.env.*
+!.env.example
+
+# Docker files (avoid recursive builds)
+Dockerfile*
+docker-compose*.yml
+.docker/
+
+# Test and coverage
+coverage/
+.nyc_output/
+*.test.js
+*.spec.js
+
+# Logs
+*.log
+logs/
+server.log
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.swp
+*.swo
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Config files that may contain secrets
+config/database.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,136 @@
+# ============================================
+# Touwaka Mate - Multi-stage Docker Build
+# Supports both Node.js and Python runtimes
+# Includes Office document processing (PPTX, XLSX, DOCX)
+# ============================================
+
+# Stage 1: Build frontend
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app/frontend
+
+# Copy frontend package files
+COPY frontend/package*.json ./
+
+# Install frontend dependencies
+RUN npm ci
+
+# Copy frontend source
+COPY frontend/ ./
+
+# Build frontend
+RUN npm run build
+
+# Stage 2: Production image with Node.js and Python
+FROM node:20-alpine
+
+# Install Python and all required system dependencies for native modules
+# - build-base, g++, make: for compiling native Node modules (better-sqlite3, tiktoken)
+# - vips-dev: for sharp image processing
+# - sqlite-dev: for better-sqlite3
+# - python3, py3-pip: for Python skills
+# - LibreOffice: for Office document processing (PPTX, XLSX, DOCX)
+# - Poppler: for PDF to image conversion
+# - git, curl: utility tools
+RUN apk add --no-cache \
+    # Build tools for native modules
+    build-base \
+    g++ \
+    gcc \
+    make \
+    python3 \
+    # Sharp dependencies (image processing)
+    vips-dev \
+    # SQLite for better-sqlite3
+    sqlite \
+    sqlite-dev \
+    # Python runtime
+    py3-pip \
+    python3-dev \
+    libffi-dev \
+    openssl-dev \
+    # Office document processing
+    libreoffice \
+    libreoffice-common \
+    poppler-utils \
+    # Fonts for LibreOffice (minimal set)
+    font-noto-cjk \
+    font-dejavu \
+    # Utility tools
+    git \
+    curl \
+    wget \
+    && ln -sf python3 /usr/bin/python \
+    && ln -sf pip3 /usr/bin/pip
+
+# Create virtual environment for Python packages (for skill dependencies)
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install common Python packages that skills might need
+# Including Office document processing libraries
+RUN pip install --no-cache-dir \
+    # Office document processing
+    python-docx \
+    python-pptx \
+    openpyxl \
+    xlrd \
+    # PDF processing
+    PyPDF2 \
+    pdfplumber \
+    # Data analysis
+    pandas \
+    # Web scraping and parsing
+    beautifulsoup4 \
+    lxml \
+    # HTTP and utilities
+    requests \
+    markdown \
+    # Image processing
+    pillow \
+    # Markitdown for document text extraction
+    "markitdown[pptx,xlsx,docx]"
+
+WORKDIR /app
+
+# Copy backend package files
+COPY package*.json ./
+
+# Install backend dependencies (production only)
+# This will compile native modules like better-sqlite3, sharp, tiktoken
+RUN npm ci --only=production
+
+# Install global npm packages for Office processing
+RUN npm install -g pptxgenjs
+
+# Copy backend source
+COPY server/ ./server/
+COPY lib/ ./lib/
+COPY models/ ./models/
+COPY scripts/ ./scripts/
+COPY config/ ./config/
+COPY data/ ./data/
+
+# Copy built frontend from builder stage
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+
+# Create data and work directories for persistence
+RUN mkdir -p /app/data /app/work
+
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup && \
+    chown -R appuser:appgroup /app
+
+# Switch to non-root user
+USER appuser
+
+# Expose port
+EXPOSE 3000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+
+# Start the application
+CMD ["node", "server/index.js"]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,65 @@ npm run dev:frontend # 前端 :5173
 
 ---
 
+## 🐳 Docker 部署
+
+### 快速启动
+
+```bash
+# 1. 复制环境配置
+cp .env.example .env
+
+# 2. 编辑 .env 文件，设置必要的配置
+# 必须修改: JWT_SECRET, JWT_REFRESH_SECRET
+# 可选修改: DB_USER, DB_PASSWORD, DB_ROOT_PASSWORD
+
+# 3. 启动服务
+docker-compose up -d
+
+# 4. 查看日志
+docker-compose logs -f app
+
+# 5. 初始化核心技能 (首次部署)
+docker-compose exec app node scripts/init-core-skills.js
+```
+
+### 环境变量说明
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `PORT` | 应用端口 | `3000` |
+| `DB_NAME` | 数据库名 | `touwaka_mate` |
+| `DB_USER` | 数据库用户 | `touwaka` |
+| `DB_PASSWORD` | 数据库密码 | `touwaka_secret` |
+| `DB_ROOT_PASSWORD` | MySQL root 密码 | `root_secret_password` |
+| `JWT_SECRET` | JWT 密钥 (必须修改) | - |
+| `JWT_REFRESH_SECRET` | JWT 刷新密钥 (必须修改) | - |
+| `LOG_LEVEL` | 日志级别 | `info` |
+
+### 常用命令
+
+```bash
+# 启动服务
+docker-compose up -d
+
+# 停止服务
+docker-compose down
+
+# 查看日志
+docker-compose logs -f app
+
+# 重新构建
+docker-compose build --no-cache
+
+# 进入容器
+docker-compose exec app sh
+
+# 备份数据
+docker-compose exec db mysqldump -u root -p touwaka_mate > backup.sql
+```
+
+---
+
 ## 🏗️ 技术栈
 
 | 层级 | 技术 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,109 @@
+# ============================================
+# Touwaka Mate - Docker Compose Configuration
+# ============================================
+# Usage:
+#   Development: docker-compose up -d
+#   Production:  docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+# ============================================
+
+services:
+  # ==========================================
+  # Main Application Service
+  # ==========================================
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: touwaka-mate
+    restart: unless-stopped
+    ports:
+      - "${PORT:-3000}:3000"
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - DB_HOST=db
+      - DB_PORT=3306
+      - DB_NAME=${DB_NAME:-touwaka_mate}
+      - DB_USER=${DB_USER:-touwaka}
+      - DB_PASSWORD=${DB_PASSWORD:-touwaka_secret}
+      - JWT_SECRET=${JWT_SECRET:-change-this-secret-in-production}
+      - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET:-change-this-refresh-secret-in-production}
+      - DATA_BASE_PATH=/app/data
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    volumes:
+      - app_data:/app/data
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - touwaka-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  # ==========================================
+  # MySQL Database Service
+  # ==========================================
+  db:
+    image: mysql:8.0
+    container_name: touwaka-mysql
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD:-root_secret_password}
+      - MYSQL_DATABASE=${DB_NAME:-touwaka_mate}
+      - MYSQL_USER=${DB_USER:-touwaka}
+      - MYSQL_PASSWORD=${DB_PASSWORD:-touwaka_secret}
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./scripts/init-database.js:/docker-entrypoint-initdb.d/init-db.js:ro
+    networks:
+      - touwaka-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DB_ROOT_PASSWORD:-root_secret_password}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-authentication-plugin=mysql_native_password
+
+  # ==========================================
+  # (Optional) phpMyAdmin for database management
+  # ==========================================
+  # Uncomment to enable
+  # phpmyadmin:
+  #   image: phpmyadmin/phpmyadmin:latest
+  #   container_name: touwaka-pma
+  #   restart: unless-stopped
+  #   environment:
+  #     - PMA_HOST=db
+  #     - PMA_PORT=3306
+  #     - PMA_USER=root
+  #     - PMA_PASSWORD=${DB_ROOT_PASSWORD:-root_secret_password}
+  #   ports:
+  #     - "8080:80"
+  #   depends_on:
+  #     - db
+  #   networks:
+  #     - touwaka-network
+
+# ==========================================
+# Networks Configuration
+# ==========================================
+networks:
+  touwaka-network:
+    driver: bridge
+
+# ==========================================
+# Volumes Configuration
+# ==========================================
+volumes:
+  mysql_data:
+    driver: local
+  app_data:
+    driver: local

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "koa": "^3.1.1",
         "koa-bodyparser": "^4.4.1",
         "koa-cors": "^0.0.16",
+        "koa-static": "^5.0.0",
         "multer": "^2.0.2",
         "mysql2": "^3.11.3",
         "sequelize": "^6.37.7",
@@ -1934,6 +1935,76 @@
       "integrity": "sha512-s15knPxe3AJBi2I/ZMPL0pSqU+PLYLO6k5tI0AqClkzavowvocPlSdFUwaHNqtjHMhsGmiq2tiX/25iILJx9YA==",
       "license": "MIT"
     },
+    "node_modules/koa-send": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
+      "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "resolve-path": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/koa-send/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-send/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-send/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-static": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
+      "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "koa-send": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/koa-static/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/koa/node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -2357,6 +2428,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pg-connection-string": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
@@ -2541,6 +2621,64 @@
       "integrity": "sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-path": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
+      "integrity": "sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==",
+      "license": "MIT",
+      "dependencies": {
+        "http-errors": "~1.6.2",
+        "path-is-absolute": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-path/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-path/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-path/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/retry-as-promised": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "koa": "^3.1.1",
     "koa-bodyparser": "^4.4.1",
     "koa-cors": "^0.0.16",
+    "koa-static": "^5.0.0",
     "multer": "^2.0.2",
     "mysql2": "^3.11.3",
     "sequelize": "^6.37.7",

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@
 import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';
 import cors from '@koa/cors';
+import serve from 'koa-static';
 import path from 'path';
 import fs from 'fs';
 import { execSync } from 'child_process';
@@ -377,6 +378,36 @@ class ApiServer {
     this.app.use(taskStaticRouter.routes());
     this.app.use(taskStaticRouter.allowedMethods());
     logger.info('Task static routes registered (GET /task-static/t/:token/p/*)');
+
+    // 前端静态文件服务（生产环境）
+    // 检查前端构建目录是否存在
+    const frontendDistPath = path.join(__dirname, '..', 'frontend', 'dist');
+    if (fs.existsSync(frontendDistPath)) {
+      // 托管静态资源文件 (JS, CSS, 图片等)
+      this.app.use(serve(frontendDistPath, {
+        maxage: 31536000000, // 1年缓存
+        gzip: true,
+      }));
+
+      // SPA fallback: 所有非 API 请求返回 index.html
+      // 这样前端路由 (如 /chat, /settings) 可以正常工作
+      this.app.use(async (ctx, next) => {
+        // 只处理非 API 请求
+        if (!ctx.path.startsWith('/api') && !ctx.path.startsWith('/task-static')) {
+          const indexPath = path.join(frontendDistPath, 'index.html');
+          if (fs.existsSync(indexPath)) {
+            ctx.type = 'html';
+            ctx.body = fs.createReadStream(indexPath);
+            return;
+          }
+        }
+        await next();
+      });
+
+      logger.info(`Frontend static files served from ${frontendDistPath}`);
+    } else {
+      logger.warn(`Frontend dist not found at ${frontendDistPath}, skipping static file serving`);
+    }
 
     // 404 处理
     this.app.use(async (ctx) => {


### PR DESCRIPTION
## 概述

添加 Docker 部署支持，让项目可以通过 docker-compose 一键部署。

Closes #214

## 变更内容

### 1. Dockerfile
- 多阶段构建（前端构建 + 生产镜像）
- 支持 Node.js 和 Python 运行环境
- 安装 Office 文档处理依赖（LibreOffice, Poppler）
- 预装常用 Python 包 (python-docx, python-pptx, openpyxl, pandas 等)

### 2. docker-compose.yml
- 应用服务（Node.js）
- MySQL 8.0 数据库服务
- 健康检查和数据持久化

### 3. 后端托管前端静态文件
- 使用 koa-static 托管前端构建输出
- SPA fallback 支持
- 生产环境只需暴露一个端口 (3000)

### 4. 其他
- 添加 .dockerignore
- 更新 README.md 添加 Docker 部署说明

## 部署步骤

```bash
# 1. 复制环境配置
cp .env.example .env

# 2. 编辑 .env 设置必要配置

# 3. 启动服务
docker-compose up -d

# 4. 访问应用
# http://localhost:3000
```

## 技术说明

- 前端在生产环境是静态文件，不监听端口
- 后端同时处理 API 请求和静态文件服务
- Vite 代理只存在于开发阶段

## 验收标准

- [ ] docker-compose up -d 可以成功启动
- [ ] 访问 localhost:3000 可以看到前端页面
- [ ] API 请求正常工作