### PR TITLE
fix: 规范化 source_path 存储格式为 skills/{目录名}

### DIFF
--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -484,7 +484,7 @@ class SkillController {
         author: skill_info.author || '',
         tags: skill_info.tags ? JSON.stringify(skill_info.tags) : '[]',
         source_type: 'local',
-        source_path: path.relative(PROJECT_ROOT, full_path),  // 存储相对路径，如 data/skills/file-operations
+        source_path: 'skills/' + path.basename(full_path),  // 存储规范化路径，如 skills/file-operations
         skill_md,
         is_active: true,
       });
@@ -883,9 +883,11 @@ class SkillController {
         // 已注册技能，使用 source_path
         let sourcePath = skill.source_path;
         
-        // 处理 source_path 可能缺少 data/ 前缀的情况
-        if (sourcePath && !sourcePath.startsWith('data/') && !path.isAbsolute(sourcePath)) {
-          sourcePath = path.join('data', sourcePath);
+        // 规范化 source_path：skills/xxx → data/skills/xxx
+        if (sourcePath && sourcePath.startsWith('skills/')) {
+          sourcePath = 'data/' + sourcePath;  // skills/pdf → data/skills/pdf
+        } else if (sourcePath && !sourcePath.startsWith('data/') && !path.isAbsolute(sourcePath)) {
+          sourcePath = path.join('data/skills', sourcePath);
         }
         skillPath = path.isAbsolute(sourcePath) ? sourcePath : path.join(PROJECT_ROOT, sourcePath);
       } else {
@@ -974,9 +976,11 @@ class SkillController {
         // 已注册技能，使用 source_path
         let sourcePath = skill.source_path;
         
-        // 处理 source_path 可能缺少 data/ 前缀的情况
-        if (sourcePath && !sourcePath.startsWith('data/') && !path.isAbsolute(sourcePath)) {
-          sourcePath = path.join('data', sourcePath);
+        // 规范化 source_path：skills/xxx → data/skills/xxx
+        if (sourcePath && sourcePath.startsWith('skills/')) {
+          sourcePath = 'data/' + sourcePath;  // skills/pdf → data/skills/pdf
+        } else if (sourcePath && !sourcePath.startsWith('data/') && !path.isAbsolute(sourcePath)) {
+          sourcePath = path.join('data/skills', sourcePath);
         }
         skillPath = path.isAbsolute(sourcePath) ? sourcePath : path.join(PROJECT_ROOT, sourcePath);
       } else {


### PR DESCRIPTION
## 问题\n\n注册技能时，数据库存储的 source_path 是 \`data/skills/pdf\` 格式，不符合 \`skills/pdf\` 的规范。\n\n## 修复\n\n1. 注册技能时，source_path 存储格式改为 \`skills/{目录名}\`\n2. 更新 listFiles 和 getFileContent 方法中的路径解析逻辑，支持新格式\n\n## 变更\n\n- \`server/controllers/skill.controller.js\` 第 487 行：存储格式改为 \`skills/{目录名}\`\n- 第 883-891 行和 976-984 行：路径解析逻辑更新