### PR TITLE
#255: fix 防止路径遍历和符号链接攻击

### DIFF
--- a/data/skills/file-operations/index.js
+++ b/data/skills/file-operations/index.js
@@ -37,20 +37,40 @@ const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 /**
  * Check if path is within allowed directories
+ * 防护：路径遍历攻击和符号链接攻击
  */
 function isPathAllowed(targetPath) {
-  const resolved = path.resolve(targetPath);
+  // 使用 path.resolve 规范化路径（处理 .. 等）
+  let resolved = path.resolve(targetPath);
+  
+  // 使用 fs.realpathSync 解析符号链接（防止符号链接逃逸）
+  try {
+    if (fs.existsSync(resolved)) {
+      resolved = fs.realpathSync(resolved);
+    }
+  } catch (e) {
+    // 路径不存在时，继续使用 path.resolve 的结果
+  }
+  
   return ALLOWED_BASE_PATHS.some(basePath => {
-    const resolvedBase = path.resolve(basePath);
+    let resolvedBase = path.resolve(basePath);
+    try {
+      if (fs.existsSync(resolvedBase)) {
+        resolvedBase = fs.realpathSync(resolvedBase);
+      }
+    } catch (e) {
+      // 基础路径不存在时，继续使用 path.resolve 的结果
+    }
     return resolved.startsWith(resolvedBase);
   });
 }
 
 /**
  * Resolve path relative to allowed base directories
+ * 防护：确保所有返回的路径都在允许的目录内
  */
 function resolvePath(relativePath) {
-  // If absolute path, check if it's allowed
+  // 如果是绝对路径，检查是否被允许
   if (path.isAbsolute(relativePath)) {
     if (!isPathAllowed(relativePath)) {
       throw new Error(`Path not allowed: ${relativePath}`);
@@ -58,16 +78,24 @@ function resolvePath(relativePath) {
     return relativePath;
   }
   
-  // Try each allowed base path
+  // 尝试每个允许的基础路径
   for (const basePath of ALLOWED_BASE_PATHS) {
     const resolved = path.join(basePath, relativePath);
     if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
+      // 再次检查解析后的路径是否被允许（防止路径遍历）
+      if (!isPathAllowed(resolved)) {
+        throw new Error(`Path not allowed: ${resolved}`);
+      }
       return resolved;
     }
   }
   
-  // Default to first base path
-  return path.join(ALLOWED_BASE_PATHS[0], relativePath);
+  // 默认使用第一个基础路径，但必须检查权限
+  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
+  if (!isPathAllowed(defaultPath)) {
+    throw new Error(`Path not allowed: ${defaultPath}`);
+  }
+  return defaultPath;
 }
 
 /**


### PR DESCRIPTION
## 安全审查发现

在 Issue #255 的代码审查中，发现了两个潜在的安全漏洞：

### 1. 路径遍历攻击 (Path Traversal)

**问题**：`resolvePath()` 函数末尾没有检查最终路径是否被允许

```javascript
// 问题代码
return path.join(ALLOWED_BASE_PATHS[0], relativePath);  // 没有检查！
```

**攻击示例**：
```
用户输入: "../../../skills/file-operations/index.js"
可能解析为: data/skills/file-operations/index.js
```

### 2. 符号链接攻击 (Symlink Attack)

**问题**：`path.resolve()` 不会解析符号链接

**攻击场景**：
1. 用户在工作目录创建符号链接：`ln -s ../../skills link_to_skills`
2. 读取 `link_to_skills/some-skill/index.js`
3. 路径检查通过（以工作目录开头）
4. 实际读取的是 `data/skills/some-skill/index.js`

## 修复内容

### 修改 [`isPathAllowed()`](data/skills/file-operations/index.js:41)

```javascript
function isPathAllowed(targetPath) {
  // 使用 path.resolve 规范化路径（处理 .. 等）
  let resolved = path.resolve(targetPath);
  
  // 使用 fs.realpathSync 解析符号链接（防止符号链接逃逸）
  try {
    if (fs.existsSync(resolved)) {
      resolved = fs.realpathSync(resolved);
    }
  } catch (e) {
    // 路径不存在时，继续使用 path.resolve 的结果
  }
  
  return ALLOWED_BASE_PATHS.some(basePath => {
    // 同样解析基础路径的符号链接
    ...
  });
}
```

### 修改 [`resolvePath()`](data/skills/file-operations/index.js:70)

```javascript
function resolvePath(relativePath) {
  ...
  // 默认使用第一个基础路径，但必须检查权限
  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
  if (!isPathAllowed(defaultPath)) {
    throw new Error(`Path not allowed: ${defaultPath}`);
  }
  return defaultPath;
}
```

## 防护效果

| 攻击类型 | 修复前 | 修复后 |
|----------|--------|--------|
| 路径遍历 (`../`) | 可能逃逸 | ✅ 被阻止 |
| 符号链接 | 可能逃逸 | ✅ 被阻止 |

Closes #255