### PR TITLE
#255: fix 为 Skill 路由添加认证和权限控制

### DIFF
--- a/server/routes/skill.routes.js
+++ b/server/routes/skill.routes.js
@@ -4,6 +4,7 @@
 
 import Router from '@koa/router';
 import multer from '@koa/multer';
+import { authenticate, requireAdmin } from '../middlewares/auth.js';
 
 // 配置 multer 用于文件上传
 const upload = multer({
@@ -20,49 +21,53 @@ const upload = multer({
 export default function createSkillRoutes(controller) {
   const router = new Router({ prefix: '/api/skills' });
 
+  // ==================== 只读操作（需要认证）====================
+
   // GET /api/skills - 获取技能列表
-  router.get('/', controller.list.bind(controller));
+  router.get('/', authenticate(), controller.list.bind(controller));
 
   // GET /api/skills/:id - 获取技能详情
-  router.get('/:id', controller.get.bind(controller));
-
-  // POST /api/skills/from-url - 从 URL 安装
-  router.post('/from-url', controller.installFromUrl.bind(controller));
-
-  // POST /api/skills/from-zip - 从 ZIP 安装
-  router.post('/from-zip', upload.single('file'), controller.installFromZip.bind(controller));
-
-  // POST /api/skills/from-path - 从本地目录安装
-  router.post('/from-path', controller.installFromPath.bind(controller));
-
-  // PUT /api/skills/:id - 更新技能
-  router.put('/:id', controller.update.bind(controller));
-
-  // DELETE /api/skills/:id - 删除技能
-  router.delete('/:id', controller.delete.bind(controller));
-
-  // POST /api/skills/:id/reanalyze - 重新分析技能
-  router.post('/:id/reanalyze', controller.reanalyze.bind(controller));
+  router.get('/:id', authenticate(), controller.get.bind(controller));
 
   // GET /api/skills/:id/parameters - 获取技能参数
-  router.get('/:id/parameters', controller.getParameters.bind(controller));
+  router.get('/:id/parameters', authenticate(), controller.getParameters.bind(controller));
+
+  // ==================== 写入操作（需要管理员权限）====================
+
+  // POST /api/skills/from-url - 从 URL 安装
+  router.post('/from-url', authenticate(), requireAdmin(), controller.installFromUrl.bind(controller));
+
+  // POST /api/skills/from-zip - 从 ZIP 安装
+  router.post('/from-zip', authenticate(), requireAdmin(), upload.single('file'), controller.installFromZip.bind(controller));
+
+  // POST /api/skills/from-path - 从本地目录安装
+  router.post('/from-path', authenticate(), requireAdmin(), controller.installFromPath.bind(controller));
+
+  // PUT /api/skills/:id - 更新技能
+  router.put('/:id', authenticate(), requireAdmin(), controller.update.bind(controller));
+
+  // DELETE /api/skills/:id - 删除技能
+  router.delete('/:id', authenticate(), requireAdmin(), controller.delete.bind(controller));
+
+  // POST /api/skills/:id/reanalyze - 重新分析技能
+  router.post('/:id/reanalyze', authenticate(), requireAdmin(), controller.reanalyze.bind(controller));
 
   // POST /api/skills/:id/parameters - 保存技能参数（全量替换）
-  router.post('/:id/parameters', controller.saveParameters.bind(controller));
+  router.post('/:id/parameters', authenticate(), requireAdmin(), controller.saveParameters.bind(controller));
 
-  // ==================== Skills Studio API ====================
+  // ==================== Skills Studio API（需要管理员权限）====================
 
   // POST /api/skills/register - 注册技能（从本地路径）
-  router.post('/register', controller.register.bind(controller));
+  router.post('/register', authenticate(), requireAdmin(), controller.register.bind(controller));
 
   // POST /api/skills/assign - 分配技能给专家
-  router.post('/assign', controller.assign.bind(controller));
+  router.post('/assign', authenticate(), requireAdmin(), controller.assign.bind(controller));
 
   // POST /api/skills/unassign - 取消技能分配
-  router.post('/unassign', controller.unassign.bind(controller));
+  router.post('/unassign', authenticate(), requireAdmin(), controller.unassign.bind(controller));
 
   // PATCH /api/skills/:id/toggle - 启用/禁用技能
-  router.patch('/:id/toggle', controller.toggle.bind(controller));
+  router.patch('/:id/toggle', authenticate(), requireAdmin(), controller.toggle.bind(controller));
 
   return router;
 }


### PR DESCRIPTION
## 问题描述

Skill 路由（`/api/skills/*`）缺少认证中间件，导致任何用户（包括未登录用户）都可以执行敏感操作。

## 修复内容

为所有 Skill 路由添加认证和权限控制：

### 只读操作（需要认证）
- `GET /api/skills` - 获取技能列表
- `GET /api/skills/:id` - 获取技能详情
- `GET /api/skills/:id/parameters` - 获取技能参数

### 写入操作（需要管理员权限）
- `POST /api/skills/from-url` - 从 URL 安装
- `POST /api/skills/from-zip` - 从 ZIP 安装
- `POST /api/skills/from-path` - 从本地目录安装
- `PUT /api/skills/:id` - 更新技能
- `DELETE /api/skills/:id` - 删除技能
- `POST /api/skills/:id/reanalyze` - 重新分析技能
- `POST /api/skills/:id/parameters` - 保存技能参数
- `POST /api/skills/register` - 注册技能
- `POST /api/skills/assign` - 分配技能给专家
- `POST /api/skills/unassign` - 取消技能分配
- `PATCH /api/skills/:id/toggle` - 启用/禁用技能

## 修复后行为

| 用户类型 | 响应 |
|---------|------|
| 未登录用户 | 401 "未提供访问令牌" |
| 已登录但非管理员 | 403 "需要管理员权限" |
| 管理员 | 正常执行操作 |

Closes #255