### PR TITLE
fix: 移除技能模式 System Prompt 中重复的工作目录信息

### DIFF
--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -414,13 +414,11 @@ ${permissionSection}
       
       return `### 路径使用规则
 - 路径是相对于系统 data/ 目录的，不需要再加 data/ 前缀
-- 当前工作目录: \`${currentPath}/\`
 - 使用 \`cat SKILL.md\` 或 \`read_file\` 查看技能说明
 - ⚠️ 技能目录是只读的，不应该写入文件
 
 ### ⚠️ 路径权限范围
 - **可访问目录**: ${accessibleDirs}
-- **当前工作目录**: \`${currentPath}/\`
 - **权限说明**: ${permissionNote}`;
     } else if (mode === 'chat') {
       const permissionNote = isAdmin


### PR DESCRIPTION
## 问题描述

在技能模式下，System Prompt 中"当前工作目录"信息出现了 **3 次重复**。

## 修复内容

移除 `generatePathPermissionSection()` 中技能模式下的重复工作目录行：
- 移除 `### 路径使用规则` 中的 `- 当前工作目录: ...`
- 移除 `### ⚠️ 路径权限范围` 中的 `- **当前工作目录**: ...`

工作目录信息已在 `### 技能信息` 部分展示，无需重复。

## 修复后效果

```markdown
## 当前技能工作目录

### 技能信息
- **技能名称**: docx
- **工作目录**: skills/docx

### 目录说明
当前目录是技能目录...

### 路径使用规则
- 路径是相对于系统 data/ 目录的...
- 使用 `cat SKILL.md` 或 `read_file` 查看技能说明
- ⚠️ 技能目录是只读的，不应该写入文件

### ⚠️ 路径权限范围
- **可访问目录**: 整个 data/ 目录
- **权限说明**: （管理员权限...）
```

## 影响范围

- 仅影响技能模式的 System Prompt 生成
- 不影响任务模式和对话模式

Closes #317