### PR TITLE
#296: refactor 清理废弃的 skill-studio 模式和快捷命令系统

### DIFF
--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -197,19 +197,6 @@
       </svg>
     </button>
 
-    <!-- 快捷指令提示 (skill-studio 模式) -->
-    <div v-if="showCommandHints && filteredCommands.length > 0" class="command-hints">
-      <div 
-        v-for="cmd in filteredCommands" 
-        :key="cmd.command"
-        class="command-item"
-        @click="applyCommand(cmd)"
-      >
-        <span class="command-name">{{ cmd.command }}</span>
-        <span class="command-desc">{{ cmd.description }}</span>
-      </div>
-    </div>
-
     <!-- 输入区域 -->
     <div class="input-area">
       <div class="input-row">
@@ -274,7 +261,6 @@ const props = defineProps<{
   isLoadingMore?: boolean
   expertAvatar?: string
   expertAvatarLarge?: string
-  showCommandHints?: boolean
   customPlaceholder?: string
 }>()
 
@@ -322,24 +308,6 @@ const isReasoningExpanded = (messageId: string): boolean => {
   return expandedReasoning.value.has(messageId)
 }
 
-// 快捷指令列表
-const commands = [
-  { command: '/import', description: t('commands.import') || '导入技能 (例: /import skills/searxng)', example: '/import skills/searxng' },
-  { command: '/create', description: t('commands.create') || '创建新技能', example: '/create 天气查询技能' },
-  { command: '/list', description: t('commands.list') || '列出所有技能', example: '/list' },
-  { command: '/assign', description: t('commands.assign') || '分配技能给专家 (例: /assign weather 给助手)', example: '/assign weather to expert_name' },
-  { command: '/help', description: t('commands.help') || '显示帮助信息', example: '/help' },
-]
-
-// 过滤后的指令
-const filteredCommands = computed(() => {
-  const text = inputText.value.trim()
-  if (!text.startsWith('/')) return []
-  
-  const query = text.toLowerCase()
-  return commands.filter(cmd => cmd.command.toLowerCase().startsWith(query))
-})
-
 // 占位符文本
 const placeholderText = computed(() => {
   return props.customPlaceholder || t('chat.placeholder')
@@ -354,12 +322,6 @@ const handleInput = () => {
       inputRef.value.style.height = inputRef.value.scrollHeight + 'px'
     }
   })
-}
-
-// 应用指令
-const applyCommand = (cmd: typeof commands[0]) => {
-  inputText.value = cmd.example
-  inputRef.value?.focus()
 }
 
 // ==================== 简化的滚动控制逻辑 ====================
