### PR TITLE
fix: 助理面板细节修正

### DIFF
--- a/frontend/src/components/panel/AssistantTab.vue
+++ b/frontend/src/components/panel/AssistantTab.vue
@@ -167,8 +167,8 @@
               </div>
               <!-- 统计信息 -->
               <div v-if="message.tokens_input || message.latency_ms" class="message-stats">
-                <span v-if="message.tokens_input">输入: {{ message.tokens_input }}</span>
-                <span v-if="message.tokens_output">输出: {{ message.tokens_output }}</span>
+                <span v-if="message.tokens_input">{{ $t('assistant.tokensInput') }}: {{ message.tokens_input }}</span>
+                <span v-if="message.tokens_output">{{ $t('assistant.tokensOutput') }}: {{ message.tokens_output }}</span>
                 <span v-if="message.latency_ms">{{ (message.latency_ms / 1000).toFixed(2) }}s</span>
               </div>
             </div>
@@ -308,6 +308,8 @@ function closeDetail() {
 
 // 判断是否可以删除
 function canDelete(request: AssistantRequest): boolean {
+  // 已归档的委托不允许删除
+  if (request.is_archived) return false
   return ['completed', 'failed', 'timeout', 'cancelled'].includes(request.status)
 }
 
@@ -318,7 +320,10 @@ function canArchive(request: AssistantRequest): boolean {
 
 // 判断是否可以重试
 function canRetry(request: AssistantRequest): boolean {
-  return ['completed', 'failed', 'timeout'].includes(request.status)
+  // 已归档的委托不允许重试
+  if (request.is_archived) return false
+  // 只允许失败的执行重试
+  return ['failed', 'timeout'].includes(request.status)
 }
 
 // 处理删除
@@ -338,6 +343,8 @@ async function handleDelete(request: AssistantRequest) {
 async function handleArchive(request: AssistantRequest) {
   try {
     await assistantStore.archiveRequest(request.request_id)
+    // 归档成功后关闭委托详情
+    closeDetail()
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : t('assistant.archiveFailed')
     toast.error(errorMsg)


### PR DESCRIPTION
## 修改内容

### 1. 归档时关闭委托详情
在 `handleArchive()` 函数中添加了 `closeDetail()` 调用，归档成功后自动关闭委托详情面板。

### 2. 已归档委托不允许重试或删除
修改了 `canDelete()` 和 `canRetry()` 函数，添加了归档状态检查：
```typescript
if (request.is_archived) return false
```

### 3. 只允许失败的执行重试
修改了 `canRetry()` 函数，将允许重试的状态从 `['completed', 'failed', 'timeout']` 改为 `['failed', 'timeout']`，移除了 `completed` 状态。

### 4. 修正硬编码中文文本
将硬编码的 `输入:` 和 `输出:` 改为使用 i18n 翻译函数 `$t('assistant.tokensInput')` 和 `$t('assistant.tokensOutput')`。

## 代码审计结果

| 检查项 | 结果 |
|--------|------|
| `npm run lint` | ✅ 通过 |
| 空catch块检查 | ✅ 无静默吞掉错误的情况 |
| 原生fetch检查 | ✅ 使用 store 调用 API，无直接 fetch |
| i18n检查 | ✅ 所有文本使用 `$t()` 翻译函数 |

## 修改文件
- `frontend/src/components/panel/AssistantTab.vue`