### PR TITLE
refactor: 移除 INTERNAL_API_KEY 和 INTERNAL_API_SECRET，重构 Internal API 认证机制

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,13 +41,6 @@ KB_IMAGES_ROOT=./data/kb-images
 JWT_SECRET=your-secret-key-change-in-production
 JWT_REFRESH_SECRET=your-refresh-secret-key
 
-# ====================
-# 内部 API 配置
-# ====================
-# 内部 API 密钥（用于服务间通信验证）
-INTERNAL_API_KEY=
-# 内部服务调用密钥（用于技能执行等内部调用认证）
-INTERNAL_API_SECRET=internal-api-secret
 
 # ====================
 # LLM Provider 配置

--- a/data/skills/erix-ssh/scripts/ssh_client.js
+++ b/data/skills/erix-ssh/scripts/ssh_client.js
@@ -16,8 +16,8 @@ const { URL } = require('url');
 
 // Configuration
 const CONFIG = {
-  internalApiBase: process.env.API_BASE || 'http://localhost:3000',
-  internalApiKey: process.env.INTERNAL_KEY || '',
+  apiBase: process.env.API_BASE || 'http://localhost:3000',
+  userAccessToken: process.env.USER_ACCESS_TOKEN || '',
   defaultTimeout: 30000,
 };
 
