### PR TITLE
chore: switch to bullseye base image, no system packages needed

### DIFF
--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -15,7 +15,7 @@
 
 services:
   app:
-    image: nikolaik/python-nodejs:python3.12-nodejs20-slim
+    image: nikolaik/python-nodejs:python3.12-nodejs20-bullseye
     container_name: touwaka-mate
     restart: unless-stopped
     ports:
@@ -42,16 +42,6 @@ services:
       - bash
       - -c
       - |
-        if [ ! -f /root/.cache/.system-installed ]; then
-          echo 'Installing system packages...'
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            libvips-dev wget
-          apt-get clean
-          rm -rf /var/lib/apt/lists/*
-          touch /root/.cache/.system-installed
-        fi
-
         if [ ! -f /root/.cache/pip/.installed ]; then
           echo 'Installing Python packages...'
           pip install --no-cache-dir -r /app/requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: nikolaik/python-nodejs:python3.12-nodejs20-slim
+    image: nikolaik/python-nodejs:python3.12-nodejs20-bullseye
     container_name: touwaka-mate
     restart: unless-stopped
     ports:
@@ -27,16 +27,6 @@ services:
       - bash
       - -c
       - |
-        if [ ! -f /root/.cache/.system-installed ]; then
-          echo 'Installing system packages...'
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            libvips-dev wget
-          apt-get clean
-          rm -rf /var/lib/apt/lists/*
-          touch /root/.cache/.system-installed
-        fi
-
         if [ ! -f /root/.cache/pip/.installed ]; then
           echo 'Installing Python packages...'
           pip install --no-cache-dir -r /app/requirements.txt


### PR DESCRIPTION
## 变更内容

- 切换基础镜像从 `slim` 到 `bullseye`（包含 wget）
- 移除所有 apt-get 安装命令

## 优势

- bullseye 镜像自带 wget，无需额外安装
- 启动时无需安装任何系统包
- 容器启动更快