### PR TITLE
fix: 修复 createAssistant 类型定义

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -777,7 +777,7 @@ export const assistantApi = {
     apiRequest<Assistant>(apiClient.put(`/assistants/${id}`, data)),
 
   // 创建助理
-  createAssistant: (data: Partial<Assistant> & { id: string; name: string }) =>
+  createAssistant: (data: Partial<Assistant> & { name: string }) =>
     apiRequest<Assistant>(apiClient.post('/assistants', data)),
 
   // 删除助理

--- a/frontend/src/components/settings/AssistantSettingsTab.vue
+++ b/frontend/src/components/settings/AssistantSettingsTab.vue
@@ -126,7 +126,7 @@ async function handleSave(data: Partial<Assistant>) {
 }
 
 // 创建助理
-async function handleCreate(data: Partial<Assistant> & { id: string; name: string }) {
+async function handleCreate(data: Partial<Assistant> & { name: string }) {
   try {
     await assistantStore.createAssistant(data)
     closeEditDialog()

--- a/frontend/src/stores/assistant.ts
+++ b/frontend/src/stores/assistant.ts
@@ -75,7 +75,7 @@ export const useAssistantStore = defineStore('assistant', () => {
     }
   }
 
-  async function createAssistant(data: Partial<Assistant> & { id: string; name: string }) {
+  async function createAssistant(data: Partial<Assistant> & { name: string }) {
     try {
       isLoading.value = true
       const newAssistant = await assistantApi.createAssistant(data)


### PR DESCRIPTION
## 变更说明

修复 `createAssistant` 函数的类型定义，移除不必要的 `id` 必填参数。

## 问题

前端类型定义要求创建助理时传入 `id`，但后端 API 实际上会自动生成 `id`，不需要前端传入。

## 修改文件

- `frontend/src/api/services.ts` - 修改 `createAssistant` API 类型
- `frontend/src/stores/assistant.ts` - 修改 `createAssistant` store 函数类型
- `frontend/src/components/settings/AssistantSettingsTab.vue` - 修改 `handleCreate` 函数类型