### PR TITLE
feat: 专家多模态能力支持 - read_file_as_data_url 工具

### DIFF
--- a/data/skills/file-operations/SKILL.md
+++ b/data/skills/file-operations/SKILL.md
@@ -48,15 +48,45 @@ allowed-tools:
 
 ### read_file
 
-读取文件内容。
+读取文件内容，支持多种模式。
 
 **参数：**
 - `path` (string, required): 文件路径
-- `mode` (string, optional): 读取模式 - `"lines"` (默认) 或 `"bytes"`
+- `mode` (string, optional): 读取模式 - `"lines"` (默认), `"bytes"`, 或 `"data_url"`
 - `from` (number, optional): 起始行（lines 模式，默认: 1）
 - `lines` (number, optional): 行数（lines 模式，默认: 100）
 - `offset` (number, optional): 起始字节（bytes 模式，默认: 0）
 - `bytes` (number, optional): 字节数（bytes 模式，默认: 50000）
+
+**读取模式：**
+| 模式 | 说明 | 用途 |
+|------|------|------|
+| `lines` | 按行读取（默认） | 读取文本文件 |
+| `bytes` | 按字节读取 | 读取二进制文件片段 |
+| `data_url` | 转换为 Data URL | **多模态 LLM 调用** |
+
+**data_url 模式（用于多模态）：**
+
+让专家能够"看到"图片文件内容。
+
+**使用方法：**
+1. 调用 `read_file(path="tasks/screenshot.png", mode="data_url")`
+2. 得到 `dataUrl: "data:image/png;base64,xxx"`
+3. 在回复中使用 Markdown 格式：`![图片描述](data:image/png;base64,xxx)`
+4. LLMClient 会自动识别并转换为多模态格式发送给模型
+
+**示例：**
+```
+# 读取图片为 Data URL
+result = read_file(path="tasks/screenshot.png", mode="data_url")
+
+# 在回复中引用
+![截图](data:image/png;base64,iVBORw0KGgo...)
+```
+
+**限制：**
+- 最大文件大小：10MB（data_url 模式）
+- 支持所有 MIME 类型（图片、PDF、音视频等）
 
 ### list_files
 

--- a/data/skills/file-operations/index.js
+++ b/data/skills/file-operations/index.js
@@ -1,4 +1,4 @@
-/**
+ /**
  * File Operations Skill - Node.js Implementation
  * 
  * File system operations including read, write, search, and manage files.
@@ -152,7 +152,7 @@ function resolvePath(relativePath) {
  * 
  * @param {object} params - Parameters
  * @param {string} params.path - File path
- * @param {string} params.mode - Read mode: "lines" (default) or "bytes"
+ * @param {string} params.mode - Read mode: "lines" (default), "bytes", or "data_url"
  * @param {number} params.from - Start line (for lines mode, 1-based)
  * @param {number} params.lines - Number of lines to read (for lines mode)
  * @param {number} params.offset - Byte offset (for bytes mode)
@@ -167,6 +167,42 @@ async function readFile(params) {
   }
   
   const stats = fs.statSync(resolvedPath);
+  
+  // Data URL mode - 读取文件为 base64 Data URL（用于多模态 LLM 调用）
+  if (mode === 'data_url') {
+    if (!stats.isFile()) {
+      throw new Error(`Not a file: ${resolvedPath}`);
+    }
+    
+    // 限制文件大小（10MB）
+    const MAX_DATA_URL_SIZE = 10 * 1024 * 1024;
+    if (stats.size > MAX_DATA_URL_SIZE) {
+      throw new Error(`File too large for Data URL: ${stats.size} bytes (max: ${MAX_DATA_URL_SIZE})`);
+    }
+    
+    // 读取文件为 base64
+    const buffer = fs.readFileSync(resolvedPath);
+    const base64 = buffer.toString('base64');
+    
+    // 获取 MIME 类型
+    const ext = path.extname(resolvedPath).slice(1).toLowerCase();
+    const mimeType = getMimeType(ext);
+    
+    // 返回 data URL
+    const dataUrl = `data:${mimeType};base64,${base64}`;
+    
+    return {
+      path: resolvedPath,
+      mode: 'data_url',
+      mimeType: mimeType,
+      dataUrl: dataUrl,
+      size: buffer.length,
+      sizeHuman: formatBytes(buffer.length),
+      // 使用提示
+      usageHint: `在回复中使用 Markdown 格式：![图片描述](data:${mimeType};base64,...)`,
+    };
+  }
+  
   if (stats.size > MAX_FILE_SIZE) {
     throw new Error(`File too large: ${stats.size} bytes (max: ${MAX_FILE_SIZE})`);
   }


### PR DESCRIPTION
## 变更说明

在 `read_file` 工具中添加 `data_url` 模式，支持专家直接使用多模态能力处理图片文件。

## 技术实现

1. 在 `readFile()` 函数中添加 `mode="data_url"` 模式
2. 读取文件并转换为 Data URL 格式（`data:image/png;base64,xxx`）
3. 专家在回复中使用 Markdown 格式引用：`![描述](data:image/png;base64,xxx)`
4. `LLMClient.processMultimodalMessages()` 自动识别并转换为多模态格式

## 使用示例

```
专家: 我需要看一下截图
→ 调用 read_file(path="tasks/screenshot.png", mode="data_url")
→ 得到 dataUrl: "data:image/png;base64,iVBORw0KGgo..."
→ 专家回复: ![截图](data:image/png;base64,...)
→ LLMClient 转换为多模态格式 → 模型"看到"图片
```

## 代码审计

- [x] `npm run lint` 通过
- [x] `node --check` 语法检查通过
- [x] CommonJS 模块格式正确
- [x] 路径安全检查
- [x] 文件大小限制（10MB）

Closes #354