### PR TITLE
#301: refactor 精简 SKILL.md 文档并修复 skill-parser 路径拼接 bug

### DIFF
--- a/data/skills/docx/SKILL.md
+++ b/data/skills/docx/SKILL.md
@@ -97,25 +97,6 @@ docx_image({ path: 'document.docx', action: 'extract', outputDir: './images' })
 docx_image({ path: 'document.docx', action: 'insert', imagePath: 'chart.png', width: 500, height: 300 })
 ```
 
-## 兼容旧工具名
-
-| 旧名称 | 新名称 |
-|--------|--------|
-| `read_document`, `read` | `docx_read(scope: 'info')` |
-| `extract_text` | `docx_read(scope: 'text')` |
-| `extract_paragraphs` | `docx_read(scope: 'paragraphs')` |
-| `extract_tables` | `docx_read(scope: 'tables')` |
-| `extract_comments` | `docx_read(scope: 'comments')` |
-| `create_document`, `create` | `docx_write(source: 'data')` |
-| `from_markdown` | `docx_write(source: 'markdown')` |
-| `add_paragraph` | `docx_edit(action: 'add_paragraph')` |
-| `replace_text` | `docx_edit(action: 'replace_text')` |
-| `add_table` | `docx_edit(action: 'add_table')` |
-| `to_markdown` | `docx_convert(format: 'markdown')` |
-| `to_html` | `docx_convert(format: 'html')` |
-| `extract_images` | `docx_image(action: 'extract')` |
-| `insert_image` | `docx_image(action: 'insert')` |
-
 ## 注意事项
 
 - **编辑限制**: 编辑操作会丢失原有格式和样式

--- a/data/skills/echarts-chart/SKILL.md
+++ b/data/skills/echarts-chart/SKILL.md
@@ -65,11 +65,3 @@ echarts_raw({
 | `graph` | 关系图 |
 | `boxplot` | 箱线图 |
 | `candlestick` | K线图 |
-
-## 兼容旧工具名
-
-| 旧名称 | 新名称 |
-|--------|--------|
-| `generate`, `generate_chart` | `echarts_generate` |
-| `generateRaw`, `generate_raw` | `echarts_raw` |
-| `types`, `get_types` | `echarts_types` |

--- a/data/skills/erix-ssh/SKILL.md
+++ b/data/skills/erix-ssh/SKILL.md
@@ -1,345 +1,169 @@
 ---
 name: ssh
-description: SSH remote server management with synchronous command execution and SFTP file transfer. Use when you need to connect to remote servers via SSH, execute commands, and transfer files. Features session-based connection management, automatic reconnection, and message history stored in SQLite.
+description: "SSH 远程服务器管理。用于连接远程服务器、执行命令、SFTP 文件传输。支持会话管理、自动重连、历史记录存储。当用户需要 SSH 连接、远程执行命令、传输文件时触发。"
 argument-hint: "[connect|exec|sudo|sftp_list|sftp_download|sftp_upload|disconnect] --session ID"
 user-invocable: false
 allowed-tools: []
 ---
 
-# SSH Remote Server Management
+# SSH - 远程服务器管理
 
-Session-based SSH client with synchronous execution, SFTP file transfer, and SQLite storage.
+基于会话的 SSH 客户端，支持同步命令执行和 SFTP 文件传输。
 
-## Design Architecture
+## 工具
 
-```
-[Main Program] --stdin--> [session_manager.js (Resident)]
-              <--stdout--+
-              <--events--+
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `ssh_connect` | 连接服务器 | `host`, `username`, `password`/`private_key` |
+| `ssh_disconnect` | 断开连接 | `session_id` |
+| `ssh_exec` | 执行命令 | `session_id`, `command` |
+| `ssh_sudo` | sudo 执行 | `session_id`, `command`, `password` |
+| `ssh_output` | 获取任务输出 | `task_id` |
+| `ssh_history` | 获取历史记录 | `session_id` |
+| `sftp_list` | 列出远程目录 | `session_id`, `path` |
+| `sftp_download` | 下载文件 | `session_id`, `remote_path`, `local_path` |
+| `sftp_upload` | 上传文件 | `session_id`, `local_path`, `remote_path` |
 
-session_manager.js:
-- is_resident: 1 (auto-started by main program)
-- stdin: receives JSON commands
-- stdout: sends JSON responses
-- stderr: logs (does not interfere with communication)
-```
-
-## Security Note
-
-**Session ID is a capability token - treat it like a password!**
-
-- Knowing the Session ID = Full control over that connection
-- LLM must save Session ID in conversation context
-- Lost Session ID = Lost access (no session list feature for security)
-- Never expose full Session ID in public (show first 8 chars only for identification)
-
-## SSH Tools
+## SSH 工具
 
 ### ssh_connect
 
-Connect to a remote SSH server and return a Session ID.
+连接到远程 SSH 服务器，返回 Session ID。
 
-**is_resident:** 0 (calls resident process)
-**script_path:** `scripts/ssh_client.js`
+**参数：**
+- `host` (string, required): 主机地址（IP 或主机名）
+- `username` (string, required): SSH 用户名
+- `port` (number, optional): SSH 端口，默认 22
+- `password` (string, optional): 密码认证
+- `private_key` (string, optional): 私钥文件路径（支持 `~` 展开）
+- `passphrase` (string, optional): 加密私钥的密码
 
-**Parameters:**
-- `host` (required): Host address (IP or hostname)
-- `username` (required): SSH username
-- `port` (optional): SSH port, default 22
-- `password` (optional): Password for authentication
-- `private_key` (optional): Path to private key file (supports `~` expansion)
-- `passphrase` (optional): Passphrase for encrypted private key
-
-**Returns:**
+**返回：**
 ```json
-{
-  "success": true,
-  "session_id": "sess_abc123..."
-}
+{ "success": true, "session_id": "sess_abc123..." }
 ```
-
----
 
 ### ssh_disconnect
 
-Disconnect from an SSH server.
+断开 SSH 连接。
 
-**is_resident:** 0
-**script_path:** `scripts/ssh_client.js`
-
-**Parameters:**
-- `session_id` (required): Session ID to disconnect
-
-**Returns:**
-```json
-{
-  "success": true,
-  "message": "Disconnected"
-}
-```
-
----
+**参数：**
+- `session_id` (string, required): 会话 ID
 
 ### ssh_exec
 
-Execute a command on the remote server. Blocks until command completes.
+在远程服务器上执行命令（同步阻塞）。
 
-**is_resident:** 0
-**script_path:** `scripts/ssh_client.js`
+**参数：**
+- `session_id` (string, required): 会话 ID
+- `command` (string, required): 要执行的命令
+- `timeout` (number, optional): 超时时间（毫秒），默认 60000
 
-**Parameters:**
-- `session_id` (required): Session ID
-- `command` (required): Command to execute
-- `timeout` (optional): Timeout in milliseconds, default 60000
-
-**Returns:**
+**返回：**
 ```json
 {
   "success": true,
   "task_id": "task_xxx",
   "exit_code": 0,
-  "stdout": "command output...",
+  "stdout": "命令输出...",
   "stderr": ""
 }
 ```
-
-**Note:** This is a synchronous call - the tool will not return until the command completes or times out.
-
----
 
 ### ssh_sudo
 
-Execute a command with sudo privileges.
+使用 sudo 权限执行命令。
 
-**is_resident:** 0
-**script_path:** `scripts/ssh_client.js`
+**参数：**
+- `session_id` (string, required): 会话 ID
+- `command` (string, required): 要执行的命令（不含 sudo 前缀）
+- `password` (string, required): sudo 密码
+- `timeout` (number, optional): 超时时间（毫秒），默认 120000
 
-**Parameters:**
-- `session_id` (required): Session ID
-- `command` (required): Command to execute (without `sudo` prefix)
-- `password` (required): Sudo password
-- `timeout` (optional): Timeout in milliseconds, default 120000
-
-**Returns:**
-```json
-{
-  "success": true,
-  "task_id": "task_xxx",
-  "exit_code": 0,
-  "stdout": "output (password masked)...",
-  "stderr": ""
-}
-```
-
-**Security Features:**
-- Password is masked in output (replaced with `********`)
-- Supports automatic password prompt detection
-
----
+**安全特性：**
+- 密码在输出中被掩码（替换为 `********`）
+- 支持自动密码提示检测
 
 ### ssh_output
 
-Get output for a previously executed task (useful if you have task_id from history).
+获取已执行任务的输出（用于历史任务）。
 
-**is_resident:** 0
-**script_path:** `scripts/ssh_client.js`
-
-**Parameters:**
-- `task_id` (required): Task ID to retrieve output for
-
-**Returns:**
-```json
-{
-  "success": true,
-  "task_id": "task_xxx",
-  "status": "completed",
-  "exit_code": 0,
-  "stdout": "...",
-  "stderr": ""
-}
-```
-
----
+**参数：**
+- `task_id` (string, required): 任务 ID
 
 ### ssh_history
 
-Get command execution history for a session.
+获取会话的命令执行历史。
 
-**is_resident:** 0
-**script_path:** `scripts/ssh_client.js`
+**参数：**
+- `session_id` (string, required): 会话 ID
+- `limit` (number, optional): 最大记录数，默认 20
 
-**Parameters:**
-- `session_id` (required): Session ID
-- `limit` (optional): Max number of records, default 20
-
-**Returns:**
-```json
-{
-  "success": true,
-  "commands": [
-    {
-      "id": "msg_xxx",
-      "task_id": "task_001",
-      "command": "ls -la",
-      "timestamp": "2024-01-15T10:30:00Z"
-    }
-  ]
-}
-```
-
----
-
-## SFTP Tools
+## SFTP 工具
 
 ### sftp_list
 
-List contents of a remote directory.
+列出远程目录内容。
 
-**is_resident:** 0 (calls resident process)
-**script_path:** `scripts/ssh_client.js`
+**参数：**
+- `session_id` (string, required): 会话 ID
+- `path` (string, required): 远程目录路径
 
-**Parameters:**
-- `session_id` (required): Session ID
-- `path` (required): Remote directory path
-
-**Returns:**
+**返回：**
 ```json
 {
   "success": true,
   "path": "/home/user",
   "entries": [
-    {
-      "filename": "example.txt",
-      "type": "file",
-      "size": 1234,
-      "mode": "0644",
-      "mtime": "2024-01-01T00:00:00Z"
-    }
+    { "filename": "example.txt", "type": "file", "size": 1234, "mode": "0644" }
   ]
 }
 ```
 
----
-
 ### sftp_download
 
-Download a file from the remote server.
+从远程服务器下载文件。
 
-**is_resident:** 0
-**script_path:** `scripts/ssh_client.js`
-
-**Parameters:**
-- `session_id` (required): Session ID
-- `remote_path` (required): Remote file path
-- `local_path` (required): Local file path to save
-
-**Returns:**
-```json
-{
-  "success": true,
-  "remote_path": "/remote/file.txt",
-  "local_path": "/local/file.txt",
-  "bytes_transferred": 12345
-}
-```
-
----
+**参数：**
+- `session_id` (string, required): 会话 ID
+- `remote_path` (string, required): 远程文件路径
+- `local_path` (string, required): 本地保存路径
 
 ### sftp_upload
 
-Upload a file to the remote server.
+上传文件到远程服务器。
 
-**is_resident:** 0
-**script_path:** `scripts/ssh_client.js`
+**参数：**
+- `session_id` (string, required): 会话 ID
+- `local_path` (string, required): 本地文件路径
+- `remote_path` (string, required): 远程保存路径
 
-**Parameters:**
-- `session_id` (required): Session ID
-- `local_path` (required): Local file path
-- `remote_path` (required): Remote file path to save
-
-**Returns:**
-```json
-{
-  "success": true,
-  "local_path": "/local/file.txt",
-  "remote_path": "/remote/file.txt",
-  "bytes_transferred": 12345
-}
-```
-
----
-
-## Resident Process
-
-### ssh_manager (internal)
-
-The resident process that manages SSH connections. **Do not call directly.**
-
-**is_resident:** 1
-**script_path:** `scripts/session_manager.js`
-
-This process is automatically started by the main program. It:
-- Listens on stdin for JSON commands
-- Responds on stdout with JSON results
-- Logs to stderr
-- Manages persistent SSH connections
-- Sends `{ "type": "ready" }` when started
-
----
-
-## Typical Workflow
+## 典型工作流程
 
 ```
