### PR TITLE
feat: recall 工具增加关键词搜索话题功能

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -675,6 +675,34 @@ class Database {
     );
   }
 
+  /**
+   * 根据关键词搜索话题
+   * 在话题标题、描述、关键词中搜索匹配的内容
+   * @param {string} expertId - 专家ID
+   * @param {string} userId - 用户ID
+   * @param {string} keyword - 搜索关键词
+   * @param {number} limit - 数量限制
+   * @returns {Promise<Array>} 匹配的话题列表
+   */
+  async searchTopicsByKeyword(expertId, userId, keyword, limit = 10) {
+    const searchPattern = `%${keyword.trim()}%`;
+    return await this.models.topic.findAll({
+      where: {
+        expert_id: expertId,
+        user_id: userId,
+        [Op.or]: [
+          { title: { [Op.like]: searchPattern } },
+          { description: { [Op.like]: searchPattern } },
+          { keywords: { [Op.like]: searchPattern } },
+        ],
+      },
+      attributes: ['id', 'expert_id', 'user_id', 'title', 'description', 'keywords', 'category', 'status', 'message_count', 'created_at', 'updated_at'],
+      order: [['updated_at', 'DESC']],
+      limit,
+      raw: true,
+    });
+  }
+
   // ============================================
   // 技能相关操作（使用 Sequelize 模型）
   // ============================================

