### PR TITLE
refactor: 合并 net_connect 到 port_scan，工具数量从 4 个减少到 3 个

### DIFF
--- a/data/skills/net-operations/SKILL.md
+++ b/data/skills/net-operations/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: net-operations
-description: Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests. Use when you need to diagnose network issues or make HTTP requests.
-argument-hint: "[check|connect|scan|request] [host]"
+description: Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, port scanning, and HTTP requests. Use when you need to diagnose network issues or make HTTP requests.
+argument-hint: "[check|scan|request] [host]"
 user-invocable: true
 ---
 
 # Network Operations
 
-Network utilities for DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests.
+Network utilities for DNS lookup, SSL analysis, HTTP headers analysis, port scanning, and HTTP requests.
 
 ## Tools
 
@@ -96,28 +96,44 @@ Unified check tool for DNS, SSL, and HTTP analysis. Use `type` parameter to spec
 }
 ```
 
-### net_connect
+### port_scan
 
-TCP connectivity testing - test if a host and port is reachable.
+Scan port(s) on a host. Supports single port mode (detailed result) and multi-port mode (scan summary).
 
-**Parameters:**
+**Single Port Mode:**
 - `host` (string, required): Hostname or IP address
-- `port` (number, optional): Port number (default: 80)
+- `port` (number, required): Port number to check
 - `timeout` (number, optional): Timeout in ms (default: 5000)
+
+**Multi-Port Mode:**
+- `host` (string, required): Hostname or IP address
+- `ports` (string|number|array, optional): Port configuration (default: "common")
+  - `"common"` - Common ports (21, 22, 23, 25, 53, 80, 110, 143, 443, 465, 587, 993, 995, 3306, 3389, 5432, 6379, 8080, 8443)
+  - `"web"` - Web ports (80, 443, 8080, 8443)
+  - `"mail"` - Mail ports (25, 110, 143, 465, 587, 993, 995)
+  - `"db"` - Database ports (1433, 1521, 3306, 5432, 6379, 27017)
+  - Array of port numbers
+- `timeout` (number, optional): Timeout per port in ms (default: 3000)
 
 **Examples:**
 ```javascript
-// Test web server connectivity
-{ "tool": "net_connect", "params": { "host": "example.com", "port": 80 } }
+// Single port check (detailed result)
+{ "tool": "port_scan", "params": { "host": "example.com", "port": 80 } }
 
 // Test SSH port
-{ "tool": "net_connect", "params": { "host": "server.example.com", "port": 22 } }
+{ "tool": "port_scan", "params": { "host": "server.example.com", "port": 22 } }
 