-1. ssh_connect → Save the returned session_id
-2. ssh_exec → Execute commands, get output directly (synchronous)
-3. ssh_exec → Execute more commands...
-4. ssh_sudo → Execute commands requiring elevated privileges
-5. ssh_disconnect → Close the connection
+1. ssh_connect → 保存返回的 session_id
+2. ssh_exec → 执行命令，直接获取输出（同步）
+3. ssh_sudo → 执行需要提权的命令
+4. sftp_list/sftp_download/sftp_upload → 文件传输
+5. ssh_disconnect → 关闭连接
 ```
 
-## Protocol (for Resident Communication)
+## 安全说明
 
-Commands sent to the resident process on stdin:
+**Session ID 是能力令牌，请像密码一样对待！**
 
-```json
-{
-  "id": "req_123",
-  "action": "connect",
-  "host": "server.example.com",
-  "username": "admin"
-}
-```
+- 知道 Session ID = 拥有该连接的完全控制权
+- LLM 必须在对话上下文中保存 Session ID
+- 丢失 Session ID = 丢失访问权限（出于安全考虑无会话列表功能）
+- 不要在公开场合暴露完整 Session ID（仅显示前 8 个字符用于识别）
 
-Responses sent on stdout:
+## 存储
 
-```json
-{
-  "id": "req_123",
-  "success": true,
-  "session_id": "sess_..."
-}
-```
+- SQLite 数据库：`./data/ssh.db`
+- 包含会话、消息和任务历史
 
-Events (unsolicited notifications):
-
-```json
-{
-  "type": "event",
-  "event": "disconnect",
-  "session_id": "sess_..."
-}
-```
-
-## Storage
-
-- SQLite database: `./data/ssh.db`
-- Contains sessions, messages, and task history
-
-## Requirements
+## 依赖
 
 - Node.js 18+
-- Run `npm install` in skill directory before first use
-- ssh2 package
-
----
-*Updated: 2026-03-14 - Added SFTP file transfer support*
+- 首次使用前在技能目录运行 `npm install`
+- ssh2 包

--- a/data/skills/file-operations/SKILL.md
+++ b/data/skills/file-operations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: file-operations
-description: File system operations including read, write, search, and manage files. Use when you need to work with files in the data directory.
-argument-hint: "[operation] [path]"
+description: "文件系统操作。用于读取、写入、搜索、管理文件。当需要在数据目录中操作文件时触发。"
+argument-hint: "[read|write|grep|info|action] [path]"
 user-invocable: true
 allowed-tools:
   - Bash(cat *)
@@ -10,288 +10,150 @@ allowed-tools:
   - Bash(find *)
 ---
 
-# File Operations
+# File Operations - 文件系统操作
 
-Complete file system operations for reading, writing, searching, and managing files.
+完整的文件系统操作，用于读取、写入、搜索和管理文件。
 
-## Tools
+## 工具
 
-### File System Information
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `fs_info` | 获取文件/目录信息 | `path`, `include_content_preview`, `hash` |
+| `read_file` | 读取文件 | `path`, `mode`, `from`, `lines` |
+| `list_files` | 列出目录内容 | `path`, `recursive` |
+| `fs_grep` | 搜索文本 | `pattern`, `path`, `use_regex` |
+| `write_file` | 写入文件 | `path`, `content`, `mode` |
+| `replace_in_file` | 替换文本 | `path`, `old`, `new` |
+| `edit_lines` | 编辑行 | `path`, `operation`, `line`, `content` |
+| `fs_action` | 文件操作 | `operation`, `source`, `destination`, `path` |
 
-#### fs_info
+## 文件信息
 
-Get detailed metadata about a file or directory. **Recommended to call before other operations** to understand what you're working with.
+### fs_info
 
-**Parameters:**
-- `path` (string, required): File or directory path
-- `include_content_preview` (boolean, optional): Include content preview for text files (default: false)
-- `hash` (string, optional): Calculate file hash - `"md5"`, `"sha256"`, or `"sha1"` (default: false, no hash)
+获取文件或目录的详细元数据。**建议在其他操作前先调用**。
 
-**Returns:**
-- `exists` (boolean): Whether the path exists
-- `type` (string): "file", "directory", or "unknown"
-- `size` (number): Size in bytes
-- `sizeHuman` (string): Human-readable size (e.g., "1.5 MB")
-- `created`, `modified`, `accessed` (Date): Timestamps
-- `isReadOnly` (boolean): Write permission check
-- `pathInfo` (object): Path components (fullPath, directory, baseName, extension, fileNameWithoutExt)
-- `mimeType` (string, files only): Inferred MIME type
-- `isTextFile` (boolean, files only): Whether the file is likely text
-- `hash` (object, files only, if requested): `{ algorithm: "md5", hash: "abc123..." }`
-- `directoryInfo` (object, directories only): Item counts and listing preview
-- `contentPreview` (object, files only): First 10 lines preview (if requested)
-- `warning` (string, optional): Large file warning
+**参数：**
+- `path` (string, required): 文件或目录路径
+- `include_content_preview` (boolean, optional): 包含内容预览（默认: false）
+- `hash` (string, optional): 计算文件哈希 - `"md5"`, `"sha256"`, `"sha1"`
 
-**Use Cases:**
-- Check if a file exists before reading
-- Determine file type (text vs binary)
-- Get file size to decide how to read it
-- Preview content structure
-- Verify file integrity with hash
+**返回：**
+- `exists`, `type`, `size`, `sizeHuman`
+- `created`, `modified`, `accessed`
+- `isReadOnly`, `pathInfo`, `mimeType`, `isTextFile`
+- `directoryInfo` (目录), `contentPreview` (文件)
 
-**Hash Examples:**
-```javascript
-// Get MD5 hash of a file
-{ "tool": "fs_info", "params": { "path": "data/file.txt", "hash": "md5" } }
+## 读取文件
 
-// Get SHA256 hash for integrity verification
-{ "tool": "fs_info", "params": { "path": "data/backup.zip", "hash": "sha256" } }
-```
+### read_file
 
-**Note:** Hash calculation is opt-in because it can be slow for large files. Only request hash when needed.
+读取文件内容。
 
-### Reading Files
+**参数：**
+- `path` (string, required): 文件路径
+- `mode` (string, optional): 读取模式 - `"lines"` (默认) 或 `"bytes"`
+- `from` (number, optional): 起始行（lines 模式，默认: 1）
+- `lines` (number, optional): 行数（lines 模式，默认: 100）
+- `offset` (number, optional): 起始字节（bytes 模式，默认: 0）
+- `bytes` (number, optional): 字节数（bytes 模式，默认: 50000）
 
-#### read_file
+### list_files
 
-Read file content with mode parameter.
+列出目录内容。
 
-**Parameters:**
-- `path` (string, required): File path
-- `mode` (string, optional): Read mode - `"lines"` (default) or `"bytes"`
-- `from` (number, optional): Start line for lines mode (default: 1)
-- `lines` (number, optional): Number of lines for lines mode (default: 100)
-- `offset` (number, optional): Start byte for bytes mode (default: 0)
-- `bytes` (number, optional): Bytes to read for bytes mode (default: 50000)
+**参数：**
+- `path` (string, required): 目录路径
+- `recursive` (boolean, optional): 递归列出（默认: false）
 
-#### list_files
+## 搜索
 
-List directory contents.
+### fs_grep
 
-**Parameters:**
-- `path` (string, required): Directory path
-- `recursive` (boolean, optional): List recursively (default: false)
+跨文件搜索文本。
 
-### Searching
+**参数：**
+- `pattern` (string, required): 搜索模式
+- `path` (string, optional): 文件或目录路径（默认: 当前）
+- `file_pattern` (string, optional): 文件模式过滤（默认: "*"）
+- `use_regex` (boolean, optional): 使用正则模式（默认: false）
+- `ignore_case` (boolean, optional): 忽略大小写（默认: true）
 
-#### fs_grep
+**搜索模式：**
+| 模式 | 说明 | 示例 |
+|------|------|------|
+| 字面量（默认） | 简单字符串匹配 | `pattern: "TODO"` |
+| 正则 | 完整正则支持 | `pattern: "TODO\\d+"` |
 
-Search text across files. Supports both single file and multi-file search.
+## 写入文件
 
-**Parameters:**
-- `pattern` (string, required): Search pattern
-- `path` (string, optional): File or directory path (default: current)
-- `file_pattern` (string, optional): File pattern filter (default: "*")
-- `use_regex` (boolean, optional): Use regex mode (default: `false`, use literal string match)
-- `ignore_case` (boolean, optional): Case insensitive search (default: `true`)
+### write_file
 
-**Search Modes:**
-| Mode | Description | Example |
-|------|-------------|---------|
-| Literal (default) | Simple string match, no special characters | `pattern: "TODO"` matches "TODO" exactly |
-| Regex | Full regex support, set `use_regex: true` | `pattern: "TODO\\d+"` matches "TODO1", "TODO123" |
+写入内容到文件。
 
-**Note:** For single file search, pass the file path directly to `path` parameter.
+**参数：**
+- `path` (string, required): 文件路径
+- `content` (string, required): 写入内容
+- `mode` (string, optional): 写入模式 - `"write"` (默认) 或 `"append"`
 
-**Examples:**
-```javascript
-// Simple string search (default, recommended for LLM)
-{ "tool": "fs_grep", "params": { "pattern": "function", "path": "src/" } }
+### replace_in_file
 
-// Regex search
-{ "tool": "fs_grep", "params": { "pattern": "function\\s+\\w+", "path": "src/", "use_regex": true } }
+替换文件中的文本。
 
-// Case sensitive search
-{ "tool": "fs_grep", "params": { "pattern": "TODO", "path": "src/", "ignore_case": false } }
-```
+**参数：**
+- `path` (string, required): 文件路径
+- `old` (string, required): 要替换的文本
+- `new` (string, required): 替换后的文本
 
-### Writing Files
+### edit_lines
 
-#### write_file
+编辑文件行。
 
-Write content to a file with optional append mode.
+**参数：**
+- `path` (string, required): 文件路径
+- `operation` (string, optional): 操作类型 - `"insert"` (默认) 或 `"delete"`
+- `line` (number, required): 行号（从1开始）
+- `end_line` (number, optional): 结束行（delete 操作）
+- `content` (string, required for insert): 插入内容
 
-**Parameters:**
-- `path` (string, required): File path
-- `content` (string, required): Content to write
-- `mode` (string, optional): Write mode - `"write"` (default, overwrite) or `"append"`
+## 文件操作
 
-#### replace_in_file
+### fs_action
 
-Replace text in a file.
+统一的文件系统操作。
 
-**Parameters:**
-- `path` (string, required): File path
-- `old` (string, required): Text to replace
-- `new` (string, required): Replacement text
+**参数：**
+- `operation` (string, optional): 操作类型 - `"copy"` (默认), `"move"`, `"delete"`, `"create_dir"`
+- `source` (string, required for copy/move): 源路径
+- `destination` (string, required for copy/move): 目标路径
+- `path` (string, required for delete/create_dir): 路径
 
-#### edit_lines
+| 操作 | 说明 | 必需参数 |
+|------|------|----------|
+| `copy` | 复制文件 | `source`, `destination` |
+| `move` | 移动文件 | `source`, `destination` |
+| `delete` | 删除文件或目录 | `path` |
+| `create_dir` | 创建目录 | `path` |
 
-Edit lines in a file with insert or delete operations.
+## 安全说明
 
-**Parameters:**
-- `path` (string, required): File path
-- `operation` (string, optional): Operation type - `"insert"` (default) or `"delete"`
-- `line` (number, required): Line number (1-based)
-- `end_line` (number, optional): End line number for delete operation (defaults to `line`)
-- `content` (string, required for insert): Content to insert
+### 路径限制
 
-**Operations:**
-| Operation | Description | Required Params |
-|-----------|-------------|-----------------|
-| `insert` | Insert content before the specified line | `path`, `line`, `content` |
-| `delete` | Delete lines from `line` to `end_line` | `path`, `line`, `end_line` (optional) |
+| 用户类型 | 相对路径 | 绝对路径 |
+|----------|----------|----------|
+| 普通用户 | ✅ 允许 | ❌ 拒绝 |
+| 管理员 | ✅ 允许 | ✅ 允许（限许可目录） |
 
-**Examples:**
-```javascript
-// Insert a line at line 5
-{ "tool": "edit_lines", "params": { "path": "file.txt", "line": 5, "content": "new line" } }
+### 允许目录
 
-// Delete line 10
-{ "tool": "edit_lines", "params": { "path": "file.txt", "operation": "delete", "line": 10 } }
+| 用户类型 | 允许目录 |
+|----------|----------|
+| 普通用户 | 当前工作目录 |
+| 管理员 | 当前工作目录 + `data/skills` |
 
