### PR TITLE
#230: feat 登录/注册页面添加语言切换开关

### DIFF
--- a/frontend/src/components/common/LangSelector.vue
+++ b/frontend/src/components/common/LangSelector.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="lang-selector">
+    <select v-model="currentLocale" class="lang-select">
+      <option v-for="lang in availableLocales" :key="lang.value" :value="lang.value">
+        {{ lang.label }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { setLocale } from '@/i18n'
+import type { Locale } from '@/i18n'
+
+// 可用语言列表
+const availableLocales = [
+  { value: 'zh-CN', label: '中文' },
+  { value: 'en-US', label: 'English' },
+]
+
+const { locale } = useI18n()
+
+// 当前语言
+const currentLocale = computed({
+  get: () => locale.value as Locale,
+  set: (value: Locale) => {
+    setLocale(value)
+  }
+})
+</script>
+
+<style scoped>
+.lang-selector {
+  margin-left: 16px;
+}
+
+.lang-select {
+  padding: 6px 12px;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #555;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.lang-select:hover {
+  border-color: #667eea;
+}
+
+.lang-select:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.1);
+}
+</style>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -6,12 +6,7 @@
           <h1 class="login-title">{{ $t('app.title') }}</h1>
           <p class="login-subtitle">{{ $t('login.subtitle') }}</p>
         </div>
-        <div class="lang-selector">
-          <select v-model="currentLocale" class="lang-select">
-            <option value="zh-CN">中文</option>
-            <option value="en-US">English</option>
-          </select>
-        </div>
+        <LangSelector />
       </div>
 
       <form class="login-form" @submit.prevent="handleLogin">
@@ -64,15 +59,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed } from 'vue'
+import { ref, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
-import { setLocale } from '@/i18n'
-import type { Locale } from '@/i18n'
+import LangSelector from '@/components/common/LangSelector.vue'
 
 const router = useRouter()
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const userStore = useUserStore()
 
 const form = reactive({
@@ -82,14 +76,6 @@ const form = reactive({
 
 const loading = ref(false)
 const error = ref('')
-
-// 当前语言
-const currentLocale = computed({
-  get: () => locale.value as Locale,
-  set: (value: Locale) => {
-    setLocale(value)
-  }
-})
 
   const handleLogin = async () => {
     error.value = ''
@@ -139,31 +125,6 @@ const currentLocale = computed({
 
 .header-content {
   flex: 1;
-}
-
-.lang-selector {
-  margin-left: 16px;
-}
-
-.lang-select {
-  padding: 6px 12px;
-  background: #f5f5f5;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  font-size: 13px;
-  color: #555;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.lang-select:hover {
-  border-color: #667eea;
-}
-
-.lang-select:focus {
-  outline: none;
-  border-color: #667eea;
-  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.1);
 }
 
 .login-title {

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -6,12 +6,7 @@
           <h1 class="register-title">{{ $t('app.title') }}</h1>
           <p class="register-subtitle">{{ $t('register.subtitle') }}</p>
         </div>
-        <div class="lang-selector">
-          <select v-model="currentLocale" class="lang-select">
-            <option value="zh-CN">中文</option>
-            <option value="en-US">English</option>
-          </select>
-        </div>
+        <LangSelector />
       </div>
 
       <form class="register-form" @submit.prevent="handleRegister">
@@ -112,16 +107,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { ref, reactive, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
-import { setLocale, type Locale } from '@/i18n'
+import LangSelector from '@/components/common/LangSelector.vue'
 import { getRegistrationConfig, verifyInvitationCode, register, type VerifyResult } from '@/api/invitation'
 
 const router = useRouter()
 const route = useRoute()
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const userStore = useUserStore()
 
 const form = reactive({
@@ -137,14 +132,6 @@ const error = ref('')
 const allowSelfRegistration = ref(false)
 const invitationValidation = ref<VerifyResult | null>(null)
 let validateTimeout: ReturnType<typeof setTimeout> | null = null
-
-// 当前语言
-const currentLocale = computed({
-  get: () => locale.value as Locale,
-  set: (value: Locale) => {
-    setLocale(value)
-  }
-})
 
 // 加载注册配置
 onMounted(async () => {
@@ -270,31 +257,6 @@ const handleRegister = async () => {
 
 .header-content {
   flex: 1;
-}
-
-.lang-selector {
-  margin-left: 16px;
-}
-
-.lang-select {
-  padding: 6px 12px;
-  background: #f5f5f5;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  font-size: 13px;
-  color: #555;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.lang-select:hover {
-  border-color: #667eea;
-}
-
-.lang-select:focus {
-  outline: none;
-  border-color: #667eea;
-  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.1);
 }
 
 .register-title {


### PR DESCRIPTION
## 变更说明

在登录页面和注册页面添加语言切换开关，允许用户在登录/注册时切换界面语言。

## 变更内容

- `frontend/src/views/LoginView.vue`: 添加语言选择器下拉框
- `frontend/src/views/RegisterView.vue`: 添加语言选择器下拉框

## 功能特性

- 语言选择器位于页面标题右侧
- 支持中文（zh-CN）和英文（en-US）切换
- 切换后立即生效，所有文本自动更新
- 语言偏好保存到 localStorage

## 测试

- [x] 登录页面语言切换正常
- [x] 注册页面语言切换正常
- [x] 语言偏好持久化正常

Closes #230