### PR TITLE
fix: 修复 source_path 反斜杠路径无法识别的问题

### DIFF
--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -883,6 +883,11 @@ class SkillController {
         // 已注册技能，使用 source_path
         let sourcePath = skill.source_path;
         
+        // 跨平台兼容：统一使用正斜杠
+        if (sourcePath) {
+          sourcePath = sourcePath.replace(/\\/g, '/');
+        }
+        
         // 规范化 source_path：skills/xxx → data/skills/xxx
         if (sourcePath && sourcePath.startsWith('skills/')) {
           sourcePath = 'data/' + sourcePath;  // skills/pdf → data/skills/pdf
@@ -975,6 +980,11 @@ class SkillController {
       if (skill) {
         // 已注册技能，使用 source_path
         let sourcePath = skill.source_path;
+        
+        // 跨平台兼容：统一使用正斜杠
+        if (sourcePath) {
+          sourcePath = sourcePath.replace(/\\/g, '/');
+        }
         
         // 规范化 source_path：skills/xxx → data/skills/xxx
         if (sourcePath && sourcePath.startsWith('skills/')) {


### PR DESCRIPTION
## 问题\n\nWindows 环境下，source_path 可能存储为 \`skills\\pdf\` 格式（反斜杠），导致 \`startsWith('skills/')\` 无法匹配。\n\n## 修复\n\n在 listFiles 和 getFileContent 方法中，先对 source_path 进行规范化处理，将反斜杠转换为正斜杠。\n\n```javascript\nif (sourcePath) {\n  sourcePath = sourcePath.replace(/\\\\/g, '/');\n}\n```