### PR TITLE
#288: fix streamChat 方法未解构 session 参数导致工具调用失败

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -133,7 +133,7 @@ class ChatService {
    * @param {Function} onError - 错误回调 (error: Error) => void
    */
   async streamChat(params, onDelta, onComplete, onError) {
-    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, access_token, is_admin } = params;
+    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, access_token, is_admin, session } = params;
 
     try {
       logger.info('[ChatService] 开始流式聊天:', { expert_id, user_id, topic_id: providedTopicId, task_id, working_path });


### PR DESCRIPTION
## 问题描述

在 `lib/chat-service.js` 的 `streamChat` 方法中，解构 `params` 参数时遗漏了 `session` 变量，但在后续代码中却引用了 `session`，导致工具调用时抛出 `ReferenceError: session is not defined` 错误。

## 错误日志

```
[2026-03-21T16:08:33.442Z] [INFO] [ChatService] 第1轮开始执行工具调用: 1
[2026-03-21T16:08:33.446Z] [ERROR] [ChatService] 流式聊天失败: session is not defined
```

## 修复内容

在解构 `params` 时添加 `session` 变量：

```diff
- const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, access_token, is_admin } = params;
+ const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, access_token, is_admin, session } = params;
```

## 测试

- [x] 工具调用正常执行
- [x] session 对象正确传递给 handleToolCalls

Closes #288