### PR TITLE
#292: fix 任务工作空间目录不存在时自动创建

### DIFF
--- a/server/controllers/task.controller.js
+++ b/server/controllers/task.controller.js
@@ -446,6 +446,16 @@ class TaskController {
       }
 
       const workspacePath = path.join(WORKSPACE_ROOT, task.workspace_path);
+      
+      // 检查工作空间是否存在，不存在则自动创建
+      try {
+        await fs.access(workspacePath);
+      } catch {
+        // 工作空间不存在，重新创建
+        logger.info(`[listFiles] 工作空间不存在，重新创建: ${workspacePath}`);
+        await this.createWorkspaceDirectories(task.created_by, task.task_id);
+      }
+      
       const targetPath = path.join(workspacePath, subdir);
 
       // 安全检查：确保目标路径在工作空间内


### PR DESCRIPTION
## 问题描述

调用 `GET /api/tasks/:id/files` 接口时，如果任务的工作空间目录不存在，会返回 404 错误：`目录不存在`

## 问题原因

`listFiles` 方法在工作空间目录不存在时直接返回错误，而没有像 `enter` 方法那样自动创建目录。

## 解决方案

在 `listFiles` 方法中添加工作空间目录检查和自动创建逻辑，与 `enter` 方法保持一致。

## 修改内容

- `server/controllers/task.controller.js` - listFiles 方法添加目录自动创建逻辑

## 测试

1. 创建一个新任务
2. 手动删除其工作空间目录
3. 调用 `GET /api/tasks/:id/files` 接口
4. 验证工作空间目录被自动创建，接口正常返回文件列表

Closes #292