### PR TITLE
refactor: 合并 http_headers 到 net_check

### DIFF
--- a/data/skills/net-operations/SKILL.md
+++ b/data/skills/net-operations/SKILL.md
@@ -1,30 +1,34 @@
 ---
 name: net-operations
-description: Network utilities including DNS lookup, SSL analysis, connectivity testing, port scanning, and HTTP requests. Use when you need to diagnose network issues or make HTTP requests.
-argument-hint: "[check|connect|scan|request|headers] [host]"
+description: Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests. Use when you need to diagnose network issues or make HTTP requests.
+argument-hint: "[check|connect|scan|request] [host]"
 user-invocable: true
 ---
 
 # Network Operations
 
-Network utilities for DNS lookup, SSL analysis, connectivity testing, port scanning, and HTTP requests.
+Network utilities for DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests.
 
 ## Tools
 
 ### net_check
 
-Unified DNS and SSL check tool. Use `type` parameter to specify check type.
+Unified check tool for DNS, SSL, and HTTP analysis. Use `type` parameter to specify check type.
 
 **Parameters:**
-- `hostname` (string, required): Hostname to check
-- `type` (string, optional): Check type - `"dns"` (default) or `"ssl"`
+- `type` (string, optional): Check type - `"dns"` (default), `"ssl"`, or `"http"`
 - `timeout` (number, optional): Timeout in ms (default: 5000)
 
-**DNS Check Parameters (type="dns"):**
+**DNS Check (type="dns"):**
+- `hostname` (string, required): Hostname to check
 - `record_type` (string, optional): DNS record type - `"A"` (default), `"AAAA"`, `"MX"`, `"TXT"`, `"CNAME"`, `"NS"`
 
-**SSL Check Parameters (type="ssl"):**
+**SSL Check (type="ssl"):**
+- `hostname` (string, required): Hostname to check
 - `port` (number, optional): Port for SSL check (default: 443)
+
+**HTTP Check (type="http"):**
+- `url` (string, required): URL to analyze
 
 **Examples:**
 ```javascript
@@ -34,14 +38,11 @@ Unified DNS and SSL check tool. Use `type` parameter to specify check type.
 // DNS lookup - MX records (mail servers)
 { "tool": "net_check", "params": { "hostname": "gmail.com", "type": "dns", "record_type": "MX" } }
 
-// DNS lookup - TXT records
-{ "tool": "net_check", "params": { "hostname": "example.com", "type": "dns", "record_type": "TXT" } }
-
 // SSL certificate analysis
 { "tool": "net_check", "params": { "hostname": "example.com", "type": "ssl" } }
 
-// SSL check on custom port
-{ "tool": "net_check", "params": { "hostname": "mail.example.com", "type": "ssl", "port": 993 } }
+// HTTP headers analysis (security & performance)
+{ "tool": "net_check", "params": { "url": "https://example.com", "type": "http" } }
 ```
 
 **DNS Response:**
@@ -74,6 +75,27 @@ Unified DNS and SSL check tool. Use `type` parameter to specify check type.
 }
 ```
 
+**HTTP Response:**
+```json
+{
+  "success": true,
+  "url": "https://example.com",
+  "hostname": "example.com",
+  "statusCode": 200,
+  "security": {
+    "hsts": true,
+    "noSniff": true,
+    "frameGuard": "DENY",
+    "csp": true
+  },
+  "performance": {
+    "cacheControl": "max-age=31536000",
+    "compression": "gzip"
+  },
+  "recommendations": []
+}
+```
+
 ### net_connect
 
 TCP connectivity testing - test if a host and port is reachable.
@@ -93,9 +115,6 @@ TCP connectivity testing - test if a host and port is reachable.
 
 // Test database port
 { "tool": "net_connect", "params": { "host": "db.example.com", "port": 3306 } }
-
-// Test HTTPS
-{ "tool": "net_connect", "params": { "host": "example.com", "port": 443 } }
 ```
 
 **Response:**
@@ -135,9 +154,6 @@ Scan multiple ports on a host.
 
 // Scan specific ports
 { "tool": "port_scan", "params": { "host": "example.com", "ports": [80, 443, 8080] } }
-
-// Scan single port
-{ "tool": "port_scan", "params": { "host": "example.com", "ports": 22 } }
 ```
 
 **Response:**
@@ -208,42 +224,6 @@ Make HTTP/HTTPS requests.
 }
 ```
 
