### PR TITLE
fix: 修复 refreshAssistantsCache 返回值解构错误

### DIFF
--- a/server/services/assistant/manager.js
+++ b/server/services/assistant/manager.js
@@ -89,8 +89,7 @@ class AssistantManager {
    * 刷新助理配置缓存
    */
   async refreshAssistantsCache() {
-    const result = await refreshAssistantsCache(this.db);
-    this.assistantsCache = result.cache;
+    this.assistantsCache = await refreshAssistantsCache(this.db);
     this.cacheTime = Date.now();
     logger.info(`[AssistantManager] 缓存了 ${this.assistantsCache.size} 个助理配置`);
   }


### PR DESCRIPTION
## 问题描述

后端启动时报错：
```
[2026-03-25T13:32:21.240Z] [ERROR] Failed to start server: Cannot read properties of undefined (reading 'size')
```

## 根因分析

在 [`manager.js`](server/services/assistant/manager.js:91) 的 `refreshAssistantsCache` 方法中，错误地解构了返回值：

```javascript
// ❌ 错误代码
const result = await refreshAssistantsCache(this.db);
this.assistantsCache = result.cache;  // result 是 Map，不是 { cache: Map }
```

而 [`config-repository.js`](server/services/assistant/config-repository.js:37) 的 `refreshAssistantsCache` 函数直接返回 Map：

```javascript
return assistantsCache;  // 直接返回 Map
```

## 修复方案

直接使用返回的 Map，不再解构：

```javascript
// ✅ 正确代码
this.assistantsCache = await refreshAssistantsCache(this.db);
```

## 验证

- [x] `npm run lint` 通过
- [x] ES 模块导入验证通过

Closes #374