### PR TITLE
fix: 修复 updateTaskLastExecutedByTopic 方法缺失导致的运行时错误

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -121,6 +121,215 @@ class ChatService {
   }
 
   /**
+   * 准备任务上下文（私有方法）
+   * 根据不同的模式（任务模式、技能模式、对话模式）构建相应的任务上下文
+   * @param {object} params - 参数
+   * @returns {Promise<object|null>} 任务上下文对象
+   */
+  async _prepareTaskContext({ task_id, user_id, working_path, session }) {
+    if (task_id) {
+      // 任务模式：根据 task_id 获取任务工作目录
+      const taskContext = await this.getTaskContext(task_id, user_id, working_path, session);
+      if (taskContext) {
+        logger.info('[ChatService] 任务上下文已加载:', taskContext.title, '路径:', working_path || '根目录');
+      }
+      return taskContext;
+    } else if (working_path) {
+      // 技能模式：没有 task_id 但有 working_path（技能目录路径）
+      logger.info('[ChatService] 技能模式工作目录:', working_path);
+      return {
+        fullWorkspacePath: working_path,
+        currentPath: '',
+        isAdmin: session?.isAdmin || false,
+        isSkillCreator: session?.roles?.includes('creator') || false,
+      };
+    } else {
+      // 对话模式：使用用户临时目录作为工作目录
+      logger.info('[ChatService] 对话模式工作目录: work/' + user_id + '/temp');
+      return {
+        fullWorkspacePath: `work/${user_id}/temp`,
+        currentPath: '',
+        isAdmin: session?.isAdmin || false,
+        isSkillCreator: session?.roles?.includes('creator') || false,
+      };
+    }
+  }
+
+  /**
+   * 执行多轮 LLM 调用（私有方法）
+   * 支持流式响应和多轮工具调用
+   * @returns {Promise<object>} LLM 调用结果
+   */
+  async _executeLLMRounds(expertService, { modelConfig, thinkingConfig, tools, currentMessages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, onDelta }) {
+    const systemSettingService = getSystemSettingService(this.db);
+    const MAX_TOOL_ROUNDS = expertService.expertConfig?.expert?.max_tool_rounds
+      || await systemSettingService.getMaxToolRounds();
+
+    let fullContent = '';
+    let fullReasoningContent = '';
+    let tokenUsage = null;
+    let allToolCalls = [];
+    let messages = [...currentMessages];
+
+    // 更新 payload 基础信息
+    llmPayload.model = modelConfig.model_name;
+    llmPayload.temperature = expertService.llmClient.getExpertLLMParams().temperature;
+    llmPayload.top_p = expertService.llmClient.getExpertLLMParams().top_p;
+    llmPayload.frequency_penalty = expertService.llmClient.getExpertLLMParams().frequency_penalty;
+    llmPayload.presence_penalty = expertService.llmClient.getExpertLLMParams().presence_penalty;
+    llmPayload.max_tokens = modelConfig.max_output_tokens || 32768;
+    if (tools.length > 0) llmPayload.tools = tools;
+
+    logger.info('[ChatService] 开始调用 LLM，当前消息数:', messages.length);
+
+    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+      let collectedToolCalls = [];
+      let roundContent = '';
+
+      logger.info('[ChatService] 第', round + 1, '轮调用 LLM...');
+
+      // 流式调用
+      await expertService.llmClient.callStream(modelConfig, messages, {
+        tools,
+        thinking: thinkingConfig.thinking,
+        reasoning: thinkingConfig.reasoning,
+        onDelta: (delta) => {
+          roundContent += delta;
+          fullContent += delta;
+          onDelta?.({ type: 'delta', content: delta });
+        },
+        onReasoningDelta: (reasoningDelta) => {
+          fullReasoningContent += reasoningDelta;
+          onDelta?.({ type: 'reasoning_delta', content: reasoningDelta });
+        },
+        onToolCall: (toolCalls) => {
+          const toolCallsForLog = Array.isArray(toolCalls) ? toolCalls : [toolCalls];
+          const displayNames = toolCallsForLog.map(call => {
+            const toolId = call.function?.name || call.name;
+            return expertService.toolManager.formatToolDisplay(toolId);
+          });
+          logger.info(`[ChatService] 第${round + 1}轮收到工具调用:`, displayNames);
+
+          if (Array.isArray(toolCalls)) {
+            collectedToolCalls.push(...toolCalls);
+          } else {
+            collectedToolCalls.push(toolCalls);
+          }
+
+          const toolCallsWithDisplayNames = toolCallsForLog.map(call => {
+            const toolId = call.function?.name || call.name;
+            return { ...call, displayName: expertService.toolManager.formatToolDisplay(toolId) };
+          });
+          onDelta?.({ type: 'tool_call', toolCalls: toolCallsWithDisplayNames });
+        },
+        onUsage: (usage) => {
+          if (usage) {
+            if (!tokenUsage) {
+              tokenUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+            }
+            tokenUsage.prompt_tokens += usage.prompt_tokens || 0;
+            tokenUsage.completion_tokens += usage.completion_tokens || 0;
+            tokenUsage.total_tokens += usage.total_tokens || 0;
+            logger.info(`[ChatService] 第${round + 1}轮 token 使用:`, {
+              prompt: usage.prompt_tokens,
+              completion: usage.completion_tokens,
+              total: usage.total_tokens,
+            });
+          }
+        },
+      });
+
+      // 如果没有工具调用，退出循环
+      if (collectedToolCalls.length === 0) {
+        logger.info(`[ChatService] 第${round + 1}轮无工具调用，完成`);
+        if (roundContent) {
+          messages = [...messages, { role: 'assistant', content: roundContent }];
+          llmPayload.messages = messages;
+          llmPayload._debug.context_messages_count = messages.length;
+          llmPayload.cached_at = new Date().toISOString();
+          this.saveLLMPayload(user_id, expert_id, llmPayload);
+        }
+        break;
+      }
+
+      logger.info(`[ChatService] 第${round + 1}轮开始执行工具调用:`, collectedToolCalls.length);
+
+      // 执行工具
+      const toolResults = await this._executeTools(expertService, {
+        collectedToolCalls,
+        user_id,
+        taskContext,
+        topic_id,
+        task_id,
+        session,
+        expert_id,
+        onDelta
+      });
+
+      // 合并工具调用和执行结果
+      const toolCallsWithResults = collectedToolCalls.map((call, index) => {
+        const result = toolResults[index];
+        return {
+          ...call,
+          result: result ? { success: result.success, data: result.data, error: result.error } : null,
+          duration: result?.duration || 0,
+          timestamp: new Date().toISOString(),
+        };
+      });
+      allToolCalls.push(...toolCallsWithResults);
+
+      // 更新消息历史
+      messages = [
+        ...messages,
+        { role: 'assistant', content: roundContent || null, tool_calls: collectedToolCalls },
+        ...expertService.toolManager.formatToolResultsForLLM(toolResults),
+      ];
+
+      // 同步更新 LLM Payload 缓存
+      llmPayload.messages = messages;
+      llmPayload._debug.context_messages_count = messages.length;
+      llmPayload.cached_at = new Date().toISOString();
+      this.saveLLMPayload(user_id, expert_id, llmPayload);
+
+      if (round + 1 >= MAX_TOOL_ROUNDS) {
+        logger.warn('[ChatService] 达到最大工具调用轮数，下一轮将强制返回文本');
+      }
+    }
+
+    // 如果 LLM 没有返回任何内容，生成默认回复
+    if (!fullContent || fullContent.trim() === '') {
+      logger.warn('[ChatService] LLM 未返回内容，生成默认回复');
+      fullContent = '我已处理您的请求，但没有生成具体的回复内容。';
+    }
+
+    return { fullContent, fullReasoningContent, tokenUsage, allToolCalls, finalMessages: messages };
+  }
+
+  /**
+   * 执行工具调用（私有方法）
+   * @returns {Promise<Array>} 工具执行结果数组
+   */
+  async _executeTools(expertService, { collectedToolCalls, user_id, taskContext, topic_id, task_id, session, expert_id, onDelta }) {
+    return await expertService.handleToolCalls(
+      collectedToolCalls,
+      user_id,
+      session?.accessToken,
+      taskContext,
+      topic_id,
+      async (toolResult) => {
+        logger.info(`[ChatService] 工具执行完成: ${toolResult.toolName}, 成功: ${toolResult.success}`);
+        const originalCall = collectedToolCalls.find(c => c.id === toolResult.toolCallId);
+        if (originalCall?.context) {
+          toolResult.context = originalCall.context;
+        }
+        await this.saveToolMessage(topic_id, user_id, toolResult, expert_id, task_id);
+        onDelta?.({ type: 'tool_result', result: toolResult });
+      },
+      session
+    );
+  }
+
+  /**
    * 处理流式聊天请求（SSE）
    * topic_id 可选，如果不提供则自动获取或创建活跃对话
    * @param {object} params - 参数
@@ -136,7 +345,7 @@ class ChatService {
    * @param {Function} onError - 错误回调 (error: Error) => void
    */
   async streamChat(params, onDelta, onComplete, onError) {
-    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, access_token, is_admin, session } = params;
+    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, session } = params;
 
     try {
       logger.info('[ChatService] 开始流式聊天:', { expert_id, user_id, topic_id: providedTopicId, task_id, working_path });
@@ -145,134 +354,77 @@ class ChatService {
       const expertService = await this.getExpertService(expert_id);
       logger.debug('[ChatService] 专家服务获取完成');
 
-      // 2. 获取任务上下文（如果在任务工作空间模式下）
-      let taskContext = null;
-      if (task_id) {
-        // 任务模式：根据 task_id 获取任务工作目录
-        taskContext = await this.getTaskContext(task_id, user_id, working_path, session);
-        if (taskContext) {
-          logger.info('[ChatService] 任务上下文已加载:', taskContext.title, '路径:', working_path || '根目录');
-        }
-      } else if (working_path) {
-        // 技能模式：没有 task_id 但有 working_path（技能目录路径）
-        // 构建简化的 taskContext，仅包含工作目录信息
-        taskContext = {
-          fullWorkspacePath: working_path,  // 技能目录路径（如 skills/file-operations）
-          currentPath: '',  // 技能模式下没有子路径
-          isAdmin: session?.isAdmin || false,
-          isSkillCreator: session?.roles?.includes('creator') || false,
-        };
-        logger.info('[ChatService] 技能模式工作目录:', working_path);
-      } else {
-        // 对话模式：使用用户临时目录作为工作目录
-        // 路径格式：work/:user_id/temp（相对于 data/ 目录）
-        taskContext = {
-          fullWorkspacePath: `work/${user_id}/temp`,
-          currentPath: '',
-          isAdmin: session?.isAdmin || false,
-          isSkillCreator: session?.roles?.includes('creator') || false,
-        };
-        logger.info('[ChatService] 对话模式工作目录: work/' + user_id + '/temp');
-      }
+      // 2. 准备任务上下文
+      const taskContext = await this._prepareTaskContext({ task_id, user_id, working_path, session });
 
-      // 3. 获取或创建活跃对话（用于前端展示，消息不再关联 topic_id）
+      // 3. 获取或创建活跃对话
       let topic_id = providedTopicId;
       let isNewTopic = false;
-
       if (!topic_id) {
-        // 获取或创建活跃话题（仅用于前端展示）
         topic_id = await this.getOrCreateActiveTopic(user_id, expert_id, task_id);
         isNewTopic = true;
       }
-
       logger.debug('[ChatService] Topic ID:', topic_id, isNewTopic ? '(新话题)' : '(继续当前话题)');
 
       // 4. 发送开始事件
       onDelta?.({ type: 'start', message_id: `msg_${Utils.newID(10)}`, topic_id, is_new_topic: isNewTopic });
 
-      // 5. 保存用户消息（topic_id = NULL，未归档状态）
+      // 5. 保存用户消息
       const userMessageId = await this.saveUserMessage(topic_id, user_id, content, expert_id, task_id);
       logger.debug('[ChatService] 用户消息已保存:', userMessageId);
 
-      // 6. 检查是否需要压缩上下文（新设计）
+      // 6. 检查是否需要压缩上下文
       const compressionCheck = await expertService.memorySystem.shouldCompressContext(
         user_id,
         expertService.getDefaultModelConfig().max_tokens || 128000,
         expertService.expertConfig?.expert?.context_threshold || 0.7,
-        5,  // 最小消息数：5条消息后开始检查压缩
-        50  // 最大未归档消息数：超过50条强制压缩
+        5,
+        50
       );
 
       if (compressionCheck.needCompress) {
         logger.info(`[ChatService] 触发上下文压缩: ${compressionCheck.reason}`);
-        // 同步执行压缩（阻塞，但必要）
         const compressResult = await expertService.memorySystem.compressContext(user_id, {
           contextSize: expertService.getDefaultModelConfig().max_tokens || 128000,
           threshold: expertService.expertConfig?.expert?.context_threshold || 0.7,
           minMessages: 5,
         });
-        // 如果创建了新 Topic，通知前端刷新
         if (compressResult.success && compressResult.topicsCreated > 0) {
           onDelta?.({ type: 'topic_updated', topicsCreated: compressResult.topicsCreated });
         }
       }
 
-      // 7. 构建上下文（新设计：Topic 总结 + 未归档消息 + 任务上下文）
+      // 7. 构建上下文
       logger.debug('[ChatService] 开始构建上下文...');
       const context = await expertService.buildContext(user_id, content, topic_id, taskContext);
       logger.debug('[ChatService] 上下文构建完成, 消息数:', context.messages?.length);
 
-      // 调用 LLM（流式），支持多轮工具调用
+      // 8. 准备 LLM 调用配置
       const startTime = Date.now();
-      // 获取最大工具调用轮数：优先使用专家配置，否则使用系统默认
-      const systemSettingService = getSystemSettingService(this.db);
-      const MAX_TOOL_ROUNDS = expertService.expertConfig?.expert?.max_tool_rounds
-        || await systemSettingService.getMaxToolRounds();
-      
-      let fullContent = '';
-      let fullReasoningContent = '';  // 存储思考内容（DeepSeek）
-      let tokenUsage = null;  // 存储真实的 token 使用信息
-      let allToolCalls = [];  // 收集所有轮次的工具调用
-      let currentMessages = [...context.messages];  // 当前对话消息
-
-      // 获取模型配置
       const modelConfig = model_id
         ? await this.getModelConfig(model_id)
         : expertService.getDefaultModelConfig();
-      
+
       logger.info('[ChatService] 使用模型:', {
         model_name: modelConfig.model_name,
         base_url: modelConfig.base_url,
         has_api_key: !!modelConfig.api_key,
       });
 
-      // 获取思考模式配置（根据模型自动检测）
-      // 传入 modelConfig 以支持用户覆盖默认模型
       const thinkingConfig = expertService.getThinkingConfig(modelConfig);
       if (thinkingConfig.thinking || thinkingConfig.reasoning) {
         logger.info('[ChatService] 思考模式配置:', thinkingConfig);
       }
 
-      // 获取工具定义
       const tools = expertService.toolManager.getToolDefinitions();
-      logger.info('[ChatService] 工具定义:', {
-        tools_count: tools.length,
-        has_tools: tools.length > 0
-      });
+      logger.info('[ChatService] 工具定义:', { tools_count: tools.length, has_tools: tools.length > 0 });
 
-      // 构建 LLM Payload 并保存到缓存（用于 Debug 面板展示）
+      // 构建 LLM Payload
       const llmPayload = {
         model: modelConfig.model_name,
-        messages: currentMessages,
-        temperature: expertService.llmClient.getExpertLLMParams().temperature,
-        top_p: expertService.llmClient.getExpertLLMParams().top_p,
-        frequency_penalty: expertService.llmClient.getExpertLLMParams().frequency_penalty,
-        presence_penalty: expertService.llmClient.getExpertLLMParams().presence_penalty,
-        max_tokens: modelConfig.max_output_tokens || 32768,
+        messages: context.messages,
         stream: true,
         stream_options: { include_usage: true },
-        ...(tools.length > 0 && { tools }),
-        // 元信息（不发送给 LLM，仅用于调试）
         _debug: {
           model_config: {
             provider_name: modelConfig.provider_name,
@@ -280,217 +432,62 @@ class ChatService {
             max_tokens: modelConfig.max_tokens,
             max_output_tokens: modelConfig.max_output_tokens,
           },
-          context_messages_count: currentMessages.length,
+          context_messages_count: context.messages.length,
           tools_count: tools.length,
         },
       };
       this.saveLLMPayload(user_id, expert_id, llmPayload);
 
-      // 多轮工具调用循环
-      logger.info('[ChatService] 开始调用 LLM，当前消息数:', currentMessages.length);
-      for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-        let collectedToolCalls = [];  // 本轮收集的工具调用
-        let roundContent = '';  // 本轮 LLM 返回的内容
+      // 9. 执行多轮 LLM 调用
+      const llmResult = await this._executeLLMRounds(expertService, {
+        modelConfig,
+        thinkingConfig,
+        tools,
+        currentMessages: context.messages,
+        llmPayload,
+        user_id,
+        expert_id,
+        taskContext,
+        topic_id,
+        task_id,
+        session,
+        onDelta
+      });
 
-        logger.info('[ChatService] 第', round + 1, '轮调用 LLM...');
-        // 流式调用
-        await expertService.llmClient.callStream(
-          modelConfig,
-          currentMessages,
-          {
-            tools,
-            // DeepSeek 思考模式参数
-            thinking: thinkingConfig.thinking,
-            // OpenAI 推理模式参数
-            reasoning: thinkingConfig.reasoning,
-            onDelta: (delta) => {
-              roundContent += delta;
-              fullContent += delta;
-              onDelta?.({ type: 'delta', content: delta });
-            },
-            // 思考内容增量回调（DeepSeek）
-            onReasoningDelta: (reasoningDelta) => {
-              fullReasoningContent += reasoningDelta;
-              onDelta?.({ type: 'reasoning_delta', content: reasoningDelta });
-            },
-            onToolCall: (toolCalls) => {
-              // 收集工具调用（llm-client 返回的是数组）
-              // 使用友好名称显示工具调用
-              const toolCallsForLog = Array.isArray(toolCalls) ? toolCalls : [toolCalls];
-              const displayNames = toolCallsForLog.map(call => {
-                const toolId = call.function?.name || call.name;
-                return expertService.toolManager.formatToolDisplay(toolId);
-              });
-              logger.info(`[ChatService] 第${round + 1}轮收到工具调用:`, displayNames);
-              if (Array.isArray(toolCalls)) {
-                collectedToolCalls.push(...toolCalls);
-              } else {
-                collectedToolCalls.push(toolCalls);
-              }
-              // 发送给前端时，添加友好名称
-              const toolCallsWithDisplayNames = toolCallsForLog.map(call => {
-                const toolId = call.function?.name || call.name;
-                return {
-                  ...call,
-                  displayName: expertService.toolManager.formatToolDisplay(toolId),
-                };
-              });
-              onDelta?.({ type: 'tool_call', toolCalls: toolCallsWithDisplayNames });
-            },
-            onUsage: (usage) => {
-              // 累加 token 使用信息（多轮调用时累加）
-              if (usage) {
-                if (!tokenUsage) {
-                  tokenUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
-                }
-                tokenUsage.prompt_tokens += usage.prompt_tokens || 0;
-                tokenUsage.completion_tokens += usage.completion_tokens || 0;
-                tokenUsage.total_tokens += usage.total_tokens || 0;
-                logger.info(`[ChatService] 第${round + 1}轮 token 使用:`, {
-                  prompt: usage.prompt_tokens,
-                  completion: usage.completion_tokens,
-                  total: usage.total_tokens,
-                });
-              }
-            },
-          }
-        );
-
-        // 如果没有工具调用，退出循环
-        if (collectedToolCalls.length === 0) {
-          logger.info(`[ChatService] 第${round + 1}轮无工具调用，完成`);
-          // 更新 payload 包含最终的 assistant 消息
-          if (roundContent) {
-            currentMessages = [
-              ...currentMessages,
-              { role: 'assistant', content: roundContent },
-            ];
-            llmPayload.messages = currentMessages;
-            llmPayload._debug.context_messages_count = currentMessages.length;
-            llmPayload.cached_at = new Date().toISOString();
-            this.saveLLMPayload(user_id, expert_id, llmPayload);
-          }
-          break;
-        }
-
-        logger.info(`[ChatService] 第${round + 1}轮开始执行工具调用:`, collectedToolCalls.length);
-
-        // 构建 toolCallId -> context 映射
-        const toolCallContexts = {};
-        for (const call of collectedToolCalls) {
-          if (call.id && call.context) {
-            toolCallContexts[call.id] = call.context;
-          }
-        }
-
-        // 执行工具（传递任务上下文和 topic_id），每完成一个工具就实时通知前端并保存消息
-        const toolResults = await expertService.handleToolCalls(
-          collectedToolCalls,
-          user_id,
-          session?.accessToken,  // 从 session 中获取 accessToken
-          taskContext,
-          topic_id,
-          // 实时回调：每执行完一个工具就保存消息并通知前端
-          async (toolResult) => {
-            logger.info(`[ChatService] 工具执行完成: ${toolResult.toolName}, 成功: ${toolResult.success}`);
-            // 关联 context（从原始 toolCall 中获取）
-            const originalCall = collectedToolCalls.find(c => c.id === toolResult.toolCallId);
-            if (originalCall?.context) {
-              toolResult.context = originalCall.context;
-            }
-            // 保存工具消息到数据库（传递 task_id 以更新任务的 last_executed_at）
-            await this.saveToolMessage(topic_id, user_id, toolResult, expert_id, task_id);
-            // 通知前端
-            onDelta?.({ type: 'tool_result', result: toolResult });
-          },
-          session  // 直接传递 session 对象，toolManager 从中读取权限信息
-        );
-        
-        // 合并工具调用和执行结果（用于保存到数据库）
-        const toolCallsWithResults = collectedToolCalls.map((call, index) => {
-          const result = toolResults[index];
-          return {
-            ...call,
-            result: result ? {
-              success: result.success,
-              data: result.data,
-              error: result.error,
-            } : null,
-            duration: result?.duration || 0,
-            timestamp: new Date().toISOString(),
-          };
-        });
-        allToolCalls.push(...toolCallsWithResults);
-
-        // 更新消息历史，加入助手消息和工具结果
-        currentMessages = [
-          ...currentMessages,
-          { role: 'assistant', content: roundContent || null, tool_calls: collectedToolCalls },
-          ...expertService.toolManager.formatToolResultsForLLM(toolResults),
-        ];
-
-        // 同步更新 LLM Payload 缓存（确保调试面板能看到最新消息）
-        llmPayload.messages = currentMessages;
-        llmPayload._debug.context_messages_count = currentMessages.length;
-        llmPayload.cached_at = new Date().toISOString();
-        this.saveLLMPayload(user_id, expert_id, llmPayload);
-
-        // 如果达到最大轮数，下一轮不传递 tools，强制返回文本
-        if (round + 1 >= MAX_TOOL_ROUNDS) {
-          logger.warn('[ChatService] 达到最大工具调用轮数，下一轮将强制返回文本');
-        }
-      }
-
-      // 如果 LLM 没有返回任何内容，生成默认回复
-      if (!fullContent || fullContent.trim() === '') {
-        logger.warn('[ChatService] LLM 未返回内容，生成默认回复');
-        fullContent = '我已处理您的请求，但没有生成具体的回复内容。';
-      }
-
+      const { fullContent, fullReasoningContent, tokenUsage } = llmResult;
       const latency = Date.now() - startTime;
 
-      // 7. 保存助手消息
-      // 注意：工具调用信息不再存储在 assistant 消息中，而是存储在独立的 tool 消息中
-      // 这样避免数据重复存储，前端从 tool 消息获取工具调用详情
+      // 10. 保存助手消息
       const messageOptions = {
-        prompt_tokens: tokenUsage?.prompt_tokens || 0,  // 输入 token
-        completion_tokens: tokenUsage?.completion_tokens || 0,  // 输出 token
+        prompt_tokens: tokenUsage?.prompt_tokens || 0,
+        completion_tokens: tokenUsage?.completion_tokens || 0,
         latency_ms: latency,
         model_name: modelConfig.model_name,
         provider_name: modelConfig.provider_name,
         expert_id,
-        reasoning_content: fullReasoningContent || null,  // 思考过程内容
-        task_id,  // 任务ID（用于更新任务的 last_executed_at）
+        reasoning_content: fullReasoningContent || null,
+        task_id,
       };
-      
-      const assistantMessageId = await this.saveAssistantMessage(
-        topic_id,
-        user_id,
-        fullContent,
-        messageOptions
-      );
 
-      // 7. 异步执行反思（不阻塞响应）
+      const assistantMessageId = await this.saveAssistantMessage(topic_id, user_id, fullContent, messageOptions);
+
+      // 11. 异步执行反思和历史归档
       expertService.performReflection(user_id, content, fullContent, topic_id).catch(err => {
         logger.error('[ChatService] 反思失败:', err.message);
       });
 
-      // 8. 异步检查并处理历史归档（不阻塞响应）
-      // 当消息积累到一定数量后，由 MemorySystem 自动总结并更新 Topic 标题
       expertService.processHistoryIfNeeded(user_id, topic_id).catch(err => {
         logger.error('[ChatService] 历史归档失败:', err.message);
       });
 
-      // 9. 更新话题时间
+      // 12. 更新话题时间
       await this.updateTopicTimestamp(topic_id);
 
-      // 10. 发送完成事件
-      // 注意：不再传递 tool_calls 字段，工具调用信息已通过 tool_result 事件传递
+      // 13. 发送完成事件
       onComplete?.({
         type: 'complete',
         message_id: assistantMessageId,
         content: fullContent,
-        // 思考内容（DeepSeek reasoning_content）
         reasoning_content: fullReasoningContent || null,
         usage: tokenUsage ? {
           prompt_tokens: tokenUsage.prompt_tokens,


### PR DESCRIPTION
## 问题描述

在部署环境中发现以下错误：
```
[ERROR] [ChatService] 流式聊天失败: this.updateTaskLastExecutedByTopic is not a function
```

## 原因分析

- `lib/chat-service.js` 第 698 行调用了 `this.updateTaskLastExecutedByTopic(topic_id)`
- 但该方法不存在，只有 `updateTaskLastExecuted(task_id)` 方法（第 872 行）

## 解决方案

### 1. 添加缺失的方法
添加 `updateTaskLastExecutedByTopic` 方法：
- 通过 `topic_id` 查找关联的任务
- 如果话题关联了任务（`topic.task_id`），则更新任务的 `last_executed_at` 和状态
- 复用 `updateTaskLastExecuted` 方法，避免代码重复

### 2. 重构 streamChat 方法（代码优化）
提取私有方法减少代码膨胀：
- `_prepareTaskContext()`: 处理任务/技能/对话模式的上下文准备
- `_executeLLMRounds()`: 处理多轮 LLM 调用和工具执行
- `_executeTools()`: 处理工具调用执行

`streamChat` 方法从 ~370 行简化为更清晰的结构，改善代码可读性和可维护性。

## 影响范围

- 自主任务执行功能
- 话题关联任务的状态更新
- `lib/chat-service.js` 代码结构优化

## 测试

- [x] 代码已提交并通过语法检查
- [x] 重构后代码编译通过
- [ ] 部署后验证错误不再出现

Closes #391