### PR TITLE
docs: 添加技能路径参数说明

### DIFF
--- a/data/skills/docx/SKILL.md
+++ b/data/skills/docx/SKILL.md
@@ -5,6 +5,28 @@ description: "Word 文档处理。用于读取、写入、编辑 .docx 文件，
 
 # DOCX - Word 文档处理
 
+## 路径参数说明
+
+> **重要**：所有工具的 `path` 参数遵循以下规则：
+
+| 参数类型 | 说明 |
+|----------|------|
+| **相对路径** | 相对于工作目录，工具自动拼接基础路径。示例：`input/file.docx` |
+| **绝对路径** | 仅管理员可用，需在允许的路径范围内 |
+
+**基础路径规则**：
+- 管理员：项目根目录 或 `data/` 目录
+- 普通用户：`data/work/{user_id}/` 目录
+
+**示例**：
+```javascript
+// 相对路径（推荐）
+docx_read({ path: 'input/document.docx', scope: 'text' })
+
+// 绝对路径（仅管理员）
+docx_read({ path: '/absolute/path/to/document.docx', scope: 'text' })
+```
+
 ## 工具
 
 | 工具 | 说明 | 关键参数 |

--- a/data/skills/pptx/SKILL.md
+++ b/data/skills/pptx/SKILL.md
@@ -5,6 +5,28 @@ description: "PowerPoint 演示文稿处理。用于读取、写入、编辑 .pp
 
 # PPTX - PowerPoint 演示文稿处理
 
+## 路径参数说明
+
+> **重要**：所有工具的 `path` 参数遵循以下规则：
+
+| 参数类型 | 说明 |
+|----------|------|
+| **相对路径** | 相对于工作目录，工具自动拼接基础路径。示例：`input/file.pptx` |
+| **绝对路径** | 仅管理员可用，需在允许的路径范围内 |
+
+**基础路径规则**：
+- 管理员：项目根目录 或 `data/` 目录
+- 普通用户：`data/work/{user_id}/` 目录
+
+**示例**：
+```javascript
+// 相对路径（推荐）
+pptx_read({ path: 'input/presentation.pptx', scope: 'info' })
+
+// 绝对路径（仅管理员）
+pptx_read({ path: '/absolute/path/to/presentation.pptx', scope: 'info' })
+```
+
 ## 工具
 
 | 工具 | 说明 | 关键参数 |

--- a/data/skills/xlsx/SKILL.md
+++ b/data/skills/xlsx/SKILL.md
@@ -5,6 +5,28 @@ description: "Excel 文件处理。用于读取、写入、编辑 .xlsx/.xls/.cs
 
 # XLSX - Excel 文件处理
 
+## 路径参数说明
+
+> **重要**：所有工具的 `path` 参数遵循以下规则：
+
+| 参数类型 | 说明 |
+|----------|------|
+| **相对路径** | 相对于工作目录，工具自动拼接基础路径。示例：`input/file.xlsx` |
+| **绝对路径** | 仅管理员可用，需在允许的路径范围内 |
+
+**基础路径规则**：
+- 管理员：项目根目录 或 `data/` 目录
+- 普通用户：`data/work/{user_id}/` 目录
+
+**示例**：
+```javascript
+// 相对路径（推荐）
+excel_read({ path: 'input/data.xlsx', scope: 'workbook' })
+
+// 绝对路径（仅管理员）
+excel_read({ path: '/absolute/path/to/data.xlsx', scope: 'workbook' })
+```
+
 ## 工具
 
 | 工具 | 说明 | 关键参数 |


### PR DESCRIPTION
## 变更内容

- 为 xlsx、docx、pptx 三个技能的 SKILL.md 添加"路径参数说明"章节
- 明确说明相对路径和绝对路径的使用规则
- 提供具体示例，帮助 LLM 正确理解路径格式

## 相关 Issue

Closes #305

## 变更文件

- `data/skills/xlsx/SKILL.md` - 添加路径参数说明
- `data/skills/docx/SKILL.md` - 添加路径参数说明
- `data/skills/pptx/SKILL.md` - 添加路径参数说明

## 后续工作

Issue #305 中还讨论了更深层次的路径权限设计优化，包括：
- 扩展权限范围（让用户可以访问整个用户工作区）
- 在 System Prompt 中注入权限范围说明

这些需要进一步讨论后实施。