### PR TITLE
#255: fix 限制普通用户只能访问自己的工作目录

### DIFF
--- a/data/skills/file-operations/index.js
+++ b/data/skills/file-operations/index.js
@@ -17,11 +17,20 @@ const IS_ADMIN = process.env.IS_ADMIN === 'true';
 // 统一使用 DATA_BASE_PATH，技能路径为 DATA_BASE_PATH/skills
 const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
 
+// 技能目录（普通用户禁止访问）
+const SKILLS_DIR = path.join(DATA_BASE_PATH, 'skills');
+
+// 用户工作目录
+const USER_ID = process.env.USER_ID || 'default';
+const USER_WORK_DIR = process.env.WORKING_DIRECTORY
+  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
+  : path.join(DATA_BASE_PATH, 'work', USER_ID);
+
 // 管理员可以访问项目根目录
 const PROJECT_ROOT = process.cwd();
 const ALLOWED_BASE_PATHS = IS_ADMIN
   ? [PROJECT_ROOT, DATA_BASE_PATH]  // 管理员：项目根目录 + data 目录
-  : [DATA_BASE_PATH, path.join(DATA_BASE_PATH, 'skills')];  // 普通用户：仅 data 目录
+  : [USER_WORK_DIR];  // 普通用户：仅用户工作目录
 
 // Maximum file size to read (50MB)
 const MAX_FILE_SIZE = 50 * 1024 * 1024;


### PR DESCRIPTION
## 问题描述

Issue #255: 普通用户调用专家时，可以通过 `file-operations` 技能读取/修改 `data/skills` 目录中的技能代码。

## 修复内容

修改 [`data/skills/file-operations/index.js`](data/skills/file-operations/index.js) 的权限控制逻辑：

### 修改前
```javascript
const ALLOWED_BASE_PATHS = IS_ADMIN
  ? [PROJECT_ROOT, DATA_BASE_PATH]
  : [DATA_BASE_PATH, path.join(DATA_BASE_PATH, 'skills')];
```

问题：普通用户可访问整个 `DATA_BASE_PATH`（即 `data/`），包含 `data/skills` 目录。

### 修改后
```javascript
const USER_ID = process.env.USER_ID || 'default';
const USER_WORK_DIR = process.env.WORKING_DIRECTORY
  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
  : path.join(DATA_BASE_PATH, 'work', USER_ID);

const ALLOWED_BASE_PATHS = IS_ADMIN
  ? [PROJECT_ROOT, DATA_BASE_PATH]
  : [USER_WORK_DIR];  // 普通用户：仅用户工作目录
```

## 安全效果

| 用户类型 | 修改前 | 修改后 |
|----------|--------|--------|
| 管理员 | 项目根目录 + data 目录 | 项目根目录 + data 目录 |
| 普通用户 | 整个 data 目录（含 skills） | 仅 `data/work/{user_id}` |

### 防护效果

1. **禁止访问 skills 目录**：普通用户无法读取/修改 `data/skills` 中的技能代码
2. **用户隔离**：普通用户只能访问自己的工作目录，无法访问其他用户的文件

Closes #255