### PR TITLE
feat: 工具调用结果存储优化 - Content摘要 + Tool_calls完整存储

### DIFF
--- a/data/skills/message-reader/SKILL.md
+++ b/data/skills/message-reader/SKILL.md
@@ -24,33 +24,54 @@ allowed-tools: []
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| tool_call_id | string | 是 | 工具调用 ID，从上下文摘要中获取 |
+| tool_call_id | string | 是 | 消息 ID，从上下文摘要中获取（格式如 "msg_xxx"） |
 
 **返回值：**
 
 ```json
 {
   "success": true,
-  "tool_call_id": "call_xxx",
+  "tool_call_id": "msg_xxx",
   "tool_name": "search",
   "content": "完整的消息内容...",
   "content_length": 1234,
+  "result_length": 1234,
+  "is_from_result": true,
   "created_at": "2026-03-15T12:00:00.000Z"
 }
 ```
 
+**返回字段说明：**
+
+| 字段 | 说明 |
+|------|------|
+| `content` | 完整的消息内容 |
+| `content_length` | 返回内容的长度 |
+| `result_length` | 原始结果长度（存储时记录） |
+| `is_from_result` | 内容是否来自 tool_calls.result（Issue #325 新增） |
+
 ## 使用场景
 
-在 Simple 上下文策略中，工具消息会被摘要为：
+### Issue #325 优化后的存储方式
+
+当工具结果超过阈值（500字符）时，系统会使用摘要存储：
 
 ```
-search → 1234 字符 | get_message_content("call_xxx")
+工具: file-operations/fs_info
+结果: 1234 字符 | 成功
+→ 调用 get_message_content("msg_xxx") 获取完整结果
 ```
 
 AI 看到此提示后，可以调用 `get_message_content` 工具获取完整结果。
 
+### 获取逻辑
+
+1. **优先从 `tool_calls.result` 获取**：新存储方式，完整结果存储在此字段
+2. **回退到 `content` 字段**：旧存储方式或短结果
+
 ## 技术说明
 
-- 使用 `tool_call_id` 作为消息唯一标识
+- 使用消息主键 `id` 作为 `tool_call_id`
 - 查询 `messages` 表中 `role='tool'` 的消息
-- `tool_call_id` 存储在 `tool_calls` 字段的 JSON 中
+- 完整结果可能存储在 `tool_calls.result` 或 `content` 字段
+- `tool_calls.result_length` 记录原始结果长度

--- a/data/skills/message-reader/index.js
+++ b/data/skills/message-reader/index.js
@@ -1,10 +1,14 @@
 /**
  * Message Reader Skill
  * 提供消息内容检索能力，用于上下文优化中的按需获取
- * 
+ *
  * 使用场景：
  * - 当工具消息被摘要后，AI 可以通过此技能获取完整消息内容
- * - 通过 tool_call_id 检索特定的 tool 角色消息
+ * - 通过 message_id 检索特定的 tool 角色消息
+ *
+ * Issue #325 优化：
+ * - 当工具结果超过阈值时，content 存摘要，完整结果存 tool_calls.result
+ * - 此技能优先从 tool_calls.result 获取完整结果
  */
 
 const logger = require('../../../lib/logger.js');
