### PR TITLE
#290: feat 完善三种对话模式的工作目录处理逻辑

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -145,6 +145,7 @@ class ChatService {
       // 2. 获取任务上下文（如果在任务工作空间模式下）
       let taskContext = null;
       if (task_id) {
+        // 任务模式：根据 task_id 获取任务工作目录
         taskContext = await this.getTaskContext(task_id, user_id, working_path);
         if (taskContext) {
           logger.info('[ChatService] 任务上下文已加载:', taskContext.title, '路径:', working_path || '根目录');
@@ -157,6 +158,14 @@ class ChatService {
           currentPath: '',  // 技能模式下没有子路径
         };
         logger.info('[ChatService] 技能模式工作目录:', working_path);
+      } else {
+        // 对话模式：使用用户临时目录作为工作目录
+        // 路径格式：work/:user_id/temp（相对于 data/ 目录）
+        taskContext = {
+          fullWorkspacePath: `work/${user_id}/temp`,
+          currentPath: '',
+        };
+        logger.info('[ChatService] 对话模式工作目录: work/' + user_id + '/temp');
       }
 
       // 3. 获取或创建活跃对话（用于前端展示，消息不再关联 topic_id）

--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -370,15 +370,38 @@ ${assistantsDescription}
 
   /**
    * 用任务工作空间上下文增强系统提示
-   * 帮助 LLM 理解当前在任务工作空间模式下，可以访问相关文件
+   * 支持三种模式：任务模式、技能模式、对话模式
    * @param {string} systemPrompt - 系统提示
    * @param {object} taskContext - 任务上下文对象
    */
   enhanceWithTaskContext(systemPrompt, taskContext) {
     if (!taskContext) return systemPrompt;
 
-    logger.info('[ContextManager] enhanceWithTaskContext: 注入任务工作空间上下文');
+    const fullPath = taskContext.fullWorkspacePath || '';
+    
+    // 判断模式类型
+    const isTaskMode = taskContext.id && taskContext.title;  // 任务模式：有任务ID和标题
+    const isSkillMode = fullPath.startsWith('skills/');      // 技能模式：路径以 skills/ 开头
+    const isChatMode = fullPath.startsWith('work/') && !isTaskMode;  // 对话模式：用户临时目录
 
+    logger.info(`[ContextManager] enhanceWithTaskContext: 模式=${isTaskMode ? '任务' : isSkillMode ? '技能' : '对话'}, 路径=${fullPath}`);
+
+    if (isSkillMode) {
+      // 技能模式：显示技能目录结构
+      return this.enhanceWithSkillContext(systemPrompt, taskContext);
+    } else if (isChatMode) {
+      // 对话模式：显示用户临时目录结构
+      return this.enhanceWithChatContext(systemPrompt, taskContext);
+    } else {
+      // 任务模式：显示任务工作空间结构
+      return this.enhanceWithTaskWorkspaceContext(systemPrompt, taskContext);
+    }
+  }
+
+  /**
+   * 任务模式：用任务工作空间上下文增强系统提示
+   */
+  enhanceWithTaskWorkspaceContext(systemPrompt, taskContext) {
     // 构建文件列表描述
     let filesDescription = '暂无文件';
     if (taskContext.inputFiles && taskContext.inputFiles.length > 0) {
@@ -394,14 +417,12 @@ ${assistantsDescription}
     const userId = taskContext.userId || 'unknown';
     const taskId = taskContext.id;
     const relativePath = taskContext.workspacePath || `${userId}/${taskId}`;
-    // 注意：路径不含 data/ 前缀，因为 AI 的工作目录已经是 data/
     const fullPath = taskContext.fullWorkspacePath || `work/${relativePath}`;
-    const systemRoot = taskContext.systemRoot || 'work';
 
     // 当前浏览路径描述
     const currentPathDisplay = taskContext.currentPath
       ? `${fullPath}/${taskContext.currentPath}`
-      : `${fullPath}/input`;
+      : fullPath;
 
     const taskPrompt = `
 ## 当前任务工作空间
@@ -413,34 +434,81 @@ ${assistantsDescription}
 - **任务标题**: ${taskContext.title}
 ${taskContext.description ? `- **任务描述**: ${taskContext.description}` : ''}
 
-### 目录结构
-\`\`\`
-${systemRoot}/                           ← 系统根目录
-└── ${userId}/                           ← 用户空间
-    └── ${taskId}/                       ← 当前任务根目录 ⭐
-        ├── input/                       ← 输入文件（用户上传）
-        ├── output/                      ← 输出文件（写入结果到这里）
-        ├── temp/                        ← 临时文件
-        └── logs/                        ← 日志
-\`\`\`
+### 目录说明
+当前目录是一个任务目录，可以根据用户的需要组织合适的目录结构。
 
-### 路径信息
-- **完整路径**: ${fullPath}
+- **工作目录**: ${fullPath}
 - **当前浏览**: ${currentPathDisplay}
 
 ### 路径使用规则
 - 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 读取用户文件: \`${fullPath}/input/{filename}\`
-- 写入结果文件: \`${fullPath}/output/{filename}\`
-- 临时文件: \`${fullPath}/temp/{filename}\`
-- 不确定路径时，先用 ls 命令探测确认
-- ⚠️ 注意：路径已经是相对于 data/ 的，不要再加 data/ 前缀！
+- 用户上传文件时，一般会创建 \`input\` 目录存放
+- 可以根据任务需要创建合适的子目录
+- 不确定目录结构时，先用 \`ls\` 命令探测
 
 ### 当前目录下的文件
 ${filesDescription}
 `;
 
     return systemPrompt + '\n\n' + taskPrompt;
+  }
+
+  /**
+   * 技能模式：用技能目录上下文增强系统提示
+   */
+  enhanceWithSkillContext(systemPrompt, taskContext) {
+    const fullPath = taskContext.fullWorkspacePath || 'skills/unknown';
+    // 从路径中提取技能名称（如 skills/file-operations → file-operations）
+    const skillName = fullPath.replace(/^skills\//, '');
+
+    const skillPrompt = `
+## 当前技能工作目录
+
+你正在**技能模式**中，当前工作目录是技能的源码目录。
+
+### 技能信息
+- **技能名称**: ${skillName}
+- **工作目录**: ${fullPath}
+
+### 目录说明
+当前目录是技能目录，各个技能的目录结构和内容不尽相同。但 \`SKILL.md\` 文件肯定存在，包含技能的详细说明。
+
+### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 当前工作目录: \`${fullPath}/\`
+- 使用 \`cat SKILL.md\` 或 \`read_file\` 查看技能说明
+- ⚠️ 技能目录是只读的，不应该写入文件
+`;
+
+    return systemPrompt + '\n\n' + skillPrompt;
+  }
+
+  /**
+   * 对话模式：用用户临时目录上下文增强系统提示
+   */
+  enhanceWithChatContext(systemPrompt, taskContext) {
+    const fullPath = taskContext.fullWorkspacePath || 'work/unknown/temp';
+
+    const chatPrompt = `
+## 当前工作目录
+
+你正在**对话模式**中，当前工作目录是用户的临时文件夹：\`${fullPath}/\`
+
+### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 可以读取临时文件夹中的现有文件
+- ⚠️ **禁止创建文件**：对话模式不支持文件创建操作
+
+### 文件操作限制
+如果用户需要创建或写入文件，请提醒用户：
+1. 创建一个任务（Task），系统会自动分配专门的工作目录
+2. 在任务目录中，可以根据需要组织合适的目录结构
+3. 用户上传文件时，一般会创建 \`input\` 目录
+
+请友好地引导用户创建任务来处理需要文件操作的需求。
+`;
+
+    return systemPrompt + '\n\n' + chatPrompt;
   }
 
   /**

--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -247,10 +247,34 @@ ${skillsDescription}
 
   /**
    * 用任务工作空间上下文增强系统提示
+   * 支持三种模式：任务模式、技能模式、对话模式
    */
   enhanceWithTaskContext(systemPrompt, taskContext) {
     if (!taskContext) return systemPrompt;
 
+    const fullPath = taskContext.fullWorkspacePath || '';
+    
+    // 判断模式类型
+    const isTaskMode = taskContext.id && taskContext.title;  // 任务模式：有任务ID和标题
+    const isSkillMode = fullPath.startsWith('skills/');      // 技能模式：路径以 skills/ 开头
+    const isChatMode = fullPath.startsWith('work/') && !isTaskMode;  // 对话模式：用户临时目录
+
+    if (isSkillMode) {
+      // 技能模式：显示技能目录结构
+      return this.enhanceWithSkillContext(systemPrompt, taskContext);
+    } else if (isChatMode) {
+      // 对话模式：显示用户临时目录结构
+      return this.enhanceWithChatContext(systemPrompt, taskContext);
+    } else {
+      // 任务模式：显示任务工作空间结构
+      return this.enhanceWithTaskWorkspaceContext(systemPrompt, taskContext);
+    }
+  }
+
+  /**
+   * 任务模式：用任务工作空间上下文增强系统提示
+   */
+  enhanceWithTaskWorkspaceContext(systemPrompt, taskContext) {
     // 构建文件列表描述
     let filesDescription = '暂无文件';
     if (taskContext.inputFiles && taskContext.inputFiles.length > 0) {
@@ -267,12 +291,11 @@ ${skillsDescription}
     const taskId = taskContext.id;
     const relativePath = taskContext.workspacePath || `${userId}/${taskId}`;
     const fullPath = taskContext.fullWorkspacePath || `work/${relativePath}`;
-    const systemRoot = taskContext.systemRoot || 'work';
 
     // 当前浏览路径描述
     const currentPathDisplay = taskContext.currentPath
       ? `${fullPath}/${taskContext.currentPath}`
-      : `${fullPath}/input`;
+      : fullPath;
 
     // 构建 README 内容（如果存在）
     let readmeSection = '';
@@ -306,34 +329,81 @@ ${taskContext.todo}
 - **任务标题**: ${taskContext.title}
 ${taskContext.description ? `- **任务描述**: ${taskContext.description}` : ''}
 ${readmeSection}${todoSection}
-### 目录结构
-\`\`\`
-${systemRoot}/                           ← 系统根目录
-└── ${userId}/                           ← 用户空间
-    └── ${taskId}/                       ← 当前任务根目录 ⭐
-        ├── input/                       ← 输入文件（用户上传）
-        ├── output/                      ← 输出文件（写入结果到这里）
-        ├── temp/                        ← 临时文件
-        └── logs/                        ← 日志
-\`\`\`
+### 目录说明
+当前目录是一个任务目录，可以根据用户的需要组织合适的目录结构。
 
-### 路径信息
-- **完整路径**: ${fullPath}
+- **工作目录**: ${fullPath}
 - **当前浏览**: ${currentPathDisplay}
 
 ### 路径使用规则
 - 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 读取用户文件: \`${fullPath}/input/{filename}\`
-- 写入结果文件: \`${fullPath}/output/{filename}\`
-- 临时文件: \`${fullPath}/temp/{filename}\`
-- 不确定路径时，先用 ls 命令探测确认
-- ⚠️ 注意：路径已经是相对于 data/ 的，不要再加 data/ 前缀！
+- 用户上传文件时，一般会创建 \`input\` 目录存放
+- 可以根据任务需要创建合适的子目录
+- 不确定目录结构时，先用 \`ls\` 命令探测
 
 ### 当前目录下的文件
 ${filesDescription}
 `;
 
     return systemPrompt + '\n\n' + taskPrompt;
+  }
+
+  /**
+   * 技能模式：用技能目录上下文增强系统提示
+   */
+  enhanceWithSkillContext(systemPrompt, taskContext) {
+    const fullPath = taskContext.fullWorkspacePath || 'skills/unknown';
+    // 从路径中提取技能名称（如 skills/file-operations → file-operations）
+    const skillName = fullPath.replace(/^skills\//, '');
+
+    const skillPrompt = `
+## 当前技能工作目录
+
+你正在**技能模式**中，当前工作目录是技能的源码目录。
+
+### 技能信息
+- **技能名称**: ${skillName}
+- **工作目录**: ${fullPath}
+
+### 目录说明
+当前目录是技能目录，各个技能的目录结构和内容不尽相同。但 \`SKILL.md\` 文件肯定存在，包含技能的详细说明。
+
+### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 当前工作目录: \`${fullPath}/\`
+- 使用 \`cat SKILL.md\` 或 \`read_file\` 查看技能说明
+- ⚠️ 技能目录是只读的，不应该写入文件
+`;
+
+    return systemPrompt + '\n\n' + skillPrompt;
+  }
+
+  /**
+   * 对话模式：用用户临时目录上下文增强系统提示
+   */
+  enhanceWithChatContext(systemPrompt, taskContext) {
+    const fullPath = taskContext.fullWorkspacePath || 'work/unknown/temp';
+
+    const chatPrompt = `
+## 当前工作目录
+
+你正在**对话模式**中，当前工作目录是用户的临时文件夹：\`${fullPath}/\`
+
+### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 可以读取临时文件夹中的现有文件
+- ⚠️ **禁止创建文件**：对话模式不支持文件创建操作
+
+### 文件操作限制
+如果用户需要创建或写入文件，请提醒用户：
+1. 创建一个任务（Task），系统会自动分配专门的工作目录
+2. 在任务目录中，可以根据需要组织合适的目录结构
+3. 用户上传文件时，一般会创建 \`input\` 目录
+
+请友好地引导用户创建任务来处理需要文件操作的需求。
+`;
+
+    return systemPrompt + '\n\n' + chatPrompt;
   }
 
   /**


### PR DESCRIPTION
## 变更说明

完善三种对话模式的工作目录处理逻辑。

### 变更内容

1. **后端路径处理** (`lib/chat-service.js`)
   - 新增对话模式处理：自动设置 `work/{user_id}/temp` 作为工作目录

2. **提示词模板优化** (`lib/context-manager.js`, `lib/context-organizer/base-organizer.js`)
   - 任务模式：说明当前是任务目录，可根据需要组织目录结构
   - 技能模式：简洁说明当前是技能目录，强调只读
   - 对话模式：说明禁止创建文件，引导用户创建任务

### 三种模式对比

| 模式 | 前端传参 | 工作目录 | 文件操作 |
|------|---------|---------|---------|
| 任务模式 | `task_id` | `work/{task.workspace_path}` | ✅ 允许 |
| 技能模式 | `working_path` | `skills/{skill_name}` | ❌ 只读 |
| 对话模式 | 无 | `work/{user_id}/temp` | ❌ 禁止创建 |

Closes #290