--- a/lib/memory-system.js
+++ b/lib/memory-system.js
@@ -211,6 +211,17 @@ class MemorySystem {
   }
 
   /**
+   * 根据关键词搜索话题
+   * @param {string} userId - 用户ID
+   * @param {string} keyword - 搜索关键词
+   * @param {number} limit - 数量限制
+   * @returns {Promise<Array>} 匹配的话题列表
+   */
+  async searchTopics(userId, keyword, limit = 10) {
+    return await this.db.searchTopicsByKeyword(this.expertId, userId, keyword, limit);
+  }
+
+  /**
    * 创建 Topic
    * @param {string} userId - 用户ID
    * @param {object} topicData - Topic 数据

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -55,7 +55,7 @@ const BUILTIN_TOOLS = [
     type: 'function',
     function: {
       name: 'recall',
-      description: '回忆话题或消息内容。可以：1) 列出最近话题；2) 获取指定话题的详细消息；3) 获取单条消息的完整内容（当上下文中显示摘要时）。当用户提到之前讨论过的话题或需要查看完整工具结果时，使用此工具。',
+      description: '回忆话题或消息内容。可以：1) 列出最近话题；2) 根据关键词搜索话题；3) 获取指定话题的详细消息；4) 获取单条消息的完整内容（当上下文中显示摘要时）。当用户提到之前讨论过的话题或需要查看完整工具结果时，使用此工具。',
       parameters: {
         type: 'object',
         properties: {
@@ -66,6 +66,10 @@ const BUILTIN_TOOLS = [
           message_id: {
             type: 'string',
             description: '消息ID。如果提供，返回该消息的完整内容（用于获取工具结果的完整内容）。',
+          },
+          keyword: {
+            type: 'string',
+            description: '搜索关键词。在话题标题、描述、关键词中搜索匹配的话题。如果提供，返回匹配的话题列表。',
           },
           start: {
             type: 'integer',
@@ -562,11 +566,12 @@ class ToolManager {
 
   /**
    * 执行 recall 工具
-   * 统一的回忆功能：列出话题、获取话题消息、获取单条消息完整内容
+   * 统一的回忆功能：列出话题、搜索话题、获取话题消息、获取单条消息完整内容
    *
    * @param {object} params - 工具参数
    * @param {string} params.topic_id - 话题ID（可选）
    * @param {string} params.message_id - 消息ID（可选，用于获取完整内容）
+   * @param {string} params.keyword - 搜索关键词（可选）
    * @param {number} params.start - 起始位置（可选，默认 0）
    * @param {number} params.count - 数量（可选，默认 5）
    * @param {object} context - 执行上下文
@@ -575,10 +580,10 @@ class ToolManager {
    */
   async executeRecall(params, context, display) {
     const startTime = Date.now();
-    const { topic_id, message_id, start = 0, count = 5 } = params;
+    const { topic_id, message_id, keyword, start = 0, count = 5 } = params;
     const userId = context.userId || context.user_id;
 
-    logger.info(`[ToolManager] recall: topic_id=${topic_id}, message_id=${message_id}, start=${start}, count=${count}, user=${userId}`);
+    logger.info(`[ToolManager] recall: topic_id=${topic_id}, message_id=${message_id}, keyword=${keyword}, start=${start}, count=${count}, user=${userId}`);
 
     try {
       // 情况 1：提供了 message_id，返回该消息的完整内容
@@ -591,7 +596,12 @@ class ToolManager {
         return await this.getTopicMessagesResult(topic_id, userId, start, count, display, startTime);
       }
 
-      // 情况 3：未提供 topic_id 和 message_id，列出最近话题
+      // 情况 3：提供了 keyword，搜索话题
+      if (keyword && keyword.trim() !== '') {
+        return await this.searchTopics(context, userId, keyword, start, count, display, startTime);
+      }
+
+      // 情况 4：未提供 topic_id、message_id 和 keyword，列出最近话题
       return await this.listTopics(context, userId, start, count, display, startTime);
 
     } catch (error) {
@@ -800,6 +810,75 @@ class ToolManager {
     return {
       success: true,
       data: {
+        total_count: topics.length,
+        start,
+        count: paginatedTopics.length,
+        topics: formattedTopics,
+      },
+      toolId: 'recall',
+      toolName: display,
+      duration: Date.now() - startTime,
+    };
+  }
+
+  /**
+   * 搜索话题
+   *
+   * @param {object} context - 执行上下文
+   * @param {string} userId - 用户ID
+   * @param {string} keyword - 搜索关键词
+   * @param {number} start - 起始位置
+   * @param {number} count - 数量
+   * @param {string} display - 工具显示名称
+   * @param {number} startTime - 开始时间
+   * @returns {Promise<object>} 执行结果
+   */
+  async searchTopics(context, userId, keyword, start, count, display, startTime) {
+    const memorySystem = context.memorySystem;
+    if (!memorySystem) {
+      return {
+        success: false,
+        error: 'MemorySystem not available in context',
+        toolId: 'recall',
+        toolName: display,
+      };
+    }
+
+    // 搜索话题
+    const topics = await memorySystem.searchTopics(userId, keyword, start + count);
+    logger.info(`[ToolManager] recall: 搜索关键词 "${keyword}" 找到 ${topics?.length || 0} 个话题`);
+
+    if (!topics || topics.length === 0) {
+      return {
+        success: true,
+        data: {
+          keyword,
+          message: `未找到包含 "${keyword}" 的话题`,
+          topics: [],
+        },
+        toolId: 'recall',
+        toolName: display,
+        duration: Date.now() - startTime,
+      };
+    }
+
+    // 应用分页
+    const paginatedTopics = topics.slice(start, start + count);
+
+    // 格式化话题列表
+    const formattedTopics = paginatedTopics.map(t => ({
+      id: t.id,
+      title: t.title,
+      description: t.description,
+      message_count: t.message_count || 0,
+      keywords: t.keywords,
+      updated_at: t.updated_at,
+    }));
+
+    return {
+      success: true,
+      data: {
+        keyword,
         total_count: topics.length,
         start,
         count: paginatedTopics.length,


### PR DESCRIPTION
## 变更说明

为 `recall` 内置工具增加关键词搜索话题功能。

### 新增功能

1. **关键词搜索话题**
   - 新增 `keyword` 参数，支持在话题标题、描述、关键词字段中搜索匹配的话题
   - 使用 SQL `LIKE` 实现模糊匹配

2. **代码变更**
   - `lib/db.js`: 新增 `searchTopicsByKeyword()` 方法
   - `lib/memory-system.js`: 新增 `searchTopics()` 方法
   - `lib/tool-manager.js`: 
     - 更新 `recall` 工具定义，添加 `keyword` 参数
     - 更新 `executeRecall()` 方法，支持关键词搜索
     - 新增 `searchTopics()` 方法

### 使用示例

```json
// 搜索包含"React"的话题
{
  "keyword": "React",
  "count": 5
}

// 搜索包含"性能优化"的话题
{
  "keyword": "性能优化"
}
```

### 返回格式

```json
{
  "success": true,
  "data": {
    "keyword": "React",
    "total_count": 3,
    "start": 0,
    "count": 3,
    "topics": [
      {
        "id": "xxx",
        "title": "React性能优化",
        "description": "讨论了useMemo和useCallback的使用场景",
        "message_count": 15,
        "keywords": ["React", "性能", "useMemo"],
        "updated_at": "2026-03-22T10:00:00Z"
      }
    ]
  }
}
```

Closes #330