-// Test database port
-{ "tool": "net_connect", "params": { "host": "db.example.com", "port": 3306 } }
+// Scan common ports
+{ "tool": "port_scan", "params": { "host": "example.com" } }
+
+// Scan web ports
+{ "tool": "port_scan", "params": { "host": "example.com", "ports": "web" } }
+
+// Scan specific ports
+{ "tool": "port_scan", "params": { "host": "example.com", "ports": [80, 443, 8080] } }
 ```
 
-**Response:**
+**Single Port Response:**
 ```json
 {
   "success": true,
@@ -129,34 +145,7 @@ TCP connectivity testing - test if a host and port is reachable.
 }
 ```
 
-### port_scan
-
-Scan multiple ports on a host.
-
-**Parameters:**
-- `host` (string, required): Hostname or IP address
-- `ports` (string|number|array, optional): Port configuration (default: "common")
-  - `"common"` - Common ports (21, 22, 23, 25, 53, 80, 110, 143, 443, 465, 587, 993, 995, 3306, 3389, 5432, 6379, 8080, 8443)
-  - `"web"` - Web ports (80, 443, 8080, 8443)
-  - `"mail"` - Mail ports (25, 110, 143, 465, 587, 993, 995)
-  - `"db"` - Database ports (1433, 1521, 3306, 5432, 6379, 27017)
-  - Single port number
-  - Array of port numbers
-- `timeout` (number, optional): Timeout per port in ms (default: 3000)
-
-**Examples:**
-```javascript
-// Scan common ports
-{ "tool": "port_scan", "params": { "host": "example.com" } }
-
-// Scan web ports
-{ "tool": "port_scan", "params": { "host": "example.com", "ports": "web" } }
-
-// Scan specific ports
-{ "tool": "port_scan", "params": { "host": "example.com", "ports": [80, 443, 8080] } }
-```
-
-**Response:**
+**Multi-Port Response:**
 ```json
 {
   "success": true,
@@ -233,7 +222,7 @@ Make HTTP/HTTPS requests.
 { "tool": "net_check", "params": { "hostname": "example.com" } }
 
 // 2. Test connectivity
-{ "tool": "net_connect", "params": { "host": "example.com", "port": 443 } }
+{ "tool": "port_scan", "params": { "host": "example.com", "port": 443 } }
 
 // 3. Check SSL certificate
 { "tool": "net_check", "params": { "hostname": "example.com", "type": "ssl" } }
@@ -262,10 +251,10 @@ Make HTTP/HTTPS requests.
 { "tool": "port_scan", "params": { "host": "myserver.com", "ports": "web" } }
 
 // Check database server
-{ "tool": "net_connect", "params": { "host": "db.myserver.com", "port": 3306 } }
+{ "tool": "port_scan", "params": { "host": "db.myserver.com", "port": 3306 } }
 
 // Check SSH access
-{ "tool": "net_connect", "params": { "host": "myserver.com", "port": 22 } }
+{ "tool": "port_scan", "params": { "host": "myserver.com", "port": 22 } }
 ```
 
 ## Security
@@ -290,6 +279,6 @@ All tools return a consistent error format:
 
 1. **Start with DNS** - If a host is unreachable, check DNS first with `net_check`
 2. **Use `net_check` for all checks** - DNS, SSL, and HTTP analysis in one unified tool
-3. **Use appropriate timeouts** - Increase timeout for slow networks
-4. **Check common ports** - Use `port_scan` with port groups for quick assessment
+3. **Use `port_scan` for connectivity** - Single port for detailed result, multi-port for quick scan
+4. **Use appropriate timeouts** - Increase timeout for slow networks
 5. **Handle errors gracefully** - Network operations can fail for many reasons

--- a/data/skills/net-operations/index.js
+++ b/data/skills/net-operations/index.js
@@ -1,13 +1,12 @@
 /**
  * Network Operations Skill - Node.js Implementation
  * 
- * Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests.
+ * Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, port scanning, and HTTP requests.
  * All operations are designed to be LLM-friendly with clear error messages.
  * 
  * Tools:
  * - net_check: Unified check tool (DNS, SSL, HTTP headers)
- * - net_connect: TCP connectivity testing
- * - port_scan: Port scanning
+ * - port_scan: Port scanning (single or multiple ports)
  * - http_request: HTTP/HTTPS requests
  * 
  * @module net-operations-skill
@@ -335,15 +334,20 @@ async function netCheck(params) {
 }
 
 /**
- * net_connect - TCP connectivity testing
+ * port_scan - Scan port(s) on a host
  * 
- * @param {object} params - Parameters
+ * Single port mode (returns detailed connection info):
  * @param {string} params.host - Hostname or IP address
- * @param {number} params.port - Port number (default: 80)
+ * @param {number} params.port - Single port number
  * @param {number} params.timeout - Timeout in ms (default: 5000)
+ * 
+ * Multi-port mode:
+ * @param {string} params.host - Hostname or IP address
+ * @param {number|array|string} params.ports - Port array or group name: "common", "web", "mail", "db"
+ * @param {number} params.timeout - Timeout per port in ms (default: 3000)
  */
-async function netConnect(params) {
-  const { host, port = 80, timeout = DEFAULT_CONNECT_TIMEOUT } = params;
+async function portScan(params) {
+  const { host, port, ports, timeout } = params;
   
   if (!host) {
     throw new Error('host is required');
@@ -354,6 +358,81 @@ async function netConnect(params) {
     throw new Error(`Invalid host format: ${host}`);
   }
   
+  // Determine single port or multi-port mode
+  const singlePort = port !== undefined ? parseInt(port) : null;
+  
+  if (singlePort !== null && !isNaN(singlePort)) {
+    // Single port mode - return detailed result
+    return await scanSinglePort(host, singlePort, timeout || DEFAULT_CONNECT_TIMEOUT);
+  }
+  
+  // Multi-port mode
+  let portList = [];
+  const portsParam = ports || 'common';
+  
+  if (typeof portsParam === 'string') {
+    switch (portsParam.toLowerCase()) {
+      case 'common':
+        portList = [21, 22, 23, 25, 53, 80, 110, 143, 443, 465, 587, 993, 995, 3306, 3389, 5432, 6379, 8080, 8443];
+        break;
+      case 'web':
+        portList = [80, 443, 8080, 8443];
+        break;
+      case 'mail':
+        portList = [25, 110, 143, 465, 587, 993, 995];
+        break;
+      case 'db':
+        portList = [1433, 1521, 3306, 5432, 6379, 27017];
+        break;
+      default:
+        const p = parseInt(portsParam);
+        if (!isNaN(p)) {
+          portList = [p];
+        } else {
+          throw new Error(`Unknown port group: ${portsParam}. Valid groups: common, web, mail, db`);
+        }
+    }
+  } else if (typeof portsParam === 'number') {
+    portList = [portsParam];
+  } else if (Array.isArray(portsParam)) {
+    portList = portsParam.map(p => parseInt(p)).filter(p => !isNaN(p) && p > 0 && p <= 65535);
+  } else {
+    throw new Error('port or ports must be specified');
+  }
+  
+  // Limit number of ports to scan
+  if (portList.length > 20) {
+    portList = portList.slice(0, 20);
+  }
+  
+  // Scan ports
+  const results = [];
+  for (const p of portList) {
+    const result = await scanSinglePortFast(host, p, timeout || DEFAULT_PORT_TIMEOUT);
+    results.push(result);
+  }
+  
+  const openPorts = results.filter(r => r.status === 'open').map(r => r.port);
+  const closedPorts = results.filter(r => r.status === 'closed').map(r => r.port);
+  const filteredPorts = results.filter(r => r.status === 'filtered').map(r => r.port);
+  
+  return {
+    success: true,
+    host,
+    scan: {
+      total: results.length,
+      open: openPorts,
+      closed: closedPorts,
+      filtered: filteredPorts,
+      results,
+    },
+  };
+}
+
+/**
+ * Scan a single port with detailed response (for single port mode)
+ */
+async function scanSinglePort(host, port, timeout) {
   const portNum = parseInt(port);
   if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
     throw new Error('port must be a number between 1 and 65535');
@@ -407,104 +486,27 @@ async function netConnect(params) {
 }
 
 /**
- * port_scan - Scan multiple ports on a host
- * 
- * @param {object} params - Parameters
- * @param {string} params.host - Hostname or IP address
- * @param {number|array} params.ports - Port number, array of ports, or common port group name
- * @param {number} params.timeout - Timeout per port in ms (default: 3000)
+ * Scan a single port fast (for multi-port mode)
  */
-async function portScan(params) {
-  const { host, ports = 'common', timeout = DEFAULT_PORT_TIMEOUT } = params;
-  
-  if (!host) {
-    throw new Error('host is required');
-  }
-  
-  // Validate host format
-  if (!HOST_REGEX.test(host) && !IP_REGEX.test(host)) {
-    throw new Error(`Invalid host format: ${host}`);
-  }
-  
-  // Determine ports to scan
-  let portList = [];
-  
-  if (typeof ports === 'string') {
-    switch (ports.toLowerCase()) {
-      case 'common':
-        portList = [21, 22, 23, 25, 53, 80, 110, 143, 443, 465, 587, 993, 995, 3306, 3389, 5432, 6379, 8080, 8443];
-        break;
-      case 'web':
-        portList = [80, 443, 8080, 8443];
-        break;
-      case 'mail':
-        portList = [25, 110, 143, 465, 587, 993, 995];
-        break;
-      case 'db':
-        portList = [1433, 1521, 3306, 5432, 6379, 27017];
-        break;
-      default:
-        // Try to parse as single port
-        const p = parseInt(ports);
-        if (!isNaN(p)) {
-          portList = [p];
-        } else {
-          throw new Error(`Unknown port group: ${ports}. Valid groups: common, web, mail, db`);
-        }
-    }
-  } else if (typeof ports === 'number') {
-    portList = [ports];
-  } else if (Array.isArray(ports)) {
-    portList = ports.map(p => parseInt(p)).filter(p => !isNaN(p) && p > 0 && p <= 65535);
-  } else {
-    throw new Error('ports must be a number, array of numbers, or port group name');
-  }
-  
-  // Limit number of ports to scan
-  if (portList.length > 20) {
-    portList = portList.slice(0, 20);
-  }
-  
-  // Scan ports
-  const results = [];
-  for (const port of portList) {
-    const result = await new Promise((resolve) => {
-      const socket = new net.Socket();
-      const timer = setTimeout(() => {
-        socket.destroy();
-        resolve({ port, status: 'filtered' });
-      }, timeout);
-      
-      socket.connect(port, host, () => {
-        clearTimeout(timer);
-        socket.destroy();
-        resolve({ port, status: 'open' });
-      });
-      
-      socket.on('error', () => {
-        clearTimeout(timer);
-        resolve({ port, status: 'closed' });
-      });
+async function scanSinglePortFast(host, port, timeout) {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    const timer = setTimeout(() => {
+      socket.destroy();
+      resolve({ port, status: 'filtered' });
+    }, timeout);
+    
+    socket.connect(port, host, () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve({ port, status: 'open' });
     });
     
-    results.push(result);
-  }
-  
-  const openPorts = results.filter(r => r.status === 'open').map(r => r.port);
-  const closedPorts = results.filter(r => r.status === 'closed').map(r => r.port);
-  const filteredPorts = results.filter(r => r.status === 'filtered').map(r => r.port);
-  
-  return {
-    success: true,
-    host,
-    scan: {
-      total: results.length,
-      open: openPorts,
-      closed: closedPorts,
-      filtered: filteredPorts,
-      results,
-    },
-  };
+    socket.on('error', () => {
+      clearTimeout(timer);
+      resolve({ port, status: 'closed' });
+    });
+  });
 }
 
 /**
@@ -670,7 +672,8 @@ async function execute(toolName, params, context = {}) {
       return await netCheck(params);
     
     case 'net_connect':
-      return await netConnect(params);
+      // Backward compatibility: redirect to port_scan single port mode
+      return await portScan({ host: params.host, port: params.port, timeout: params.timeout });
     
     case 'port_scan':
       return await portScan(params);

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,43 @@
+## 变更概述
+
+为内置工具 `execute_javascript` 添加权限控制，仅 `admin` 和 `creator` 角色可执行脚本。
+
+## 变更详情
+
+### 1. 内置工具权限控制
+
+**`lib/tool-manager.js`**:
+- 为 `execute_javascript` 添加 `allowedRoles: ['admin', 'creator']` 配置
+- 在 `executeBuiltinTool()` 方法中添加权限检查逻辑
+- 新增 `getUserRole()` 方法用于提取用户角色
+
+### 2. 技能清理与重构
+
+- **删除 `data/skills/http-client/`**: 功能已合并到 `net-operations`
+- **删除 `lib/skill-meta.js`**: 权限控制逻辑移至 `tool-manager.js`
+- **重构 `net-operations` 工具命名**:
+  - `dns_lookup` → `net_dns`
+  - `ping` → `net_ping`
+  - `port_check` → `net_port`
+  - `http_request` → `net_request`
+
+### 3. 沙箱模块白名单
+
+**`lib/skill-runner.js`**:
+- 添加 `dns`、`net` 内置模块到 `BUILTIN_MODULES` 白名单
+
+## 权限设计
+
+| 角色 | execute_javascript 权限 |
+|------|------------------------|
+| `admin` | ✅ 可执行 |
+| `creator` | ✅ 可执行 |
+| `user` | ❌ 权限拒绝 |
+
+## 测试验证
+
+- [x] `npm run lint` 通过
+- [x] ES 模块导入验证通过
+- [x] 代码审计通过
+
+Closes #358


### PR DESCRIPTION
## 变更概述

将 `net_connect` 合并到 `port_scan`，工具数量从 4 个减少到 3 个。

## 变更详情

### 工具变更

| 变更前 | 变更后 |
|--------|--------|
| `net_connect` (单端口) | 合并到 `port_scan` |
| `port_scan` (多端口) | `port_scan` (单端口 + 多端口) |
| 4 个工具 | 3 个工具 |

### port_scan 新增单端口模式

```javascript
// 单端口检查（详细结果）
{ "tool": "port_scan", "params": { "host": "example.com", "port": 80 } }

// 多端口扫描（汇总结果）
{ "tool": "port_scan", "params": { "host": "example.com", "ports": "web" } }
```

**单端口返回**：
```json
{
  "success": true,
  "host": "example.com",
  "port": 80,
  "status": "open",
  "responseTime": 15,
  "message": "Port 80 is open on example.com (15ms)"
}
```

## 最终工具列表

| 工具 | 功能 |
|------|------|
| `net_check` | DNS/SSL/HTTP 检查 |
| `port_scan` | 端口扫描（单端口/多端口） |
| `http_request` | HTTP 请求 |

## 兼容性

`net_connect` 仍然可用，内部重定向到 `port_scan` 单端口模式。

## 测试验证

- [x] 语法检查通过