### PR TITLE
docs: PR 标题格式规范调整

### DIFF
--- a/docs/core/SOUL.md
+++ b/docs/core/SOUL.md
@@ -133,7 +133,9 @@ Issue（任务单） → 创建分支 → 开发 → PR → 合并 → 关闭 Is
 
 ### 提交规范
 
-格式：`#{issue}: type 描述`（直接关联 Issue）
+**Git Commit 格式**：`#{issue}: type 描述`（直接关联 Issue）
+
+**PR Title 格式**：`type: 描述`（不带 Issue 编号前缀，在 body 中用 `Closes #xxx` 关联）
 
 类型：`feat` | `fix` | `refactor` | `docs` | `test` | `chore`
 


### PR DESCRIPTION
## 变更内容

修改 `docs/core/SOUL.md` 中的 PR 标题格式规范。

### 修改前
- PR 标题格式：`#{issue}: type 描述`

### 修改后
- **Git Commit 格式**：`#{issue}: type 描述`（保持不变）
- **PR Title 格式**：`type: 描述`（不带 Issue 编号前缀，在 body 中用 `Closes #xxx` 关联）

## 示例

| 类型 | 格式 |
|------|------|
| Git Commit | `#298: feat 技能编辑弹窗增加删除按钮` |
| PR Title | `feat: 技能编辑弹窗增加删除按钮` |
| PR Body | `Closes #298` |

Closes #314