@@ -77,14 +77,18 @@ async function httpRequest(url, options, body) {
 
 /**
  * Invoke SSH resident tool via internal API
+ * Uses user's access token for authentication
  */
 async function invokeSSHTOol(action, params, timeout) {
-  const url = `${CONFIG.internalApiBase}/internal/resident/invoke`;
-
-  const headers = {};
-  if (CONFIG.internalApiKey) {
-    headers['X-Internal-Key'] = CONFIG.internalApiKey;
+  if (!CONFIG.userAccessToken) {
+    throw new Error('用户未登录，无法调用 SSH 工具（缺少 USER_ACCESS_TOKEN）');
   }
+
+  const url = `${CONFIG.apiBase}/internal/resident/invoke`;
+
+  const headers = {
+    'Authorization': `Bearer ${CONFIG.userAccessToken}`,
+  };
 
   const response = await httpRequest(url, {
     method: 'POST',

--- a/data/skills/remote-llm/index.js
+++ b/data/skills/remote-llm/index.js
@@ -19,14 +19,16 @@ const { URL } = require('url');
 
 // 配置（超时从环境变量读取，由 skill-loader 通过数据库设置）
 const CONFIG = {
-  // 内部 API 配置
-  internalApiBase: process.env.INTERNAL_API_BASE || 'http://localhost:3000',
-  internalApiKey: process.env.INTERNAL_KEY || '',
+  // API 基础地址
+  apiBase: process.env.API_BASE || 'http://localhost:3000',
   
   // 超时配置（毫秒）- 支持环境变量覆盖
   // TIMEOUT_RESIDENT_SKILL 来自 system_settings.timeout.resident_skill（秒）-> 转换为毫秒
   defaultTimeout: parseInt(process.env.TIMEOUT_RESIDENT_SKILL || '300000', 10),
 };
+
+// 当前用户上下文（每次 invoke 时更新）
+let currentUser = null;
 
 // 任务队列
 const taskQueue = [];
@@ -109,15 +111,19 @@ async function httpRequest(url, options, body) {
 }
 
 /**
- * 通过内部 API 获取模型配置
+ * 通过 API 获取模型配置
+ * 使用用户的 accessToken 认证
  */
 async function getModelConfig(modelId) {
-  const url = `${CONFIG.internalApiBase}/internal/models/${modelId}`;
-  
-  const headers = {};
-  if (CONFIG.internalApiKey) {
-    headers['X-Internal-Key'] = CONFIG.internalApiKey;
+  if (!currentUser?.accessToken) {
+    throw new Error('用户未登录，无法获取模型配置');
   }
+  
+  const url = `${CONFIG.apiBase}/internal/models/${modelId}`;
+  
+  const headers = {
+    'Authorization': `Bearer ${currentUser.accessToken}`,
+  };
 
   const response = await httpRequest(url, {
     method: 'GET',
@@ -211,7 +217,8 @@ async function callRemoteLLM(modelConfig, params) {
 }
 
 /**
- * 通过内部 API 将结果推送给专家
+ * 通过 API 将结果推送给专家
+ * 使用用户的 accessToken 认证
  * @param {Object} params - 参数对象
  * @param {string} params.user_id - 用户ID
  * @param {string} params.expert_id - 专家ID
@@ -223,12 +230,15 @@ async function callRemoteLLM(modelConfig, params) {
 async function notifyExpert(params) {
   const { user_id, expert_id, content, task_id, trigger_expert = true, error } = params;
 
-  const url = `${CONFIG.internalApiBase}/internal/messages/insert`;
-  
-  const headers = {};
-  if (CONFIG.internalApiKey) {
-    headers['X-Internal-Key'] = CONFIG.internalApiKey;
+  if (!currentUser?.accessToken) {
+    throw new Error('用户未登录，无法推送消息');
   }
+
+  const url = `${CONFIG.apiBase}/internal/messages/insert`;
+  
+  const headers = {
+    'Authorization': `Bearer ${currentUser.accessToken}`,
+  };
 
   const body = {
     user_id,
@@ -321,8 +331,14 @@ async function processQueue() {
 
 /**
  * 处理任务调用
+ * @param {string} taskId - 任务ID
+ * @param {Object} params - 任务参数
+ * @param {Object} user - 用户上下文 { userId, accessToken, expertId, isAdmin }
  */
-async function handleInvoke(taskId, params) {
+async function handleInvoke(taskId, params, user) {
+  // 更新当前用户上下文
+  currentUser = user;
+  
   // 立即返回确认
   sendResponse({
     task_id: taskId,
@@ -349,7 +365,7 @@ async function handleInvoke(taskId, params) {
  */
 async function main() {
   log('Remote LLM Executor started (resident mode)');
-  log(`Internal API: ${CONFIG.internalApiBase}`);
+  log(`API Base: ${CONFIG.apiBase}`);
 
   // 使用 stdin 事件替代 readline（沙箱不允许 readline 模块）
   let buffer = '';
@@ -366,7 +382,7 @@ async function main() {
         
         switch (command.command) {
           case 'invoke':
-            handleInvoke(command.task_id, command.params);
+            handleInvoke(command.task_id, command.params, command.user);
             break;
             
           case 'exit':

--- a/data/skills/remote-llm/submit.js
+++ b/data/skills/remote-llm/submit.js
@@ -24,8 +24,8 @@ const { URL } = require('url');
 
 // 配置
 const CONFIG = {
-  internalApiBase: process.env.API_BASE || 'http://localhost:3000',
-  internalApiKey: process.env.INTERNAL_KEY || '',
+  apiBase: process.env.API_BASE || 'http://localhost:3000',
+  userAccessToken: process.env.USER_ACCESS_TOKEN || '',
   defaultTimeout: 10000,
   dataBasePath: process.env.DATA_BASE_PATH || process.cwd(),
 };
@@ -110,14 +110,18 @@ async function resolveModelId(modelIdOrName) {
 
 /**
  * 通过内部 API 调用驻留进程
+ * 使用用户的 accessToken 认证
  */
 async function invokeResidentTool(params) {
-  const url = `${CONFIG.internalApiBase}/internal/resident/invoke`;
-  
-  const headers = {};
-  if (CONFIG.internalApiKey) {
-    headers['X-Internal-Key'] = CONFIG.internalApiKey;
+  if (!CONFIG.userAccessToken) {
+    throw new Error('用户未登录，无法调用驻留进程（缺少 USER_ACCESS_TOKEN）');
   }
+
+  const url = `${CONFIG.apiBase}/internal/resident/invoke`;
+  
+  const headers = {
+    'Authorization': `Bearer ${CONFIG.userAccessToken}`,
+  };
 
   const response = await httpRequest(url, {
     method: 'POST',

--- a/server/controllers/internal.controller.js
+++ b/server/controllers/internal.controller.js
@@ -4,8 +4,8 @@
  * 用于驻留进程调用，插入消息并触发专家响应
  *
  * 认证方式：
- * - IP 白名单（仅允许本地调用）
- * - 或内部服务密钥（X-Internal-Key header）
+ * - 用户 JWT Token（通过 Authorization header）
+ * - 仅允许本地 IP 调用（作为安全后备）
  */
 
 import logger from '../../lib/logger.js';
@@ -26,7 +26,6 @@ class InternalController {
     this.Provider = db.getModel('provider');
     this.expertConnections = options.expertConnections || new Map();
     this.chatService = options.chatService || null;
-    this.internalKey = process.env.INTERNAL_API_KEY || null;
   }
 
   /**
@@ -328,38 +327,33 @@ class InternalController {
 
   /**
    * 验证内部调用权限
+   * 安全策略：
+   * 1. 必须有已认证的用户 session（通过 JWT Token）
+   * 2. 只允许本地 IP 访问（作为额外安全层）
    */
   validateInternalAccess(ctx) {
-    // 方式一：检查内部密钥
-    if (this.internalKey) {
-      const requestKey = ctx.get('X-Internal-Key');
-      if (requestKey === this.internalKey) {
-        return true;
-      }
-      // 如果有 internalKey 但密钥不匹配，也允许通过 IP 检查
+    // 1. 检查用户是否已认证（通过 JWT Token）
+    const session = ctx.state.session;
+    if (!session?.id) {
+      logger.warn(`Internal API access denied: no authenticated user`);
+      return false;
     }
 
-    // 方式二：检查 IP（仅允许本地或相同主机）
+    // 2. 检查 IP（只允许本地访问）
     const clientIp = ctx.ip || ctx.request.ip;
     const localIps = ['::1', '::ffff:127.0.0.1', '127.0.0.1', 'localhost', '0.0.0.0'];
-    if (localIps.includes(clientIp)) {
-      return true;
-    }
+    const isLocalIp = localIps.includes(clientIp);
 
-    // 允许来自同一台机器的其他 IP（如 Docker 桥接 IP）
+    // 检查 X-Forwarded-For（Docker 桥接等场景）
     const remoteAddress = ctx.request?.headers?.['x-forwarded-for'] || '';
-    if (remoteAddress.includes('127.0.0.1') || remoteAddress.includes('localhost')) {
-      return true;
+    const isForwardedLocal = remoteAddress.includes('127.0.0.1') || remoteAddress.includes('localhost');
+
+    if (!isLocalIp && !isForwardedLocal) {
+      logger.warn(`Internal API access denied from IP: ${clientIp} (localhost only)`);
+      return false;
     }
 
-    // 如果配置了 internalKey 且没有 IP 匹配，记录警告但也允许通过（兼容本地服务调用）
-    if (this.internalKey) {
-      logger.warn(`Internal API: 允许无密钥访问 from IP: ${clientIp} (internalKey 已配置)`);
-      return true;
-    }
-
-    logger.warn(`Internal API access denied from IP: ${clientIp}, internalKey: ${!!this.internalKey}`);
-    return false;
+    return true;
   }
 
   /**

--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,7 @@ import logger from '../lib/logger.js';
 
 // 中间件
 import { responseMiddleware } from './middlewares/index.js';
+import * as authMiddleware from './middlewares/auth.js';
 
 // 控制器
 import AuthController from './controllers/auth.controller.js';
@@ -388,8 +389,8 @@ class ApiServer {
     this.controllers.debug.setResidentSkillManager(this.residentSkillManager);
     // 将 Scheduler 共享给 DebugController
     this.controllers.debug.setScheduler(this.scheduler);
-    this.app.use(internalRoutes(this.controllers.internal).routes());
-    this.app.use(internalRoutes(this.controllers.internal).allowedMethods());
+    this.app.use(internalRoutes(this.controllers.internal, authMiddleware).routes());
+    this.app.use(internalRoutes(this.controllers.internal, authMiddleware).allowedMethods());
     logger.info('Internal routes registered (POST /internal/messages/insert, GET /internal/models/:model_id, POST /internal/resident/invoke)');
 
     // Task Static 静态文件服务路由（Issue #140）

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -27,28 +27,6 @@ const authenticate = () => {
       token = ctx.query.token;
     }
 
-    // 内部服务调用：支持 X-User-Id header（来自技能执行等内部调用）
-    const internalUserId = ctx.headers['x-user-id'];
-    const internalSecret = ctx.headers['x-internal-secret'];
-    const INTERNAL_SECRET = process.env.INTERNAL_API_SECRET || 'internal-api-secret';
-
-    if (!token && internalUserId && internalSecret === INTERNAL_SECRET) {
-      // 内部服务调用认证成功
-      // 支持数字和字符串（UUID）类型的 userId
-      const parsedUserId = parseInt(internalUserId, 10);
-      const userId = isNaN(parsedUserId) ? internalUserId : parsedUserId;
-      ctx.state.session = {
-        id: userId,
-        roles: ['user'],
-        isAdmin: false,
-        accessToken: null,
-      };
-      ctx.state.authType = 'internal';
-      console.log('[Auth] Internal auth:', { userId });
-      await next();
-      return;
-    }
-
     if (!token) {
       ctx.error('未提供访问令牌', 401);
       return;

--- a/server/routes/internal.routes.js
+++ b/server/routes/internal.routes.js
@@ -1,13 +1,17 @@
 /**
  * Internal Routes - 内部 API 路由
- * 
- * 用于服务间通信，不走用户认证
- * 
+ *
+ * 用于驻留式技能调用，需要用户 JWT 认证
+ *
  * API 设计：
  * - POST /internal/messages/insert - 插入消息并触发专家响应
  * - GET /internal/models/:model_id - 获取模型配置（含 Provider 信息）
  * - GET /internal/models/resolve?name=xxx - 通过名称解析模型 ID
  * - POST /internal/resident/invoke - 调用驻留式技能工具
+ *
+ * 安全策略：
+ * - 必须提供有效的用户 JWT Token
+ * - 只允许本地 IP 访问
  */
 
 import Router from '@koa/router';
@@ -15,24 +19,28 @@ import Router from '@koa/router';
 /**
  * 创建内部路由
  * @param {Object} controller - InternalController 实例
+ * @param {Object} authMiddleware - 认证中间件
  * @returns {Router}
  */
-export default function createInternalRoutes(controller) {
+export default function createInternalRoutes(controller, authMiddleware) {
   const router = new Router({
     prefix: '/internal'
   });
 
+  // 所有 internal API 都需要用户认证
+  const requireAuth = authMiddleware.authenticate();
+
   // 消息插入 API
-  router.post('/messages/insert', controller.insertMessage.bind(controller));
+  router.post('/messages/insert', requireAuth, controller.insertMessage.bind(controller));
 
   // 通过名称解析模型 ID（必须在 /:model_id 之前注册）
-  router.get('/models/resolve', controller.resolveModelName.bind(controller));
+  router.get('/models/resolve', requireAuth, controller.resolveModelName.bind(controller));
 
   // 获取模型配置 API
-  router.get('/models/:model_id', controller.getModelConfig.bind(controller));
+  router.get('/models/:model_id', requireAuth, controller.getModelConfig.bind(controller));
 
   // 调用驻留式技能工具 API
-  router.post('/resident/invoke', controller.invokeResidentTool.bind(controller));
+  router.post('/resident/invoke', requireAuth, controller.invokeResidentTool.bind(controller));
 
   return router;
 }

--- a/server/services/assistant-manager.js
+++ b/server/services/assistant-manager.js
@@ -16,6 +16,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { Sequelize } from 'sequelize';
 import fs from 'fs/promises';
 import path from 'path';
+import http from 'http';
+import https from 'https';
 import logger from '../../lib/logger.js';
 import Utils from '../../lib/utils.js';
 import AssistantMessageService from './assistant-message-service.js';


### PR DESCRIPTION
## 变更概述

移除 `INTERNAL_API_KEY` 和 `INTERNAL_API_SECRET`，重构 Internal API 认证机制。

## 问题背景

1. **`INTERNAL_API_SECRET` - 死代码**
   - `server/middlewares/auth.js` 中有检查 `X-Internal-Secret` header 的代码
   - 但没有任何代码发送这个 header，完全是死代码

2. **`INTERNAL_API_KEY` - 设计缺陷**
   - 环境变量名不匹配：代码使用 `INTERNAL_KEY`，但 `.env.example` 定义的是 `INTERNAL_API_KEY`
   - 驻留式技能（remote-llm, erix-ssh）使用这个 key 调用 Internal API
   - 但技能执行时已经有 `USER_ACCESS_TOKEN`（用户的 JWT Token）

3. **安全漏洞**
   - `InternalController.validateInternalAccess()` 的逻辑存在绕过风险

## 解决方案

1. 移除 `INTERNAL_API_SECRET` 相关死代码
2. 移除 `INTERNAL_API_KEY`，改用用户的 JWT Token 认证
3. 重构 `validateInternalAccess()` 要求：
   - 必须有已认证的用户 session（通过 JWT Token）
   - IP 必须是本地地址

## 修改文件

- `server/middlewares/auth.js` - 移除死代码
- `server/controllers/internal.controller.js` - 重构认证逻辑
- `server/routes/internal.routes.js` - 添加 JWT 认证中间件
- `server/index.js` - 传递 authMiddleware
- `data/skills/remote-llm/index.js` - 使用 `user.accessToken`
- `data/skills/remote-llm/submit.js` - 使用 `USER_ACCESS_TOKEN`
- `data/skills/erix-ssh/scripts/ssh_client.js` - 使用 `USER_ACCESS_TOKEN`
- `.env.example` - 移除相关配置项

## 新的认证架构

```
用户发起请求 → JWT Token
      ↓
技能执行环境 (USER_ACCESS_TOKEN 环境变量)
      ↓
驻留式技能调用 Internal API
      ↓
Authorization: Bearer <token>
      ↓
InternalController 验证：
  1. JWT Token 有效
  2. IP 是本地地址
```

Closes #342