-// Delete lines 10-15
-{ "tool": "edit_lines", "params": { "path": "file.txt", "operation": "delete", "line": 10, "end_line": 15 } }
-```
+## 最佳实践
 
-**Tip:** For content replacement (e.g., "replace 'foo' with 'bar'"), use `replace_in_file` tool instead.
-
-### File System Operations
-
-#### fs_action
-
-Unified file system operations: copy, move, delete, and create directory.
-
-**Parameters:**
-- `operation` (string, optional): Operation type - `"copy"` (default), `"move"`, `"delete"`, or `"create_dir"`
-- `source` (string, required for copy/move): Source path
-- `destination` (string, required for copy/move): Destination path
-- `path` (string, required for delete/create_dir): Path to delete or directory to create
-
-**Operations:**
-| Operation | Description | Required Params |
-|-----------|-------------|-----------------|
-| `copy` | Copy file to destination | `source`, `destination` |
-| `move` | Move file to destination | `source`, `destination` |
-| `delete` | Delete file or directory (recursive) | `path` |
-| `create_dir` | Create directory (recursive) | `path` |
-
-**Examples:**
-```javascript
-// Copy a file
-{ "tool": "fs_action", "params": { "source": "file.txt", "destination": "backup.txt" } }
-
-// Move a file
-{ "tool": "fs_action", "params": { "operation": "move", "source": "old.txt", "destination": "new.txt" } }
-
-// Delete a file or directory
-{ "tool": "fs_action", "params": { "operation": "delete", "path": "unwanted.txt" } }
-
-// Create a directory
-{ "tool": "fs_action", "params": { "operation": "create_dir", "path": "new_folder" } }
-```
-
-## Security
-
-### Path Restrictions
-
-| User Type | Relative Path | Absolute Path |
-|-----------|---------------|---------------|
-| Normal User | ✅ Allowed (relative to working directory) | ❌ Denied |
-| Admin | ✅ Allowed (relative to working directory) | ✅ Allowed (within permitted directories) |
-
-### Allowed Directories
-
-| User Type | Allowed Directories |
-|-----------|---------------------|
-| Normal User | Current working directory only (task or temp) |
-| Admin | Current working directory + `data/skills` directory |
-
-### Examples
-
-```javascript
-// Normal user - relative path (allowed)
-list_files({ path: "." })  // Lists current working directory
-
-// Normal user - absolute path (denied)
-list_files({ path: "d:/projects/.../data/skills" })  // Error!
-
-// Admin - relative path (allowed)
-list_files({ path: "." })  // Lists current working directory
-
-// Admin - absolute path to skills (allowed)
-list_files({ path: "d:/projects/.../data/skills/file-operations" })  // OK!
-```
-
-## Examples
-
-```javascript
-// Get file/directory information (recommended first step)
-{ "tool": "fs_info", "params": { "path": "data/example.txt" } }
-
-// Get file info with content preview
-{ "tool": "fs_info", "params": { "path": "data/example.txt", "include_content_preview": true } }
-
-// Check if a directory exists and see its contents
-{ "tool": "fs_info", "params": { "path": "data/src" } }
-
-// Read a file (lines mode)
-{ "tool": "read_file", "params": { "path": "data/example.txt" } }
-
-// Read file in bytes mode
-{ "tool": "read_file", "params": { "path": "data/binary.bin", "mode": "bytes", "bytes": 1000 } }
-
-// Search in files
-{ "tool": "fs_grep", "params": { "pattern": "TODO", "path": "data/src" } }
-
-// Write a file
-{ "tool": "write_file", "params": { "path": "data/output.txt", "content": "Hello!" } }
-
-// Append to a file
-{ "tool": "write_file", "params": { "path": "data/log.txt", "content": "New entry\n", "mode": "append" } }
-
-// Copy a file
-{ "tool": "fs_action", "params": { "source": "data/file.txt", "destination": "data/backup.txt" } }
-
-// Move a file
-{ "tool": "fs_action", "params": { "operation": "move", "source": "data/old.txt", "destination": "data/new.txt" } }
-
-// Delete a file or directory
-{ "tool": "fs_action", "params": { "operation": "delete", "path": "data/unwanted.txt" } }
-
-// Create a directory
-{ "tool": "fs_action", "params": { "operation": "create_dir", "path": "data/new_folder" } }
-```
-
-## Best Practices for LLM
-
-1. **Always call `fs_info` first** when working with an unknown path:
-   - Check if the file exists
-   - Determine if it's a file or directory
-   - See the file size before reading
-   - Check if it's a text file
-
-2. **Use `include_content_preview`** to quickly understand file structure without reading the entire file
-
-3. **Handle large files carefully**:
-   - Check `size` or `sizeHuman` before reading
-   - Use `from` and `lines` parameters to read in chunks
-   - Watch for `warning` field in `fs_info` response
-
-4. **Example workflow**:
-   ```
-   1. fs_info(path) → Check existence, type, size
-   2. If text file and small: read_file(path)
-   3. If text file and large: read_file(path, from=1, lines=100)
-   4. If directory: list_files(path) for detailed listing
-   ```
+1. **先调用 `fs_info`** 检查文件是否存在、类型、大小
+2. **使用 `include_content_preview`** 快速了解文件结构
+3. **处理大文件时** 检查 `size`，使用 `from`/`lines` 分块读取
+4. **内容替换** 使用 `replace_in_file`，行操作使用 `edit_lines`

--- a/data/skills/kb-editor/SKILL.md
+++ b/data/skills/kb-editor/SKILL.md
@@ -1,8 +1,14 @@
+---
+name: kb-editor
+description: "知识库编辑技能。用于创建和管理知识库、文章、节、段落、标签。当知识专家需要整理知识、导入文档、构建知识结构时触发。"
+argument-hint: "[create_kb|create_article|create_section|create_paragraph] --kb_id=xxx"
+user-invocable: false
+allowed-tools: []
+---
+
 # KB Editor - 知识库编辑技能
 
 知识库管理技能，用于创建和管理知识库、文章、节、段落、标签。
-
-**目标用户**：知识专家（专门负责整理知识的 AI 专家）
 
 ## 知识库结构
 
@@ -16,409 +22,130 @@ knowledge_bases (知识库)
         └── kb_paragraphs (段，可标记为知识点)
 ```
 
-## 功能
+## 工具
 
-- 知识库 CRUD（创建/读取/更新/删除）
-- 文章 CRUD（支持标签关联）
-- 节 CRUD（无限层级树状结构）
-- 段落 CRUD（可标记为知识点）
-- 标签 CRUD
-- 获取可用的嵌入模型列表
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `list_my_kbs` | 列出我的知识库 | `page`, `pageSize` |
+| `list_embedding_models` | 获取嵌入模型列表 | - |
+| `get_kb` | 获取知识库详情 | `id` |
+| `create_kb` | 创建知识库 | `name`, `description`, `embedding_model_id` |
+| `update_kb` | 更新知识库 | `id`, `name`, `description` |
+| `delete_kb` | 删除知识库 | `id` |
+| `list_articles` | 列出文章 | `kb_id`, `page`, `status`, `search` |
+| `get_article` | 获取文章详情 | `kb_id`, `id` |
+| `get_article_tree` | 获取文章完整结构 | `kb_id`, `article_id` |
+| `create_article` | 创建文章 | `kb_id`, `title`, `tags[]` |
+| `update_article` | 更新文章 | `kb_id`, `id`, `title`, `tags[]` |
+| `delete_article` | 删除文章 | `kb_id`, `id` |
+| `list_sections` | 列出节 | `kb_id`, `article_id` |
+| `create_section` | 创建节 | `kb_id`, `article_id`, `parent_id`, `title` |
+| `update_section` | 更新节 | `kb_id`, `id`, `title` |
+| `move_section` | 移动节 | `kb_id`, `id`, `direction` |
+| `delete_section` | 删除节 | `kb_id`, `id` |
+| `list_paragraphs` | 列出段落 | `kb_id`, `section_id` |
+| `create_paragraph` | 创建段落 | `kb_id`, `section_id`, `content`, `is_knowledge_point` |
+| `update_paragraph` | 更新段落 | `kb_id`, `id`, `content` |
+| `move_paragraph` | 移动段落 | `kb_id`, `id`, `direction` |
+| `delete_paragraph` | 删除段落 | `kb_id`, `id` |
+| `list_tags` | 列出标签 | `kb_id` |
+| `create_tag` | 创建标签 | `kb_id`, `name` |
+| `update_tag` | 更新标签 | `kb_id`, `id`, `name` |
+| `delete_tag` | 删除标签 | `kb_id`, `id` |
 
-## 权限
+## 知识库操作
 
-只能操作 `owner_id === userId` 的知识库（由 API 层验证）
-
----
-
-## 工具清单
-
-### 知识库操作
-
-#### list_my_kbs
+### list_my_kbs
 
 列出当前用户拥有的知识库。
 
-**参数**：
+**参数：**
 - `page` (integer, optional): 页码，默认 1
 - `pageSize` (integer, optional): 每页数量，默认 20
 
-#### list_embedding_models
-
-获取可用的嵌入模型列表，用于创建知识库时选择。
-
-**参数**：无
-
-#### get_kb
-
-获取知识库详情。
-
-**参数**：
-- `id` (string, required): 知识库 ID
-
-#### create_kb
+### create_kb
 
 创建知识库。
 
-**参数**：
+**参数：**
 - `name` (string, required): 知识库名称
 - `description` (string, optional): 知识库描述
 - `embedding_model_id` (string, optional): 嵌入模型 ID，默认 bge-m3
 - `embedding_dim` (integer, optional): 向量维度，默认 1024
 
-#### update_kb
+## 文章操作
 
-更新知识库。
-
-**参数**：
-- `id` (string, required): 知识库 ID
-- `name` (string, optional): 新名称
-- `description` (string, optional): 新描述
-- `embedding_model_id` (string, optional): 新嵌入模型 ID
-- `embedding_dim` (integer, optional): 新向量维度
-
-#### delete_kb
-
-删除知识库。
-
-**参数**：
-- `id` (string, required): 知识库 ID
-
----
-
-### 文章操作
-
-#### list_articles
-
-获取知识库下的文章列表。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `page` (integer, optional): 页码，默认 1
-- `pageSize` (integer, optional): 每页数量，默认 20
-- `status` (string, optional): 状态过滤（pending/processing/ready/error）
-- `search` (string, optional): 搜索关键词
-
-#### get_article
-
-获取文章详情。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 文章 ID
-
-#### get_article_tree
-
-获取文章的完整树状结构（包含所有节和段落）。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `article_id` (string, required): 文章 ID
-
-**返回示例**：
-```json
-{
-  "article": { "id": "art_001", "title": "Python 入门教程" },
-  "tree": [
-    {
-      "id": "sec_001",
-      "title": "第一章 Python简介",
-      "level": 1,
-      "children": [
-        {
-          "id": "sec_002",
-          "title": "1.1 什么是Python",
-          "level": 2,
-          "children": [],
-          "paragraphs": [
-            { "id": "para_001", "content": "...", "is_knowledge_point": true }
-          ]
-        }
-      ],
-      "paragraphs": []
-    }
-  ]
-}
-```
-
-#### create_article
+### create_article
 
 创建文章。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `title` (string, required): 文章标题
 - `summary` (string, optional): 文章摘要
-- `source_type` (string, optional): 来源类型（manual/upload/url）
-- `source_url` (string, optional): 来源 URL
-- `file_path` (string, optional): 本地文件路径
-- `status` (string, optional): 状态（pending/processing/ready/error）
 - `tags` (string[], optional): 标签名数组，如 `['Python', '编程']`
 
-#### update_article
+### get_article_tree
 
-更新文章。
+获取文章的完整树状结构（包含所有节和段落）。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 文章 ID
-- `title` (string, optional): 新标题
-- `summary` (string, optional): 新摘要
-- `source_type` (string, optional): 来源类型
-- `source_url` (string, optional): 来源 URL
-- `file_path` (string, optional): 本地文件路径
-- `status` (string, optional): 状态
-- `tags` (string[], optional): 标签名数组
+- `article_id` (string, required): 文章 ID
 
-#### delete_article
+## 节操作
 
-删除文章（级联删除所有节和段落）。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 文章 ID
-
----
-
-### 节操作
-
-#### list_sections
-
-查询节列表。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `article_id` (string, optional): 文章 ID 过滤
-- `page` (integer, optional): 页码，默认 1
-- `pageSize` (integer, optional): 每页数量，默认 100
-
-#### create_section
+### create_section
 
 创建节。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `article_id` (string, required): 所属文章 ID
 - `parent_id` (string, optional): 父节 ID（用于创建子节）
 - `title` (string, required): 节标题
 
-**说明**：
-- 如果不传 `parent_id`，创建的是顶级节（章）
-- 如果传 `parent_id`，创建的是子节
+**说明：**
+- 不传 `parent_id` 创建顶级节（章）
+- 传 `parent_id` 创建子节
 - 系统自动计算 `level` 和 `position`
 - 最大层级深度为 10 层
 
-#### update_section
+## 段落操作
 
-更新节。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 节 ID
-- `title` (string, optional): 新标题
-
-#### move_section
-
-移动节（与相邻节交换位置）。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 节 ID
-- `direction` (string, required): 移动方向，"up" 或 "down"
-
-#### delete_section
-
-删除节（级联删除所有子节和段落）。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 节 ID
-
----
-
-### 段落操作
-
-#### list_paragraphs
-
-查询段落列表。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `section_id` (string, optional): 节 ID 过滤
-- `is_knowledge_point` (boolean, optional): 是否知识点过滤
-- `page` (integer, optional): 页码，默认 1
-- `pageSize` (integer, optional): 每页数量，默认 100
-
-#### create_paragraph
+### create_paragraph
 
 创建段落。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `section_id` (string, required): 所属节 ID
 - `title` (string, optional): 段落标题
 - `content` (string, required): 段落内容
-- `context` (string, optional): 知识点上下文。当 `is_knowledge_point` 为 `true` 时，使用一两句话总结该知识点及其所在文章（中文），便于语义检索
+- `context` (string, optional): 知识点上下文（用于语义检索）
 - `is_knowledge_point` (boolean, optional): 是否为知识点，默认 false
-- `token_count` (integer, optional): Token 数量，默认 0
 
-⚠️ **核心原则：严格保留原文**：
+⚠️ **核心原则：严格保留原文**
 - `content` 必须是**原文完整复制**，禁止提炼、总结、改写或省略
 - 即使原文很长，也要完整录入，不能截断
 - 如果原文有多个段落，每个段落应单独创建一条记录
-- **完整性优先**：宁可多录入也不要遗漏任何内容
 
-**重要：知识点段落**：
+**知识点段落：**
 - 设置 `is_knowledge_point: true` 的段落会被向量化，可用于语义搜索
 - 普通段落不会被向量化，只作为上下文展示
 
-**Context 字段说明**：
-- **用途**：用于语义检索时提供上下文信息，帮助技能更准确地定位知识点
-- **生成原则**：用一两句话总结该知识点和知识点所处的文章（中文）
-- **示例**：如果知识点是"Python 是一种解释型语言"，Context 可以是"Python 编程语言简介 - 介绍 Python 的基本特性和应用场景"
-
-#### update_paragraph
-
-更新段落。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 段落 ID
-- `title` (string, optional): 新标题
-- `content` (string, optional): 新内容（原文，不要提炼或总结）
-- `context` (string, optional): 知识点上下文。当 `is_knowledge_point` 为 `true` 时，使用一两句话总结该知识点及其所在文章（中文），便于语义检索
-- `is_knowledge_point` (boolean, optional): 是否为知识点
-- `token_count` (integer, optional): Token 数量
-
-#### move_paragraph
-
-移动段落（与相邻段交换位置）。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 段落 ID
-- `direction` (string, required): 移动方向，"up" 或 "down"
-
-#### delete_paragraph
-
-删除段落。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 段落 ID
-
----
-
-### 标签操作
-
-#### list_tags
-
-获取标签列表。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `page` (integer, optional): 页码，默认 1
-- `pageSize` (integer, optional): 每页数量，默认 100
-
-#### create_tag
-
-创建标签。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `name` (string, required): 标签名称
-- `description` (string, optional): 标签描述
-
-#### update_tag
-
-更新标签。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 标签 ID
-- `name` (string, optional): 新名称
-- `description` (string, optional): 新描述
-
-#### delete_tag
-
-删除标签。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 标签 ID
-
----
+**Context 字段说明：**
+- 用途：用于语义检索时提供上下文信息
+- 生成原则：用一两句话总结该知识点和知识点所处的文章（中文）
+- 示例：如果知识点是"Python 是一种解释型语言"，Context 可以是"Python 编程语言简介 - 介绍 Python 的基本特性和应用场景"
 
 ## 环境变量
