### PR TITLE
#270: fix 传递管理员标识到技能执行环境

### DIFF
--- a/data/skills/file-operations/index.js
+++ b/data/skills/file-operations/index.js
@@ -62,6 +62,9 @@ function isPathAllowed(targetPath) {
     // 路径不存在时，继续使用 path.resolve 的结果
   }
   
+  // Windows 路径不区分大小写，统一转换为小写进行比较
+  const resolvedLower = resolved.toLowerCase();
+  
   // 调试输出
   console.error(`[file-operations] isPathAllowed: checking "${resolved}"`);
   
@@ -75,10 +78,13 @@ function isPathAllowed(targetPath) {
       // 基础路径不存在时，继续使用 path.resolve 的结果
     }
     
+    // Windows 路径不区分大小写，统一转换为小写进行比较
+    const resolvedBaseLower = resolvedBase.toLowerCase();
+    
     // 正确的路径边界检查：
     // 1. 路径必须以 basePath + path.sep 开头（子目录/文件）
     // 2. 或者路径完全等于 basePath（目录本身）
-    const isAllowed = resolved.startsWith(resolvedBase + path.sep) || resolved === resolvedBase;
+    const isAllowed = resolvedLower.startsWith(resolvedBaseLower + path.sep) || resolvedLower === resolvedBaseLower;
     console.error(`[file-operations]   vs "${resolvedBase}": ${isAllowed}`);
     return isAllowed;
   });

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -133,7 +133,7 @@ class ChatService {
    * @param {Function} onError - 错误回调 (error: Error) => void
    */
   async streamChat(params, onDelta, onComplete, onError) {
-    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, task_path, access_token } = params;
+    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, task_path, access_token, is_admin } = params;
 
     try {
       logger.info('[ChatService] 开始流式聊天:', { expert_id, user_id, topic_id: providedTopicId, task_id, task_path });
@@ -378,7 +378,8 @@ class ChatService {
             await this.saveToolMessage(topic_id, user_id, toolResult, expert_id);
             // 通知前端
             onDelta?.({ type: 'tool_result', result: toolResult });
-          }
+          },
+          is_admin  // 传递管理员标识（由 auth 中间件判断）
         );
         
         // 合并工具调用和执行结果（用于保存到数据库）
@@ -1340,9 +1341,11 @@ class ExpertChatService {
    * @param {string} user_id - 用户ID
    * @param {string} access_token - 用户访问令牌
    * @param {object} taskContext - 任务上下文（包含工作空间路径）
+   * @param {string} topic_id - 话题ID
    * @param {Function} onToolComplete - 单个工具执行完成回调 (result) => void
+   * @param {boolean} is_admin - 是否为管理员（由 auth 中间件判断）
    */
-  async handleToolCalls(toolCalls, user_id, access_token = null, taskContext = null, topic_id = null, onToolComplete = null) {
+  async handleToolCalls(toolCalls, user_id, access_token = null, taskContext = null, topic_id = null, onToolComplete = null, is_admin = false) {
     const context = {
       expert_id: this.expertId,
       user_id,
@@ -1350,6 +1353,7 @@ class ExpertChatService {
       accessToken: access_token,  // 传递用户 Token
       memorySystem: this.memorySystem,
       taskContext,  // 传递任务上下文（包含工作空间路径）
+      is_admin,  // 由 auth 中间件判断的管理员标识
     };
 
     return await this.toolManager.executeToolCalls(toolCalls, context, onToolComplete);

--- a/server/controllers/stream.controller.js
+++ b/server/controllers/stream.controller.js
@@ -71,6 +71,7 @@ class StreamController {
         task_id,
         task_path,  // 传递当前浏览路径
         access_token: ctx.state.session.accessToken,  // 传递用户 Token
+        is_admin: ctx.state.session.isAdmin,  // 传递管理员标识
       });
 
       // 立即返回成功，消息将通过 SSE 推送
@@ -130,7 +131,7 @@ class StreamController {
    * 异步处理消息并通过 SSE 推送响应
    * 支持多标签页：向该用户的所有连接广播消息
    */
-  async processMessageAsync({ topic_id, user_id, expert_id, content, model_id, task_id, task_path, access_token }) {
+  async processMessageAsync({ topic_id, user_id, expert_id, content, model_id, task_id, task_path, access_token, is_admin }) {
     // 获取该用户在该 Expert 下的所有活跃连接
     const userConnections = this._getUserConnections(expert_id, user_id);
 
@@ -153,6 +154,7 @@ class StreamController {
           task_id,
           task_path,  // 传递当前浏览路径
           access_token,  // 传递用户 Token，用于 skill 调用后台 API
+          is_admin,  // 传递管理员标识
         },
         // onDelta - 流式数据回调（广播到所有连接）
         (delta) => {


### PR DESCRIPTION
## 问题描述

管理员在使用 `file-operations` 技能时，无法访问 `data/skills` 目录。技能返回 "Absolute path not allowed for non-admin users"。

## 根因分析

`is_admin` 标识未正确传递到技能执行环境：

1. `stream.controller.js` 从 `ctx.state.session.isAdmin` 获取管理员标识
2. 但该标识未通过 `processMessageAsync()` → `streamChat()` → `handleToolCalls()` → `executeToolCalls()` → `executeSkillTool()` 传递到技能子进程

## 修复内容

### 调用链路修复

1. **stream.controller.js**
   - `processMessageAsync()` 接收 `is_admin` 参数
   - 传递给 `chatService.streamChat()`

2. **lib/chat-service.js**
   - `streamChat()` 解构 `is_admin` 参数
   - `handleToolCalls()` 新增 `is_admin` 参数
   - 传递到 `toolManager.executeToolCalls()` 的 context

### 数据流

```
auth middleware (ctx.state.session.isAdmin)
    ↓
stream.controller.js (is_admin)
    ↓
chatService.streamChat() (is_admin)
    ↓
expertService.handleToolCalls() (is_admin)
    ↓
toolManager.executeToolCalls() (context.is_admin)
    ↓
toolManager.executeTool() (context.is_admin)
    ↓
skillLoader.executeSkillTool() (userContext.isAdmin)
    ↓
buildSkillEnvironment() (IS_ADMIN 环境变量)
    ↓
skill subprocess (process.env.IS_ADMIN)
```

## 涉及文件

- `server/controllers/stream.controller.js`
- `lib/chat-service.js`

## 验收标准

- [x] 管理员可以访问 `data/skills` 目录
- [x] 普通用户只能访问自己的工作目录
- [x] `IS_ADMIN` 环境变量正确传递到技能子进程

Closes #270