### PR TITLE
fix: 修复 skill-manager 注册技能时路径重复问题

### DIFF
--- a/data/skills/skill-manager/IMPORT_GUIDE.md
+++ b/data/skills/skill-manager/IMPORT_GUIDE.md
@@ -78,11 +78,11 @@ skill-manager_register_skill(
 ```
 
 **✅ source_path 自动规范化**：
-- 系统会自动处理路径格式，以下格式都会被规范化为 `skills/pdf`：
-  - `data/skills/pdf` → `skills/pdf`（移除 data/ 前缀）
-  - `pdf` → `skills/pdf`（添加 skills/ 前缀）
-  - `skills/pdf` → `skills/pdf`（保持不变）
-- 推荐使用 `skills/{目录名}` 格式以保持一致性
+- 系统会自动处理路径格式，以下格式都会被规范化为技能目录名：
+  - `data/skills/pdf` → `pdf`（移除 data/skills 前缀）
+  - `skills/pdf` → `pdf`（移除 skills 前缀）
+  - `pdf` → `pdf`（保持不变）
+- 推荐直接使用技能目录名（如 `pdf`）或 `skills/{目录名}` 格式
 
 ### 6. 验证注册结果
 

--- a/data/skills/skill-manager/index.js
+++ b/data/skills/skill-manager/index.js
@@ -135,15 +135,19 @@ async function registerSkill(params) {
     throw new Error('tools 参数是必需的。请先读取 SKILL.md，理解工具定义后传入 tools 数组。');
   }
 
-  // 规范化 source_path：必须以 skills/ 开头，不能以 data/ 开头
-  // 移除 data/ 前缀（如果存在）
+  // 规范化 source_path：提取技能目录名
+  // 支持多种格式：skills/pdf, data/skills/pdf, pdf
+  // 最终只保留技能目录名（如 pdf）
+  
+  // 移除 data/ 前缀
   if (source_path.startsWith('data/')) {
-    source_path = source_path.substring(5); // 移除 'data/'
+    source_path = source_path.substring(5); // data/skills/pdf → skills/pdf
   }
-  // 确保以 skills/ 开头
-  if (!source_path.startsWith('skills/')) {
-    source_path = 'skills/' + source_path;
+  // 移除 skills/ 前缀，只保留技能目录名
+  if (source_path.startsWith('skills/')) {
+    source_path = source_path.substring(7); // skills/pdf → pdf
   }
+  // 此时 source_path 应该只是技能目录名（如 pdf）
 
   return await httpRequest('POST', '/api/skills/register', {
     source_path,


### PR DESCRIPTION
## 问题\n\n注册技能时，如果传入 \`skills/pdf\` 格式的路径，会导致路径重复：\n- skill-manager 规范化为 \`skills/pdf\`\n- 服务端 validateSkillPath 拼接为 \`data/skills/skills/pdf\`\n\n## 修复\n\n修改 skill-manager/index.js 的路径规范化逻辑，将 source_path 统一转换为技能目录名（如 \`pdf\`），让服务端正确拼接为 \`data/skills/pdf\`。\n\n## 支持的输入格式\n\n- \`pdf\` → \`pdf\`\n- \`skills/pdf\` → \`pdf\`\n- \`data/skills/pdf\` → \`pdf\`