-
-以下环境变量由 skill-loader 自动注入：
 
 | 变量名 | 说明 | 必需 |
 |--------|------|------|
 | `USER_ACCESS_TOKEN` | 用户的 JWT access token | ✅ |
 | `API_BASE` | API 基础地址 | ✅ |
 | `USER_ID` | 用户 ID（调试用） | 可选 |
-
----
-
-## 使用示例
-
-### 创建知识库和文章
-
-```javascript
-// 1. 创建知识库
-create_kb(name="产品文档", description="产品相关文档和知识")
-
-// 2. 创建文章
-create_article(kb_id="kb123", title="功能介绍", tags=["产品", "功能"])
-
-// 3. 创建文章（带标签）
-create_article(kb_id="kb123", title="API 文档", tags=["API", "开发"])
-```
-
-### 创建文章内容结构
-
-```javascript
-// 1. 创建顶级节（章）
-create_section(kb_id="kb123", article_id="art456", title="第一章 快速开始")
-
-// 2. 创建子节
-create_section(kb_id="kb123", article_id="art456", parent_id="sec001", title="1.1 安装")
-
-// 3. 创建段落
-create_paragraph(
-  kb_id="kb123",
-  section_id="sec002",
-  content="安装非常简单，只需要运行 npm install 命令即可完成...",
-  is_knowledge_point=true
-)
-
-// 4. 创建普通段落（不会向量化）
-create_paragraph(
-  kb_id="kb123",
-  section_id="sec002",
-  content="这是补充说明文字，不需要被检索..."
-)
-```
-
-### 获取文章完整结构
-
-```javascript
-// 获取文章树（包含所有节和段落）
-get_article_tree(kb_id="kb123", article_id="art456")
-```
-
-### 标签管理
-
-```javascript
-// 创建标签
-create_tag(kb_id="kb123", name="重要", description="重要内容")
-
-// 给文章设置标签（在创建或更新文章时）
-create_article(kb_id="kb123", title="新文章", tags=["重要", "产品"])
-```
-
----
 
 ## 典型工作流程
 
@@ -435,12 +162,6 @@ create_article(kb_id="kb123", title="新文章", tags=["重要", "产品"])
 2. `move_section` / `move_paragraph` - 调整顺序
 3. `update_section` / `update_paragraph` - 修改内容
 
----
+## 权限说明
 
-## 技术说明
-
-- 通过 API 调用执行操作，使用用户 Token 认证
-- 所有权限验证由 API 层完成
-- 节支持无限层级（最大 10 层）
-- 只有标记为知识点的段落会被向量化
-- 标签与文章是多对多关系
+只能操作 `owner_id === userId` 的知识库（由 API 层验证）。

--- a/data/skills/kb-search/SKILL.md
+++ b/data/skills/kb-search/SKILL.md
@@ -1,191 +1,115 @@
+---
+name: kb-search
+description: "知识库检索技能。用于查询和搜索知识库内容，支持语义搜索。当专家需要检索知识、查找知识点时触发。"
+argument-hint: "[search|global_search|list_articles] --kb_id=xxx"
+user-invocable: false
+allowed-tools: []
+---
+
 # KB Search - 知识库检索技能
 
 用于查询和搜索知识库内容的技能。
 
-**目标用户**：所有专家（用于检索知识）
+## 工具
 
-## 知识库结构
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `list_my_kbs` | 列出我的知识库 | `page`, `pageSize` |
+| `get_kb` | 获取知识库详情 | `id` |
+| `list_articles` | 列出文章 | `kb_id`, `page`, `status`, `search` |
+| `get_article` | 获取文章详情 | `kb_id`, `id` |
+| `get_article_tree` | 获取文章完整结构 | `kb_id`, `article_id` |
+| `list_sections` | 列出节 | `kb_id`, `article_id` |
+| `list_paragraphs` | 列出段落 | `kb_id`, `section_id` |
+| `list_knowledge_points` | 列出知识点 | `kb_id`, `section_id` |
+| `list_tags` | 列出标签 | `kb_id` |
+| `search` | 语义搜索 | `kb_id`, `query`, `top_k` |
+| `search_in_article` | 文章内搜索 | `kb_id`, `article_id`, `query` |
+| `global_search` | 全局搜索 | `query`, `top_k` |
 
-```
-knowledge_bases (知识库)
-├── kb_tags (标签)
-│   └── kb_article_tags (文章-标签关联)
-└── kb_articles (文章)
-    └── kb_sections (节，自指向无限层级)
-        ├── kb_sections (子节...)
-        └── kb_paragraphs (段，可标记为知识点)
-```
+## 知识库查询
 
-## 功能
-
-- 知识库查询
-- 文章查询
-- 节查询
-- 段落查询（知识点）
-- 标签查询
-- 语义搜索
-
-## 权限
-
-只能查询 `owner_id === userId` 的知识库（由 API 层验证）
-
----
-
-## 工具清单
-
-### 知识库查询
-
-#### list_my_kbs
+### list_my_kbs
 
 列出当前用户可访问的知识库。
 
-**参数**：
+**参数：**
 - `page` (integer, optional): 页码，默认 1
 - `pageSize` (integer, optional): 每页数量，默认 20
 
-#### get_kb
+### get_kb
 
 获取知识库详情。
 
-**参数**：
+**参数：**
 - `id` (string, required): 知识库 ID
 
----
+## 文章查询
 
-### 文章查询
-
-#### list_articles
+### list_articles
 
 获取知识库下的文章列表。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `page` (integer, optional): 页码，默认 1
 - `pageSize` (integer, optional): 每页数量，默认 20
 - `status` (string, optional): 状态过滤（pending/processing/ready/error）
 - `search` (string, optional): 搜索关键词
 
-#### get_article
-
-获取文章详情。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `id` (string, required): 文章 ID
-
-#### get_article_tree
+### get_article_tree
 
 获取文章的完整树状结构（包含所有节和段落）。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `article_id` (string, required): 文章 ID
 
-**返回示例**：
-```json
-{
-  "article": { "id": "art_001", "title": "Python 入门教程" },
-  "tree": [
-    {
-      "id": "sec_001",
-      "title": "第一章 Python简介",
-      "level": 1,
-      "children": [...],
-      "paragraphs": [...]
-    }
-  ]
-}
-```
+## 段落查询
 
----
-
-### 节查询
-
-#### list_sections
-
-查询节列表。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `article_id` (string, optional): 文章 ID 过滤
-- `page` (integer, optional): 页码，默认 1
-- `pageSize` (integer, optional): 每页数量，默认 100
-
----
-
-### 段落查询
-
-#### list_paragraphs
-
-查询段落列表。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `section_id` (string, optional): 节 ID 过滤
-- `is_knowledge_point` (boolean, optional): 是否知识点过滤
-- `page` (integer, optional): 页码，默认 1
-- `pageSize` (integer, optional): 每页数量，默认 100
-
-#### list_knowledge_points
+### list_knowledge_points
 
 获取知识点列表（便捷方法，只返回标记为知识点的段落）。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `section_id` (string, optional): 节 ID 过滤
 - `page` (integer, optional): 页码，默认 1
 - `pageSize` (integer, optional): 每页数量，默认 100
 
----
+## 搜索操作
 
-### 标签查询
-
-#### list_tags
-
-获取标签列表。
-
-**参数**：
-- `kb_id` (string, required): 知识库 ID
-- `page` (integer, optional): 页码，默认 1
-- `pageSize` (integer, optional): 每页数量，默认 100
-
----
-
-### 搜索操作
-
-#### search
+### search
 
 在指定知识库中进行语义搜索（搜索知识点段落）。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `query` (string, required): 搜索查询
 - `top_k` (integer, optional): 返回结果数量，默认 5
 - `threshold` (number, optional): 相似度阈值，默认 0.1
 - `format` (string, optional): 输出格式，可选 'table'
 
-#### search_in_article
+### search_in_article
 
-在指定文章中进行语义搜索（结构路径）。
+在指定文章中进行语义搜索。
 
-**参数**：
+**参数：**
 - `kb_id` (string, required): 知识库 ID
 - `article_id` (string, required): 文章 ID
 - `query` (string, required): 搜索查询
 - `top_k` (integer, optional): 返回结果数量，默认 5
 - `threshold` (number, optional): 相似度阈值，默认 0.1
 
-#### global_search
+### global_search
 
 全局语义搜索，搜索用户所有知识库。
 
-**参数**：
+**参数：**
 - `query` (string, required): 搜索查询
 - `top_k` (integer, optional): 返回结果数量，默认 10
 - `threshold` (number, optional): 相似度阈值，默认 0.1
 - `format` (string, optional): 输出格式，可选 'table'
-
----
 
 ## 环境变量
 
@@ -194,51 +118,6 @@ knowledge_bases (知识库)
 | `USER_ACCESS_TOKEN` | 用户的 JWT access token | ✅ |
 | `API_BASE` | API 基础地址 | ✅ |
 | `USER_ID` | 用户 ID（调试用） | 可选 |
-
----
-
-## 使用示例
-
-### 查看知识库和文章
-
-```javascript
-// 1. 列出我的知识库
-list_my_kbs()
-
-// 2. 获取知识库详情
-get_kb(id="kb123")
-
-// 3. 列出知识库下的文章
-list_articles(kb_id="kb123")
-
-// 4. 获取文章的完整结构
-get_article_tree(kb_id="kb123", article_id="art456")
-```
-
-### 语义搜索
-
-```javascript
-// 在知识库中搜索
-search(kb_id="kb123", query="如何安装 Python", top_k=5)
-
-// 在特定文章中搜索
-search_in_article(kb_id="kb123", article_id="art456", query="变量定义")
-
-// 全局搜索
-global_search(query="配置环境变量", top_k=10)
-```
-
-### 查询知识点
-
-```javascript
-// 获取知识库中的所有知识点
-list_knowledge_points(kb_id="kb123")
-
-// 获取特定节下的知识点
-list_knowledge_points(kb_id="kb123", section_id="sec789")
-```
-
----
 
 ## 典型工作流程
 
@@ -254,11 +133,12 @@ list_knowledge_points(kb_id="kb123", section_id="sec789")
 2. `get_article_tree` - 查看文章完整结构
 3. `list_knowledge_points` - 查看特定节的知识点
 
----
+## 权限说明
+
+只能查询 `owner_id === userId` 的知识库（由 API 层验证）。
 
 ## 技术说明
 
 - 通过 API 调用执行操作，使用用户 Token 认证
-- 所有权限验证由 API 层完成
 - 搜索只在 `is_knowledge_point=true` 的段落中进行
 - 搜索结果包含相似度分数和完整路径信息

--- a/data/skills/message-reader/SKILL.md
+++ b/data/skills/message-reader/SKILL.md
@@ -1,14 +1,22 @@
-# Message Reader Skill
+---
+name: message-reader
+description: "消息内容检索技能。用于上下文优化中的按需获取，当工具消息被摘要后，AI 可通过此技能获取完整消息内容。"
+argument-hint: "get_message_content --tool_call_id=xxx"
+user-invocable: false
+allowed-tools: []
+---
+
+# Message Reader - 消息内容检索技能
 
 提供消息内容检索能力，用于上下文优化中的按需获取。
 
-## 功能说明
+## 工具
 
-当工具消息被摘要后，AI 可以通过此技能获取完整消息内容。
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `get_message_content` | 获取完整消息内容 | `tool_call_id` |
 
-## 工具列表
-
-### get_message_content
+## get_message_content
 
 获取指定工具消息的完整内容。
 

--- a/data/skills/pdf/SKILL.md
+++ b/data/skills/pdf/SKILL.md
@@ -1,546 +1,250 @@
 ---
 name: pdf
-description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and converting PDFs to images for VL model recognition. If the user mentions a .pdf file or asks to produce one, use this skill.
+description: "PDF 文件处理。用于读取、提取文本/表格、合并、拆分、旋转、水印、加密/解密、表单填写、图片提取、转换为图片。当用户提到 .pdf 文件或需要操作 PDF 时触发。"
 license: Proprietary. LICENSE.txt has complete terms
 argument-hint: "[operation] [path]"
 user-invocable: true
-tools:
-  - read_pdf
-  - extract_text
-  - extract_tables
-  - merge_pdfs
-  - split_pdf
-  - rotate_pages
-  - create_pdf
-  - convert_to_images
-  - pdf_to_markdown
-  - encrypt_pdf
-  - decrypt_pdf
-  - add_watermark
-  - check_fillable_fields
-  - extract_form_field_info
-  - fill_fillable_fields
-  - extract_form_structure
-  - fill_pdf_form_with_annotations
-  - check_bounding_boxes
-  - extract_images
 ---
 
-# PDF Processing Guide
+# PDF - PDF 文件处理
 
-## Overview
+## 工具
 
