### PR TITLE
fix: 普通用户进入设置页面出现 403 错误

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -2701,9 +2701,11 @@ onMounted(() => {
   providerStore.loadProviders()
   // 加载所有专家列表（包括非活跃的）
   expertStore.loadExperts({})
-  // 加载权限列表和专家列表（用于角色管理）
-  loadAllPermissions()
-  loadAllExperts()
+  // 加载权限列表和专家列表（用于角色管理）- 仅管理员需要
+  if (isAdmin.value) {
+    loadAllPermissions()
+    loadAllExperts()
+  }
 })
 </script>
 


### PR DESCRIPTION
## 问题描述

普通用户进入系统后访问设置页面时，控制台出现 403 Forbidden 错误：

```
GET https://test.touwaka.cc/api/roles/experts/all 403 (Forbidden)
GET https://test.touwaka.cc/api/roles/permissions/all 403 (Forbidden)
```

## 原因分析

`SettingsView.vue` 的 `onMounted` 钩子无条件调用了两个管理员专属 API：
- `loadAllPermissions()` → `GET /api/roles/permissions/all`
- `loadAllExperts()` → `GET /api/roles/experts/all`

这两个 API 在后端使用 `requireAdmin()` 中间件保护，普通用户无权访问。

## 解决方案

在调用这两个 API 前添加 `isAdmin.value` 检查，只有管理员用户才执行这些调用。

## 修改内容

```diff
-  // 加载权限列表和专家列表（用于角色管理）
-  loadAllPermissions()
-  loadAllExperts()
+  // 加载权限列表和专家列表（用于角色管理）- 仅管理员需要
+  if (isAdmin.value) {
+    loadAllPermissions()
+    loadAllExperts()
+  }
```

## 影响范围

- 修复了普通用户访问设置页面时的 403 错误
- 不影响管理员用户的正常使用
- 角色管理 tab 已通过 `adminOnly: true` 对普通用户隐藏

Closes #249