### PR TITLE
#226: feat 实现 Toast 消息组件替代 alert()

### DIFF
--- a/docs/design/drafts/issue-226-toast-analysis.md
+++ b/docs/design/drafts/issue-226-toast-analysis.md
@@ -1,0 +1,246 @@
+# Issue #226 Toast 组件设计分析报告
+
+## ✌Bazinga！
+
+**分析日期**: 2026-03-19  
+**分析人**: Maria
+
+---
+
+## 一、项目现状分析
+
+### 1.1 技术栈
+
+| 层级 | 技术 |
+|------|------|
+| 前端框架 | Vue 3 + TypeScript + Vite |
+| 状态管理 | Pinia (Composition API 风格) |
+| 国际化 | vue-i18n (zh-CN, en-US) |
+| 样式 | CSS 变量 + Scoped CSS |
+
+### 1.2 alert() 使用统计
+
+通过代码搜索，项目中共有 **63 处** 使用 `alert()` 调用，分布在以下文件：
+
+| 文件 | 调用次数 | 主要用途 |
+|------|----------|----------|
+| `SettingsView.vue` | 22 | 各种操作失败/成功提示 |
+| `TasksTab.vue` | 14 | 任务操作、文件操作提示 |
+| `OrganizationTab.vue` | 4 | 部门/职位操作提示 |
+| `SolutionsView.vue` | 6 | 解决方案 CRUD 提示 |
+| `KnowledgeDetailView.vue` | 4 | 向量化操作提示 |
+| `DebugTab.vue` | 4 | 清空对话、复制操作提示 |
+| `AssistantTab.vue` | 3 | 删除/归档操作提示 |
+| `SkillsView.vue` | 1 | 技能状态切换提示 |
+| `AssistantRoster.vue` | 1 | 加载失败提示 |
+| `AssistantResult.vue` | 1 | 复制失败提示 |
+| `SolutionDetailView.vue` | 2 | 加载/创建任务提示 |
+| `SystemConfigTab.vue` | 2 | 系统配置保存提示 |
+| `PackageWhitelistTab.vue` | 2 | 白名单保存提示 |
+| `AssistantEditDialog.vue` | 3 | 表单验证提示 |
+
+### 1.3 现有 CSS 变量
+
+项目已在 [`App.vue`](frontend/src/App.vue:44) 定义了完整的状态色变量：
+
+```css
+--success-color: #4caf50;
+--warning-color: #ff9800;
+--danger-color: #f44336;
+--error-color: #f44336;
+```
+
+同时支持暗色主题 (`[data-theme="dark"]`)。
+
+---
+
+## 二、Issue #226 设计评估
+
+### 2.1 设计优点 ✅
+
+| 方面 | 评价 |
+|------|------|
+| **组件结构** | Toast.vue + toast.ts store 组合符合项目架构 |
+| **功能完整性** | 4 种类型、自动消失、手动关闭、堆叠显示 |
+| **API 设计** | `toast.success()`, `toast.error()` 等方法简洁易用 |
+| **UI 设计** | 位置、样式、动画都有考虑 |
+| **任务拆分** | 清晰的步骤划分，便于实施 |
+
+### 2.2 需要补充/调整的地方 ⚠️
+
+#### 1. i18n 支持应为必选
+
+**问题**: 设计文档标注"添加 i18n 支持（可选）"  
+**分析**: 项目已有完整的国际化体系，所有用户可见文本都应支持 i18n  
+**建议**: 
+- 在 `zh-CN.ts` 和 `en-US.ts` 中添加 `toast` 命名空间
+- Toast 组件内部支持 i18n key 自动翻译
+
+```typescript
+// 建议的 i18n 结构
+toast: {
+  success: '成功',
+  error: '错误',
+  warning: '警告',
+  info: '提示',
+  close: '关闭',
+}
+```
+
+#### 2. Store 风格需统一
+
+**问题**: 设计文档未明确 Store 实现风格  
+**分析**: 项目现有 store 使用 Composition API 风格（参见 [`counter.ts`](frontend/src/stores/counter.ts:4)）  
+**建议**: 使用 Composition API 风格实现
+
+```typescript
+// 推荐实现风格
+export const useToastStore = defineStore('toast', () => {
+  const items = ref<ToastItem[]>([])
+  
+  function show(item: Omit<ToastItem, 'id'>) { ... }
+  function success(message: string, options?: Partial<ToastItem>) { ... }
+  
+  return { items, show, success, ... }
+})
+```
+
+#### 3. 组件位置调整
+
+**问题**: 设计建议放在 `frontend/src/components/common/Toast.vue`  
+**分析**: 项目目前没有 `common` 目录  
+**建议**: 
+- 方案 A: 创建 `components/common/` 目录，存放通用组件
+- 方案 B: 直接放在 `components/` 下
+
+推荐方案 A，便于后续添加其他通用组件。
+
+#### 4. 暗色主题支持
+
+**问题**: 设计未提及暗色主题  
+**分析**: 项目已有完整的暗色主题支持  
+**建议**: Toast 组件样式应使用 CSS 变量，自动适配暗色主题
+
+```css
+/* 使用现有变量 */
+--success-color
+--warning-color
+--danger-color
+--bg-primary (背景)
+--text-primary (文字)
+```
+
+#### 5. 可访问性 (Accessibility)
+
+**问题**: 设计未提及无障碍支持  
+**建议**: 
+- 添加 `role="alert"` 或 `role="status"` 属性
+- 添加 `aria-live="polite"` 确保屏幕阅读器播报
+- 键盘可访问关闭按钮
+
+#### 6. 类型定义位置
+
+**问题**: 类型定义位置未明确  
+**建议**: 在 `frontend/src/types/` 下创建 `toast.ts` 或添加到现有类型文件
+
+#### 7. 过渡动画实现
+
+**问题**: 设计提到"从右侧滑入，淡出消失"但未详细说明  
+**建议**: 使用 Vue `<Transition>` 组件 + CSS 动画
+
+```vue
+<TransitionGroup name="toast" tag="div">
+  <div v-for="item in items" :key="item.id" class="toast-item">
+    ...
+  </div>
+</TransitionGroup>
+```
+
+```css
+.toast-enter-from { transform: translateX(100%); opacity: 0; }
+.toast-leave-to { transform: translateX(100%); opacity: 0; }
+```
+
+---
+
+## 三、补充建议
+
+### 3.1 增强 API
+
+建议增加以下功能：
+
+```typescript
+// 1. 支持 HTML 内容（可选）
+toast.success({ 
+  message: '<strong>保存成功</strong>', 
+  html: true 
+})
+
+// 2. 支持操作按钮
+toast.error({
+  message: '保存失败',
+  action: { label: '重试', onClick: () => retry() }
+})
+
+// 3. 支持持久化（duration: 0）
+toast.info({
+  message: '系统将在 5 分钟后维护',
+  duration: 0,  // 不自动关闭
+  closable: true
+})
+```
+
+### 3.2 全局错误处理集成
+
+建议在全局错误处理器中集成 Toast：
+
+```typescript
+// main.ts
+app.config.errorHandler = (err) => {
+  const toast = useToastStore()
+  toast.error(err.message || '未知错误')
+}
+```
+
+### 3.3 API 响应拦截器集成
+
+建议在 axios 拦截器中集成 Toast：
+
+```typescript
+// api/index.ts
+axios.interceptors.response.use(
+  response => response,
+  error => {
+    const toast = useToastStore()
+    toast.error(error.response?.data?.message || '请求失败')
+    return Promise.reject(error)
+  }
+)
+```
+
+---
+
+## 四、结论
+
+### 4.1 总体评价
+
+Issue #226 的设计方案**基本满足项目需要**，核心功能设计合理，任务拆分清晰。
+
+### 4.2 实施前需补充
+
+| 优先级 | 补充项 |
+|--------|--------|
+| **必须** | i18n 支持（必选）、暗色主题支持、Store 风格统一 |
+| **建议** | 可访问性支持、组件位置确认、类型定义位置 |
+| **可选** | 操作按钮、HTML 内容支持、全局错误处理集成 |
+
+### 4.3 实施建议
+
+1. 先创建基础组件和 Store
+2. 在 1-2 个文件中试点替换 `alert()`
+3. 验证功能后逐步替换其他文件
+4. 最后考虑增强功能
+
+---
+
+**分析完成！** 亲爱的

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <RouterView />
+  <Toast />
 </template>
 
 <script setup lang="ts">