-This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `read_pdf` | 读取 PDF 元数据 | `path` |
+| `extract_text` | 提取文本 | `path`, `from_page`, `to_page` |
+| `extract_tables` | 提取表格 | `path`, `page` |
+| `merge_pdfs` | 合并 PDF | `paths[]`, `output` |
+| `split_pdf` | 拆分 PDF | `path`, `output_dir`, `pages_per_file` |
+| `rotate_pages` | 旋转页面 | `path`, `output`, `pages[]`, `degrees` |
+| `create_pdf` | 创建 PDF | `output`, `content[]` |
+| `convert_to_images` | 转为图片 | `path`, `output_dir`, `dpi`, `format` |
+| `pdf_to_markdown` | 转为 Markdown | `path`, `output` |
+| `encrypt_pdf` | 加密 PDF | `path`, `output`, `user_password` |
+| `decrypt_pdf` | 解密 PDF | `path`, `output`, `password` |
+| `add_watermark` | 添加水印 | `path`, `output`, `watermark` |
+| `check_fillable_fields` | 检查可填写字段 | `path` |
+| `extract_form_field_info` | 提取表单字段信息 | `path`, `output` |
+| `fill_fillable_fields` | 填写表单字段 | `path`, `field_values`, `output` |
+| `extract_form_structure` | 提取表单结构 | `path`, `output` |
+| `fill_pdf_form_with_annotations` | 用注释填写表单 | `path`, `fields_json`, `output` |
+| `check_bounding_boxes` | 验证边界框 | `fields_json` |
+| `extract_images` | 提取图片 | `path`, `output_dir` |
 
-## Tools
+## 基本操作
 
-### Basic Operations
+### read_pdf
 
-#### read_pdf
+读取 PDF 元数据和基本信息。
 
-Read PDF metadata and basic information.
+**参数：**
+- `path` (string, required): PDF 文件路径
 
-**Parameters:**
-- `path` (string, required): PDF file path
+**返回：** 页数、元数据（标题、作者、主题、创建者）、加密状态
 
-**Returns:** Page count, metadata (title, author, subject, creator), encryption status
+### extract_text
 
-#### extract_text
+从 PDF 页面提取文本内容。
 
-Extract text content from PDF pages.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `from_page` (number, optional): 起始页（从1开始，默认: 1）
+- `to_page` (number, optional): 结束页（包含）
+- `preserve_layout` (boolean, optional): 保留布局（默认: false）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `from_page` (number, optional): Start page (1-based, default: 1)
-- `to_page` (number, optional): End page (inclusive)
-- `preserve_layout` (boolean, optional): Preserve layout (default: false)
+### extract_tables
 
-#### extract_tables
+使用 pdfplumber 从 PDF 提取表格。
 
-Extract tables from PDF using pdfplumber.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `page` (number, optional): 指定页码（从1开始，不指定则提取所有）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `page` (number, optional): Specific page number (1-based, extracts all if not specified)
+## 编辑操作
 
-### Editing Operations
+### merge_pdfs
 
-#### merge_pdfs
+合并多个 PDF 文件。
 
-Merge multiple PDF files into one.
+**参数：**
+- `paths` (string[], required): PDF 文件路径数组（至少2个）
+- `output` (string, required): 输出文件路径
 
-**Parameters:**
-- `paths` (string[], required): Array of PDF file paths (at least 2)
-- `output` (string, required): Output file path
+### split_pdf
 
-#### split_pdf
+将 PDF 拆分为多个文件。
 
-Split PDF into multiple files.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output_dir` (string, required): 输出目录
+- `pages_per_file` (number, optional): 每个文件的页数（默认: 1）
+- `prefix` (string, optional): 输出文件名前缀（默认: "page"）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output_dir` (string, required): Output directory
-- `pages_per_file` (number, optional): Pages per output file (default: 1)
-- `prefix` (string, optional): Output filename prefix (default: "page")
+### rotate_pages
 
-#### rotate_pages
+旋转 PDF 页面。
 
-Rotate pages in PDF.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output` (string, required): 输出文件路径
+- `pages` (number[], optional): 要旋转的页码（从1开始，为空则旋转所有）
+- `degrees` (number, optional): 旋转角度 - 90, 180, 270（默认: 90）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output` (string, required): Output file path
-- `pages` (number[], optional): Page numbers to rotate (1-based, all if empty)
-- `degrees` (number, optional): Rotation degrees - 90, 180, 270 (default: 90)
+## 创建和转换
 
-### Creation and Conversion
+### create_pdf
 
-#### create_pdf
+创建新的 PDF 文件。
 
-Create a new PDF with text content.
+**参数：**
+- `output` (string, required): 输出文件路径
+- `title` (string, optional): PDF 标题
+- `content` (string[], required): 文本内容数组（每项为一页）
+- `page_size` (string, optional): 页面大小 - "letter" 或 "a4"（默认: "a4"）
 
-**Parameters:**
-- `output` (string, required): Output file path
-- `title` (string, optional): PDF title
-- `content` (string[], required): Array of text content (each item is a page)
-- `page_size` (string, optional): Page size - "letter" or "a4" (default: "a4")
+### convert_to_images
 
-#### convert_to_images
+将 PDF 页面转换为图片。
 
-Convert PDF pages to images.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output_dir` (string, required): 输出目录
+- `dpi` (number, optional): 分辨率 DPI（默认: 150）
+- `format` (string, optional): 图片格式 - "png" 或 "jpeg"（默认: "png"）
+- `from_page` (number, optional): 起始页（从1开始）
+- `to_page` (number, optional): 结束页（包含）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output_dir` (string, required): Output directory
-- `dpi` (number, optional): Resolution DPI (default: 150)
-- `format` (string, optional): Image format - "png" or "jpeg" (default: "png")
-- `from_page` (number, optional): Start page (1-based)
-- `to_page` (number, optional): End page (inclusive)
+### pdf_to_markdown
 
-#### pdf_to_markdown
+将 PDF 转换为 Markdown 格式。
 
-Convert PDF to Markdown format.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output` (string, optional): 输出 markdown 文件路径
+- `from_page` (number, optional): 起始页（从1开始）
+- `to_page` (number, optional): 结束页（包含）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output` (string, optional): Output markdown file path
-- `from_page` (number, optional): Start page (1-based)
-- `to_page` (number, optional): End page (inclusive)
+## 安全操作
 
-### Security Operations
+### encrypt_pdf
 
-#### encrypt_pdf
+使用密码保护加密 PDF。
 
-Encrypt PDF with password protection.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output` (string, required): 输出文件路径
+- `user_password` (string, required): 打开 PDF 的密码
+- `owner_password` (string, optional): 编辑密码（默认使用 user_password）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output` (string, required): Output file path
-- `user_password` (string, required): Password to open the PDF
-- `owner_password` (string, optional): Password for editing (defaults to user_password)
+### decrypt_pdf
 
-#### decrypt_pdf
+移除 PDF 密码保护。
 
-Remove password protection from PDF.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output` (string, required): 输出文件路径
+- `password` (string, required): 当前密码
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output` (string, required): Output file path
-- `password` (string, required): Current password
+### add_watermark
 
-#### add_watermark
+为 PDF 页面添加水印。
 
-Add watermark to PDF pages.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output` (string, required): 输出文件路径
+- `watermark` (string, required): 水印文本或水印 PDF 路径
+- `is_text` (boolean, optional): true 为文本水印，false 为 PDF 路径（默认: true）
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output` (string, required): Output file path
-- `watermark` (string, required): Watermark text or watermark PDF path
-- `is_text` (boolean, optional): True if watermark is text, false if PDF path (default: true)
+## 表单操作
 
-### Form Operations
+### check_fillable_fields
 
-#### check_fillable_fields
+检查 PDF 是否有可填写的表单字段。
 
-Check if PDF has fillable form fields.
+**参数：**
+- `path` (string, required): PDF 文件路径
 
-**Parameters:**
-- `path` (string, required): PDF file path
+### extract_form_field_info
 
-#### extract_form_field_info
+提取可填写表单字段的信息。
 
-Extract information about fillable form fields.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output` (string, required): 输出 JSON 文件路径
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output` (string, required): Output JSON file path
+### fill_fillable_fields
 
-#### fill_fillable_fields
+填写 PDF 中的可填写表单字段。
 
-Fill fillable form fields in a PDF.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `field_values` (string, required): 包含字段值的 JSON 文件
+- `output` (string, required): 输出 PDF 文件路径
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `field_values` (string, required): JSON file with field values
-- `output` (string, required): Output PDF file path
+### extract_form_structure
 
-#### extract_form_structure
+为不可填写的表单提取表单结构。
 
-Extract form structure for non-fillable forms.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output` (string, required): 输出 JSON 文件路径
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output` (string, required): Output JSON file path
+### fill_pdf_form_with_annotations
 
-#### fill_pdf_form_with_annotations
+使用文本注释填写不可填写的 PDF 表单。
 
-Fill non-fillable PDF forms with text annotations.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `fields_json` (string, required): 字段 JSON 文件路径
+- `output` (string, required): 输出 PDF 文件路径
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `fields_json` (string, required): Fields JSON file path
-- `output` (string, required): Output PDF file path
+### check_bounding_boxes
 
-#### check_bounding_boxes
+验证表单字段的边界框。
 
-Validate bounding boxes for form fields.
+**参数：**
+- `fields_json` (string, required): 字段 JSON 文件路径
 
-**Parameters:**
-- `fields_json` (string, required): Fields JSON file path
+## 其他操作
 
-### Other Operations
+### extract_images
 
-#### extract_images
+从 PDF 中提取嵌入的图片。
 
-Extract embedded images from PDF.
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output_dir` (string, required): 输出目录
 
-**Parameters:**
-- `path` (string, required): PDF file path
-- `output_dir` (string, required): Output directory
+## 常见任务
 
-## Quick Start
+### 扫描版 PDF 处理
 
-```python
-from pypdf import PdfReader, PdfWriter
+对于扫描版 PDF 或基于图片的 PDF，文本提取可能失败。使用 `convert_to_images` 转换为图片，然后发送给 VL（视觉语言）模型进行文字识别。
 
-# Read a PDF
-reader = PdfReader("document.pdf")
-print(f"Pages: {len(reader.pages)}")
+**工作流程：**
+1. 使用 `convert_to_images` 将 PDF 页面转换为 PNG/JPEG 图片
+2. 将生成的图片发送给 VL 模型（如 GPT-4V、Claude Vision、Qwen-VL）
+3. VL 模型将识别并提取图片中的文字
 
-# Extract text
-text = ""
-for page in reader.pages:
-    text += page.extract_text()
+**示例：**
+```javascript
+convert_to_images({ path: "scanned.pdf", output_dir: "./images", dpi: 200 })
 ```
 