-### http_headers
-
-Fetch and analyze HTTP response headers for security and performance.
-
-**Parameters:**
-- `url` (string, required): URL to analyze
-- `timeout` (number, optional): Timeout in ms (default: 10000)
-
-**Examples:**
-```javascript
-// Analyze headers
-{ "tool": "http_headers", "params": { "url": "https://example.com" } }
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "url": "https://example.com",
-  "statusCode": 200,
-  "headers": { ... },
-  "security": {
-    "hsts": true,
-    "noSniff": true,
-    "frameGuard": "DENY",
-    "csp": true
-  },
-  "performance": {
-    "cacheControl": "max-age=31536000",
-    "compression": "gzip"
-  },
-  "server": "nginx",
-  "recommendations": []
-}
-```
-
 ## Common Use Cases
 
 ### Diagnose Network Issues
@@ -262,6 +242,19 @@ Fetch and analyze HTTP response headers for security and performance.
 { "tool": "http_request", "params": { "url": "https://example.com" } }
 ```
 
+### Security Audit
+
+```javascript
+// Check HTTP security headers
+{ "tool": "net_check", "params": { "url": "https://example.com", "type": "http" } }
+
+// Check SSL certificate
+{ "tool": "net_check", "params": { "hostname": "example.com", "type": "ssl" } }
+
+// Scan common ports
+{ "tool": "port_scan", "params": { "host": "example.com" } }
+```
+
 ### Check Server Health
 
 ```javascript
@@ -273,19 +266,6 @@ Fetch and analyze HTTP response headers for security and performance.
 
 // Check SSH access
 { "tool": "net_connect", "params": { "host": "myserver.com", "port": 22 } }
