### PR TITLE
fix: 任务模式工作目录说明添加相对于 data/ 目录的提示，移除重复

### DIFF
--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -318,7 +318,7 @@ ${readmeSection}${todoSection}
 ### 目录说明
 当前目录是一个任务目录，可以根据用户的需要组织合适的目录结构。
 
-- **工作目录**: ${fullPath}
+- **工作目录**: \`${fullPath}/\`（相对于 data/ 目录）
 - **当前浏览**: ${currentPathDisplay}
 
 ${permissionSection}
@@ -452,7 +452,6 @@ ${permissionSection}
 
 ### ⚠️ 路径权限范围
 - **可访问目录**: ${accessibleDirs}
-- **当前任务目录**: \`${currentPath}/\`
 - **路径格式**: 相对于 data/ 目录，例如 \`${currentPath}/input/file.xlsx\`
 - **权限说明**: ${permissionNote}`;
     }


### PR DESCRIPTION
## 问题描述

任务模式下，工作目录显示为 `work/123/456`，但没有明确说明这是相对于 data/ 目录的路径。同时存在重复问题：

1. "工作目录" 没有说明相对于 data/
2. "当前任务目录" 与 "工作目录" 重复

## 修复内容

1. 在 `generateTaskWorkspaceSection()` 中，为工作目录添加 "（相对于 data/ 目录）" 说明
2. 移除 `generatePathPermissionSection()` 中任务模式的 "当前任务目录" 行

## 修复后效果

```markdown
### 目录说明
当前目录是一个任务目录，可以根据用户的需要组织合适的目录结构。

- **工作目录**: `work/123/456/`（相对于 data/ 目录）
- **当前浏览**: work/123/456

### 路径使用规则
- 路径是相对于系统 data/ 目录的...

### ⚠️ 路径权限范围
- **可访问目录**: data/work/123/
- **路径格式**: 相对于 data/ 目录，例如 `work/123/456/input/file.xlsx`
- **权限说明**: ...
```

## 影响范围

- 仅影响任务模式的 System Prompt 生成
- 提升路径说明的清晰度，消除重复

Closes #321