### PR TITLE
fix: 邀请链接复制失败时提供手动复制方式

### DIFF
--- a/frontend/src/components/settings/InvitationTab.vue
+++ b/frontend/src/components/settings/InvitationTab.vue
@@ -87,6 +87,29 @@
       </div>
     </div>
 
+    <!-- 链接显示弹窗 -->
+    <div v-if="showLinkModal" class="modal-overlay" @click.self="closeLinkModal">
+      <div class="modal-content link-modal">
+        <div class="modal-header">
+          <h3>{{ $t('invitation.inviteLink') }}</h3>
+          <button class="btn-close" @click="closeLinkModal">×</button>
+        </div>
+        <div class="modal-body">
+          <p class="link-hint">{{ $t('invitation.linkHint') }}</p>
+          <div class="link-display">
+            <input
+              ref="linkInputRef"
+              type="text"
+              :value="currentLink"
+              readonly
+              class="link-input"
+              @click="selectLink"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- 使用记录弹窗 -->
     <div v-if="showUsageModal" class="modal-overlay" @click.self="closeUsageModal">
       <div class="modal-content">
@@ -123,7 +146,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   getInvitationQuota,
@@ -147,6 +170,11 @@ const showUsageModal = ref(false)
 const usageLoading = ref(false)
 const usageList = ref<InvitationUsage[]>([])
 const currentInvitation = ref<Invitation | null>(null)
+
+// 链接显示弹窗
+const showLinkModal = ref(false)
+const currentLink = ref('')
+const linkInputRef = ref<HTMLInputElement | null>(null)
 
 // 加载数据
 onMounted(async () => {
@@ -195,8 +223,29 @@ const copyInviteLink = async (code: string) => {
     await navigator.clipboard.writeText(link)
     alert(t('invitation.copySuccess'))
   } catch (err) {
-    alert(t('invitation.copyError'))
+    // 剪贴板被禁用时，显示链接弹窗让用户手动复制
+    currentLink.value = link
+    showLinkModal.value = true
+    nextTick(() => {
+      // 自动选中链接文本
+      if (linkInputRef.value) {
+        linkInputRef.value.select()
+      }
+    })
   }
+}
+
+// 选中链接文本
+const selectLink = () => {
+  if (linkInputRef.value) {
+    linkInputRef.value.select()
+  }
+}
+
+// 关闭链接弹窗
+const closeLinkModal = () => {
+  showLinkModal.value = false
+  currentLink.value = ''
 }
 
 // 撤销邀请码
@@ -502,5 +551,43 @@ const formatDate = (dateStr: string) => {
 .usage-time {
   font-size: 13px;
   color: #666;
+}
+
+/* Link Modal */
+.link-modal {
+  max-width: 550px;
+}
+
+.link-hint {
+  margin: 0 0 16px 0;
+  color: #666;
+  font-size: 14px;
+}
+
+.link-display {
+  display: flex;
+  gap: 8px;
+}
+
+.link-input {
+  flex: 1;
+  padding: 12px 16px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-family: monospace;
+  font-size: 14px;
+  background: #f8f9fa;
+  color: #333;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.link-input:hover {
+  border-color: #667eea;
+}
+
+.link-input:focus {
+  outline: none;
+  border-color: #667eea;
 }
 </style>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1350,6 +1350,8 @@ thinkingFormatDeepseek: 'DeepSeek/GLM Format',
     // Code info
     code: 'Invitation Code',
     invitationLink: 'Invitation Link',
+    inviteLink: 'Invitation Link',
+    linkHint: 'Clipboard access is blocked by browser. Please select and copy the link below:',
     copyLink: 'Copy Link',
     copySuccess: 'Invitation link copied to clipboard',
     maxUses: 'Max Uses',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1343,6 +1343,8 @@ thinkingFormatDeepseek: 'DeepSeek/GLM 格式',
     // 邀请码信息
     code: '邀请码',
     invitationLink: '邀请链接',
+    inviteLink: '邀请链接',
+    linkHint: '浏览器禁用了剪贴板访问，请手动选择并复制以下链接：',
     copyLink: '复制链接',
     copySuccess: '邀请链接已复制到剪贴板',
     maxUses: '最大使用次数',


### PR DESCRIPTION
## 问题描述

在邀请管理页面，当用户点击复制邀请链接按钮时，如果浏览器禁用了剪贴板访问权限（如非 HTTPS 环境、用户拒绝授权等），只会显示"复制失败"的错误提示，用户无法获取邀请链接。

## 解决方案

当剪贴板 API 失败时，弹出一个对话框显示完整的邀请链接 URL，用户可以手动选择并复制。

## 修改内容

1. **InvitationTab.vue** - 添加链接显示弹窗
   - 新增 `showLinkModal`、`currentLink`、`linkInputRef` 状态
   - 修改 `copyInviteLink()` 函数，失败时显示弹窗
   - 新增 `selectLink()`、`closeLinkModal()` 方法
   - 添加弹窗模板和样式

2. **国际化文本** - 添加新的翻译键
   - `invitation.inviteLink` - 弹窗标题
   - `invitation.linkHint` - 提示文本

## 测试要点

- [ ] 正常情况下复制功能仍然可用
- [ ] 剪贴板被禁用时弹出对话框
- [ ] 点击输入框自动全选链接
- [ ] 用户可以手动 Ctrl+C 复制链接

Closes #350