### PR TITLE
fix: remove better-sqlite3 dependency for Docker deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "touwaka-mate",
       "version": "2.0.0",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@koa/cors": "^5.0.0",
         "@koa/multer": "^4.0.0",
@@ -16,7 +16,6 @@
         "@xenova/transformers": "^2.17.2",
         "adm-zip": "^0.5.16",
         "bcryptjs": "^2.4.3",
-        "better-sqlite3": "^12.8.0",
         "docx": "^8.5.0",
         "dotenv": "^16.6.1",
         "echarts": "^5.5.0",
@@ -1135,20 +1134,6 @@
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
-    "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -1169,15 +1154,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -2015,12 +1991,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT"
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
     "node_modules/flatbuffers": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@xenova/transformers": "^2.17.2",
     "adm-zip": "^0.5.16",
     "bcryptjs": "^2.4.3",
-    "better-sqlite3": "^12.8.0",
     "docx": "^8.5.0",
     "dotenv": "^16.6.1",
     "echarts": "^5.5.0",


### PR DESCRIPTION
## 变更说明

移除 `better-sqlite3` 依赖，解决 Docker 镜像部署失败问题。

## 问题背景

Docker 部署时报错：
```
npm error gyp ERR! stack Error: not found: make
npm error gyp ERR! stack at getNotFoundError
```

`better-sqlite3` 是一个需要原生编译的 Node.js 模块，需要 `make` 等构建工具，而基础镜像中缺少这些工具。

## 解决方案

- 从 `package.json` 移除 `better-sqlite3` 依赖
- 更新 `package-lock.json`

## 影响范围

- `erix-ssh` 技能已迁移到 JSON 文件存储（`db-json.js`）
- 不再需要 SQLite 原生模块

## 测试

- [x] `npm install` 成功执行
- [x] `package-lock.json` 已更新