@@ -1646,56 +1608,6 @@ defineExpose({
 
 @keyframes spin {
   to { transform: rotate(360deg); }
-}
-
-/* 快捷指令提示 */
-.command-hints {
-  position: absolute;
-  bottom: 100%;
-  left: 16px;
-  right: 16px;
-  background: var(--bg-primary, #fff);
-  border: 1px solid var(--border-color, #e0e0e0);
-  border-radius: 8px;
-  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
-  max-height: 200px;
-  overflow-y: auto;
-  z-index: 10;
-  margin-bottom: 4px;
-}
-
-.command-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
-  cursor: pointer;
-  transition: background 0.2s;
-}
-
-.command-item:hover {
-  background: var(--bg-hover, #f0f0f0);
-}
-
-.command-item:first-child {
-  border-radius: 8px 8px 0 0;
-}
-
-.command-item:last-child {
-  border-radius: 0 0 8px 8px;
-}
-
-.command-name {
-  font-family: monospace;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--primary-color, #2196f3);
-  min-width: 80px;
-}
-
-.command-desc {
-  font-size: 13px;
-  color: var(--text-secondary, #666);
 }
 
 /* 滚动到底部按钮 */

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -16,13 +16,7 @@
                   <span v-if="!currentExpert?.avatar_base64">🤖</span>
                 </div>
                 <h2 class="expert-name">{{ currentExpert?.name || $t('chat.title') }}</h2>
-                <!-- skill-studio 显示模型选择器 -->
-                <ModelSelector
-                  v-if="is_skill_studio"
-                  v-model="selected_model_id"
-                  class="model-selector"
-                />
-                <span v-else-if="currentModel" class="model-badge">{{ currentModel.name }}</span>
+                <span v-if="currentModel" class="model-badge">{{ currentModel.name }}</span>
                 <!-- 工作空间模式状态 -->
                 <span
                   class="workspace-mode-tag"
@@ -64,7 +58,6 @@
                 :is-loading-more="chatStore.isLoadingMore"
                 :expert-avatar="currentExpert?.avatar_base64"
                 :expert-avatar-large="currentExpert?.avatar_large_base64"
-                :show-command-hints="is_skill_studio"
                 :custom-placeholder="autonomousPlaceholder"
                 @send="handleSendMessage"
                 @retry="handleRetry"
@@ -114,7 +107,6 @@ import { Splitpanes, Pane } from 'splitpanes'
 import 'splitpanes/dist/splitpanes.css'
 import ChatWindow, { type ChatMessage } from '@/components/ChatWindow.vue'
 import RightPanel from '@/components/panel/RightPanel.vue'
-import ModelSelector from '@/components/ModelSelector.vue'
 import { useChatStore } from '@/stores/chat'
 import { useModelStore } from '@/stores/model'
 import { useExpertStore } from '@/stores/expert'
@@ -203,25 +195,7 @@ const setSendingTimeoutProtection = () => {
 const MAX_RECONNECT_ATTEMPTS = 10
 
 // 从路由参数获取 expertId
-// skill-studio 作为一个普通专家，通过 /chat/skill-studio 访问
 const currentExpertId = computed(() => route.params.expertId as string)
-
-// 判断是否是 skill-studio 模式
-const is_skill_studio = computed(() => currentExpertId.value === 'skill-studio')
-
-// skill-studio 模式下选择的模型
-const selected_model_id = ref<string>('')
-
-// 初始化模型选择
-watch(() => modelStore.models, (models) => {
-  if (is_skill_studio.value && models.length > 0 && !selected_model_id.value) {
-    // 默认选择第一个可用模型
-    const active_model = models.find(m => m.is_active)
-    if (active_model) {
-      selected_model_id.value = active_model.id
-    }
-  }
-}, { immediate: true })
 
 // 当前专家
 const currentExpert = computed(() => {
@@ -248,7 +222,7 @@ const autonomousPlaceholder = computed(() => {
   if (isAutonomousMode.value) {
     return t('chat.autonomousModeHint') || 'AI 正在自主执行任务，输入已禁用...'
   }
-  return is_skill_studio.value ? t('chat.commandHint') : undefined
+  return undefined
 })
 
 // 工作空间模式：task | skill | none
@@ -701,10 +675,8 @@ const handleSendMessage = async (content: string) => {
     connectToExpert(expert_id)
   }
 
-  // skill-studio 使用用户选择的模型，其他专家使用绑定的模型
-  const model_id = is_skill_studio.value
-    ? selected_model_id.value
-    : (currentModel.value?.id || currentExpert.value?.expressive_model_id)
+  // 使用专家绑定的模型
+  const model_id = currentModel.value?.id || currentExpert.value?.expressive_model_id
 
   // 添加用户消息到本地
   const userMessage = chatStore.addLocalMessage({
@@ -1095,10 +1067,6 @@ onMounted(async () => {
   background: var(--badge-bg, #e3f2fd);
   color: var(--primary-color, #2196f3);
   border-radius: 12px;
-}
-
-.model-selector {
-  margin-left: 8px;
 }
 
 .no-expert-selected {


### PR DESCRIPTION
## Summary

清理废弃的 skill-studio 模式和快捷命令系统代码。

## Changes

### ChatWindow.vue
- 移除 `showCommandHints` prop
- 移除 `commands` 数组定义
- 移除 `filteredCommands` computed 属性
- 移除 `applyCommand` 方法
- 移除快捷指令提示模板（command-hints template）
- 移除快捷指令相关 CSS 样式

### ChatView.vue
- 移除 `ModelSelector` 组件导入和使用
- 移除 `is_skill_studio` computed 属性
- 移除 `selected_model_id` ref 及其初始化逻辑
- 移除 `showCommandHints` prop 传递
- 移除 `autonomousPlaceholder` 中的 skill-studio 分支
- 移除 `handleSendMessage` 中的 skill-studio 模型选择逻辑
- 移除 `.model-selector` CSS 样式

## Related

Closes #296