### PR TITLE
#247: fix 修复注册配置保存后无法读取的问题

### DIFF
--- a/server/controllers/system-setting.controller.js
+++ b/server/controllers/system-setting.controller.js
@@ -36,6 +36,12 @@ const DEFAULT_SETTINGS = {
   tool: {
     max_rounds: 20,         // 最大工具调用轮数
   },
+  registration: {
+    allow_self_registration: true,    // 是否允许自主注册
+    default_invitation_quota: 10,     // 默认邀请配额
+    default_invitation_max_uses: 5,   // 默认邀请码最大使用次数
+    invitation_expiry_days: 30,       // 邀请码有效期（天）
+  },
 };
 
 class SystemSettingController {


### PR DESCRIPTION
## 问题描述

设置界面 - 系统配置 - 注册配置，点击保存后刷新页面，参数恢复为修改前的值。

## 问题原因

[`system-setting.controller.js`](server/controllers/system-setting.controller.js:10) 中的 `DEFAULT_SETTINGS` 缺少 `registration` 配置部分。

[`_parseSettings`](server/controllers/system-setting.controller.js:62) 方法中有以下关键检查：
```javascript
if (result[section] && key in result[section]) {
  result[section][key] = this._parseValue(...);
}
```

由于 `DEFAULT_SETTINGS` 没有 `registration` section：
1. `result.registration` 是 `undefined`
2. 即使数据库中有 registration 配置，也不会被解析返回
3. 保存时数据写入数据库，但读取时被忽略

## 修复内容

在 `DEFAULT_SETTINGS` 中添加 `registration` 配置定义：
```javascript
registration: {
  allow_self_registration: true,
  default_invitation_quota: 10,
  default_invitation_max_uses: 5,
  invitation_expiry_days: 30,
},
```

## 测试验证

- [x] `npm run lint` 通过
- [x] 代码审计清单检查通过

Closes #247