### PR TITLE
#305: refactor system prompt injection with separated section generators

### DIFF
--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -146,7 +146,25 @@ class ContextManager {
   }
 
   /**
+   * 统一的段落拼接方法
+   * 将新段落追加到系统提示中，处理换行符
+   * @param {string} basePrompt - 基础系统提示
+   * @param {string|null} section - 要追加的段落（如果为 null 或空，返回原提示）
+   * @returns {string} 拼接后的系统提示
+   */
+  appendSection(basePrompt, section) {
+    if (!section) return basePrompt;
+    return basePrompt + '\n\n' + section;
+  }
+
+  /**
    * 构建包含 Topic 总结的系统提示（新设计）
+   *
+   * 重构说明：
+   * - 每个 generateSection* 方法只负责生成内容，不负责拼接
+   * - 使用 appendSection() 统一处理拼接逻辑
+   * - 职责分离，便于测试和维护
+   *
    * @param {Array} innerVoices - 内心独白列表
    * @param {string} topicSummaries - Topic 总结文本
    * @param {string} userInfoGuidance - 用户信息引导提示（可选）
@@ -161,96 +179,52 @@ class ContextManager {
     // 基础 System Prompt
     let systemPrompt = expert.prompt_template || expert.system_prompt || expert.introduction || '';
 
-    // 添加当前时间信息（放在最前面，让模型知道当前时间）
-    systemPrompt = this.enhanceWithTimestamp(systemPrompt);
-
-    // 添加 Soul
-    systemPrompt = this.enhanceWithSoul(systemPrompt, this.soul, expert);
-
-    // 添加可用技能描述（在 Soul 之后，帮助 LLM 理解工具能力）
+    // 逐段添加内容，每段独立生成
+    systemPrompt = this.appendSection(systemPrompt, this.generateTimestampSection());
+    systemPrompt = this.appendSection(systemPrompt, this.generateSoulSection(this.soul, expert));
+    
     if (skills && skills.length > 0) {
-      systemPrompt = this.enhanceWithSkills(systemPrompt, skills);
+      systemPrompt = this.appendSection(systemPrompt, this.generateSkillsSection(skills));
     }
-
-    // 添加可用助理列表
+    
     if (assistants && assistants.length > 0) {
-      systemPrompt = this.enhanceWithAssistants(systemPrompt, assistants);
+      systemPrompt = this.appendSection(systemPrompt, this.generateAssistantsSection(assistants));
     }
-
-    // 添加任务工作空间上下文（在 Skills 之后、Topic 总结之前）
+    
     if (taskContext) {
-      systemPrompt = this.enhanceWithTaskContext(systemPrompt, taskContext);
+      systemPrompt = this.appendSection(systemPrompt, this.generateTaskContextSection(taskContext));
     }
-
-    // 添加 Topic 总结（新设计：在 Skills 之后、Inner Voices 之前）
+    
     if (topicSummaries) {
-      systemPrompt = this.enhanceWithTopicSummaries(systemPrompt, topicSummaries);
+      systemPrompt = this.appendSection(systemPrompt, this.generateTopicSummariesSection(topicSummaries));
     }
-
-    // 添加 RAG 检索上下文（知识库检索结果）
+    
     if (ragContext) {
-      systemPrompt = this.enhanceWithRAGContext(systemPrompt, ragContext);
+      systemPrompt = this.appendSection(systemPrompt, this.generateRAGContextSection(ragContext));
     }
-
-    // 添加 Inner Voices
+    
     if (innerVoices.length > 0) {
-      systemPrompt = this.enhanceWithInnerVoices(systemPrompt, innerVoices);
+      systemPrompt = this.appendSection(systemPrompt, this.generateInnerVoicesSection(innerVoices));
     }
-
-    // 添加用户信息引导提示
+    
     if (userInfoGuidance) {
-      systemPrompt = this.enhanceWithUserInfoGuidance(systemPrompt, userInfoGuidance);
+      systemPrompt = this.appendSection(systemPrompt, this.generateUserInfoGuidanceSection(userInfoGuidance));
     }
 
     return systemPrompt;
   }
 
-  /**
-   * 用 Topic 总结增强系统提示
-   * @param {string} systemPrompt - 系统提示
-   * @param {string} topicSummaries - Topic 总结文本
-   */
-  enhanceWithTopicSummaries(systemPrompt, topicSummaries) {
-    if (!topicSummaries) return systemPrompt;
-
-    const topicPrompt = `
-## 之前的对话话题总结
-以下是你们之前讨论过的话题，帮助你了解对话历史：
-
-${topicSummaries}
-`;
-
-    return systemPrompt + '\n\n' + topicPrompt;
-  }
+  // ========================================
+  // 新一代 Section 生成方法（只生成内容，不拼接）
+  // ========================================
 
   /**
-   * 用 RAG 检索上下文增强系统提示
-   * @param {string} systemPrompt - 系统提示
-   * @param {string} ragContext - RAG 检索上下文（知识库检索结果）
+   * 生成时间戳段落
+   * @returns {string} 时间戳段落内容
    */