-## Python Libraries
-
-### pypdf - Basic Operations
-
-#### Merge PDFs
-
-```python
-from pypdf import PdfWriter, PdfReader
-
-writer = PdfWriter()
-for pdf_file in ["doc1.pdf", "doc2.pdf", "doc3.pdf"]:
-    reader = PdfReader(pdf_file)
-    for page in reader.pages:
-        writer.add_page(page)
-
-with open("merged.pdf", "wb") as output:
-    writer.write(output)
-```
-
-#### Split PDF
-
-```python
-reader = PdfReader("input.pdf")
-for i, page in enumerate(reader.pages):
-    writer = PdfWriter()
-    writer.add_page(page)
-    with open(f"page_{i+1}.pdf", "wb") as output:
-        writer.write(output)
-```
-
-#### Extract Metadata
-
-```python
-reader = PdfReader("document.pdf")
-meta = reader.metadata
-print(f"Title: {meta.title}")
-print(f"Author: {meta.author}")
-print(f"Subject: {meta.subject}")
-print(f"Creator: {meta.creator}")
-```
-
-#### Rotate Pages
-
-```python
-reader = PdfReader("input.pdf")
-writer = PdfWriter()
-
-page = reader.pages[0]
-page.rotate(90)  # Rotate 90 degrees clockwise
-writer.add_page(page)
-
-with open("rotated.pdf", "wb") as output:
-    writer.write(output)
-```
-
-### pdfplumber - Text and Table Extraction
-
-#### Extract Text with Layout
-
-```python
-import pdfplumber
-
-with pdfplumber.open("document.pdf") as pdf:
-    for page in pdf.pages:
-        text = page.extract_text()
-        print(text)
-```
-
-#### Extract Tables
-
-```python
-with pdfplumber.open("document.pdf") as pdf:
-    for i, page in enumerate(pdf.pages):
-        tables = page.extract_tables()
-        for j, table in enumerate(tables):
-            print(f"Table {j+1} on page {i+1}:")
-            for row in table:
-                print(row)
-```
-
-#### Advanced Table Extraction
-
-```python
-import pandas as pd
-
-with pdfplumber.open("document.pdf") as pdf:
-    all_tables = []
-    for page in pdf.pages:
-        tables = page.extract_tables()
-        for table in tables:
-            if table:  # Check if table is not empty
-                df = pd.DataFrame(table[1:], columns=table[0])
-                all_tables.append(df)
-
-# Combine all tables
-if all_tables:
-    combined_df = pd.concat(all_tables, ignore_index=True)
-    combined_df.to_excel("extracted_tables.xlsx", index=False)
-```
-
-### reportlab - Create PDFs
-
-#### Basic PDF Creation
-
-```python
-from reportlab.lib.pagesizes import letter
-from reportlab.pdfgen import canvas
-
-c = canvas.Canvas("hello.pdf", pagesize=letter)
-width, height = letter
-
-# Add text
-c.drawString(100, height - 100, "Hello World!")
-c.drawString(100, height - 120, "This is a PDF created with reportlab")
-
-# Add a line
-c.line(100, height - 140, 400, height - 140)
-
-# Save
-c.save()
-```
-
-#### Create PDF with Multiple Pages
-
-```python
-from reportlab.lib.pagesizes import letter
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak
-from reportlab.lib.styles import getSampleStyleSheet
-
-doc = SimpleDocTemplate("report.pdf", pagesize=letter)
-styles = getSampleStyleSheet()
-story = []
-
-# Add content
-title = Paragraph("Report Title", styles['Title'])
-story.append(title)
-story.append(Spacer(1, 12))
-
-body = Paragraph("This is the body of the report. " * 20, styles['Normal'])
-story.append(body)
-story.append(PageBreak())
-
-# Page 2
-story.append(Paragraph("Page 2", styles['Heading1']))
-story.append(Paragraph("Content for page 2", styles['Normal']))
-
-# Build PDF
-doc.build(story)
-```
-
-#### Subscripts and Superscripts
-
-**IMPORTANT**: Never use Unicode subscript/superscript characters (₀₁₂₃₄₅₆₇₈₉, ⁰¹²³⁴⁵⁶⁷⁸⁹) in ReportLab PDFs. The built-in fonts do not include these glyphs, causing them to render as solid black boxes.
-
-Instead, use ReportLab's XML markup tags in Paragraph objects:
-
-```python
-from reportlab.platypus import Paragraph
-from reportlab.lib.styles import getSampleStyleSheet
-
-styles = getSampleStyleSheet()
-
-# Subscripts: use <sub> tag
-chemical = Paragraph("H<sub>2</sub>O", styles['Normal'])
-
-# Superscripts: use <super> tag
-squared = Paragraph("x<super>2</super> + y<super>2</super>", styles['Normal'])
-```
-
-For canvas-drawn text (not Paragraph objects), manually adjust font the size and position rather than using Unicode subscripts/superscripts.
-
-## Command-Line Tools
-
-### pdftotext (poppler-utils)
-
-```bash
-# Extract text
-pdftotext input.pdf output.txt
-
-# Extract text preserving layout
-pdftotext -layout input.pdf output.txt
-
-# Extract specific pages
-pdftotext -f 1 -l 5 input.pdf output.txt  # Pages 1-5
-```
-
-### qpdf
-
-```bash
-# Merge PDFs
-qpdf --empty --pages file1.pdf file2.pdf -- merged.pdf
-
-# Split pages
-qpdf input.pdf --pages . 1-5 -- pages1-5.pdf
-qpdf input.pdf --pages . 6-10 -- pages6-10.pdf
-
-# Rotate pages
-qpdf input.pdf output.pdf --rotate=+90:1  # Rotate page 1 by 90 degrees
-
-# Remove password
-qpdf --password=mypassword --decrypt encrypted.pdf decrypted.pdf
-```
-
-### pdftk (if available)
-
-```bash
-# Merge
-pdftk file1.pdf file2.pdf cat output merged.pdf
-
-# Split
-pdftk input.pdf burst
-
-# Rotate
-pdftk input.pdf rotate 1east output rotated.pdf
-```
-
-## Common Tasks
-
-### Convert Scanned PDFs to Images for VL Model Recognition
-
-For scanned PDFs or image-based PDFs where text extraction fails, use `convert_to_images` tool to convert PDF pages to images, then send images to VL (Vision-Language) model for text recognition.
-
-**Workflow:**
-1. Use `convert_to_images` tool to convert PDF pages to PNG/JPEG images
-2. Send the generated images to VL model (e.g., GPT-4V, Claude Vision, Qwen-VL)
-3. VL model will recognize and extract text from the images
-
-**Example:**
-```
-# Step 1: Convert PDF to images
-Tool: convert_to_images
-Params: { "path": "scanned.pdf", "output_dir": "./images", "dpi": 200 }
-
-# Step 2: Send images to VL model for recognition
-# The images are now ready for VL model processing
-```
-
-**Benefits of using VL model over traditional OCR:**
-- Better handling of complex layouts
-- Multi-language support without additional language packs
-- Understanding of tables, forms, and structured content
-- No need to install Tesseract or language packs
-
-### Add Watermark
-
-```python
-from pypdf import PdfReader, PdfWriter
-
-# Create watermark (or load existing)
-watermark = PdfReader("watermark.pdf").pages[0]
-
-# Apply to all pages
-reader = PdfReader("document.pdf")
-writer = PdfWriter()
-
-for page in reader.pages:
-    page.merge_page(watermark)
-    writer.add_page(page)
-
-with open("watermarked.pdf", "wb") as output:
-    writer.write(output)
-```
-
-### Extract Images
-
-```bash
-# Using pdfimages (poppler-utils)
-pdfimages -j input.pdf output_prefix
-
-# This extracts all images as output_prefix-000.jpg, output_prefix-001.jpg, etc.
-```
-
-### Password Protection
-
-```python
-from pypdf import PdfReader, PdfWriter
-
-reader = PdfReader("input.pdf")
-writer = PdfWriter()
-
-for page in reader.pages:
-    writer.add_page(page)
-
-# Add password
-writer.encrypt("userpassword", "ownerpassword")
-
-with open("encrypted.pdf", "wb") as output:
-    writer.write(output)
-```
-
-## Quick Reference
-
-| Task               | Best Tool                       | Command/Code                 |
-| ------------------ | ------------------------------- | ---------------------------- |
-| Merge PDFs         | pypdf                           | `writer.add_page(page)`    |
-| Split PDFs         | pypdf                           | One page per file            |
-| Extract text       | pdfplumber                      | `page.extract_text()`      |
-| Extract tables     | pdfplumber                      | `page.extract_tables()`    |
-| Create PDFs        | reportlab                       | Canvas or Platypus           |
-| Command line merge | qpdf                            | `qpdf --empty --pages ...` |
-| Scanned PDFs       | convert_to_images + VL model    | Convert to image first       |
-| Fill PDF forms     | pdf-lib or pypdf (see FORMS.md) | See FORMS.md                 |
-
-## Next Steps
-
-- For advanced pypdfium2 usage, see REFERENCE.md
-- For JavaScript libraries (pdf-lib), see REFERENCE.md
-- If you need to fill out a PDF form, follow the instructions in FORMS.md
-- For troubleshooting guides, see REFERENCE.md
-
----
+## 快速参考
+
+| 任务 | 最佳工具 | 说明 |
+|------|----------|------|
+| 合并 PDF | `merge_pdfs` | 多个 PDF 合并为一个 |
+| 拆分 PDF | `split_pdf` | 按页拆分 |
+| 提取文本 | `extract_text` | 获取文本内容 |
+| 提取表格 | `extract_tables` | 获取表格数据 |
+| 创建 PDF | `create_pdf` | 从文本创建 |
+| 扫描版 PDF | `convert_to_images` + VL 模型 | 先转图片再识别 |
+| 填写表单 | `fill_fillable_fields` | 见 FORMS.md |
+
+## 更多资源
+
+- **表单填写**: 详见 [`FORMS.md`](./forms.md)
+- **高级用法**: 详见 [`REFERENCE.md`](./reference.md)

--- a/data/skills/pptx/SKILL.md
+++ b/data/skills/pptx/SKILL.md
@@ -94,25 +94,6 @@ pptx_export({ path: 'presentation.pptx', action: 'thumbnail', output: 'thumb.png
 pptx_export({ action: 'merge', paths: ['part1.pptx', 'part2.pptx'], output: 'merged.pptx' })
 ```
 
-## 兼容旧工具名
-
-| 旧名称 | 新名称 |
-|--------|--------|
-| `read_presentation`, `read` | `pptx_read(scope: 'info')` |
-| `extract_text` | `pptx_read(scope: 'text')` |
-| `extract_structure` | `pptx_read(scope: 'structure')` |
-| `create_presentation`, `create` | `pptx_write(source: 'data')` |
-| `from_markdown` | `pptx_write(source: 'markdown')` |
-| `add_slide` | `pptx_slide(action: 'add')` |
-| `delete_slide` | `pptx_slide(action: 'delete')` |
-| `update_slide` | `pptx_slide(action: 'update')` |
-| `extract_images` | `pptx_image(action: 'extract')` |
-| `add_image` | `pptx_image(action: 'add')` |
-| `add_table` | `pptx_table()` |
-| `export_to_images` | `pptx_export(action: 'images')` |
-| `generate_thumbnail` | `pptx_export(action: 'thumbnail')` |
-| `merge_presentations`, `merge` | `pptx_export(action: 'merge')` |
-
 ## 注意事项
 
 - **幻灯片编号**: 从 1 开始

--- a/data/skills/prompt-editor/SKILL.md
+++ b/data/skills/prompt-editor/SKILL.md
@@ -1,136 +1,63 @@
-# Prompt Editor
+---
+name: prompt-editor
+description: "提示词编辑技能。用于读取、备份、修改、恢复系统提示词。当需要修改专家的系统提示词时触发。"
+argument-hint: "[read|backup|update|restore|list_backups] --prompt_path=xxx"
+user-invocable: false
+allowed-tools: []
+---
 
-## 概述
+# Prompt Editor - 提示词编辑技能
 
-Alice 的自我编辑技能。用于读取、备份、修改系统提示词。
+用于读取、备份、修改、恢复系统提示词的技能。
 
-## 功能
+## 工具
 
-- **read_prompt**: 读取系统提示词文件
-- **backup_prompt**: 创建备份（带时间戳）
-- **update_prompt**: 更新提示词内容
-- **restore_prompt**: 从备份恢复
-- **list_backups**: 列出所有备份
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `read_prompt` | 读取提示词 | `prompt_path` |
+| `backup_prompt` | 创建备份 | `prompt_path` |
+| `update_prompt` | 更新提示词 | `prompt_path`, `content` |
+| `restore_prompt` | 恢复备份 | `backup_path`, `prompt_path` |
+| `list_backups` | 列出备份 | `backup_dir` |
 
-## 工具定义
-
-### read_prompt
+## read_prompt
 
 读取系统提示词文件内容。
 
-```json
-{
-  "name": "read_prompt",
-  "description": "读取系统提示词文件",
-  "script_path": "scripts/read_prompt.py",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "prompt_path": {
-        "type": "string",
-        "description": "提示词文件路径"
-      }
-    },
-    "required": ["prompt_path"]
-  }
-}
-```
+**参数：**
+- `prompt_path` (string, required): 提示词文件路径
 
-### backup_prompt
+## backup_prompt
 
-创建提示词备份。
+创建提示词备份（带时间戳）。
 
-```json
-{
-  "name": "backup_prompt",
-  "description": "创建提示词备份（带时间戳）",
-  "script_path": "scripts/backup_prompt.py",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "prompt_path": {
-        "type": "string",
-        "description": "提示词文件路径"
-      }
-    },
-    "required": ["prompt_path"]
-  }
-}
-```
+**参数：**
+- `prompt_path` (string, required): 提示词文件路径
 
-### update_prompt
+## update_prompt
 
 更新提示词内容。
 
-```json
-{
-  "name": "update_prompt",
-  "description": "更新提示词内容",
-  "script_path": "scripts/update_prompt.py",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "prompt_path": {
-        "type": "string",
-        "description": "提示词文件路径"
-      },
-      "content": {
-        "type": "string",
-        "description": "新的提示词内容"
-      }
-    },
-    "required": ["prompt_path", "content"]
-  }
-}
-```
+**参数：**
+- `prompt_path` (string, required): 提示词文件路径
+- `content` (string, required): 新的提示词内容
 
-### restore_prompt
+**说明：** 执行前自动创建备份
+
+## restore_prompt
 
 从备份恢复提示词。
 
-```json
-{
-  "name": "restore_prompt",
-  "description": "从备份恢复提示词",
-  "script_path": "scripts/restore_prompt.py",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "backup_path": {
-        "type": "string",
-        "description": "备份文件路径"
-      },
-      "prompt_path": {
-        "type": "string",
-        "description": "目标提示词文件路径"
-      }
-    },
-    "required": ["backup_path", "prompt_path"]
-  }
-}
-```
+**参数：**
+- `backup_path` (string, required): 备份文件路径
+- `prompt_path` (string, required): 目标提示词文件路径
 
-### list_backups
+## list_backups
 
 列出所有备份文件。
 
-```json
-{
-  "name": "list_backups",
-  "description": "列出所有提示词备份",
-  "script_path": "scripts/list_backups.py",
-  "parameters": {
-    "type": "object",
-    "properties": {
-      "backup_dir": {
-        "type": "string",
-        "description": "备份目录路径"
-      }
-    },
-    "required": ["backup_dir"]
-  }
-}
-```
+**参数：**
+- `backup_dir` (string, required): 备份目录路径
 
 ## 安全机制
 
@@ -155,4 +82,3 @@ Alice 的自我编辑技能。用于读取、备份、修改系统提示词。
 
 5. 恢复备份
    restore_prompt(backup_path="config/backups/prompt-2026-03-09.md", prompt_path="config/system-prompt.md")
-```

--- a/data/skills/remote-llm/SKILL.md
+++ b/data/skills/remote-llm/SKILL.md
@@ -1,111 +1,42 @@
+---
+name: remote-llm
+description: "远程 LLM 调用技能。用于调用远程 LLM（如 Claude、Gemini、DeepSeek 等），支持图片处理。当需要使用其他 LLM 处理任务时触发。"
+argument-hint: "remote_llm_submit --file=xxx"
+user-invocable: false
+allowed-tools: []
+---
+
 # Remote LLM - 远程 LLM 调用技能
 