@@ -7,6 +8,7 @@ import { onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 import { useUserStore } from '@/stores/user'
 import { useI18n } from 'vue-i18n'
+import Toast from '@/components/common/Toast.vue'
 
 const userStore = useUserStore()
 const { locale } = useI18n()

--- a/frontend/src/components/assistant/AssistantResult.vue
+++ b/frontend/src/components/assistant/AssistantResult.vue
@@ -72,6 +72,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useToastStore } from '@/stores/toast'
 
 const props = withDefaults(
   defineProps<{
@@ -95,6 +96,7 @@ const props = withDefaults(
 )
 
 const { t } = useI18n()
+const toast = useToastStore()
 const showWarning = ref(false)
 
 // 成功图标
@@ -131,7 +133,7 @@ async function handleCopy() {
     await navigator.clipboard.writeText(props.content)
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('assistant.copyFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 </script>

--- a/frontend/src/components/assistant/AssistantRoster.vue
+++ b/frontend/src/components/assistant/AssistantRoster.vue
@@ -85,10 +85,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useToastStore } from '@/stores/toast'
 import type { Assistant } from '@/types'
 import { assistantApi } from '@/api/services'
 
 const { t } = useI18n()
+const toast = useToastStore()
 
 const assistants = ref<Assistant[]>([])
 const isLoading = ref(false)
@@ -122,7 +124,7 @@ async function loadAssistants() {
     assistants.value = await assistantApi.getAssistants()
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('assistant.loadFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   } finally {
     isLoading.value = false
   }

--- a/frontend/src/components/common/Toast.vue
+++ b/frontend/src/components/common/Toast.vue
@@ -1,0 +1,197 @@
+<template>
+  <Teleport to="body">
+    <div class="toast-container" role="region" aria-label="通知消息">
+      <TransitionGroup name="toast" tag="div">
+        <div
+          v-for="item in toastStore.items"
+          :key="item.id"
+          :class="['toast-item', `toast-${item.type}`]"
+          :role="item.type === 'error' ? 'alert' : 'status'"
+          :aria-live="item.type === 'error' ? 'assertive' : 'polite'"
+        >
+          <span class="toast-icon" aria-hidden="true">
+            <!-- Success Icon -->
+            <svg v-if="item.type === 'success'" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" />
+            </svg>
+            <!-- Error Icon -->
+            <svg v-else-if="item.type === 'error'" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z" />
+            </svg>
+            <!-- Warning Icon -->
+            <svg v-else-if="item.type === 'warning'" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+            </svg>
+            <!-- Info Icon -->
+            <svg v-else viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+            </svg>
+          </span>
+          <span class="toast-message">{{ item.message }}</span>
+          <button
+            v-if="item.closable"
+            class="toast-close"
+            :aria-label="t('toast.close')"
+            @click="toastStore.remove(item.id)"
+          >
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z" />
+            </svg>
+          </button>
+        </div>
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { useToastStore } from '@/stores/toast'
+import { useI18n } from 'vue-i18n'
+
+const toastStore = useToastStore()
+const { t } = useI18n()
+</script>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 400px;
+  pointer-events: none;
+}
+
+.toast-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-primary, #ffffff);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  pointer-events: auto;
+  min-height: 48px;
+}
+
+/* 类型样式 */
+.toast-success {
+  border-left: 4px solid var(--success-color, #4caf50);
+}
+
+.toast-success .toast-icon {
+  color: var(--success-color, #4caf50);
+}
+
+.toast-error {
+  border-left: 4px solid var(--danger-color, #f44336);
+}
+
+.toast-error .toast-icon {
+  color: var(--danger-color, #f44336);
+}
+
+.toast-warning {
+  border-left: 4px solid var(--warning-color, #ff9800);
+}
+
+.toast-warning .toast-icon {
+  color: var(--warning-color, #ff9800);
+}
+
+.toast-info {
+  border-left: 4px solid var(--primary-color, #2196f3);
+}
+
+.toast-info .toast-icon {
+  color: var(--primary-color, #2196f3);
+}
+
+/* 图标 */
+.toast-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+}
+
+.toast-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* 消息内容 */
+.toast-message {
+  flex: 1;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-primary, #333333);
+  word-break: break-word;
+}
+
+/* 关闭按钮 */
+.toast-close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary, #999999);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.toast-close:hover {
+  color: var(--text-primary, #333333);
+  background: var(--hover-bg, #e8e8e8);
+}
+
+.toast-close svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* 动画 */
+.toast-enter-from {
+  transform: translateX(100%);
+  opacity: 0;
+}
+
+.toast-leave-to {
+  transform: translateX(100%);
+  opacity: 0;
+}
+
+.toast-enter-active {
+  transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+}
+
+.toast-leave-active {
+  transition: transform 0.2s ease-in, opacity 0.2s ease-in;
+}
+
+.toast-move {
+  transition: transform 0.3s ease-out;
+}
+
+/* 暗色主题 */
+[data-theme="dark"] .toast-item {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+/* 响应式 */
+@media (max-width: 480px) {
+  .toast-container {
+    left: 16px;
+    right: 16px;
+    max-width: none;
+  }
+}
+</style>

--- a/frontend/src/components/panel/AssistantTab.vue
+++ b/frontend/src/components/panel/AssistantTab.vue
@@ -175,12 +175,14 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAssistantStore } from '@/stores/assistant'
+import { useToastStore } from '@/stores/toast'
 import type { AssistantRequest, AssistantMessageType } from '@/types'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const route = useRoute()
 const assistantStore = useAssistantStore()
+const toast = useToastStore()
 
 // 当前专家ID
 const currentExpertId = computed(() => route.params.expertId as string)
@@ -315,7 +317,7 @@ async function handleDelete(request: AssistantRequest) {
     await assistantStore.deleteRequest(request.request_id)
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('assistant.deleteFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -325,7 +327,7 @@ async function handleArchive(request: AssistantRequest) {
     await assistantStore.archiveRequest(request.request_id)
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('assistant.archiveFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -335,7 +337,7 @@ async function handleUnarchive(request: AssistantRequest) {
     await assistantStore.unarchiveRequest(request.request_id)
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('assistant.unarchiveFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 

--- a/frontend/src/components/panel/DebugTab.vue
+++ b/frontend/src/components/panel/DebugTab.vue
@@ -149,6 +149,7 @@ import { useModelStore } from '@/stores/model'
 import { useExpertStore } from '@/stores/expert'
 import { useUserStore } from '@/stores/user'
 import { useProviderStore } from '@/stores/provider'
+import { useToastStore } from '@/stores/toast'
 import { messageApi, debugApi } from '@/api/services'
 
 const { t } = useI18n()
@@ -157,6 +158,7 @@ const modelStore = useModelStore()
 const expertStore = useExpertStore()
 const userStore = useUserStore()
 const providerStore = useProviderStore()
+const toast = useToastStore()
 
 const isAdmin = computed(() => userStore.isAdmin)
 const currentExpertId = computed(() => expertStore.currentExpert?.id)
@@ -236,9 +238,9 @@ const handleClearHistory = async () => {
     chatStore.topics = []
     // 清空 Payload
     llmPayload.value = null
-    alert(`对话历史和话题已清空\n删除消息: ${result.deleted_messages_count} 条\n删除话题: ${result.deleted_topics_count} 个`)
+    toast.success(`对话历史和话题已清空，删除消息: ${result.deleted_messages_count} 条，删除话题: ${result.deleted_topics_count} 个`)
   } catch (error) {
-    alert('清空对话历史失败: ' + (error instanceof Error ? error.message : '未知错误'))
+    toast.error('清空对话历史失败: ' + (error instanceof Error ? error.message : '未知错误'))
   } finally {
     isClearing.value = false
   }
@@ -299,10 +301,10 @@ const copyPayload = async () => {
   try {
     const payloadStr = JSON.stringify(llmPayload.value, null, 2)
     await navigator.clipboard.writeText(payloadStr)
-    alert(t('common.copied'))
+    toast.success(t('common.copied'))
   } catch (error) {
     console.error('复制失败:', error)
-    alert(t('common.copyFailed'))
+    toast.error(t('common.copyFailed'))
   }
 }
 </script>

--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -500,6 +500,7 @@ import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { useTaskStore } from '@/stores/task'
+import { useToastStore } from '@/stores/toast'
 import Pagination from '@/components/Pagination.vue'
 import CodePreview from '@/components/CodePreview.vue'
 import type { Task, TaskFile, TaskStatus } from '@/types'
@@ -509,6 +510,7 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const taskStore = useTaskStore()
+const toast = useToastStore()
 
 const searchQuery = ref('')
 const statusFilter = ref<'all' | 'active' | 'archived'>('all')
@@ -581,7 +583,7 @@ const toggleAutonomousMode = async () => {
         updateData.expert_id = expertId
       } else {
         // 没有专家ID，无法开启自主模式
-        alert(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
+        toast.warning(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
         return
       }
     }
@@ -589,7 +591,7 @@ const toggleAutonomousMode = async () => {
     await taskStore.updateTask(taskStore.currentTask.id, updateData)
   } catch (error) {
     console.error('Failed to toggle autonomous mode:', error)
-    alert(t('tasks.toggleAutonomousFailed') || '切换自动运行模式失败')
+    toast.error(t('tasks.toggleAutonomousFailed') || '切换自动运行模式失败')
   } finally {
     isTogglingAutonomous.value = false
   }
@@ -607,7 +609,7 @@ const handleToggleAutonomousFromList = async (task: Task, event: Event) => {
   if (newStatus === 'autonomous') {
     const expertId = route.params.expertId as string
     if (!expertId) {
-      alert(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
+      toast.warning(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
       return
     }
     
@@ -617,13 +619,13 @@ const handleToggleAutonomousFromList = async (task: Task, event: Event) => {
     
     isTogglingAutonomous.value = true
     try {
-      await taskStore.updateTask(task.id, { 
-        status: newStatus, 
-        expert_id: expertId 
+      await taskStore.updateTask(task.id, {
+        status: newStatus,
+        expert_id: expertId
       })
     } catch (error) {
       console.error('Failed to enable autonomous mode:', error)
-      alert(t('tasks.toggleAutonomousFailed') || '切换自动运行模式失败')
+      toast.error(t('tasks.toggleAutonomousFailed') || '切换自动运行模式失败')
     } finally {
       isTogglingAutonomous.value = false
     }
@@ -634,7 +636,7 @@ const handleToggleAutonomousFromList = async (task: Task, event: Event) => {
       await taskStore.updateTask(task.id, { status: newStatus })
     } catch (error) {
       console.error('Failed to disable autonomous mode:', error)
-      alert(t('tasks.toggleAutonomousFailed') || '切换自动运行模式失败')
+      toast.error(t('tasks.toggleAutonomousFailed') || '切换自动运行模式失败')
     } finally {
       isTogglingAutonomous.value = false
     }
@@ -773,7 +775,7 @@ const handleSubmitTask = async () => {
     closeTaskDialog()
   } catch (error) {
     console.error('Failed to save task:', error)
-    alert(t('tasks.saveTaskFailed') || '保存任务失败')
+    toast.error(t('tasks.saveTaskFailed') || '保存任务失败')
   } finally {
     isSubmitting.value = false
   }
@@ -785,7 +787,7 @@ const handleArchiveTask = async (task: Task) => {
     await taskStore.updateTask(task.id, { status: 'archived' })
   } catch (error) {
     console.error('Failed to archive task:', error)
-    alert(t('tasks.archiveTaskFailed') || '归档任务失败')
+    toast.error(t('tasks.archiveTaskFailed') || '归档任务失败')
   }
 }
 
@@ -795,7 +797,7 @@ const handleRestoreTask = async (task: Task) => {
     await taskStore.updateTask(task.id, { status: 'active' })
   } catch (error) {
     console.error('Failed to restore task:', error)
-    alert(t('tasks.restoreTaskFailed') || '恢复任务失败')
+    toast.error(t('tasks.restoreTaskFailed') || '恢复任务失败')
   }
 }
 
@@ -815,7 +817,7 @@ const confirmDeleteTask = async () => {
     taskToDelete.value = null
   } catch (error) {
     console.error('Failed to delete task:', error)
-    alert(t('tasks.deleteTaskFailed') || '删除任务失败')
+    toast.error(t('tasks.deleteTaskFailed') || '删除任务失败')
   }
 }
 
@@ -852,7 +854,7 @@ const handleFileUpload = async (event: Event) => {
     input.value = ''
   } catch (error) {
     console.error('Failed to upload file:', error)
-    alert(t('tasks.uploadFileFailed') || '上传文件失败')
+    toast.error(t('tasks.uploadFileFailed') || '上传文件失败')
   }
 }
 
@@ -1051,7 +1053,7 @@ const handleDownload = async (file: TaskFile) => {
     await taskStore.downloadFile(file.path)
   } catch (error) {
     console.error('Failed to download file:', error)
-    alert(t('tasks.downloadFileFailed') || '下载文件失败')
+    toast.error(t('tasks.downloadFileFailed') || '下载文件失败')
   }
 }
 
@@ -1207,7 +1209,7 @@ const saveEdit = async () => {
     previewOriginalContent.value = previewContent.value
   } catch (error) {
     console.error('Failed to save file:', error)
-    alert(t('tasks.saveFileFailed') || '保存文件失败')
+    toast.error(t('tasks.saveFileFailed') || '保存文件失败')
   } finally {
     previewSaving.value = false
   }
@@ -1239,7 +1241,7 @@ const handleDeleteFile = async () => {
     fileToDelete.value = null
   } catch (error) {
     console.error('Failed to delete file:', error)
-    alert(t('tasks.deleteFileFailed') || '删除文件失败')
+    toast.error(t('tasks.deleteFileFailed') || '删除文件失败')
   }
 }
 

--- a/frontend/src/components/settings/AssistantEditDialog.vue
+++ b/frontend/src/components/settings/AssistantEditDialog.vue
@@ -156,6 +156,7 @@ import { ref, reactive, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Assistant, AIModel } from '@/types'
 import { useSkillStore } from '@/stores/skill'
+import { useToastStore } from '@/stores/toast'
 
 const props = defineProps<{
   assistant: Assistant | null
@@ -171,6 +172,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const skillStore = useSkillStore()
+const toast = useToastStore()
 
 const saving = ref(false)
 
@@ -240,17 +242,17 @@ function handleAssistantTypeKeydown(e: KeyboardEvent) {
 async function handleSubmit() {
   // 创建模式验证
   if (props.isCreate && !form.assistant_type) {
-    alert(t('assistant.assistantTypeRequired'))
+    toast.warning(t('assistant.assistantTypeRequired'))
     return
   }
   if (!form.name) {
-    alert(t('assistant.nameRequired'))
+    toast.warning(t('assistant.nameRequired'))
     return
   }
 
   // direct 模式必须选择工具
   if (form.execution_mode === 'direct' && !form.tool_name) {
-    alert(t('assistant.toolNameRequired'))
+    toast.warning(t('assistant.toolNameRequired'))
     return
   }
 

--- a/frontend/src/components/settings/OrganizationTab.vue
+++ b/frontend/src/components/settings/OrganizationTab.vue
@@ -190,8 +190,10 @@ import { useI18n } from 'vue-i18n'
 import { departmentApi, positionApi } from '@/api/services'
 import type { Department, Position, CreateDepartmentRequest, CreatePositionRequest } from '@/types'
 import DepartmentTreeNode from './DepartmentTreeNode.vue'
+import { useToastStore } from '@/stores/toast'
 
 const { t } = useI18n()
+const toast = useToastStore()
 
 // 状态
 const loading = ref(false)
@@ -303,7 +305,7 @@ const saveDepartment = async () => {
     closeDepartmentDialog()
   } catch (error) {
     console.error('Failed to save department:', error)
-    alert(t('common.saveFailed'))
+    toast.error(t('common.saveFailed'))
   }
 }
 
@@ -320,7 +322,7 @@ const deleteDepartment = async (dept: Department) => {
     await loadDepartmentTree()
   } catch (error: any) {
     console.error('Failed to delete department:', error)
-    alert(error.response?.data?.message || t('common.deleteFailed'))
+    toast.error(error.response?.data?.message || t('common.deleteFailed'))
   }
 }
 
@@ -365,7 +367,7 @@ const savePosition = async () => {
     closePositionDialog()
   } catch (error) {
     console.error('Failed to save position:', error)
-    alert(t('common.saveFailed'))
+    toast.error(t('common.saveFailed'))
   }
 }
 
@@ -378,7 +380,7 @@ const deletePosition = async (position: Position) => {
     await loadPositions(selectedDepartment.value!.id)
   } catch (error: any) {
     console.error('Failed to delete position:', error)
-    alert(error.response?.data?.message || t('common.deleteFailed'))
+    toast.error(error.response?.data?.message || t('common.deleteFailed'))
   }
 }
 

--- a/frontend/src/components/settings/PackageWhitelistTab.vue
+++ b/frontend/src/components/settings/PackageWhitelistTab.vue
@@ -155,10 +155,12 @@
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { usePackageWhitelistStore } from '@/stores/packageWhitelist'
+import { useToastStore } from '@/stores/toast'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const store = usePackageWhitelistStore()
+const toast = useToastStore()
 
 // 当前激活的 tab
 const activeTab = ref<'nodejs' | 'python'>('nodejs')
@@ -278,12 +280,12 @@ const saveWhitelist = async () => {
       allowed_python_packages: [...form.allowed_python_packages],
     })
     if (success) {
-      alert(t('settings.saveSuccess'))
+      toast.success(t('settings.saveSuccess'))
     } else {
-      alert(t('settings.saveFailed'))
+      toast.error(t('settings.saveFailed'))
     }
   } catch (error) {
-    alert(t('settings.saveFailed') + ': ' + error)
+    toast.error(t('settings.saveFailed') + ': ' + error)
   } finally {
     saving.value = false
   }

--- a/frontend/src/components/settings/SystemConfigTab.vue
+++ b/frontend/src/components/settings/SystemConfigTab.vue
@@ -362,11 +362,13 @@
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { useSystemSettingsStore } from '@/stores/systemSettings'
+import { useToastStore } from '@/stores/toast'
 import { useI18n } from 'vue-i18n'
 import PackageWhitelistTab from './PackageWhitelistTab.vue'
 
 const { t } = useI18n()
 const systemSettingsStore = useSystemSettingsStore()
+const toast = useToastStore()
 
 // 子 Tab 状态
 const activeSubTab = ref<'llm' | 'general' | 'timeout' | 'packages'>('general')
@@ -429,9 +431,9 @@ const saveConfig = async () => {
       timeout: { ...form.timeout },
       tool: { ...form.tool },
     })
-    alert(t('settings.saveSuccess'))
+    toast.success(t('settings.saveSuccess'))
   } catch (error) {
-    alert(t('settings.saveFailed') + ': ' + error)
+    toast.error(t('settings.saveFailed') + ': ' + error)
   } finally {
     saving.value = false
   }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1,4 +1,13 @@
 export default {
+  // Toast Messages
+  toast: {
+    success: 'Success',
+    error: 'Error',
+    warning: 'Warning',
+    info: 'Info',
+    close: 'Close',
+  },
+
   // Common
   common: {
     confirm: 'Confirm',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1,4 +1,13 @@
 export default {
+  // Toast 消息
+  toast: {
+    success: '成功',
+    error: '错误',
+    warning: '警告',
+    info: '提示',
+    close: '关闭',
+  },
+
   // 通用
   common: {
     confirm: '确认',

--- a/frontend/src/stores/toast.ts
+++ b/frontend/src/stores/toast.ts
@@ -1,0 +1,108 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import type { ToastItem, ToastOptions, ToastType } from '@/types/toast'
+import { TOAST_DEFAULTS } from '@/types/toast'
+
+/** 生成唯一 ID */
+function generateId(): string {
+  return `toast-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+export const useToastStore = defineStore('toast', () => {
+  /** 当前显示的 Toast 列表 */
+  const items = ref<ToastItem[]>([])
+
+  /**
+   * 显示 Toast 消息
+   * @param options Toast 配置选项
+   */
+  function show(options: ToastOptions): void {
+    const item: ToastItem = {
+      id: generateId(),
+      type: options.type,
+      message: options.message,
+      duration: options.duration ?? TOAST_DEFAULTS.duration,
+      closable: options.closable ?? TOAST_DEFAULTS.closable,
+    }
+
+    // 添加到列表
+    items.value.push(item)
+
+    // 限制最大显示数量，移除最早的
+    if (items.value.length > TOAST_DEFAULTS.maxItems) {
+      items.value.shift()
+    }
+
+    // 设置自动关闭定时器
+    if (item.duration && item.duration > 0) {
+      setTimeout(() => {
+        remove(item.id)
+      }, item.duration)
+    }
+  }
+
+  /**
+   * 显示成功消息
+   * @param message 消息内容
+   * @param options 可选配置
+   */
+  function success(message: string, options?: Partial<ToastOptions>): void {
+    show({ type: 'success', message, ...options })
+  }
+
+  /**
+   * 显示错误消息
+   * @param message 消息内容
+   * @param options 可选配置
+   */
+  function error(message: string, options?: Partial<ToastOptions>): void {
+    show({ type: 'error', message, ...options })
+  }
+
+  /**
+   * 显示警告消息
+   * @param message 消息内容
+   * @param options 可选配置
+   */
+  function warning(message: string, options?: Partial<ToastOptions>): void {
+    show({ type: 'warning', message, ...options })
+  }
+
+  /**
+   * 显示信息消息
+   * @param message 消息内容
+   * @param options 可选配置
+   */
+  function info(message: string, options?: Partial<ToastOptions>): void {
+    show({ type: 'info', message, ...options })
+  }
+
+  /**
+   * 移除指定 Toast
+   * @param id Toast ID
+   */
+  function remove(id: string): void {
+    const index = items.value.findIndex((item) => item.id === id)
+    if (index !== -1) {
+      items.value.splice(index, 1)
+    }
+  }
+
+  /**
+   * 清空所有 Toast
+   */
+  function clear(): void {
+    items.value = []
+  }
+
+  return {
+    items,
+    show,
+    success,
+    error,
+    warning,
+    info,
+    remove,
+    clear,
+  }
+})

--- a/frontend/src/types/toast.ts
+++ b/frontend/src/types/toast.ts
@@ -1,0 +1,53 @@
+/**
+ * Toast 消息类型定义
+ */
+
+/** Toast 消息类型 */
+export type ToastType = 'success' | 'error' | 'warning' | 'info'
+
+/** Toast 消息项 */
+export interface ToastItem {
+  /** 唯一标识 */
+  id: string
+  /** 消息类型 */
+  type: ToastType
+  /** 消息内容 */
+  message: string
+  /** 持续时间（毫秒），默认 3000，0 表示不自动关闭 */
+  duration?: number
+  /** 是否显示关闭按钮，默认 true */
+  closable?: boolean
+}
+
+/** 创建 Toast 的参数（不含 id） */
+export type ToastOptions = Omit<ToastItem, 'id'>
+
+/** Toast Store 接口 */
+export interface ToastStore {
+  /** 当前显示的 Toast 列表 */
+  items: ToastItem[]
+  /** 显示 Toast */
+  show(options: ToastOptions): void
+  /** 显示成功消息 */
+  success(message: string, options?: Partial<ToastOptions>): void
+  /** 显示错误消息 */
+  error(message: string, options?: Partial<ToastOptions>): void
+  /** 显示警告消息 */
+  warning(message: string, options?: Partial<ToastOptions>): void
+  /** 显示信息消息 */
+  info(message: string, options?: Partial<ToastOptions>): void
+  /** 移除指定 Toast */
+  remove(id: string): void
+  /** 清空所有 Toast */
+  clear(): void
+}
+
+/** Toast 默认配置 */
+export const TOAST_DEFAULTS = {
+  /** 默认持续时间 3 秒 */
+  duration: 3000,
+  /** 默认显示关闭按钮 */
+  closable: true,
+  /** 最大显示数量 */
+  maxItems: 5,
+} as const

--- a/frontend/src/views/KnowledgeDetailView.vue
+++ b/frontend/src/views/KnowledgeDetailView.vue
@@ -374,6 +374,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeBaseStore } from '@/stores/knowledgeBase'
+import { useToastStore } from '@/stores/toast'
 import SectionTreeNode from '@/components/SectionTreeNode.vue'
 import type { KbArticle, KbSection, KbParagraph } from '@/types'
 import { marked } from 'marked'
@@ -383,6 +384,7 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const kbStore = useKnowledgeBaseStore()
+const toast = useToastStore()
 
 // State
 const isLoading = ref(true)
@@ -495,7 +497,7 @@ const handleRevectorize = async () => {
           setTimeout(pollProgress, 1000)
         } else if (progress.status === 'completed') {
           // 完成
-          alert(`重新向量化完成！\n总计: ${progress.total}\n成功: ${progress.success}\n失败: ${progress.failed}\n向量维度: ${progress.embedding_dim}`)
+          toast.success(`重新向量化完成！总计: ${progress.total}，成功: ${progress.success}，失败: ${progress.failed}，向量维度: ${progress.embedding_dim}`)
           // 刷新段落列表（如果有选中章节）
           if (selectedSection.value?.id) {
             await kbStore.loadParagraphs(requireKbId(), selectedSection.value.id)
@@ -511,7 +513,7 @@ const handleRevectorize = async () => {
     // 开始轮询
     pollProgress()
   } catch (error: any) {
-    alert('重新向量化失败: ' + (error.message || '未知错误'))
+    toast.error('重新向量化失败: ' + (error.message || '未知错误'))
     isRevectorizing.value = false
     revectorizeJobId = ''
   }
@@ -743,9 +745,9 @@ const handleParagraphRevectorize = async (paragraph: KbParagraph) => {
     })
     // 刷新段落列表
     await kbStore.loadParagraphs(requireKbId(), selectedSection.value.id)
-    alert('已触发段落重新向量化，请稍后刷新查看结果')
+    toast.info('已触发段落重新向量化，请稍后刷新查看结果')
   } catch (error: any) {
-    alert('重新向量化失败: ' + (error.message || '未知错误'))
+    toast.error('重新向量化失败: ' + (error.message || '未知错误'))
   }
 }
 

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1580,6 +1580,7 @@ import { useUserStore } from '@/stores/user'
 import { useModelStore } from '@/stores/model'
 import { useProviderStore } from '@/stores/provider'
 import { useExpertStore } from '@/stores/expert'
+import { useToastStore } from '@/stores/toast'
 import { compressSmallAvatar, compressLargeAvatar } from '@/utils/imageCompress'
 import { expertApi, userApi, roleApi } from '@/api/services'
 import type { AIModel, ModelProvider, ProviderFormData, ModelFormData, Expert, ExpertSkill, ExpertSkillConfig, UserListItem, CreateUserRequest, UpdateUserRequest, Role, Permission, ExpertSimple, UpdateRoleRequest } from '@/types'
@@ -1592,6 +1593,7 @@ const userStore = useUserStore()
 const modelStore = useModelStore()
 const providerStore = useProviderStore()
 const expertStore = useExpertStore()
+const toast = useToastStore()
 
 const activeTab = ref('profile')
 const profileSubTab = ref<'basic' | 'password'>('basic')
@@ -1902,7 +1904,7 @@ const loadUsers = async () => {
     userTotalPages.value = response.pages
   } catch (err) {
     console.error('加载用户列表失败:', err)
-    alert(t('settings.loadUsersFailed'))
+    toast.error(t('settings.loadUsersFailed'))
   } finally {
     usersLoading.value = false
   }
@@ -2025,7 +2027,7 @@ const saveUser = async () => {
     loadUsers()
   } catch (err) {
     console.error('保存用户失败:', err)
-    alert(t('settings.saveUserFailed'))
+    toast.error(t('settings.saveUserFailed'))
   }
 }
 
@@ -2059,7 +2061,7 @@ const deleteUser = async () => {
     loadUsers()
   } catch (err) {
     console.error('删除用户失败:', err)
-    alert(t('settings.deleteUserFailed'))
+    toast.error(t('settings.deleteUserFailed'))
   }
 }
 
@@ -2070,10 +2072,10 @@ const handleResetPassword = async () => {
   try {
     await userApi.resetPassword(editingUser.value.id, { password: userForm.newPassword })
     userForm.newPassword = ''
-    alert(t('settings.resetPasswordSuccess'))
+    toast.success(t('settings.resetPasswordSuccess'))
   } catch (err) {
     console.error('重置密码失败:', err)
-    alert(t('settings.resetPasswordFailed'))
+    toast.error(t('settings.resetPasswordFailed'))
   }
 }
 
@@ -2090,7 +2092,7 @@ const handleUserAvatarUpload = async (event: Event) => {
     console.log(`用户头像压缩: ${Math.round(result.originalSize / 1024)}KB → ${Math.round(result.compressedSize / 1024)}KB`)
   } catch (err) {
     console.error('压缩用户头像失败:', err)
-    alert(err instanceof Error ? err.message : t('settings.imageProcessFailed'))
+    toast.error(err instanceof Error ? err.message : t('settings.imageProcessFailed'))
   }
   input.value = ''
 }
@@ -2122,7 +2124,7 @@ const loadRolesForManagement = async () => {
     rolesList.value = roles
   } catch (err) {
     console.error('加载角色列表失败:', err)
-    alert(t('settings.loadRolesFailed'))
+    toast.error(t('settings.loadRolesFailed'))
   } finally {
     rolesLoading.value = false
   }
@@ -2135,7 +2137,7 @@ const loadAllPermissions = async () => {
     allPermissions.value = permissions
   } catch (err) {
     console.error('加载权限列表失败:', err)
-    alert(t('settings.loadPermissionsFailed'))
+    toast.error(t('settings.loadPermissionsFailed'))
   }
 }
 
@@ -2146,7 +2148,7 @@ const loadAllExperts = async () => {
     allExperts.value = experts
   } catch (err) {
     console.error('加载专家列表失败:', err)
-    alert(t('settings.loadExpertsFailed'))
+    toast.error(t('settings.loadExpertsFailed'))
   }
 }
 
@@ -2229,7 +2231,7 @@ const saveRole = async () => {
     closeRoleDialog()
   } catch (err) {
     console.error('保存角色失败:', err)
-    alert(t('settings.saveRoleFailed'))
+    toast.error(t('settings.saveRoleFailed'))
   }
 }
 
@@ -2242,10 +2244,10 @@ const saveRolePermissions = async () => {
       permission_ids: rolePermissionIds.value,
     })
     rolePermissionsChanged.value = false
-    alert(t('settings.savePermissionsSuccess'))
+    toast.success(t('settings.savePermissionsSuccess'))
   } catch (err) {
     console.error('保存权限配置失败:', err)
-    alert(t('settings.savePermissionsFailed'))
+    toast.error(t('settings.savePermissionsFailed'))
   }
 }
 
@@ -2258,10 +2260,10 @@ const saveRoleExperts = async () => {
       expert_ids: roleExpertIds.value,
     })
     roleExpertsChanged.value = false
-    alert(t('settings.saveExpertsSuccess'))
+    toast.success(t('settings.saveExpertsSuccess'))
   } catch (err) {
     console.error('保存专家访问权限失败:', err)
-    alert(t('settings.saveExpertsFailed'))
+    toast.error(t('settings.saveExpertsFailed'))
   }
 }
 
@@ -2286,11 +2288,11 @@ const handleChangePassword = async () => {
     passwordForm.old_password = ''
     passwordForm.new_password = ''
     passwordForm.confirm_password = ''
-    alert(t('settings.changePasswordSuccess'))
+    toast.success(t('settings.changePasswordSuccess'))
   } catch (err) {
     console.error('修改密码失败:', err)
     const errorMsg = err instanceof Error ? err.message : t('settings.changePasswordFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   } finally {
     passwordLoading.value = false
   }
@@ -2347,7 +2349,7 @@ const saveProvider = async () => {
     closeProviderDialog()
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('settings.saveProviderFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -2376,7 +2378,7 @@ const deleteProvider = async () => {
   } catch (err) {
     // 显示错误信息给用户
     const errorMsg = err instanceof Error ? err.message : t('settings.deleteProviderFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -2432,7 +2434,7 @@ const saveModel = async () => {
     closeModelDialog()
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('settings.saveModelFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -2457,7 +2459,7 @@ const deleteModel = async () => {
   } catch (err) {
     // 显示错误信息给用户
     const errorMsg = err instanceof Error ? err.message : t('settings.deleteModelFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -2538,7 +2540,7 @@ const saveExpert = async () => {
     closeExpertDialog()
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('settings.saveExpertFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -2553,7 +2555,7 @@ const handleSmallAvatarUpload = async (event: Event) => {
     console.log(`小头像压缩: ${Math.round(result.originalSize / 1024)}KB → ${Math.round(result.compressedSize / 1024)}KB`)
   } catch (err) {
     console.error('压缩小头像失败:', err)
-    alert(err instanceof Error ? err.message : t('settings.imageProcessFailed'))
+    toast.error(err instanceof Error ? err.message : t('settings.imageProcessFailed'))
   }
   input.value = ''
 }
@@ -2569,7 +2571,7 @@ const handleLargeAvatarUpload = async (event: Event) => {
     console.log(`大头像压缩: ${Math.round(result.originalSize / 1024)}KB → ${Math.round(result.compressedSize / 1024)}KB`)
   } catch (err) {
     console.error('压缩大头像失败:', err)
-    alert(err instanceof Error ? err.message : t('settings.imageProcessFailed'))
+    toast.error(err instanceof Error ? err.message : t('settings.imageProcessFailed'))
   }
   input.value = ''
 }
@@ -2600,7 +2602,7 @@ const deleteExpert = async () => {
   } catch (err) {
     // 显示错误信息给用户
     const errorMsg = err instanceof Error ? err.message : t('settings.deleteExpertFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 
@@ -2628,7 +2630,7 @@ const loadExpertSkills = async (expertId: string) => {
     skillsList.value = response.skills || []
   } catch (err) {
     console.error('加载技能列表失败:', err)
-    alert(t('settings.loadSkillsFailed'))
+    toast.error(t('settings.loadSkillsFailed'))
   } finally {
     skillsLoading.value = false
   }
@@ -2652,7 +2654,7 @@ const saveSkills = async () => {
     closeSkillsDialog()
   } catch (err) {
     console.error('保存技能配置失败:', err)
-    alert(t('settings.saveSkillsFailed'))
+    toast.error(t('settings.saveSkillsFailed'))
   }
 }
 

--- a/frontend/src/views/SkillsView.vue
+++ b/frontend/src/views/SkillsView.vue
@@ -186,11 +186,13 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useSkillStore } from '@/stores/skill'
+import { useToastStore } from '@/stores/toast'
 import type { Skill } from '@/types'
 import SkillParametersModal from '@/components/SkillParametersModal.vue'
 
 const { t } = useI18n()
 const skillStore = useSkillStore()
+const toast = useToastStore()
 
 const searchQuery = ref('')
 const filterStatus = ref('')
@@ -269,7 +271,7 @@ const toggleSkillActive = async (skill: Skill) => {
     await skillStore.toggleSkillActive(skill.id)
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('skills.toggleFailed')
-    alert(errorMsg)
+    toast.error(errorMsg)
   }
 }
 

--- a/frontend/src/views/SolutionDetailView.vue
+++ b/frontend/src/views/SolutionDetailView.vue
@@ -69,6 +69,7 @@ import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import apiClient from '@/api/client'
+import { useToastStore } from '@/stores/toast'
 
 interface Solution {
   id: number
@@ -85,6 +86,7 @@ interface Solution {
 const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
+const toast = useToastStore()
 
 // State
 const solution = ref<Solution | null>(null)
@@ -117,7 +119,7 @@ const loadSolution = async () => {
   } catch (error) {
     console.error('Failed to load solution:', error)
     solution.value = null
-    alert(t('solutions.loadFailed', '加载解决方案失败'))
+    toast.error(t('solutions.loadFailed', '加载解决方案失败'))
   } finally {
     isLoading.value = false
   }
@@ -155,7 +157,7 @@ const createTaskFromSolution = async () => {
     }
   } catch (error) {
     console.error('Failed to create task:', error)
-    alert(t('solutions.createTaskFailed', '创建任务失败'))
+    toast.error(t('solutions.createTaskFailed', '创建任务失败'))
   } finally {
     isCreatingTask.value = false
   }

--- a/frontend/src/views/SolutionsView.vue
+++ b/frontend/src/views/SolutionsView.vue
@@ -162,6 +162,7 @@ import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
+import { useToastStore } from '@/stores/toast'
 import apiClient from '@/api/client'
 
 interface Solution {
@@ -179,6 +180,7 @@ interface Solution {
 const { t } = useI18n()
 const router = useRouter()
 const userStore = useUserStore()
+const toast = useToastStore()
 
 // Admin check
 const isAdmin = computed(() => userStore.isAdmin)
@@ -238,7 +240,7 @@ const loadSolutions = async () => {
     }
   } catch (error) {
     console.error('Failed to load solutions:', error)
-    alert(t('solutions.loadFailed', '加载解决方案失败'))
+    toast.error(t('solutions.loadFailed', '加载解决方案失败'))
   } finally {
     isLoading.value = false
   }
@@ -283,7 +285,7 @@ const openEditDialog = async (solution: Solution) => {
     tagsInput.value = (fullSolution.tags || []).join(', ')
   } catch (error) {
     console.error('Failed to load solution:', error)
-    alert(t('solutions.loadDetailFailed', '加载解决方案详情失败'))
+    toast.error(t('solutions.loadDetailFailed', '加载解决方案详情失败'))
     formData.value = {
       name: solution.name,
       slug: solution.slug,
@@ -305,7 +307,7 @@ const closeDialog = () => {
 
 const saveSolution = async () => {
   if (!formData.value.name.trim()) {
-    alert(t('solutions.nameRequired', '名称不能为空'))
+    toast.warning(t('solutions.nameRequired', '名称不能为空'))
     return
   }
 
@@ -335,7 +337,7 @@ const saveSolution = async () => {
     loadSolutions()
   } catch (error) {
     console.error('Failed to save solution:', error)
-    alert(t('solutions.saveFailed', '保存失败'))
+    toast.error(t('solutions.saveFailed', '保存失败'))
   } finally {
     isSaving.value = false
   }
@@ -354,7 +356,7 @@ const deleteSolution = async () => {
     loadSolutions()
   } catch (error) {
     console.error('Failed to delete solution:', error)
-    alert(t('solutions.deleteFailed', '删除失败'))
+    toast.error(t('solutions.deleteFailed', '删除失败'))
   }
 }
 


### PR DESCRIPTION
## 概述

实现统一的 Toast 消息组件，替代项目中 63+ 处 `alert()` 调用，提升用户体验。

Closes #226

## 变更内容

### 新增文件
- `frontend/src/types/toast.ts` - Toast 类型定义
- `frontend/src/stores/toast.ts` - Pinia Store（Composition API 风格）
- `frontend/src/components/common/Toast.vue` - Toast 组件

### 修改文件
- `frontend/src/App.vue` - 注册 Toast 容器
- `frontend/src/i18n/locales/zh-CN.ts` - 添加 toast 翻译键
- `frontend/src/i18n/locales/en-US.ts` - 添加 toast 翻译键
- 14 个 Vue 文件 - 替换 `alert()` 为 `toast.success/error/warning/info()`

## 功能特性

- ✅ 四种消息类型：success / error / warning / info
- ✅ 自动关闭（默认 3 秒）
- ✅ 手动关闭按钮
- ✅ 最大显示 5 条，超出自动移除最早的
- ✅ 滑入/滑出动画
- ✅ 暗色主题支持
- ✅ 响应式布局
- ✅ 无障碍支持（role="alert/status", aria-live）
- ✅ i18n 国际化

## 使用方式

```typescript
import { useToastStore } from '@/stores/toast'

const toast = useToastStore()

// 基本用法
toast.success('操作成功')
toast.error('操作失败')
toast.warning('警告信息')
toast.info('提示信息')

// 自定义配置
toast.success('消息', { duration: 5000, closable: false })
```

## 测试验证

- [x] `npm run lint` 通过
- [x] 前端构建成功
- [x] i18n 键完整性验证
- [x] 代码审计清单检查通过