### PR TITLE
#294: feat 技能编辑模式前端路由支持

### DIFF
--- a/frontend/src/components/panel/SkillsDirectoryTab.vue
+++ b/frontend/src/components/panel/SkillsDirectoryTab.vue
@@ -221,17 +221,22 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { skill_api } from '@/api/services'
 import { useSkillDirectoryStore } from '@/stores/skillDirectory'
+import { useTaskStore } from '@/stores/task'
 import { useToastStore } from '@/stores/toast'
 import CodePreview from '@/components/CodePreview.vue'
 import type { Skill } from '@/types'
 
+const route = useRoute()
+const router = useRouter()
 const { t } = useI18n()
 const skillDirectoryStore = useSkillDirectoryStore()
+const taskStore = useTaskStore()
 const toast = useToastStore()
 
 // 技能列表（用于判断注册状态）
@@ -310,6 +315,12 @@ const selectDirectory = (dir: { name: string; path: string; skill_id?: string; d
 const enterDirectory = async (dir: { name: string; path: string; skill_id?: string }) => {
   const registrationStatus = getDirectoryRegistrationStatus(dir.name)
   
+  // 进入技能目录浏览时，退出任务模式（互斥）
+  if (taskStore.currentTask) {
+    taskStore.exitTask()
+    console.log('[SkillsDirectoryTab] 已退出任务模式，进入技能目录浏览')
+  }
+  
   skillDirectoryStore.enterBrowseMode({
     name: dir.name,
     path: dir.path,
@@ -317,12 +328,30 @@ const enterDirectory = async (dir: { name: string; path: string; skill_id?: stri
     skill_id: registrationStatus.skill_id || dir.name
   })
   
+  // 更新 URL，添加 skillName 参数
+  const expertId = route.params.expertId
+  if (expertId) {
+    router.replace({
+      name: 'chat-with-skill',
+      params: { expertId, skillName: dir.name }
+    })
+  }
+  
   await skillDirectoryStore.loadSkillFiles()
 }
 
 // 退出浏览模式
 const exitBrowseMode = () => {
   skillDirectoryStore.exitBrowseMode()
+  
+  // 清除 URL 中的 skillName 参数
+  const expertId = route.params.expertId
+  if (expertId) {
+    router.replace({
+      name: 'chat',
+      params: { expertId }
+    })
+  }
 }
 
 // 刷新文件列表

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -41,6 +41,11 @@ const router = createRouter({
           component: () => import('@/views/ChatView.vue'),
         },
         {
+          path: 'chat/:expertId/skill/:skillName',
+          name: 'chat-with-skill',
+          component: () => import('@/views/ChatView.vue'),
+        },
+        {
           path: 'settings',
           name: 'settings',
           component: () => import('@/views/SettingsView.vue'),

--- a/frontend/src/stores/skillDirectory.ts
+++ b/frontend/src/stores/skillDirectory.ts
@@ -282,6 +282,31 @@ export const useSkillDirectoryStore = defineStore('skillDirectory', () => {
     return response
   }
 
+  /**
+   * 根据技能名称加载并进入技能浏览模式
+   * 用于从 URL 恢复技能状态
+   */
+  const loadAndEnterSkillByName = async (skillName: string): Promise<boolean> => {
+    // 确保已加载技能目录列表
+    if (skillDirectories.value.length === 0) {
+      await loadSkillDirectories()
+    }
+
+    // 查找匹配的技能目录
+    const skill = skillDirectories.value.find(s => s.name === skillName)
+    if (!skill) {
+      console.warn(`Skill not found: ${skillName}`)
+      return false
+    }
+
+    // 进入浏览模式
+    enterBrowseMode(skill)
+    await loadSkillFiles()
+    
+    console.log(`[SkillDirectory] Entered skill mode from URL: ${skillName}`)
+    return true
+  }
+
   return {
     // State
     skillDirectories,
@@ -322,5 +347,6 @@ export const useSkillDirectoryStore = defineStore('skillDirectory', () => {
     navigateUp,
     getFileContent,
     createSkillDirectory,
+    loadAndEnterSkillByName,
   }
 })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -35,17 +35,20 @@
                 >
                   <!-- 任务模式 -->
                   <template v-if="workspaceMode === 'task'">
-                    📁 {{ taskStore.currentTask?.title }}
+                    <span class="mode-icon task-icon"></span>
+                    <span class="mode-label">{{ taskStore.currentTask?.title }}</span>
                   </template>
                   
                   <!-- 技能模式 -->
                   <template v-else-if="workspaceMode === 'skill'">
-                    🛠️ {{ currentSkillDisplayName }}
+                    <span class="mode-icon skill-icon"></span>
+                    <span class="mode-label">{{ currentSkillDisplayName }}</span>
                   </template>
                   
                   <!-- 无工作空间 -->
                   <template v-else>
-                    ⚠️ {{ $t('chat.noDirectory') }}
+                    <span class="mode-icon warning-icon"></span>
+                    <span class="mode-label">{{ $t('chat.noDirectory') }}</span>
                   </template>
                 </span>
               </div>
@@ -741,24 +744,26 @@ const handleSendMessage = async (content: string) => {
       model_id,
     }
     
-    // 如果在任务模式下，添加 task_id 和 working_path
+    // 任务模式：只传 task_id，不传 working_path
+    // 后端会根据 task_id 自动确定任务工作目录
     if (taskStore.currentTask) {
       messageParams.task_id = taskStore.currentTask.id  // 使用数据库主键
-      // 添加当前浏览路径
-      if (taskStore.currentPath) {
-        messageParams.working_path = taskStore.currentPath
-      }
+      // 不再传递 working_path，后端根据 task_id 自动处理
     }
     
-    // 如果在技能模式下，添加技能目录路径作为 working_path
-    if (skillDirectoryStore.currentWorkingSkill) {
+    // 技能模式：传技能目录路径作为 working_path
+    // 注意：技能模式与任务模式互斥，如果已在任务模式则不会进入此分支
+    // 优先使用 currentWorkingSkill，其次使用 browsingSkill
+    const activeSkill = skillDirectoryStore.currentWorkingSkill || skillDirectoryStore.browsingSkill
+    if (!taskStore.currentTask && activeSkill) {
       // 技能目录路径（如 data/skills/file-operations）
       // 后端工作目录是相对于 data/ 的，所以需要去掉 data/ 前缀
-      let skillPath = skillDirectoryStore.currentWorkingSkill.path
+      let skillPath = activeSkill.path
       if (skillPath.startsWith('data/')) {
         skillPath = skillPath.substring(5)  // 去掉 'data/' 前缀
       }
       messageParams.working_path = skillPath
+      console.log('[ChatView] Skill mode - working_path:', skillPath, 'from activeSkill:', activeSkill.name)
     }
     
     // 使用 messageApi 发送消息（自动处理认证）
@@ -858,8 +863,9 @@ const initChat = async (expertId: string) => {
   connectToExpert(expertId)
 }
 
-// 从路由获取 taskId
+// 从路由获取 taskId 和 skillName
 const currentTaskId = computed(() => route.params.taskId as string | undefined)
+const currentSkillName = computed(() => route.params.skillName as string | undefined)
 
 // 监听路由参数变化（expertId）
 watch(
@@ -911,6 +917,45 @@ watch(
       // URL 中没有 taskId，但当前有任务，退出任务模式
       console.log('No taskId in URL, exiting task mode')
       taskStore.exitTask()
+    }
+  },
+  { immediate: true }
+)
+
+// 监听路由参数变化（skillName）- 用于从 URL 恢复技能状态
+watch(
+  currentSkillName,
+  async (skillName) => {
+    console.log('Route skillName changed:', skillName)
+    
+    // 必须等用户登录后再处理
+    if (!userStore.isLoggedIn) {
+      console.log('User not logged in, skip skill handling')
+      return
+    }
+
+    // 如果有任务模式，技能模式应该被忽略（任务优先）
+    if (taskStore.currentTask) {
+      console.log('Task mode active, ignoring skill route')
+      return
+    }
+
+    if (skillName && skillDirectoryStore.browsingSkill?.name !== skillName) {
+      // URL 中有 skillName，但当前技能不匹配，需要加载技能
+      console.log('Loading skill from URL:', skillName)
+      const success = await skillDirectoryStore.loadAndEnterSkillByName(skillName)
+      if (!success) {
+        // 技能加载失败（可能不存在），清除 URL 中的 skillName
+        console.warn('Failed to load skill, removing skillName from URL')
+        router.replace({
+          name: 'chat',
+          params: { expertId: currentExpertId.value }
+        })
+      }
+    } else if (!skillName && skillDirectoryStore.browsingSkill) {
+      // URL 中没有 skillName，但当前有技能浏览，退出技能模式
+      console.log('No skillName in URL, exiting skill browse mode')
+      skillDirectoryStore.exitBrowseMode()
     }
   },
   { immediate: true }
@@ -1112,45 +1157,117 @@ onMounted(async () => {
 /* 工作空间模式标签（融合到头部） */
 .workspace-mode-tag {
   font-size: 12px;
-  padding: 2px 8px;
+  padding: 4px 10px;
   background: var(--secondary-bg, #f0f0f0);
-  color: var(--text-hint, #999);
-  border-radius: 10px;
+  color: var(--text-secondary, #666);
+  border-radius: 16px;
   margin-left: 8px;
-  transition: all 0.2s;
+  transition: all 0.25s ease;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+/* 模式图标基础样式 */
+.workspace-mode-tag .mode-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  position: relative;
+}
+
+/* 任务图标 - 文件夹样式 */
+.workspace-mode-tag .mode-icon.task-icon {
+  background: linear-gradient(135deg, #ffd54f 0%, #ffb300 100%);
+  box-shadow: 0 1px 2px rgba(255, 179, 0, 0.3);
+}
+
+.workspace-mode-tag .mode-icon.task-icon::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 10px;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 1px;
+}
+
+/* 技能图标 - 工具样式 */
+.workspace-mode-tag .mode-icon.skill-icon {
+  background: linear-gradient(135deg, #ce93d8 0%, #9c27b0 100%);
+  box-shadow: 0 1px 2px rgba(156, 39, 176, 0.3);
+}
+
+.workspace-mode-tag .mode-icon.skill-icon::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 8px;
+  height: 8px;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  border-radius: 2px;
+}
+
+/* 警告图标 */
+.workspace-mode-tag .mode-icon.warning-icon {
+  background: linear-gradient(135deg, #ffcc80 0%, #ff9800 100%);
+  box-shadow: 0 1px 2px rgba(255, 152, 0, 0.3);
+}
+
+.workspace-mode-tag .mode-icon.warning-icon::before {
+  content: '!';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 10px;
+  font-weight: bold;
+  color: white;
+}
+
+/* 模式标签文字 */
+.workspace-mode-tag .mode-label {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* 任务模式样式 */
 .workspace-mode-tag.in-task {
-  background: var(--primary-color, #2196f3);
-  color: white;
-  cursor: default;
+  background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
+  color: #1565c0;
+  border: 1px solid rgba(33, 150, 243, 0.2);
 }
 
 /* 技能模式样式 */
 .workspace-mode-tag.in-skill {
-  background: #9c27b0;  /* 紫色，区分于任务的蓝色 */
-  color: white;
-  cursor: default;
+  background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
+  color: #7b1fa2;
+  border: 1px solid rgba(156, 39, 176, 0.2);
 }
 
 /* 未选择目录的警告样式 */
 .workspace-mode-tag.no-workspace {
-  background: var(--warning-bg, #fff3e0);
-  color: var(--warning-color, #e65100);
-  border: 1px solid var(--warning-border, #ffb74d);
+  background: linear-gradient(135deg, #fff8e1 0%, #ffecb3 100%);
+  color: #e65100;
+  border: 1px solid rgba(255, 152, 0, 0.3);
   animation: pulse-warning 2s ease-in-out infinite;
 }
 
 @keyframes pulse-warning {
   0%, 100% {
-    opacity: 1;
+    box-shadow: 0 1px 3px rgba(255, 152, 0, 0.1);
   }
   50% {
-    opacity: 0.7;
+    box-shadow: 0 2px 8px rgba(255, 152, 0, 0.25);
   }
 }
 </style>


### PR DESCRIPTION
## 功能描述

为技能编辑模式添加前端路由支持，允许用户通过 URL 直接访问技能目录编辑页面。

## 修改内容

- `frontend/src/router/index.ts` - 添加 `/chat/:expertId/skill/:skillName` 路由
- `frontend/src/stores/skillDirectory.ts` - 添加 `loadAndEnterSkillByName` 方法用于 URL 状态恢复
- `frontend/src/views/ChatView.vue` - 技能模式的工作路径处理和 URL 参数监听
- `frontend/src/components/panel/SkillsDirectoryTab.vue` - 进入/退出技能目录时更新 URL

## 功能特性

1. 支持通过 URL 直接访问技能目录：`/chat/:expertId/skill/:skillName`
2. 技能模式与任务模式互斥，进入技能目录自动退出任务模式
3. 技能模式下发送消息时正确传递 `working_path` 参数

Closes #294