### PR TITLE
#245: fix 优化记忆系统中location字段的LLM提取引导

### DIFF
--- a/lib/memory-system.js
+++ b/lib/memory-system.js
@@ -533,7 +533,8 @@ ${conversationText}
 - 总结详细（50-100字）
 - startIndex 和 endIndex 是消息在数组中的索引（从 0 开始）
 - 话题之间不应该有重叠
-- 如果所有消息属于同一个话题，只返回一个话题`;
+- 如果所有消息属于同一个话题，只返回一个话题
+- location 为居住城市，非文件路径`;
 
     try {
       const response = await this.llmClient.callExpressive([
@@ -789,7 +790,7 @@ ${conversationText}
 - age: 数字年龄 / null
 - preferredName: 用户希望被称呼的名字 / null
 - occupation: 职业 / null
-- location: 所在地 / null
+- location: 居住城市（如：北京、上海）/ null
 
 ## 返回格式
 {


### PR DESCRIPTION
## 变更说明

优化记忆系统中 `location` 字段的 LLM 提取引导，防止将文件路径误判为地理位置。

## 变更内容

**文件：** `lib/memory-system.js`

**修改 1：`summarizeConversation` 方法（第792行）**
```diff
- - location: 所在地 / null
+ - location: 居住城市（如：北京、上海）/ null
```

**修改 2：`identifyTopics` 方法（第537行）**
```diff
+ - location 为居住城市，非文件路径
```

## 问题原因

"所在地" 太模糊，LLM 可能理解为"文件所在位置"、"项目所在位置"等，导致将 `D:\projects\node\` 这样的路径错误提取为 location 字段值。

## 测试验证

后续对话中，LLM 应能正确识别 location 字段，不再将文件路径误判为地理位置。

Closes #245