-```
-
-### Security Audit
-
-```javascript
-// Analyze HTTP headers
-{ "tool": "http_headers", "params": { "url": "https://example.com" } }
-
-// Check SSL certificate
-{ "tool": "net_check", "params": { "hostname": "example.com", "type": "ssl" } }
-
-// Scan common ports
-{ "tool": "port_scan", "params": { "host": "example.com", "ports": "common" } }
 ```
 
 ## Security
@@ -309,7 +289,7 @@ All tools return a consistent error format:
 ## Best Practices for LLM
 
 1. **Start with DNS** - If a host is unreachable, check DNS first with `net_check`
-2. **Use appropriate timeouts** - Increase timeout for slow networks
-3. **Check common ports** - Use `port_scan` with port groups for quick assessment
-4. **Handle errors gracefully** - Network operations can fail for many reasons
-5. **Use `net_check` for both DNS and SSL** - The unified tool is more efficient
+2. **Use `net_check` for all checks** - DNS, SSL, and HTTP analysis in one unified tool
+3. **Use appropriate timeouts** - Increase timeout for slow networks
+4. **Check common ports** - Use `port_scan` with port groups for quick assessment
+5. **Handle errors gracefully** - Network operations can fail for many reasons

--- a/data/skills/net-operations/index.js
+++ b/data/skills/net-operations/index.js
@@ -1,15 +1,14 @@
 /**
  * Network Operations Skill - Node.js Implementation
  * 
- * Network utilities including DNS lookup, connectivity testing, port scanning, and HTTP requests.
+ * Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests.
  * All operations are designed to be LLM-friendly with clear error messages.
  * 
  * Tools:
- * - net_check: DNS lookup and SSL certificate analysis
+ * - net_check: Unified check tool (DNS, SSL, HTTP headers)
  * - net_connect: TCP connectivity testing
  * - port_scan: Port scanning
  * - http_request: HTTP/HTTPS requests
- * - http_headers: HTTP headers analysis
  * 
  * @module net-operations-skill
  */
@@ -216,13 +215,108 @@ async function analyzeSSL(params) {
 }
 
 /**
- * net_check - Unified DNS and SSL check tool
+ * HTTP headers analysis - fetch and analyze HTTP response headers
+ */
+async function analyzeHTTP(params) {
+  const { url, timeout = DEFAULT_HTTP_TIMEOUT } = params;
+  
+  if (!url) {
+    throw new Error('url is required');
+  }
+  
+  // Parse URL to get hostname for the check
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (e) {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  
+  // Use HEAD request for headers only
+  const result = await httpRequestInternal({ url, method: 'HEAD', timeout, follow_redirects: false });
+  
+  if (!result.success) {
+    return result;
+  }
+  
+  // Analyze headers
+  const headers = result.headers;
+  const analysis = {
+    success: true,
+    url,
+    hostname: parsedUrl.hostname,
+    statusCode: result.statusCode,
+    headers,
+    security: {},
+    performance: {},
+    recommendations: [],
+  };
+  
+  // Security analysis
+  if (headers['strict-transport-security']) {
+    analysis.security.hsts = true;
+  } else {
+    analysis.security.hsts = false;
+    analysis.recommendations.push('Consider adding Strict-Transport-Security header');
+  }
+  
+  if (headers['x-content-type-options'] === 'nosniff') {
+    analysis.security.noSniff = true;
+  } else {
+    analysis.security.noSniff = false;
+    analysis.recommendations.push('Consider adding X-Content-Type-Options: nosniff header');
+  }
+  
+  if (headers['x-frame-options']) {
+    analysis.security.frameGuard = headers['x-frame-options'];
+  } else {
+    analysis.security.frameGuard = false;
+    analysis.recommendations.push('Consider adding X-Frame-Options header');
+  }
+  
+  if (headers['content-security-policy']) {
+    analysis.security.csp = true;
+  } else {
+    analysis.security.csp = false;
+    analysis.recommendations.push('Consider adding Content-Security-Policy header');
+  }
+  
+  // Performance analysis
+  if (headers['cache-control']) {
+    analysis.performance.cacheControl = headers['cache-control'];
+  }
+  
+  if (headers['content-encoding']) {
+    analysis.performance.compression = headers['content-encoding'];
+  } else {
+    analysis.recommendations.push('Consider enabling compression (gzip/br)');
+  }
+  
+  // Server info
+  if (headers['server']) {
+    analysis.server = headers['server'];
+  }
+  
+  return analysis;
+}
+
+/**
+ * net_check - Unified check tool for DNS, SSL, and HTTP
  * 
  * @param {object} params - Parameters
+ * @param {string} params.type - Check type: "dns" (default), "ssl", or "http"
+ * 
+ * DNS check params:
  * @param {string} params.hostname - Hostname to check
- * @param {string} params.type - Check type: "dns" (default) or "ssl"
- * @param {string} params.record_type - DNS record type (for type="dns"): "A", "AAAA", "MX", "TXT", "CNAME", "NS"
+ * @param {string} params.record_type - DNS record type: "A", "AAAA", "MX", "TXT", "CNAME", "NS"
+ * 
+ * SSL check params:
+ * @param {string} params.hostname - Hostname to check
  * @param {number} params.port - Port for SSL check (default: 443)
+ * 
+ * HTTP check params:
+ * @param {string} params.url - URL to analyze
+ * 
  * @param {number} params.timeout - Timeout in ms
  */
 async function netCheck(params) {
@@ -233,8 +327,10 @@ async function netCheck(params) {
       return await dnsLookup(params);
     case 'ssl':
       return await analyzeSSL(params);
+    case 'http':
+      return await analyzeHTTP(params);
     default:
-      throw new Error(`Invalid check type: ${type}. Valid types: dns, ssl`);
+      throw new Error(`Invalid check type: ${type}. Valid types: dns, ssl, http`);
   }
 }
 
@@ -412,18 +508,9 @@ async function portScan(params) {
 }
 
 /**
- * HTTP request - make HTTP/HTTPS requests
- * 
- * @param {object} params - Parameters
- * @param {string} params.url - Request URL
- * @param {string} params.method - HTTP method (default: "GET")
- * @param {object} params.headers - Request headers
- * @param {string|object} params.body - Request body
- * @param {number} params.timeout - Timeout in ms (default: 10000)
- * @param {boolean} params.follow_redirects - Follow redirects (default: true)
- * @param {number} redirectCount - Internal: redirect counter
+ * HTTP request - make HTTP/HTTPS requests (internal function)
  */
-async function httpRequest(params, redirectCount = 0) {
+async function httpRequestInternal(params, redirectCount = 0) {
   const {
     url: requestUrl,
     method = 'GET',
@@ -484,7 +571,7 @@ async function httpRequest(params, redirectCount = 0) {
           return;
         }
         
-        httpRequest({ ...params, url: res.headers.location }, redirectCount + 1)
+        httpRequestInternal({ ...params, url: res.headers.location }, redirectCount + 1)
           .then(resolve)
           .catch(reject);
         return;
@@ -555,84 +642,18 @@ async function httpRequest(params, redirectCount = 0) {
 }
 
 /**
- * HTTP headers analysis - fetch and analyze HTTP response headers
+ * http_request - make HTTP/HTTPS requests (public API)
  * 
  * @param {object} params - Parameters
- * @param {string} params.url - URL to analyze
+ * @param {string} params.url - Request URL
+ * @param {string} params.method - HTTP method (default: "GET")
+ * @param {object} params.headers - Request headers
+ * @param {string|object} params.body - Request body
  * @param {number} params.timeout - Timeout in ms (default: 10000)
+ * @param {boolean} params.follow_redirects - Follow redirects (default: true)
  */
-async function httpHeaders(params) {
-  const { url, timeout = DEFAULT_HTTP_TIMEOUT } = params;
-  
-  if (!url) {
-    throw new Error('url is required');
-  }
-  
-  // Use HEAD request for headers only
-  const result = await httpRequest({ url, method: 'HEAD', timeout, follow_redirects: false });
-  
-  if (!result.success) {
-    return result;
-  }
-  
-  // Analyze headers
-  const headers = result.headers;
-  const analysis = {
-    success: true,
-    url,
-    statusCode: result.statusCode,
-    headers,
-    security: {},
-    performance: {},
-    recommendations: [],
-  };
-  
-  // Security analysis
-  if (headers['strict-transport-security']) {
-    analysis.security.hsts = true;
-  } else {
-    analysis.security.hsts = false;
-    analysis.recommendations.push('Consider adding Strict-Transport-Security header');
-  }
-  
-  if (headers['x-content-type-options'] === 'nosniff') {
-    analysis.security.noSniff = true;
-  } else {
-    analysis.security.noSniff = false;
-    analysis.recommendations.push('Consider adding X-Content-Type-Options: nosniff header');
-  }
-  
-  if (headers['x-frame-options']) {
-    analysis.security.frameGuard = headers['x-frame-options'];
-  } else {
-    analysis.security.frameGuard = false;
-    analysis.recommendations.push('Consider adding X-Frame-Options header');
-  }
-  
-  if (headers['content-security-policy']) {
-    analysis.security.csp = true;
-  } else {
-    analysis.security.csp = false;
-    analysis.recommendations.push('Consider adding Content-Security-Policy header');
-  }
-  
-  // Performance analysis
-  if (headers['cache-control']) {
-    analysis.performance.cacheControl = headers['cache-control'];
-  }
-  
-  if (headers['content-encoding']) {
-    analysis.performance.compression = headers['content-encoding'];
-  } else {
-    analysis.recommendations.push('Consider enabling compression (gzip/br)');
-  }
-  
-  // Server info
-  if (headers['server']) {
-    analysis.server = headers['server'];
-  }
-  
-  return analysis;
+async function httpRequest(params) {
+  return await httpRequestInternal(params);
 }
 
 /**
@@ -656,9 +677,6 @@ async function execute(toolName, params, context = {}) {
     
     case 'http_request':
       return await httpRequest(params);
-    
-    case 'http_headers':
-      return await httpHeaders(params);
     
     default:
       throw new Error(`Unknown tool: ${toolName}`);


### PR DESCRIPTION
## 变更概述

将 `http_headers` 工具合并到 `net_check`，减少工具数量，简化 API。

## 变更详情

### 工具变更

| 变更前 | 变更后 |
|--------|--------|
| `net_check` (dns/ssl) | `net_check` (dns/ssl/http) |
| `http_headers` | 合并到 `net_check` |
| 5 个工具 | 4 个工具 |

### net_check 新增 type="http"

```javascript
// HTTP headers 分析（安全 + 性能）
{ "tool": "net_check", "params": { "url": "https://example.com", "type": "http" } }
```

**返回内容**：
- 安全检查：HSTS、CSP、X-Frame-Options 等
- 性能检查：压缩、缓存控制
- 改进建议

## 工具列表

| 工具 | 功能 |
|------|------|
| `net_check` | 统一检查（DNS/SSL/HTTP） |
| `net_connect` | TCP 连接测试 |
| `port_scan` | 端口扫描 |
| `http_request` | HTTP 请求 |

## 测试验证

- [x] 语法检查通过