-## 概述
-
-这是一个**双层架构技能**，用于让专家调用远程 LLM（如 Claude、Gemini、DeepSeek 等）：
-
-1. **驻留进程** (`index.js`)：跟随系统启动，处理异步 LLM 调用
-2. **专家入口** (`submit.js`)：专家调用的入口工具，提交请求后立即返回
+双层架构技能，用于让专家调用远程 LLM。
 
 ## 架构
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                           专家层                                 │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  Tool: remote_llm_submit (专家调用)                      │   │
-│  │  - 参数: file, files, prompt (可选)                      │   │
-│  │  - model_id/prompt 等从 skill_parameters 读取            │   │
-│  │  - 返回: "已放入队列，完成后会通知您"                      │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                              │                                  │
-│                              ▼                                  │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  Internal API: POST /internal/resident/invoke           │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                              │                                  │
-│                              ▼                                  │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  ResidentSkillManager                                    │   │
-│  │  - 管理驻留进程                                          │   │
-│  │  - 转发任务请求                                          │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                              │                                  │
-│                              ▼ (stdin/stdout)                   │
-├─────────────────────────────────────────────────────────────────┤
-│                        驻留进程层                                │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  Tool: remote-llm-executor (驻留进程)                    │   │
-│  │  - is_resident = 1                                       │   │
-│  │  - 跟随系统启动                                          │   │
-│  │  - 查询 ai_models 表获取 API 配置                        │   │
-│  │  - 发起远程 LLM 调用                                     │   │
-│  │  - 完成后调用 /internal/messages/insert 通知专家         │   │
-│  └─────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────┘
+专家 → remote_llm_submit (提交) → 驻留进程 (异步执行) → 结果通知
 ```
 
-## 技能信息
+- **驻留进程** (`index.js`)：跟随系统启动，处理异步 LLM 调用
+- **专家入口** (`submit.js`)：专家调用的入口工具，提交请求后立即返回
 
-| 属性 | 值 |
-|------|-----|
-| 名称 | remote-llm |
-| 版本 | 2.1.0 |
-| 类型 | 混合（驻留进程 + 普通工具） |
-| 依赖 | 无外部依赖（使用 Node.js 内置模块） |
+## 工具
 
-## 参数配置
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `remote_llm_submit` | 提交 LLM 请求 | `file`, `files`, `prompt` |
+| `remote-llm-executor` | 驻留进程（内部） | - |
 
-### skill_parameters 表（环境变量注入）
+## remote_llm_submit
 
-这些参数在 `skill_parameters` 表中配置，注入为环境变量，专家无需关心：
+提交异步 LLM 请求。
 
-| 参数名 | 环境变量 | 说明 |
-|--------|----------|------|
-| model_id | SKILL_MODEL_ID | 目标模型 ID（ai_models 表） |
-| prompt | SKILL_PROMPT | 默认 prompt |
-| system_prompt | SKILL_SYSTEM_PROMPT | 系统提示（可选） |
-| max_tokens | SKILL_MAX_TOKENS | 最大输出 token |
-| temperature | SKILL_TEMPERATURE | 温度参数 |
-
-### skill_tools.parameters（专家传入参数）
-
-专家调用时可以传入的参数：
+**参数：**
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| file | string | 否 | 本地图片路径（支持相对 DATA_BASE_PATH 的路径） |
-| files | array | 否 | 多个本地图片路径数组 |
-| prompt | string | 否 | 额外的提示内容（会追加到默认 prompt 后） |
-
-## 工具列表
-
-### 1. remote_llm_submit - 专家调用入口
-
-专家调用此工具提交异步 LLM 请求。
-
-**调用示例：**
-
-```json
-// 简单调用（使用默认配置）
-{}
-
-// 处理图片
-{
-  "file": "work/user123/temp/image.png"
-}
-
-// 处理多张图片
-{
-  "files": ["work/user123/temp/img1.png", "work/user123/temp/img2.jpg"]
-}
-
-// 追加额外指令
-{
-  "file": "work/user123/temp/image.png",
-  "prompt": "请详细分析这张图片中的文字内容"
-}
-```
+| `file` | string | 否 | 本地图片路径 |
+| `files` | array | 否 | 多个本地图片路径数组 |
+| `prompt` | string | 否 | 额外提示内容（追加到默认 prompt 后） |
 
 **返回：**
 
@@ -113,42 +44,22 @@
 {
   "success": true,
   "task_id": "task_xxx",
-  "message": "已放入队列，待执行完成后会通知您（已附加 1 个图片）",
+  "message": "已放入队列，待执行完成后会通知您",
   "status": "queued"
 }
 ```
 
-### 2. remote-llm-executor - 驻留进程（内部使用）
+## 参数配置
 
-驻留进程，跟随系统启动，处理实际的 LLM 调用。
+### skill_parameters 表（环境变量注入）
 
-**通信协议：**
-
-**输入 (stdin):**
-```json
-{
-  "command": "invoke",
-  "task_id": "task_xxx",
-  "params": {
-    "user_id": "user_xxx",
-    "expert_id": "expert_xxx",
-    "model_id": "model_xxx",
-    "prompt": "用户的问题",
-    "system_prompt": "系统提示",
-    "temperature": 0.7,
-    "max_tokens": 4096
-  }
-}
-```
-
-**输出 (stdout):**
-```json
-// 立即返回任务确认
-{"task_id": "task_xxx", "result": {"status": "queued", "message": "已放入队列"}}
-
-// 日志消息
-{"type": "log", "message": "正在调用模型 xxx..."}
-```
+| 参数名 | 环境变量 | 说明 |
+|--------|----------|------|
+| `model_id` | SKILL_MODEL_ID | 目标模型 ID（ai_models 表） |
+| `prompt` | SKILL_PROMPT | 默认 prompt |
+| `system_prompt` | SKILL_SYSTEM_PROMPT | 系统提示（可选） |
+| `max_tokens` | SKILL_MAX_TOKENS | 最大输出 token |
+| `temperature` | SKILL_TEMPERATURE | 温度参数 |
 
 ## 图片处理
 
@@ -161,62 +72,10 @@
 
 ### 图片处理流程
 
-1. 专家传入本地图片路径（相对 DATA_BASE_PATH 或绝对路径）
+1. 专家传入本地图片路径
 2. `submit.js` 自动将图片读取并转换为 base64
 3. 构建 OpenAI Vision 格式的消息内容
 4. 发送给驻留进程处理
-
-### 多模态消息格式
-
-当传入图片时，prompt 会转换为 OpenAI Vision 格式：
-
-```json
-[
-  { "type": "text", "text": "请把图片中的文字转为文本给我。" },
-  { "type": "image_url", "image_url": { "url": "data:image/png;base64,..." } }
-]
-```
-
-## 数据库配置
-
-### ai_models 表
-
-模型配置存储在 `ai_models` 表中，关联 `providers` 表获取 API 配置：
-
-```sql
-SELECT 
-  m.id, m.model_name, m.max_output_tokens,
-  p.base_url, p.api_key, p.timeout
-FROM ai_models m
-JOIN providers p ON m.provider_id = p.id
-WHERE m.id = ?
-```
-
-### skill_tools 表注册
-
-需要注册两个工具：
-
-```sql
--- 驻留进程（is_resident = 1）
-INSERT INTO skill_tools (skill_id, name, description, is_resident, script_path)
-VALUES (
-  'remote-llm',
-  'remote-llm-executor',
-  '驻留进程：执行远程 LLM 调用',
-  1,
-  'index.js'
-);
-
--- 专家调用入口（is_resident = 0）
-INSERT INTO skill_tools (skill_id, name, description, is_resident, script_path)
-VALUES (
-  'remote-llm',
-  'remote_llm_submit',
-  '提交远程 LLM 调用请求',
-  0,
-  'submit.js'
-);
-```
 
 ## 使用流程
 