-  enhanceWithRAGContext(systemPrompt, ragContext) {
-    if (!ragContext) return systemPrompt;
-
-    const ragPrompt = `
-## 相关知识库内容
-以下是从知识库中检索到的相关内容，请参考这些信息回答用户问题：
-
-${ragContext}
-`;
-
-    return systemPrompt + '\n\n' + ragPrompt;
-  }
-
-  /**
-   * 用当前时间戳增强系统提示
-   * 让模型能够感知当前日期和时间
-   * @param {string} systemPrompt - 系统提示
-   * @returns {string} 增强后的系统提示
-   */
-  enhanceWithTimestamp(systemPrompt) {
+  generateTimestampSection() {
     const now = new Date();
 
-    // 格式化日期和时间（中文格式）
     const dateString = now.toLocaleDateString('zh-CN', {
       year: 'numeric',
       month: 'long',
@@ -264,47 +238,72 @@ ${ragContext}
       hour12: false,
     });
 
-    const timestampPrompt = `
-## 当前时间
+    return `## 当前时间
 现在是中国标准时间（CST, UTC+8）：
 - **日期**：${dateString}
 - **时间**：${timeString}
 
-请根据当前时间来理解和回应用户的请求。
-`;
-
-    return systemPrompt + '\n\n' + timestampPrompt;
+请根据当前时间来理解和回应用户的请求。`;
   }
 
   /**
-   * 用可用技能信息增强系统提示
-   * 帮助 LLM 理解每个技能的用途和何时应该调用工具
-   * @param {string} systemPrompt - 系统提示
-   * @param {Array} skills - 技能列表，每项包含 id, name, description, tools
-   *   - tools 可以是字符串数组（工具名称）或对象数组（包含 name 和 description）
+   * 生成 Soul 段落
+   * @param {object} soul - Soul 配置
+   * @param {object} expert - 专家配置（可选）
+   * @returns {string|null} Soul 段落内容，如果所有字段为空则返回 null
    */
-  enhanceWithSkills(systemPrompt, skills) {
-    if (!skills || skills.length === 0) {
-      logger.info('[ContextManager] enhanceWithSkills: 没有技能需要注入');
-      return systemPrompt;
+  generateSoulSection(soul, expert = null) {
+    if (!soul) return null;
+
+    const sections = [];
+
+    if (soul.coreValues?.trim()) {
+      sections.push(`## 你的核心价值观\n${soul.coreValues.trim()}`);
     }
 
-    logger.info(`[ContextManager] enhanceWithSkills: 注入 ${skills.length} 个技能到 System Prompt`);
+    if (soul.behavioralGuidelines?.trim()) {
+      sections.push(`## 你的行为准则\n${soul.behavioralGuidelines.trim()}`);
+    }
+
+    if (soul.taboos?.trim()) {
+      sections.push(`## 你的禁忌（绝对不能做的事）\n${soul.taboos.trim()}`);
+    }
+
+    if (soul.emotionalTone?.trim()) {
+      sections.push(`## 你的情感基调\n${soul.emotionalTone.trim()}`);
+    }
+
+    const speakingStyle = expert?.speaking_style || soul.speakingStyle;
+    if (speakingStyle?.trim()) {
+      sections.push(`## 你的说话风格\n${speakingStyle.trim()}`);
+    }
+
+    if (sections.length === 0) return null;
+
+    return sections.join('\n\n');
+  }
+
+  /**
+   * 生成技能段落
+   * @param {Array} skills - 技能列表
+   * @returns {string|null} 技能段落内容
+   */
+  generateSkillsSection(skills) {
+    if (!skills || skills.length === 0) {
+      return null;
+    }
+
+    logger.info(`[ContextManager] generateSkillsSection: 注入 ${skills.length} 个技能到 System Prompt`);
     skills.forEach(s => logger.info(`[ContextManager] - ${s.id}: ${s.name}`));
 
-    // 构建技能描述文本
     const skillsDescription = skills.map(skill => {
-      // 构建工具列表描述
       let toolsDescription = '无特定工具';
       if (skill.tools && skill.tools.length > 0) {
         if (typeof skill.tools[0] === 'object' && skill.tools[0].name) {
-          // tools 是对象数组，包含 name 和 description
-          // 工具名已经是 skillIdShort_toolName 格式（6字符前缀），直接使用
           toolsDescription = skill.tools.map(t => {
             return `  - \`${t.name}\`: ${t.description || '无描述'}`;
           }).join('\n');
         } else {
-          // tools 是字符串数组（兼容旧格式）
           toolsDescription = skill.tools.map(t => {
             return `  - \`${t}\``;
           }).join('\n');
@@ -315,94 +314,77 @@ ${ragContext}
 ${toolsDescription}`;
     }).join('\n\n');
 
-    const skillsPrompt = `
-## 你的可用技能
+    return `## 你的可用技能
 你拥有以下技能，可以在合适的时候调用相关工具来完成任务：
 
 ${skillsDescription}
 
-当你需要使用这些技能时，系统会自动调用相应的工具。你只需要在回复中自然地表达即可，系统会处理工具调用。
-`;
-
-    logger.info('[ContextManager] enhanceWithSkills: System Prompt 已增强');
-    return systemPrompt + '\n\n' + skillsPrompt;
+当你需要使用这些技能时，系统会自动调用相应的工具。你只需要在回复中自然地表达即可，系统会处理工具调用。`;
   }
 
   /**
-   * 用可用助理列表增强系统提示
-   * 帮助 LLM 知道有哪些助理可以召唤
-   * @param {string} systemPrompt - 系统提示
-   * @param {Array} assistants - 可用助理列表
+   * 生成助理段落
+   * @param {Array} assistants - 助理列表
+   * @returns {string|null} 助理段落内容
    */
-  enhanceWithAssistants(systemPrompt, assistants) {
+  generateAssistantsSection(assistants) {
     if (!assistants || assistants.length === 0) {
-      return systemPrompt;
+      return null;
     }
 
-    // 只保留已启用的助理
     const activeAssistants = assistants.filter(a => a.is_active);
     if (activeAssistants.length === 0) {
-      return systemPrompt;
+      return null;
     }
 
-    logger.info(`[ContextManager] enhanceWithAssistants: 注入 ${activeAssistants.length} 个助理到 System Prompt`);
+    logger.info(`[ContextManager] generateAssistantsSection: 注入 ${activeAssistants.length} 个助理到 System Prompt`);
 
-    // 构建助理描述文本
     const assistantsDescription = activeAssistants.map(a => {
       const executionMode = a.execution_mode || 'llm';
       const modelInfo = a.model_id ? `\n  - 模型: ${a.model_id}` : '';
       return `- **${a.name}** (${a.assistant_type}): ${a.description || '暂无描述'}\n  - 执行模式: ${executionMode}${modelInfo}`;
     }).join('\n\n');
 
-    const assistantsPrompt = `
-## 可用助理
+    return `## 可用助理
 你可以通过 \`assistant_summon\` 工具召唤以下助理来帮助你完成任务：
 
 ${assistantsDescription}
 
 **使用方式**：
-当需要调用助理时，使用 \`assistant_summon(type="助理类型", task="任务描述", input={...})\` 格式调用。
-`;
-
-    logger.info('[ContextManager] enhanceWithAssistants: System Prompt 已增强');
-    return systemPrompt + '\n\n' + assistantsPrompt;
+当需要调用助理时，使用 \`assistant_summon(type="助理类型", task="任务描述", input={...})\` 格式调用。`;
   }
 
   /**
-   * 用任务工作空间上下文增强系统提示
-   * 支持三种模式：任务模式、技能模式、对话模式
-   * @param {string} systemPrompt - 系统提示
-   * @param {object} taskContext - 任务上下文对象
+   * 生成任务上下文段落（根据模式分发）
+   * @param {object} taskContext - 任务上下文
+   * @returns {string|null} 任务上下文段落内容
    */
-  enhanceWithTaskContext(systemPrompt, taskContext) {
-    if (!taskContext) return systemPrompt;
+  generateTaskContextSection(taskContext) {
+    if (!taskContext) return null;
 
     const fullPath = taskContext.fullWorkspacePath || '';
     
-    // 判断模式类型
-    const isTaskMode = taskContext.id && taskContext.title;  // 任务模式：有任务ID和标题
-    const isSkillMode = fullPath.startsWith('skills/');      // 技能模式：路径以 skills/ 开头
-    const isChatMode = fullPath.startsWith('work/') && !isTaskMode;  // 对话模式：用户临时目录
+    const isTaskMode = taskContext.id && taskContext.title;
+    const isSkillMode = fullPath.startsWith('skills/');
+    const isChatMode = fullPath.startsWith('work/') && !isTaskMode;
 
-    logger.info(`[ContextManager] enhanceWithTaskContext: 模式=${isTaskMode ? '任务' : isSkillMode ? '技能' : '对话'}, 路径=${fullPath}`);
+    logger.info(`[ContextManager] generateTaskContextSection: 模式=${isTaskMode ? '任务' : isSkillMode ? '技能' : '对话'}, 路径=${fullPath}`);
 
     if (isSkillMode) {
-      // 技能模式：显示技能目录结构
-      return this.enhanceWithSkillContext(systemPrompt, taskContext);
+      return this.generateSkillContextSection(taskContext);
     } else if (isChatMode) {
-      // 对话模式：显示用户临时目录结构
-      return this.enhanceWithChatContext(systemPrompt, taskContext);
+      return this.generateChatContextSection(taskContext);
     } else {
-      // 任务模式：显示任务工作空间结构
-      return this.enhanceWithTaskWorkspaceContext(systemPrompt, taskContext);
+      return this.generateTaskWorkspaceSection(taskContext);
     }
   }
 
   /**
-   * 任务模式：用任务工作空间上下文增强系统提示
+   * 生成任务工作空间段落（任务模式）
+   * @param {object} taskContext - 任务上下文
+   * @returns {string} 任务工作空间段落内容
    */
-  enhanceWithTaskWorkspaceContext(systemPrompt, taskContext) {
-    // 构建文件列表描述
+  generateTaskWorkspaceSection(taskContext) {
     let filesDescription = '暂无文件';
     if (taskContext.inputFiles && taskContext.inputFiles.length > 0) {
       const fileList = taskContext.inputFiles.map(file => {
@@ -413,19 +395,19 @@ ${assistantsDescription}
       filesDescription = fileList;
     }
 
-    // 获取路径信息
     const userId = taskContext.userId || 'unknown';
     const taskId = taskContext.id;
     const relativePath = taskContext.workspacePath || `${userId}/${taskId}`;
     const fullPath = taskContext.fullWorkspacePath || `work/${relativePath}`;
 
-    // 当前浏览路径描述
     const currentPathDisplay = taskContext.currentPath
       ? `${fullPath}/${taskContext.currentPath}`
       : fullPath;
 
-    const taskPrompt = `
-## 当前任务工作空间
+    // 生成路径权限范围说明
+    const permissionSection = this.generatePathPermissionSection(userId, fullPath, 'task');
+
+    return `## 当前任务工作空间
 
 你正在**任务工作空间模式**中。以下是当前任务的详细信息：
 
@@ -440,29 +422,25 @@ ${taskContext.description ? `- **任务描述**: ${taskContext.description}` : '
 - **工作目录**: ${fullPath}
 - **当前浏览**: ${currentPathDisplay}
 
-### 路径使用规则
-- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 用户上传文件时，一般会创建 \`input\` 目录存放
-- 可以根据任务需要创建合适的子目录
-- 不确定目录结构时，先用 \`ls\` 命令探测
-
+${permissionSection}
 ### 当前目录下的文件
-${filesDescription}
-`;
-
-    return systemPrompt + '\n\n' + taskPrompt;
+${filesDescription}`;
   }
 
   /**
-   * 技能模式：用技能目录上下文增强系统提示
+   * 生成技能目录段落（技能模式）
+   * @param {object} taskContext - 任务上下文
+   * @returns {string} 技能目录段落内容
    */
-  enhanceWithSkillContext(systemPrompt, taskContext) {
+  generateSkillContextSection(taskContext) {
     const fullPath = taskContext.fullWorkspacePath || 'skills/unknown';
-    // 从路径中提取技能名称（如 skills/file-operations → file-operations）
     const skillName = fullPath.replace(/^skills\//, '');
+    const userId = taskContext.userId || 'unknown';
 
-    const skillPrompt = `
-## 当前技能工作目录
+    // 生成路径权限范围说明
+    const permissionSection = this.generatePathPermissionSection(userId, fullPath, 'skill');
+
+    return `## 当前技能工作目录
 
 你正在**技能模式**中，当前工作目录是技能的源码目录。
 
@@ -473,31 +451,26 @@ ${filesDescription}
 ### 目录说明
 当前目录是技能目录，各个技能的目录结构和内容不尽相同。但 \`SKILL.md\` 文件肯定存在，包含技能的详细说明。
 
-### 路径使用规则
-- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 当前工作目录: \`${fullPath}/\`
-- 使用 \`cat SKILL.md\` 或 \`read_file\` 查看技能说明
-- ⚠️ 技能目录是只读的，不应该写入文件
-`;
-
-    return systemPrompt + '\n\n' + skillPrompt;
+${permissionSection}`;
   }
 
   /**
-   * 对话模式：用用户临时目录上下文增强系统提示
+   * 生成对话模式段落
+   * @param {object} taskContext - 任务上下文
+   * @returns {string} 对话模式段落内容
    */
-  enhanceWithChatContext(systemPrompt, taskContext) {
+  generateChatContextSection(taskContext) {
     const fullPath = taskContext.fullWorkspacePath || 'work/unknown/temp';
+    const userId = taskContext.userId || 'unknown';
 
-    const chatPrompt = `
-## 当前工作目录
+    // 生成路径权限范围说明
+    const permissionSection = this.generatePathPermissionSection(userId, fullPath, 'chat');
+
+    return `## 当前工作目录
 
 你正在**对话模式**中，当前工作目录是用户的临时文件夹：\`${fullPath}/\`
 
-### 路径使用规则
-- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 可以读取临时文件夹中的现有文件
-- ⚠️ **禁止创建文件**：对话模式不支持文件创建操作
+${permissionSection}
 
 ### 文件操作限制
 如果用户需要创建或写入文件，请提醒用户：
@@ -505,10 +478,116 @@ ${filesDescription}
 2. 在任务目录中，可以根据需要组织合适的目录结构
 3. 用户上传文件时，一般会创建 \`input\` 目录
 
-请友好地引导用户创建任务来处理需要文件操作的需求。
-`;
+请友好地引导用户创建任务来处理需要文件操作的需求。`;
+  }
 
-    return systemPrompt + '\n\n' + chatPrompt;
+  /**
+   * 生成路径权限范围说明段落
+   * @param {string} userId - 用户ID
+   * @param {string} currentPath - 当前工作路径
+   * @param {string} mode - 模式类型 ('task' | 'skill' | 'chat')
+   * @returns {string} 路径权限说明段落
+   */
+  generatePathPermissionSection(userId, currentPath, mode) {
+    if (mode === 'skill') {
+      // 技能模式：只读访问
+      return `### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 当前工作目录: \`${currentPath}/\`
+- 使用 \`cat SKILL.md\` 或 \`read_file\` 查看技能说明
+- ⚠️ 技能目录是只读的，不应该写入文件`;
+    } else if (mode === 'chat') {
+      // 对话模式：只读访问
+      return `### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 可以读取临时文件夹中的现有文件
+- ⚠️ **禁止创建文件**：对话模式不支持文件创建操作`;
+    } else {
+      // 任务模式：读写访问
+      return `### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 用户上传文件时，一般会创建 \`input\` 目录存放
+- 可以根据任务需要创建合适的子目录
+- 不确定目录结构时，先用 \`ls\` 命令探测
+
+### ⚠️ 路径权限范围
+- **可访问目录**: \`data/work/${userId}/\` 及其所有子目录
+- **当前任务目录**: \`${currentPath}/\`
+- **路径格式**: 相对于 data/ 目录，例如 \`${currentPath}/input/file.xlsx\``;
+    }
+  }
+
+  /**
+   * 生成 Topic 总结段落
+   * @param {string} topicSummaries - Topic 总结文本
+   * @returns {string|null} Topic 总结段落内容
+   */
+  generateTopicSummariesSection(topicSummaries) {
+    if (!topicSummaries) return null;
+
+    return `## 之前的对话话题总结
+以下是你们之前讨论过的话题，帮助你了解对话历史：
+
+${topicSummaries}`;
+  }
+
+  /**
+   * 生成 RAG 上下文段落
+   * @param {string} ragContext - RAG 检索上下文
+   * @returns {string|null} RAG 上下文段落内容
+   */
+  generateRAGContextSection(ragContext) {
+    if (!ragContext) return null;
+
+    return `## 相关知识库内容
+以下是从知识库中检索到的相关内容，请参考这些信息回答用户问题：
+
+${ragContext}`;
+  }
+
+  /**
+   * 生成 Inner Voices 段落
+   * @param {Array} innerVoices - 内心独白列表
+   * @returns {string|null} Inner Voices 段落内容
+   */
+  generateInnerVoicesSection(innerVoices) {
+    if (!innerVoices || innerVoices.length === 0) return null;
+
+    const trend = this.analyzeTrend(innerVoices);
+
+    let innerVoiceText = '';
+
+    if (trend.trend === 'declining' && trend.latest?.nextRoundAdvice) {
+      innerVoiceText += `【重要提醒】最近表现有下降趋势，请注意：${trend.latest.nextRoundAdvice}\n\n`;
+    }
+
+    const monologues = innerVoices
+      .filter(iv => iv.monologue)
+      .map(iv => iv.monologue)
+      .join('\n');
+
+    if (monologues) {
+      innerVoiceText += `最近的内心独白：\n${monologues}`;
+    }
+
+    return `## 你的内心独白（前几轮的反思结果）
+这是你对自己之前表现的反思：
+
+${innerVoiceText}
+
+请根据这些反思调整你这一轮的回复。`;
+  }
+
+  /**
+   * 生成用户信息引导段落
+   * @param {string} guidance - 引导提示
+   * @returns {string|null} 用户信息引导段落内容
+   */
+  generateUserInfoGuidanceSection(guidance) {
+    if (!guidance) return null;
+
+    return `## 对话提示
+${guidance}`;
   }
 
   /**
@@ -538,112 +617,6 @@ ${filesDescription}
       logger.warn('[ContextManager] 构建 Topic 总结失败:', error.message);
       return null;
     }
-  }
-
-  /**
-   * 用 Soul 增强系统提示
-   *
-   * 空字段处理逻辑：
-   * - `null`、`undefined`、空字符串均视为空
-   * - 空字段对应的章节标题也会被省略，不会输出空白内容
-   * - 如果所有字段都为空，直接返回原 systemPrompt
-   *
-   * @param {string} systemPrompt - 基础系统提示
-   * @param {object} soul - Soul 配置（字段为纯字符串）
-   * @param {object} expert - 专家配置（可选，用于 speaking_style）
-   * @returns {string} 增强后的系统提示
-   */
-  enhanceWithSoul(systemPrompt, soul, expert = null) {
-    if (!soul) return systemPrompt;
-
-    const sections = [];
-
-    // 核心价值观（纯字符串）
-    if (soul.coreValues?.trim()) {
-      sections.push(`## 你的核心价值观\n${soul.coreValues.trim()}`);
-    }
-
-    // 行为准则（纯字符串）
-    if (soul.behavioralGuidelines?.trim()) {
-      sections.push(`## 你的行为准则\n${soul.behavioralGuidelines.trim()}`);
-    }
-
-    // 禁忌（纯字符串）
-    if (soul.taboos?.trim()) {
-      sections.push(`## 你的禁忌（绝对不能做的事）\n${soul.taboos.trim()}`);
-    }
-
-    // 情感基调
-    if (soul.emotionalTone?.trim()) {
-      sections.push(`## 你的情感基调\n${soul.emotionalTone.trim()}`);
-    }
-
-    // 说话风格
-    const speakingStyle = expert?.speaking_style || soul.speakingStyle;
-    if (speakingStyle?.trim()) {
-      sections.push(`## 你的说话风格\n${speakingStyle.trim()}`);
-    }
-
-    // 如果没有有效内容，直接返回原提示
-    if (sections.length === 0) return systemPrompt;
-
-    const soulPrompt = '\n\n' + sections.join('\n\n');
-    return systemPrompt + soulPrompt;
-  }
-
-  /**
-   * 用 Inner Voices 增强系统提示
-   */
-  enhanceWithInnerVoices(systemPrompt, innerVoices) {
-    if (!innerVoices || innerVoices.length === 0) return systemPrompt;
-
-    // 分析评分趋势
-    const trend = this.analyzeTrend(innerVoices);
-
-    // 构建 Inner Voice 文本
-    let innerVoiceText = '';
-
-    // 如果趋势下降，强调 nextRoundAdvice
-    if (trend.trend === 'declining' && trend.latest?.nextRoundAdvice) {
-      innerVoiceText += `【重要提醒】最近表现有下降趋势，请注意：${trend.latest.nextRoundAdvice}\n\n`;
-    }
-
-    // 添加最近的内心独白
-    const monologues = innerVoices
-      .filter(iv => iv.monologue)
-      .map(iv => iv.monologue)
-      .join('\n');
-
-    if (monologues) {
-      innerVoiceText += `最近的内心独白：\n${monologues}`;
-    }
-
-    const innerVoicePrompt = `
-## 你的内心独白（前几轮的反思结果）
-这是你对自己之前表现的反思：
-
-${innerVoiceText}
-
-请根据这些反思调整你这一轮的回复。
-`;
-
-    return systemPrompt + '\n\n' + innerVoicePrompt;
-  }
-
-  /**
-   * 用用户信息引导提示增强系统提示
-   * @param {string} systemPrompt - 系统提示
-   * @param {string} guidance - 引导提示
-   */
-  enhanceWithUserInfoGuidance(systemPrompt, guidance) {
-    if (!guidance) return systemPrompt;
-
-    const guidancePrompt = `
-## 对话提示
-${guidance}
-`;
-
-    return systemPrompt + '\n\n' + guidancePrompt;
   }
 
   /**

--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -131,12 +131,19 @@ export class BaseContextOrganizer extends IContextOrganizer {
   }
 
   /**
-   * 用当前时间戳增强系统提示
+   * 统一的段落拼接方法
    */
-  enhanceWithTimestamp(systemPrompt) {
+  appendSection(basePrompt, section) {
+    if (!section) return basePrompt;
+    return basePrompt + '\n\n' + section;
+  }
+
+  /**
+   * 生成时间戳段落
+   */
+  generateTimestampSection() {
     const now = new Date();
 
-    // 格式化日期和时间（中文格式）
     const dateString = now.toLocaleDateString('zh-CN', {
       year: 'numeric',
       month: 'long',
@@ -150,79 +157,64 @@ export class BaseContextOrganizer extends IContextOrganizer {
       hour12: false,
     });
 
-    const timestampPrompt = `
-## 当前时间
+    return `## 当前时间
 现在是中国标准时间（CST, UTC+8）：
 - **日期**：${dateString}
 - **时间**：${timeString}
 
-请根据当前时间来理解和回应用户的请求。
-`;
-
-    return systemPrompt + '\n\n' + timestampPrompt;
+请根据当前时间来理解和回应用户的请求。`;
   }
 
   /**
-   * 用 Soul 增强系统提示
+   * 生成 Soul 段落
    */
-  enhanceWithSoul(systemPrompt, soul, expert = null) {
-    if (!soul) return systemPrompt;
+  generateSoulSection(soul, expert = null) {
+    if (!soul) return null;
 
     const sections = [];
 
-    // 核心价值观（纯字符串）
     if (soul.coreValues?.trim()) {
       sections.push(`## 你的核心价值观\n${soul.coreValues.trim()}`);
     }
 
-    // 行为准则（纯字符串）
     if (soul.behavioralGuidelines?.trim()) {
       sections.push(`## 你的行为准则\n${soul.behavioralGuidelines.trim()}`);
     }
 
-    // 禁忌（纯字符串）
     if (soul.taboos?.trim()) {
       sections.push(`## 你的禁忌（绝对不能做的事）\n${soul.taboos.trim()}`);
     }
 
-    // 情感基调
     if (soul.emotionalTone?.trim()) {
       sections.push(`## 你的情感基调\n${soul.emotionalTone.trim()}`);
     }
 
-    // 说话风格
     const speakingStyle = expert?.speaking_style || soul.speakingStyle;
     if (speakingStyle?.trim()) {
       sections.push(`## 你的说话风格\n${speakingStyle.trim()}`);
     }
 
-    // 如果没有有效内容，直接返回原提示
-    if (sections.length === 0) return systemPrompt;
+    if (sections.length === 0) return null;
 
-    const soulPrompt = '\n\n' + sections.join('\n\n');
-    return systemPrompt + soulPrompt;
+    return sections.join('\n\n');
   }
 
   /**
-   * 用可用技能信息增强系统提示
+   * 生成技能段落
    */
-  enhanceWithSkills(systemPrompt, skills) {
+  generateSkillsSection(skills) {
     if (!skills || skills.length === 0) {
-      return systemPrompt;
+      return null;
     }
 
-    // 构建技能描述文本
     const skillsDescription = skills.map(skill => {
-      // 构建工具列表描述
       let toolsDescription = '无特定工具';
       if (skill.tools && skill.tools.length > 0) {
         if (typeof skill.tools[0] === 'object' && skill.tools[0].name) {
-          // tools 是对象数组，包含 name 和 description
           toolsDescription = skill.tools.map(t => {
             return `  - \`${t.name}\`: ${t.description || '无描述'}`;
           }).join('\n');
         } else {
-          // tools 是字符串数组（兼容旧格式）
           toolsDescription = skill.tools.map(t => {
             return `  - \`${t}\``;
           }).join('\n');
@@ -233,49 +225,39 @@ export class BaseContextOrganizer extends IContextOrganizer {
 ${toolsDescription}`;
     }).join('\n\n');
 
-    const skillsPrompt = `
-## 你的可用技能
+    return `## 你的可用技能
 你拥有以下技能，可以在合适的时候调用相关工具来完成任务：
 
 ${skillsDescription}
 
-当你需要使用这些技能时，系统会自动调用相应的工具。你只需要在回复中自然地表达即可，系统会处理工具调用。
-`;
-
-    return systemPrompt + '\n\n' + skillsPrompt;
+当你需要使用这些技能时，系统会自动调用相应的工具。你只需要在回复中自然地表达即可，系统会处理工具调用。`;
   }
 
   /**
-   * 用任务工作空间上下文增强系统提示
-   * 支持三种模式：任务模式、技能模式、对话模式
+   * 生成任务上下文段落（根据模式分发）
    */
-  enhanceWithTaskContext(systemPrompt, taskContext) {
-    if (!taskContext) return systemPrompt;
+  generateTaskContextSection(taskContext) {
+    if (!taskContext) return null;
 
     const fullPath = taskContext.fullWorkspacePath || '';
     
-    // 判断模式类型
-    const isTaskMode = taskContext.id && taskContext.title;  // 任务模式：有任务ID和标题
-    const isSkillMode = fullPath.startsWith('skills/');      // 技能模式：路径以 skills/ 开头
-    const isChatMode = fullPath.startsWith('work/') && !isTaskMode;  // 对话模式：用户临时目录
+    const isTaskMode = taskContext.id && taskContext.title;
+    const isSkillMode = fullPath.startsWith('skills/');
+    const isChatMode = fullPath.startsWith('work/') && !isTaskMode;
 
     if (isSkillMode) {
-      // 技能模式：显示技能目录结构
-      return this.enhanceWithSkillContext(systemPrompt, taskContext);
+      return this.generateSkillContextSection(taskContext);
     } else if (isChatMode) {
-      // 对话模式：显示用户临时目录结构
-      return this.enhanceWithChatContext(systemPrompt, taskContext);
+      return this.generateChatContextSection(taskContext);
     } else {
-      // 任务模式：显示任务工作空间结构
-      return this.enhanceWithTaskWorkspaceContext(systemPrompt, taskContext);
+      return this.generateTaskWorkspaceSection(taskContext);
     }
   }
 
   /**
-   * 任务模式：用任务工作空间上下文增强系统提示
+   * 生成任务工作空间段落（任务模式）
    */
-  enhanceWithTaskWorkspaceContext(systemPrompt, taskContext) {
-    // 构建文件列表描述
+  generateTaskWorkspaceSection(taskContext) {
     let filesDescription = '暂无文件';
     if (taskContext.inputFiles && taskContext.inputFiles.length > 0) {
       const fileList = taskContext.inputFiles.map(file => {
@@ -286,13 +268,11 @@ ${skillsDescription}
       filesDescription = fileList;
     }
 
-    // 获取路径信息
     const userId = taskContext.userId || 'unknown';
     const taskId = taskContext.id;
     const relativePath = taskContext.workspacePath || `${userId}/${taskId}`;
     const fullPath = taskContext.fullWorkspacePath || `work/${relativePath}`;
 
-    // 当前浏览路径描述
     const currentPathDisplay = taskContext.currentPath
       ? `${fullPath}/${taskContext.currentPath}`
       : fullPath;
@@ -319,8 +299,10 @@ ${taskContext.todo}
 `;
     }
 
-    const taskPrompt = `
-## 当前任务工作空间
+    // 生成路径权限范围说明
+    const permissionSection = this.generatePathPermissionSection(userId, fullPath, 'task');
+
+    return `## 当前任务工作空间
 
 你正在**任务工作空间模式**中。以下是当前任务的详细信息：
 
@@ -335,29 +317,23 @@ ${readmeSection}${todoSection}
 - **工作目录**: ${fullPath}
 - **当前浏览**: ${currentPathDisplay}
 
-### 路径使用规则
-- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 用户上传文件时，一般会创建 \`input\` 目录存放
-- 可以根据任务需要创建合适的子目录
-- 不确定目录结构时，先用 \`ls\` 命令探测
-
+${permissionSection}
 ### 当前目录下的文件
-${filesDescription}
-`;
-
-    return systemPrompt + '\n\n' + taskPrompt;
+${filesDescription}`;
   }
 
   /**
-   * 技能模式：用技能目录上下文增强系统提示
+   * 生成技能目录段落（技能模式）
    */
-  enhanceWithSkillContext(systemPrompt, taskContext) {
+  generateSkillContextSection(taskContext) {
     const fullPath = taskContext.fullWorkspacePath || 'skills/unknown';
-    // 从路径中提取技能名称（如 skills/file-operations → file-operations）
     const skillName = fullPath.replace(/^skills\//, '');
+    const userId = taskContext.userId || 'unknown';
 
-    const skillPrompt = `
-## 当前技能工作目录
+    // 生成路径权限范围说明
+    const permissionSection = this.generatePathPermissionSection(userId, fullPath, 'skill');
+
+    return `## 当前技能工作目录
 
 你正在**技能模式**中，当前工作目录是技能的源码目录。
 
@@ -368,31 +344,24 @@ ${filesDescription}
 ### 目录说明
 当前目录是技能目录，各个技能的目录结构和内容不尽相同。但 \`SKILL.md\` 文件肯定存在，包含技能的详细说明。
 
-### 路径使用规则
-- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 当前工作目录: \`${fullPath}/\`
-- 使用 \`cat SKILL.md\` 或 \`read_file\` 查看技能说明
-- ⚠️ 技能目录是只读的，不应该写入文件
-`;
-
-    return systemPrompt + '\n\n' + skillPrompt;
+${permissionSection}`;
   }
 
   /**
-   * 对话模式：用用户临时目录上下文增强系统提示
+   * 生成对话模式段落
    */
-  enhanceWithChatContext(systemPrompt, taskContext) {
+  generateChatContextSection(taskContext) {
     const fullPath = taskContext.fullWorkspacePath || 'work/unknown/temp';
+    const userId = taskContext.userId || 'unknown';
 
-    const chatPrompt = `
-## 当前工作目录
+    // 生成路径权限范围说明
+    const permissionSection = this.generatePathPermissionSection(userId, fullPath, 'chat');
+
+    return `## 当前工作目录
 
 你正在**对话模式**中，当前工作目录是用户的临时文件夹：\`${fullPath}/\`
 
-### 路径使用规则
-- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 可以读取临时文件夹中的现有文件
-- ⚠️ **禁止创建文件**：对话模式不支持文件创建操作
+${permissionSection}
 
 ### 文件操作限制
 如果用户需要创建或写入文件，请提醒用户：
@@ -400,62 +369,76 @@ ${filesDescription}
 2. 在任务目录中，可以根据需要组织合适的目录结构
 3. 用户上传文件时，一般会创建 \`input\` 目录
 
-请友好地引导用户创建任务来处理需要文件操作的需求。
-`;
-
-    return systemPrompt + '\n\n' + chatPrompt;
+请友好地引导用户创建任务来处理需要文件操作的需求。`;
   }
 
   /**
-   * 用 Topic 总结增强系统提示
+   * 生成路径权限范围说明段落
    */
-  enhanceWithTopicSummaries(systemPrompt, topicSummaries) {
-    if (!topicSummaries) return systemPrompt;
+  generatePathPermissionSection(userId, currentPath, mode) {
+    if (mode === 'skill') {
+      return `### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 当前工作目录: \`${currentPath}/\`
+- 使用 \`cat SKILL.md\` 或 \`read_file\` 查看技能说明
+- ⚠️ 技能目录是只读的，不应该写入文件`;
+    } else if (mode === 'chat') {
+      return `### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 可以读取临时文件夹中的现有文件
+- ⚠️ **禁止创建文件**：对话模式不支持文件创建操作`;
+    } else {
+      return `### 路径使用规则
+- 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
+- 用户上传文件时，一般会创建 \`input\` 目录存放
+- 可以根据任务需要创建合适的子目录
+- 不确定目录结构时，先用 \`ls\` 命令探测
 
-    const topicPrompt = `
-## 之前的对话话题总结
+### ⚠️ 路径权限范围
+- **可访问目录**: \`data/work/${userId}/\` 及其所有子目录
+- **当前任务目录**: \`${currentPath}/\`
+- **路径格式**: 相对于 data/ 目录，例如 \`${currentPath}/input/file.xlsx\``;
+    }
+  }
+
+  /**
+   * 生成 Topic 总结段落
+   */
+  generateTopicSummariesSection(topicSummaries) {
+    if (!topicSummaries) return null;
+
+    return `## 之前的对话话题总结
 以下是你们之前讨论过的话题，帮助你了解对话历史：
 
-${topicSummaries}
-`;
-
-    return systemPrompt + '\n\n' + topicPrompt;
+${topicSummaries}`;
   }
 
   /**
-   * 用 RAG 检索上下文增强系统提示
+   * 生成 RAG 上下文段落
    */
-  enhanceWithRAGContext(systemPrompt, ragContext) {
-    if (!ragContext) return systemPrompt;
+  generateRAGContextSection(ragContext) {
+    if (!ragContext) return null;
 
-    const ragPrompt = `
-## 相关知识库内容
+    return `## 相关知识库内容
 以下是从知识库中检索到的相关内容，请参考这些信息回答用户问题：
 
-${ragContext}
-`;
-
-    return systemPrompt + '\n\n' + ragPrompt;
+${ragContext}`;
   }
 
   /**
-   * 用 Inner Voices 增强系统提示
+   * 生成 Inner Voices 段落
    */
-  enhanceWithInnerVoices(systemPrompt, innerVoices) {
-    if (!innerVoices || innerVoices.length === 0) return systemPrompt;
+  generateInnerVoicesSection(innerVoices) {
+    if (!innerVoices || innerVoices.length === 0) return null;
 
-    // 分析评分趋势
     const trend = this.analyzeTrend(innerVoices);
 
-    // 构建 Inner Voice 文本
     let innerVoiceText = '';
 
-    // 如果趋势下降，强调 nextRoundAdvice
     if (trend.trend === 'declining' && trend.latest?.nextRoundAdvice) {
       innerVoiceText += `【重要提醒】最近表现有下降趋势，请注意：${trend.latest.nextRoundAdvice}\n\n`;
     }
 
-    // 添加最近的内心独白
     const monologues = innerVoices
       .filter(iv => iv.monologue)
       .map(iv => iv.monologue)
@@ -465,30 +448,22 @@ ${ragContext}
       innerVoiceText += `最近的内心独白：\n${monologues}`;
     }
 
-    const innerVoicePrompt = `
-## 你的内心独白（前几轮的反思结果）
+    return `## 你的内心独白（前几轮的反思结果）
 这是你对自己之前表现的反思：
 
 ${innerVoiceText}
 
-请根据这些反思调整你这一轮的回复。
-`;
-
-    return systemPrompt + '\n\n' + innerVoicePrompt;
+请根据这些反思调整你这一轮的回复。`;
   }
 
   /**
-   * 用用户信息引导提示增强系统提示
+   * 生成用户信息引导段落
    */
-  enhanceWithUserInfoGuidance(systemPrompt, guidance) {
-    if (!guidance) return systemPrompt;
+  generateUserInfoGuidanceSection(guidance) {
+    if (!guidance) return null;
 
-    const guidancePrompt = `
-## 对话提示
-${guidance}
-`;
-
-    return systemPrompt + '\n\n' + guidancePrompt;
+    return `## 对话提示
+${guidance}`;
   }
 
   /**
@@ -749,6 +724,11 @@ ${guidance}
 
   /**
    * 构建基础系统提示
+   *
+   * 重构说明：
+   * - 每个 generateSection* 方法只负责生成内容，不负责拼接
+   * - 使用 appendSection() 统一处理拼接逻辑
+   * - 职责分离，便于测试和维护
    */
   buildBaseSystemPrompt(innerVoices = [], topicSummaries = null, userInfoGuidance = null, skills = [], taskContext = null, ragContext = null) {
     const expert = this.expertConfig.expert || this.expertConfig;
@@ -756,40 +736,32 @@ ${guidance}
     // 基础 System Prompt
     let systemPrompt = expert.prompt_template || expert.system_prompt || expert.introduction || '';
 
-    // 添加当前时间信息
-    systemPrompt = this.enhanceWithTimestamp(systemPrompt);
-
-    // 添加 Soul
-    systemPrompt = this.enhanceWithSoul(systemPrompt, this.soul, expert);
-
-    // 添加可用技能描述
+    // 逐段添加内容，每段独立生成
+    systemPrompt = this.appendSection(systemPrompt, this.generateTimestampSection());
+    systemPrompt = this.appendSection(systemPrompt, this.generateSoulSection(this.soul, expert));
+    
     if (skills && skills.length > 0) {
-      systemPrompt = this.enhanceWithSkills(systemPrompt, skills);
+      systemPrompt = this.appendSection(systemPrompt, this.generateSkillsSection(skills));
     }
-
-    // 添加任务工作空间上下文
+    
     if (taskContext) {
-      systemPrompt = this.enhanceWithTaskContext(systemPrompt, taskContext);
+      systemPrompt = this.appendSection(systemPrompt, this.generateTaskContextSection(taskContext));
     }
-
-    // 添加 Topic 总结
+    
     if (topicSummaries) {
-      systemPrompt = this.enhanceWithTopicSummaries(systemPrompt, topicSummaries);
+      systemPrompt = this.appendSection(systemPrompt, this.generateTopicSummariesSection(topicSummaries));
     }
-
-    // 添加 RAG 检索上下文
+    
     if (ragContext) {
-      systemPrompt = this.enhanceWithRAGContext(systemPrompt, ragContext);
+      systemPrompt = this.appendSection(systemPrompt, this.generateRAGContextSection(ragContext));
     }
-
-    // 添加 Inner Voices
+    
     if (innerVoices.length > 0) {
-      systemPrompt = this.enhanceWithInnerVoices(systemPrompt, innerVoices);
+      systemPrompt = this.appendSection(systemPrompt, this.generateInnerVoicesSection(innerVoices));
     }
-
-    // 添加用户信息引导提示
+    
     if (userInfoGuidance) {
-      systemPrompt = this.enhanceWithUserInfoGuidance(systemPrompt, userInfoGuidance);
+      systemPrompt = this.appendSection(systemPrompt, this.generateUserInfoGuidanceSection(userInfoGuidance));
     }
 
     return systemPrompt;


### PR DESCRIPTION
## 📝 变更说明

重构 system prompt 注入策略，将不同功能的注入分离为独立方法，并添加路径权限信息注入。

### 🔧 主要变更

1. **新增 `appendSection()` 方法**
   - 统一处理 section 拼接，避免过度拼接
   - 自动处理空值情况

2. **重构方法命名规范**
   - `enhanceWith*()` → `generateSection*()`
   - 新方法只负责生成内容，不负责拼接
   - 职责分离：生成与拼接解耦

3. **新增 `generatePathPermissionSection()`**
   - 根据模式（task/skill/chat）生成路径权限信息
   - 注入到 system prompt 中，帮助 LLM 理解路径规则
   - 解决专家反馈的路径拼接困惑问题

4. **移除旧方法**
   - 删除已废弃的 `enhanceWith*` 方法
   - 不保持向后兼容（按用户要求）

### 📁 修改文件

- `lib/context-manager.js` - 重构 system prompt 构建逻辑
- `lib/context-organizer/base-organizer.js` - 同步重构模式

### 🔗 相关 Issue

Closes #305