### PR TITLE
#242: fix TokenCleanup 使用错误的数据库方法导致 DELETE 失败

### DIFF
--- a/server/jobs/token-cleanup.js
+++ b/server/jobs/token-cleanup.js
@@ -84,7 +84,7 @@ class TokenCleanupJob {
    */
   async cleanupExpiredTokens() {
     try {
-      const [result] = await this.db.query(
+      const result = await this.db.execute(
         `DELETE FROM task_token WHERE expires_at < NOW()`
       );
       return result.affectedRows || 0;
@@ -100,7 +100,7 @@ class TokenCleanupJob {
   async cleanupOldLogs() {
     try {
       const cutoffDate = new Date(Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000);
-      const [result] = await this.db.query(
+      const result = await this.db.execute(
         `DELETE FROM task_token_access_log WHERE accessed_at < ?`,
         [cutoffDate]
       );


### PR DESCRIPTION
## 问题描述

后端启动时，TokenCleanup 任务报错：

```
[ERROR] Query failed: results.map is not a function {"sql":"DELETE FROM task_token WHERE expires_at < NOW()"}
[ERROR] [TokenCleanup] Failed to cleanup expired tokens: results.map is not a function
```

## 原因分析

`server/jobs/token-cleanup.js` 中的 `cleanupExpiredTokens()` 和 `cleanupOldLogs()` 方法使用了 `db.query()` 方法执行 DELETE 语句。

但 `lib/db.js` 中的 `query()` 方法使用 `QueryTypes.SELECT`，返回的是结果数组，而不是 `[result, metadata]` 格式。

DELETE 语句应该使用 `db.execute()` 方法，该方法专门用于 UPDATE/DELETE 操作，返回 `{ affectedRows, changedRows }` 格式。

## 修复内容

| 文件 | 修改 |
|------|------|
| `server/jobs/token-cleanup.js:87` | `db.query()` → `db.execute()` |
| `server/jobs/token-cleanup.js:103` | `db.query()` → `db.execute()` |

## 影响范围

- Token 清理任务
- 访问日志清理任务

Closes #242