### PR TITLE
feat: 邀请码列表直接显示邀请链接

### DIFF
--- a/frontend/src/components/settings/InvitationTab.vue
+++ b/frontend/src/components/settings/InvitationTab.vue
@@ -44,12 +44,47 @@
           :key="invitation.id"
           class="invitation-item"
         >
-          <div class="invitation-main">
-            <div class="invitation-code">
-              <span class="code-label">{{ invitation.code }}</span>
-              <span :class="['status-badge', invitation.status]">
-                {{ $t(`invitation.status.${invitation.status}`) }}
-              </span>
+          <div class="invitation-content">
+            <div class="invitation-header">
+              <div class="invitation-code">
+                <span class="code-label">{{ invitation.code }}</span>
+                <span :class="['status-badge', invitation.status]">
+                  {{ $t(`invitation.status.${invitation.status}`) }}
+                </span>
+              </div>
+              <div class="invitation-actions">
+                <button
+                  class="btn-action copy"
+                  :title="$t('invitation.copyLink')"
+                  @click="copyInviteLink(invitation.code)"
+                >
+                  📋
+                </button>
+                <button
+                  v-if="invitation.status === 'active'"
+                  class="btn-action revoke"
+                  :title="$t('invitation.revoke')"
+                  @click="handleRevoke(invitation)"
+                >
+                  ❌
+                </button>
+                <button
+                  class="btn-action view"
+                  :title="$t('invitation.viewUsage')"
+                  @click="showUsage(invitation)"
+                >
+                  👥
+                </button>
+              </div>
+            </div>
+            <div class="invitation-link">
+              <input
+                type="text"
+                :value="getInviteLink(invitation.code)"
+                readonly
+                class="link-input-inline"
+                @click="($event.target as HTMLInputElement).select()"
+              />
             </div>
             <div class="invitation-meta">
               <span>{{ $t('invitation.usedCount', { used: invitation.usedCount, max: invitation.maxUses }) }}</span>
@@ -58,30 +93,6 @@
               </span>
               <span v-else>{{ $t('invitation.neverExpires') }}</span>
             </div>
-          </div>
-          <div class="invitation-actions">
-            <button
-              class="btn-action copy"
-              :title="$t('invitation.copyLink')"
-              @click="copyInviteLink(invitation.code)"
-            >
-              📋
-            </button>
-            <button
-              v-if="invitation.status === 'active'"
-              class="btn-action revoke"
-              :title="$t('invitation.revoke')"
-              @click="handleRevoke(invitation)"
-            >
-              ❌
-            </button>
-            <button
-              class="btn-action view"
-              :title="$t('invitation.viewUsage')"
-              @click="showUsage(invitation)"
-            >
-              👥
-            </button>
           </div>
         </div>
       </div>
@@ -214,10 +225,15 @@ const handleCreateInvitation = async () => {
   }
 }
 
+// 获取邀请链接
+const getInviteLink = (code: string) => {
+  const baseUrl = window.location.origin
+  return `${baseUrl}/register?code=${code}`
+}
+
 // 复制邀请链接
 const copyInviteLink = async (code: string) => {
-  const baseUrl = window.location.origin
-  const link = `${baseUrl}/register?code=${code}`
+  const link = getInviteLink(code)
   
   try {
     await navigator.clipboard.writeText(link)
@@ -380,23 +396,27 @@ const formatDate = (dateStr: string) => {
 }
 
 .invitation-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding: 16px;
   background: #f8f9fa;
   border-radius: 8px;
 }
 
-.invitation-main {
-  flex: 1;
+.invitation-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.invitation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
 }
 
 .invitation-code {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 8px;
 }
 
 .code-label {
@@ -431,6 +451,32 @@ const formatDate = (dateStr: string) => {
 .status-badge.revoked {
   background: #f5f5f5;
   color: #757575;
+}
+
+.invitation-link {
+  margin-bottom: 8px;
+}
+
+.link-input-inline {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  font-family: monospace;
+  font-size: 13px;
+  background: #fff;
+  color: #333;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.link-input-inline:hover {
+  border-color: #667eea;
+}
+
+.link-input-inline:focus {
+  outline: none;
+  border-color: #667eea;
 }
 
 .invitation-meta {


### PR DESCRIPTION
## 问题描述

邀请管理页面的邀请链接复制功能依赖剪贴板 API，在某些浏览器环境下可能被禁用。用户希望直接在每个邀请码下方显示完整的邀请链接 URL，方便手动复制。

## 解决方案

在每个邀请码卡片中直接显示邀请链接输入框：
- 用户点击输入框自动全选链接
- 可以手动 Ctrl+C 复制链接
- 保留原有的复制按钮作为快捷方式

## 修改内容

1. **InvitationTab.vue** - 在每个邀请码下方添加链接输入框
   - 新增 `getInviteLink()` 函数生成链接
   - 调整布局，将操作按钮移到顶部右侧
   - 添加内联链接输入框样式

## 界面效果

每个邀请码卡片现在显示：
- 第一行：邀请码 + 状态徽章 + 操作按钮
- 第二行：完整的邀请链接输入框（点击全选）
- 第三行：使用次数 + 过期时间

Closes #352