@@ -21,7 +25,7 @@ const tools = {
       properties: {
         tool_call_id: {
           type: 'string',
-          description: '工具调用 ID，从上下文摘要中获取',
+          description: '消息 ID，从上下文摘要中获取（格式如 "msg_xxx"）',
         },
       },
       required: ['tool_call_id'],
@@ -31,8 +35,13 @@ const tools = {
 
 /**
  * 获取消息内容
+ *
+ * Issue #325 优化后的获取逻辑：
+ * 1. 优先从 tool_calls.result 获取完整结果（新存储方式）
+ * 2. 如果 tool_calls.result 不存在，使用 content 字段（旧存储方式或短结果）
+ *
  * @param {Object} params - 参数
- * @param {string} params.tool_call_id - 工具调用 ID
+ * @param {string} params.tool_call_id - 消息 ID（消息主键）
  * @param {Object} context - 上下文
  * @returns {Promise<Object>} 消息内容
  */
@@ -47,7 +56,7 @@ async function get_message_content(params, context) {
   }
 
   try {
-    // tool_call_id 现在是消息主键 ID，直接用 ID 查询
+    // tool_call_id 是消息主键 ID，直接用 ID 查询
     const messages = await db.query(`
       SELECT id, role, content, tool_calls, created_at
       FROM messages
@@ -72,14 +81,42 @@ async function get_message_content(params, context) {
       };
     }
 
-    logger.info(`[message-reader] 检索到消息: id=${message.id}, content_length=${message.content?.length || 0}`);
+    // 解析 tool_calls JSON
+    let toolMetaData = {};
+    try {
+      toolMetaData = typeof message.tool_calls === 'string'
+        ? JSON.parse(message.tool_calls)
+        : message.tool_calls || {};
+    } catch (e) {
+      logger.warn('[message-reader] 解析 tool_calls 失败:', e.message);
+    }
+
+    // Issue #325: 优先从 tool_calls.result 获取完整结果
+    // 如果 result 字段存在，说明使用了新的摘要存储方式
+    let fullContent;
+    let isFromResult = false;
+    
+    if (toolMetaData.result !== undefined && toolMetaData.result !== null) {
+      // 新存储方式：完整结果在 tool_calls.result 中
+      fullContent = typeof toolMetaData.result === 'string'
+        ? toolMetaData.result
+        : JSON.stringify(toolMetaData.result);
+      isFromResult = true;
+      logger.info(`[message-reader] 从 tool_calls.result 获取完整内容: id=${message.id}, length=${fullContent.length}`);
+    } else {
+      // 旧存储方式或短结果：使用 content 字段
+      fullContent = message.content || '';
+      logger.info(`[message-reader] 从 content 获取内容: id=${message.id}, length=${fullContent.length}`);
+    }
 
     return {
       success: true,
       tool_call_id,
-      tool_name: JSON.parse(message.tool_calls || '{}').name || 'unknown',
-      content: message.content,
-      content_length: message.content?.length || 0,
+      tool_name: toolMetaData.name || 'unknown',
+      content: fullContent,
+      content_length: fullContent.length,
+      result_length: toolMetaData.result_length || fullContent.length,  // 原始结果长度
+      is_from_result: isFromResult,  // 标识内容来源
       created_at: message.created_at,
     };
   } catch (error) {

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -736,9 +736,11 @@ class ChatService {
    * 保存工具消息
    * 每个工具调用完成后立即保存，实现增量持久化
    *
-   * 设计原则：
-   * - 存储层完整保存所有信息，不做截断
-   * - 上下文构建时根据场景决定使用多少内容
+   * 设计原则（Issue #325 优化）：
+   * - 当结果超过阈值时：content 存摘要，tool_calls.result 存完整结果
+   * - 当结果不超过阈值时：content 直接存完整结果
+   * - 上下文构建时使用摘要，减少 token 消耗
+   * - 通过 message-reader 技能可召回完整结果
    *
    * @param {string} topic_id - 话题ID（用于关联，但消息 topic_id 为 NULL）
    * @param {string} user_id - 用户ID
@@ -749,27 +751,47 @@ class ChatService {
   async saveToolMessage(topic_id, user_id, toolResult, expert_id = null) {
     const message_id = Utils.newID(20);
 
-    // 构建 tool_calls 字段内容（完整存储）
-    // 格式: { tool_call_id, name, arguments, success, duration, timestamp, context }
-    const toolCallsData = {
-      tool_call_id: toolResult.toolCallId,
-      name: toolResult.toolName,
-      arguments: toolResult.arguments || null,  // 工具调用参数（完整）
-      success: toolResult.success,
-      duration: toolResult.duration || 0,
-      timestamp: new Date().toISOString(),
-      context: toolResult.context || null,  // 工具调用前的状态文本上下文
-    };
+    // 工具结果摘要阈值（字符数）
+    // 超过此阈值时，content 存摘要，完整结果存 tool_calls.result
+    const SUMMARY_THRESHOLD = 500;
 
-    // 完整存储工具返回结果（不再截断）
-    // 上下文构建时由 ContextOrganizer 决定使用多少内容
-    let content = '';
+    // 获取完整结果
+    let fullResult = '';
     if (toolResult.data !== undefined) {
-      content = typeof toolResult.data === 'string'
+      fullResult = typeof toolResult.data === 'string'
         ? toolResult.data
         : JSON.stringify(toolResult.data);
     } else if (toolResult.error) {
-      content = toolResult.error;
+      fullResult = toolResult.error;
+    }
+
+    const resultLength = fullResult.length;
+    const isSuccess = toolResult.success;
+
+    // 构建 tool_calls 字段内容
+    // 格式: { tool_call_id, name, arguments, success, duration, timestamp, context, result_length, result? }
+    const toolCallsData = {
+      tool_call_id: toolResult.toolCallId,
+      name: toolResult.toolName,
+      arguments: toolResult.arguments || null,
+      success: isSuccess,
+      duration: toolResult.duration || 0,
+      timestamp: new Date().toISOString(),
+      context: toolResult.context || null,
+      result_length: resultLength,  // 新增：结果长度
+    };
+
+    // 根据阈值决定存储策略
+    let content;
+    if (resultLength > SUMMARY_THRESHOLD) {
+      // 超过阈值：content 存摘要，完整结果存 tool_calls.result
+      content = this.buildToolResultSummary(message_id, toolResult.toolName, resultLength, isSuccess);
+      toolCallsData.result = fullResult;  // 完整结果存入 tool_calls
+      logger.info(`[ChatService] 工具结果超过阈值(${SUMMARY_THRESHOLD})，使用摘要模式: ${toolResult.toolName}, result_length: ${resultLength}`);
+    } else {
+      // 不超过阈值：content 直接存完整结果
+      content = fullResult;
+      logger.debug(`[ChatService] 工具结果未超过阈值，直接存储: ${toolResult.toolName}, result_length: ${resultLength}`);
     }
 
     await this.Message.create({
@@ -778,12 +800,27 @@ class ChatService {
       user_id,
       expert_id,
       role: 'tool',
-      content,  // 完整的工具返回内容（不再截断）
-      tool_calls: JSON.stringify(toolCallsData),  // 工具元数据（含完整 arguments）
+      content,  // 摘要或完整结果
+      tool_calls: JSON.stringify(toolCallsData),  // 工具元数据（含完整 result）
     });
 
-    logger.debug(`[ChatService] 工具消息已保存: ${toolResult.toolName}, message_id: ${message_id}, content_length: ${content.length}`);
+    logger.debug(`[ChatService] 工具消息已保存: ${toolResult.toolName}, message_id: ${message_id}, content_length: ${content.length}, is_summary: ${resultLength > SUMMARY_THRESHOLD}`);
     return message_id;
+  }
+
+  /**
+   * 构建工具结果摘要
+   * @param {string} messageId - 消息ID（用于召回）
+   * @param {string} toolName - 工具名称
+   * @param {number} resultLength - 结果长度
+   * @param {boolean} isSuccess - 是否成功
+   * @returns {string} 摘要文本
+   */
+  buildToolResultSummary(messageId, toolName, resultLength, isSuccess) {
+    const status = isSuccess ? '成功' : '失败';
+    return `工具: ${toolName}
+结果: ${resultLength} 字符 | ${status}
+→ 调用 get_message_content("${messageId}") 获取完整结果`;
   }
 
   /**


### PR DESCRIPTION
## 背景

Issue #325 提出工具调用结果存储优化方案，参考业界最佳实践（Anthropic、LangChain、OpenAI），实现 **Content 摘要 + Tool_calls 完整存储** 的策略。

## 实现方案

### 阈值策略

```javascript
const SUMMARY_THRESHOLD = 500; // 字符数

if (toolResult.length > SUMMARY_THRESHOLD) {
  // 生成摘要，完整结果存 tool_calls.result
  message.content = buildToolSummary(toolName, toolResult, messageId);
  message.tool_calls.result = toolResult;
} else {
  // 短结果直接存 content
  message.content = toolResult;
}
```

### 数据结构调整

```json
// tool_calls JSON 结构
{
  "tool_call_id": "call_xxx",
  "name": "file-operations/fs_info",
  "arguments": {"path": "skills/docx/SKILL.md"},
  "success": true,
  "duration": 247,
  "timestamp": "2026-03-22T17:34:09.047Z",
  "result_length": 1234,  // 新增：结果长度
  "result": "..."         // 新增：完整结果（超过阈值时）
}
```

## 修改文件

| 文件 | 修改内容 |
|------|----------|
| `lib/chat-service.js` | `saveToolMessage()` 添加阈值判断，content 存摘要，tool_calls.result 存完整结果 |
| `data/skills/message-reader/index.js` | `get_message_content()` 优先从 tool_calls.result 获取完整结果 |
| `data/skills/message-reader/SKILL.md` | 更新文档说明新的存储方式 |

## 优点

1. **大幅减少上下文 token 消耗**：长工具结果不再占用上下文
2. **保留完整数据供后续检索**：通过 message-reader 技能可召回完整结果
3. **LLM 仍能理解"做了什么"**：摘要包含工具名、结果长度、召回方式
4. **向后兼容**：短结果仍直接存储，不影响现有逻辑

## 测试

- [x] 语法检查通过
- [x] 代码提交成功

Closes #325