@@ -229,48 +88,9 @@ VALUES (
 
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
-| API_BASE | 内部 API 地址 | http://localhost:3000 |
-| INTERNAL_KEY | 内部 API 密钥 | 空（使用 IP 白名单） |
-| DATA_BASE_PATH | 数据基础路径 | 当前工作目录 |
-
-## 内部 API
-
-### GET /internal/models/:model_id
-
-获取模型配置（含 Provider 信息）。
-
-### POST /internal/resident/invoke
-
-调用驻留式技能工具。
-
-**请求体：**
-```json
-{
-  "skill_id": "remote-llm",
-  "tool_name": "remote-llm-executor",
-  "params": { ... }
-}
-```
-
-### POST /internal/messages/insert
-
-插入消息并通知专家（用于结果推送）。
-
-**请求体：**
-```json
-{
-  "user_id": "user_xxx",
-  "expert_id": "expert_xxx",
-  "content": "消息内容",
-  "role": "assistant",
-  "trigger_expert": true  // 可选，是否触发专家响应
-}
-```
-
-**trigger_expert 参数说明：**
-- `true`: 插入消息后，自动触发专家进行响应（专家会"看到"这条消息并生成回复）
-- `false` 或不传: 仅插入消息，不触发专家响应
-- 默认值: `true`（远程 LLM 调用完成后默认触发专家响应）
+| `API_BASE` | 内部 API 地址 | http://localhost:3000 |
+| `INTERNAL_KEY` | 内部 API 密钥 | 空（使用 IP 白名单） |
+| `DATA_BASE_PATH` | 数据基础路径 | 当前工作目录 |
 
 ## 错误处理
 
@@ -285,19 +105,3 @@ VALUES (
 2. API 密钥从数据库获取，不暴露给前端
 3. 用户只能使用已配置的模型
 4. 文件路径基于 DATA_BASE_PATH，防止路径遍历
-
-## 调试
-
-```bash
-# 检查驻留进程状态
-curl http://localhost:3000/api/debug/resident-status
-
-# 手动测试驻留进程
-echo '{"command":"ping"}' | node data/skills/remote-llm/index.js
-```
-
-## 变更历史
-
-- v2.1.0: 简化参数设计，添加本地图片 base64 转换支持
-- v2.0.0: 重构为双层架构（驻留进程 + 专家入口）
-- v1.0.0: 初始版本

--- a/data/skills/wikijs/SKILL.md
+++ b/data/skills/wikijs/SKILL.md
@@ -1,321 +1,131 @@
 ---
 name: wikijs
-description: Interact with Wiki.js instances via GraphQL API and REST upload endpoint. Supports page CRUD operations (list, get, create, update, delete), directory browsing, asset management (upload with proper multipart format, list, delete folders), and search. Use when working with Wiki.js wikis for documentation management, content migration, automated wiki operations, or file uploads. Requires WIKIJS_URL and WIKIJS_TOKEN environment variables.
+description: "Wiki.js 交互技能。通过 GraphQL API 和 REST 上传端点操作 Wiki.js，支持页面 CRUD、目录浏览、资源管理、搜索。当需要管理 Wiki.js 文档、内容迁移、自动化操作时触发。"
+argument-hint: "[listPages|getPage|createPage|updatePage|deletePage|uploadFile] --path=xxx"
+user-invocable: false
+allowed-tools: []
 ---
 
-# Wiki.js
+# Wiki.js - Wiki 交互技能
 
-Interact with Wiki.js instances programmatically via GraphQL API and REST upload endpoint.
+通过 GraphQL API 和 REST 上传端点操作 Wiki.js 实例。
 
-## Quick Start
+## 工具
 
-Required environment variables:
-- `WIKIJS_URL` - Wiki.js instance URL (e.g., `https://wiki.example.com`)
-- `WIKIJS_TOKEN` - API token from Admin > API Access
+| 工具 | 说明 | 关键参数 |
+|------|------|----------|
+| `listPages` | 列出所有页面 | `orderBy` |
+| `getPageByPath` | 按路径获取页面 | `path`, `locale` |
+| `getPageById` | 按 ID 获取页面 | `id` |
+| `createPage` | 创建页面 | `path`, `title`, `content` |
+| `updatePage` | 更新页面 | `id`, `content`, `title` |
+| `deletePage` | 删除页面 | `id` |
+| `getPageTree` | 获取页面树 | `mode`, `locale` |
+| `searchPages` | 搜索页面 | `query`, `locale` |
+| `uploadFile` | 上传文件 | `filePath`, `filename`, `folderId` |
+| `listAssetFolders` | 列出资源文件夹 | `parentId` |
+| `createAssetFolder` | 创建资源文件夹 | `name`, `slug`, `parentId` |
+| `listAssets` | 列出资源 | `folderId`, `kind` |
+| `deleteAsset` | 删除资源 | `id` |
 
-Basic usage:
-```javascript
-const WikiJSClient = require('./scripts/wikijs_client');
+## 页面操作
 
-const client = new WikiJSClient();
-const pages = await client.listPages();
+### listPages
+
+列出所有页面。
+
+**参数：**
+- `orderBy` (string, optional): 排序方式，默认 'TITLE'
+
+### getPageByPath
+
+按路径获取页面。
+
+**参数：**
+- `path` (string, required): 页面路径
+- `locale` (string, required): 语言代码，如 'en'
+
+### createPage
+
+创建页面。
+
+**参数：**
+- `path` (string, required): 页面路径
+- `title` (string, required): 页面标题
+- `content` (string, required): 页面内容（Markdown）
+- `locale` (string, optional): 语言代码，默认 'en'
+- `description` (string, optional): 页面描述
+- `tags` (string[], optional): 标签数组
+- `isPublished` (boolean, optional): 是否发布，默认 true
+
+### updatePage
+
+更新页面。
+
+**参数：**
+- `id` (number, required): 页面 ID
+- `content` (string, optional): 新内容
+- `title` (string, optional): 新标题
+
+### deletePage
+
+删除页面。
+
+**参数：**
+- `id` (number, required): 页面 ID
+
+## 文件上传
+
+### uploadFile
+
+上传文件到 Wiki.js。
+
+**参数：**
+- `filePath` (string, required): 本地文件路径
+- `filename` (string, required): 文件名
+- `folderId` (number, required): 目标文件夹 ID
+
+**返回：**
+```json
+{ "succeeded": true, "message": "ok" }
 ```
 
-## Core Operations
+**上传格式说明：**
+Wiki.js 文件上传需要**两个字段都命名为 `mediaUpload`**：
+1. 第一个字段：文件夹元数据 JSON `{"folderId": 1}`
+2. 第二个字段：实际文件内容
 
-### Pages
+## 资源管理
 
-**List all pages:**
-```javascript
-const pages = await client.listPages({ orderBy: 'TITLE' });
-```
+### listAssetFolders
 
-**Get page by path:**
-```javascript
-const page = await client.getPageByPath('folder/page-name', 'en');
-```
+列出资源文件夹。
 
-**Get page by ID:**
-```javascript
-const page = await client.getPageById(123);
-```
+**参数：**
+- `parentId` (number, required): 父文件夹 ID（根目录为 0）
 
-**Create page:**
-```javascript
-await client.createPage({
-    path: 'docs/new-page',
-    title: 'New Page',
-    content: '# Hello World',
-    locale: 'en',
-    description: 'Page description',
-    tags: ['tag1', 'tag2'],
-    isPublished: true
-});
-```
+### listAssets
 
-**Update page:**
-```javascript
-await client.updatePage(123, {
-    content: '# Updated content',
-    title: 'New Title'
-});
-```
+列出资源。
 
-**Delete page:**
-```javascript
-await client.deletePage(123);
-```
+**参数：**
+- `folderId` (number, required): 文件夹 ID
+- `kind` (string, optional): 资源类型 - 'ALL', 'IMAGE', 'BINARY', 'PDF', 'CODE', 'MARKUP', 'VIDEO', 'AUDIO'
 
-### Directory Tree
+## 配置要求
 
-**Get page tree:**
-```javascript
-const tree = await client.getPageTree('FOLDERS', 'en');
-```
+需要以下环境变量：
+- `WIKIJS_URL` - Wiki.js 实例 URL（如 `https://wiki.example.com`）
+- `WIKIJS_TOKEN` - API Token（从 Admin > API Access 获取）
 
-Modes: `ALL`, `FOLDERS`, `PAGES`
+## 常见上传错误
 
-### Search
+| 错误 | 原因 | 解决方案 |
+|------|------|----------|
+| "Missing upload folder metadata" | 缺少 JSON 元数据字段 | 添加 `mediaUpload={"folderId":1}` |
+| "Missing upload payload" | 缺少文件字段 | 添加文件字段 `mediaUpload` |
+| "You are not authorized" | 无 `write:assets` 权限 | 检查 API Token 权限 |
 
-**Search pages:**
-```javascript
-const results = await client.searchPages('keyword', 'en');
-```
+## 相关技能
 
-## File Upload (IMPORTANT)
-
-Wiki.js file upload uses a **special multipart format** requiring **TWO fields named `mediaUpload`**:
-
-### Upload Format
-
-```
-Field 1 (text):  mediaUpload = {"folderId": 1}    ← Folder metadata (JSON)
-Field 2 (file):  mediaUpload = <binary data>      ← Actual file content
-```
-
-Both fields MUST have the same name `mediaUpload`.
-
-### Upload Methods
-
-**Method 1: Using the client (Recommended)**
-```javascript
-// Upload from file path
-const result = await client.uploadFile(
-    '/path/to/image.png',
-    'image.png',
-    1  // folderId
-);
-
-// Upload from Buffer
-const fs = require('fs');
-const fileBuffer = fs.readFileSync('image.png');
-const result = await client.uploadFile(fileBuffer, 'image.png', 1);
-
-// Check result
-if (result.succeeded) {
-    console.log('Upload successful!');
-}
-```
-
-**Method 2: Manual multipart construction**
-```javascript
-const https = require('https');
-const fs = require('fs');
-
-const boundary = '----WikiJSUploadBoundary';
-const folderId = 1;
-const filename = 'image.png';
-const fileData = fs.readFileSync(filename);
-
-// Build body with TWO mediaUpload fields
-let body = Buffer.alloc(0);
-
-// Field 1: mediaUpload (folder metadata as JSON text)
-body = Buffer.concat([
-    body,
-    Buffer.from(`--${boundary}\r\n`),
-    Buffer.from('Content-Disposition: form-data; name="mediaUpload"\r\n\r\n'),
-    Buffer.from(`{"folderId":${folderId}}\r\n`)
-]);
-
-// Field 2: mediaUpload (the actual file)
-body = Buffer.concat([
-    body,
-    Buffer.from(`--${boundary}\r\n`),
-    Buffer.from(`Content-Disposition: form-data; name="mediaUpload"; filename="${filename}"\r\n`),
-    Buffer.from('Content-Type: image/png\r\n\r\n'),
-    fileData,
-    Buffer.from('\r\n')
-]);
-
-// End boundary
-body = Buffer.concat([
-    body,
-    Buffer.from(`--${boundary}--\r\n`)
-]);
-
-// Send request
-const options = {
-    hostname: 'wiki.example.com',
-    port: 443,
-    path: '/u',
-    method: 'POST',
-    headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': `multipart/form-data; boundary=${boundary}`,
-        'Content-Length': body.length
-    }
-};
-
-const req = https.request(options, (res) => {
-    let data = '';
-    res.on('data', (chunk) => { data += chunk; });
-    res.on('end', () => {
-        if (data === 'ok') {
-            console.log('Upload successful!');
-        }
-    });
-});
-
-req.write(body);
-req.end();
-```
-
-### Common Upload Errors
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| "Missing upload folder metadata" | Missing JSON metadata field | Add text field `mediaUpload={"folderId":1}` |
-| "Missing upload payload" | Missing file field | Add file field named `mediaUpload` |
-| "You are not authorized" | No `write:assets` permission | Check API token scopes in Admin > API Access |
-| 403 Forbidden | Permission denied | Ensure token has `write:assets` or `manage:system` scope |
-
-## Asset Management
-
-### Folders
-
-**List asset folders:**
-```javascript
-const folders = await client.listAssetFolders(0);
-```
-
-**Create asset folder:**
-```javascript
-await client.createAssetFolder('Images', 'images', 0);
-```
-
-### Assets
-
-**List assets in folder:**
-```javascript
-const assets = await client.listAssets(1, 'IMAGE');
-```
-
-Kinds: `ALL`, `IMAGE`, `BINARY`, `PDF`, `CODE`, `MARKUP`, `VIDEO`, `AUDIO`
-
-**Delete asset:**
-```javascript
-await client.deleteAsset(456);
-```
-
-**Get asset URL:**
-```javascript
-const url = client.getAssetUrl('ppt-images', 'slide_01.png');
-// Returns: https://wiki.example.com/ppt-images/slide_01.png
-```
-
-## Working with Content
-
-### Markdown with Asset References
-
-After uploading images, reference them in pages:
-```javascript
-// Upload images first
-const fs = require('fs');
-const path = require('path');
-
-const imageDir = 'tmp/ppt_extracted/slides_png_hd2';
-const files = fs.readdirSync(imageDir).filter(f => f.endsWith('.png'));
-
-for (const file of files) {
-    await client.uploadFile(path.join(imageDir, file), file, 1);
-}
-
-// Create page with references
-const content = `# Presentation
-
-## Slide 1
-![Slide 1](/ppt-images/slide_01.png)
-
-## Slide 2
-![Slide 2](/ppt-images/slide_02.png)
-`;
-
-await client.createPage({
-    path: 'docs/presentation',
-    title: 'My Presentation',
-    content: content
-});
-```
-
-### Embedded Images (Base64 Alternative)
-
-For self-contained pages without external assets:
-```javascript
-const fs = require('fs');
-
-const imageBuffer = fs.readFileSync('image.png');
-const b64 = imageBuffer.toString('base64');
-const dataUri = `data:image/png;base64,${b64}`;
-
-const content = `![Image](${dataUri})`;
-```
-
-## Scripts
-
-### `wikijs_client.js`
-Main client class with all API methods including proper file upload handling.
-
-## Related Skills
-
-### PPT to Wiki.js Bridge
-
-For converting PowerPoint presentations to Wiki.js pages, use the **ppt-to-wiki** skill:
-
-```bash
-node skills/ppt-to-wiki/scripts/ppt_to_wiki.js \
-    --content tmp/ppt_extracted/content.md \
-    --images tmp/ppt_extracted/slides_png_hd2 \
-    --output-path "ppt/presentation-name" \
-    --title "Presentation Title" \
-    --upload-to-folder 1
-```
-
-See `skills/ppt-to-wiki/SKILL.md` for details.
-
-## Error Handling
-
-All methods return an object with `responseResult`:
-```javascript
-const result = await client.createPage({...});
-if (result.data?.pages?.create?.responseResult?.succeeded) {
-    const pageId = result.data.pages.create.page.id;
-} else {
-    const error = result.data?.pages?.create?.responseResult?.message;
-}
-```
-
-Or using async/await with try/catch:
-```javascript
-try {
-    const pages = await client.listPages();
-} catch (err) {
-    console.error('Error:', err.message);
-}
-```
-
-## References
-
-- **API Documentation**: See [references/api_docs.md](references/api_docs.md) for complete GraphQL schema reference
-- **Common Patterns**: See [references/patterns.md](references/patterns.md) for usage examples
-- **Upload Deep Dive**: See [references/upload_guide.md](references/upload_guide.md) for detailed upload documentation
+PPT 转 Wiki.js：使用 **ppt-to-wiki** 技能将 PowerPoint 转换为 Wiki.js 页面。

--- a/data/skills/xlsx/SKILL.md
+++ b/data/skills/xlsx/SKILL.md
@@ -111,31 +111,6 @@ excel_calc({ path: 'data.xlsx', sheet: 'Sheet1' })
 // 返回: { formulas: [{ cell: 'C1', formula: 'SUM(A1:B1)', value: 15 }] }
 ```
 
-## 兼容旧工具名
-
-| 旧名称 | 新名称 |
-|--------|--------|
-| `read_workbook`, `read` | `excel_read(scope: 'workbook')` |
-| `read_sheet` | `excel_read(scope: 'sheet')` |
-| `read_cell` | `excel_read(scope: 'cell')` |
-| `create_workbook`, `create` | `excel_write(scope: 'workbook')` |
-| `write_sheet` | `excel_write(scope: 'sheet')` |
-| `write_cell` | `excel_write(scope: 'cell')` |
-| `add_sheet` | `excel_sheet(action: 'add')` |
-| `delete_sheet` | `excel_sheet(action: 'delete')` |
-| `rename_sheet` | `excel_sheet(action: 'rename')` |
-| `copy_sheet` | `excel_sheet(action: 'copy')` |
-| `set_column_width` | `excel_format(type: 'column')` |
-| `set_cell_style` | `excel_format(type: 'cell')` |
-| `filter_data` | `excel_query(action: 'filter')` |
-| `sort_data` | `excel_query(action: 'sort')` |
-| `find_data` | `excel_query(action: 'find')` |
-| `to_json` | `excel_convert(format: 'json', direction: 'to')` |
-| `from_json` | `excel_convert(format: 'json', direction: 'from')` |
-| `to_csv` | `excel_convert(format: 'csv', direction: 'to')` |
-| `from_csv` | `excel_convert(format: 'csv', direction: 'from')` |
-| `calculate_formulas` | `excel_calc()` |
-
 ## 输出规范
 
 - **字体**: 使用专业字体（Arial, Times New Roman）

--- a/lib/skill-parser.js
+++ b/lib/skill-parser.js
@@ -94,18 +94,17 @@ export async function validateSkillPath(sourcePath, projectRoot, allowedDirs = [
   if (path.isAbsolute(sourcePath)) {
     fullPath = path.normalize(sourcePath);
   } else {
-    // 相对路径：只允许在指定的允许目录下
-    fullPath = path.normalize(path.resolve(projectRoot, ...allowedDirs[0].split('/'), sourcePath));
+    // 相对路径：拼接所有允许目录，如 ['data', 'skills'] => projectRoot/data/skills/sourcePath
+    // 支持多级目录，如 ['data', 'skills'] 或 ['data/skills']
+    const baseDir = allowedDirs.join(path.sep);
+    fullPath = path.normalize(path.resolve(projectRoot, baseDir, sourcePath));
   }
 
   // 检查路径是否在允许的目录内
-  const allowedPaths = allowedDirs.map(dir => 
-    path.resolve(projectRoot, dir)
-  );
+  // 将 allowedDirs 拼接成完整路径进行检查
+  const allowedBasePath = path.resolve(projectRoot, allowedDirs.join(path.sep));
 
-  const isAllowed = allowedPaths.some(allowedPath => 
-    fullPath.startsWith(allowedPath + path.sep) || fullPath === allowedPath
-  );
+  const isAllowed = fullPath.startsWith(allowedBasePath + path.sep) || fullPath === allowedBasePath;
 
   if (!isAllowed) {
     return {


### PR DESCRIPTION
## 变更内容

Closes #301

### 1. SKILL.md 精简（13 个文件）

| 文件 | 改进内容 |
|------|----------|
| `pdf/SKILL.md` | 移除 Python 教程代码（pypdf, pdfplumber, reportlab 示例） |
| `erix-ssh/SKILL.md` | 精简架构说明和协议细节 |
| `kb-editor/SKILL.md` | 添加 YAML 元数据，精简示例 |
| `kb-search/SKILL.md` | 添加 YAML 元数据，精简结构 |
| `prompt-editor/SKILL.md` | 添加 YAML 元数据 |
| `message-reader/SKILL.md` | 添加 YAML 元数据 |
| `file-operations/SKILL.md` | 精简冗余示例 |
| `remote-llm/SKILL.md` | 移除变更历史，精简架构说明 |
| `wikijs/SKILL.md` | 精简代码示例 |
| `xlsx/SKILL.md` | 移除兼容旧工具名表格（25 行） |
| `echarts-chart/SKILL.md` | 移除兼容旧工具名表格（7 行） |
| `docx/SKILL.md` | 移除兼容旧工具名表格（19 行） |
| `pptx/SKILL.md` | 移除兼容旧工具名表格（20 行） |

### 2. skill-parser.js Bug 修复

**问题**：`validateSkillPath` 函数只使用了 `allowedDirs[0]`，导致技能注册时路径错误
- 传入 `['data', 'skills']` 时，只用了 `'data'`
- 导致路径变成 `data/xlsx` 而不是 `data/skills/xlsx`

**修复**：将 `allowedDirs` 数组用 `path.sep` 拼接成完整路径

## 改进原则

1. **描述精炼**：description 字段明确说明何时触发该技能
2. **工具表格**：每个技能开头有工具总览表格
3. **移除教程**：Python/JavaScript 教程代码已移除（LLM 只加载 `skill_tools` 表）
4. **移除兼容表**：兼容旧工具名是代码实现细节，不需要在 SKILL.md 中说明

## 统计

- 14 files changed
- 665 insertions(+)
- 2198 deletions(-)