### PR TITLE
feat: 为 file-operations 技能添加文件操作引导提示

### DIFF
--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -314,11 +314,39 @@ class ContextManager {
 ${toolsDescription}`;
     }).join('\n\n');
 
+    // 检查是否有 file-operations 技能
+    const hasFileOperations = skills.some(s => s.name === 'file-operations');
+    const fileOperationsGuidance = hasFileOperations ? `
+
+### ⚠️ 文件操作重要提示
+
+**在读取文件之前，必须先了解文件信息！**
+
+直接读取图片、压缩包、二进制文件对 LLM 是无意义的（会被截断）。正确做法：
+
+1. **先调用 \`fs_info\`** 获取文件信息：
+   - \`size\` / \`sizeHuman\`: 文件大小
+   - \`mimeType\`: 文件类型（image/png, application/zip 等）
+   - \`isTextFile\`: 是否为文本文件
+
+2. **根据文件信息选择处理方式**：
+   - **图片文件** → 使用 \`read_file(mode="data_url")\` 传给多模态模型
+   - **压缩包** → 委托助理处理，或使用解压工具
+   - **二进制文件** → 委托助理处理，或使用专门工具
+   - **大文本文件** → 使用 \`from\` / \`lines\` 参数分块读取
+   - **普通文本文件** → 正常读取
+
+**示例流程**：
+\`\`\`
+1. fs_info(path="input/screenshot.png")  → 得知是图片，大小 500KB
+2. read_file(path="input/screenshot.png", mode="data_url")  → 转为 base64 供多模态模型处理
+\`\`\`` : '';
+
     return `## 你的可用技能
 你拥有以下技能，可以在合适的时候调用相关工具来完成任务：
 
 ${skillsDescription}
-
+${fileOperationsGuidance}
 当你需要使用这些技能时，系统会自动调用相应的工具。你只需要在回复中自然地表达即可，系统会处理工具调用。`;
   }
 


### PR DESCRIPTION
## 变更说明

为 `file-operations` 技能添加文件操作引导提示，指导 LLM 在读取文件前先获取文件信息。

## 问题背景

LLM 经常直接调用 `read_file` 读取图片、压缩包和二进制文件，但这些文件被截断后对 LLM 毫无意义。

## 解决方案

当专家拥有 `file-operations` 技能时，自动在 System Prompt 中注入引导提示：

1. **先调用 `fs_info`** 获取文件信息（大小、类型、是否文本文件）
2. **根据文件类型选择处理方式**：
   - 图片文件 → 使用 `read_file(mode="data_url")` 传给多模态模型
   - 压缩包 → 委托助理处理
   - 二进制文件 → 委托助理处理
   - 大文本文件 → 分块读取
   - 普通文本文件 → 正常读取

## 修改文件

- `lib/context-manager.js` - `generateSkillsSection()` 方法添加条件性引导提示