### PR TITLE
#306: fix Sequelize BIT(1) 字段自动转换为 boolean

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -35,6 +35,17 @@ class Database {
           port: this.config.port || 3306,
           dialect: 'mysql',
           logging: (msg) => logger.debug('[SQL]', msg),
+          // MySQL BIT(1) 字段自动转换为 boolean
+          // 解决 raw: true 查询时 BIT(1) 返回 Buffer 对象的问题
+          dialectOptions: {
+            typeCast: function (field, next) {
+              if (field.type === 'BIT' && field.length === 1) {
+                const bytes = field.buffer();
+                return bytes[0] === 1;
+              }
+              return next();
+            }
+          },
           pool: {
             max: this.config.connectionLimit || 10,
             min: 0,

--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -166,6 +166,7 @@ class SkillController {
           tools: tools.map(t => ({
             ...t,
             type: t.type || 'http',
+            is_resident: !!t.is_resident,
           })),
           assigned_experts: assigned_experts.map(e => ({
             id: e['expert.id'] || e.expert_id,


### PR DESCRIPTION
## 变更说明

修复 Sequelize 在 `raw: true` 查询时 MySQL `BIT(1)` 字段返回 Buffer 对象的问题。

### 问题

- MySQL 驱动返回 `BIT(1)` 字段为 Buffer 对象
- JavaScript 中 Buffer 对象总是 truthy，导致所有布尔字段判断错误
- 例如：`is_resident` 字段无论实际值是什么，前端都显示为"驻留"

### 解决方案

在 [`lib/db.js`](lib/db.js:37) 的 Sequelize 连接配置中添加 `dialectOptions.typeCast`：

```javascript
dialectOptions: {
  typeCast: function (field, next) {
    if (field.type === 'BIT' && field.length === 1) {
      const bytes = field.buffer();
      return bytes[0] === 1;
    }
    return next();
  }
}
```

### 影响范围

- 所有 `BIT(1)` 布尔字段：`is_active`、`is_enabled`、`is_resident` 等
- 符合项目规范（SOUL.md 要求使用 `BIT(1)` 存储布尔值）

### 测试

- [ ] 技能编辑弹窗中 `is_resident` 字段正确显示
- [ ] 技能列表中 `is_active` 过滤正常工作
- [ ] 专家列表中 `is_active` 过滤正常工作

Closes #306