### PR TITLE
feat: 将所有 Modal 改为 static 模式防止误关闭

### DIFF
--- a/frontend/src/components/MySkillParametersModal.vue
+++ b/frontend/src/components/MySkillParametersModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="visible" class="dialog-overlay" @click.self="close">
+  <div v-if="visible" class="dialog-overlay">
     <div class="dialog">
       <h3 class="dialog-title">
         {{ $t('skills.myParameters.title') }}: {{ skill?.name }}

--- a/frontend/src/components/SkillParametersModal.vue
+++ b/frontend/src/components/SkillParametersModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="visible" class="dialog-overlay" @click.self="close">
+  <div v-if="visible" class="dialog-overlay">
     <div class="dialog">
       <h3 class="dialog-title">
         {{ $t('skills.parameters.title') }}: {{ skill?.name }}

--- a/frontend/src/components/assistant/AssistantRequestCard.vue
+++ b/frontend/src/components/assistant/AssistantRequestCard.vue
@@ -75,7 +75,7 @@
 
     <!-- 结果详情弹窗 -->
     <Teleport to="body">
-      <div v-if="showDetail" class="detail-modal-overlay" @click.self="showDetail = false">
+      <div v-if="showDetail" class="detail-modal-overlay">
         <div class="detail-modal">
           <div class="modal-header">
             <h3>{{ assistantName }} - {{ $t('assistant.resultTitle') }}</h3>

--- a/frontend/src/components/assistant/AssistantResult.vue
+++ b/frontend/src/components/assistant/AssistantResult.vue
@@ -49,7 +49,7 @@
 
     <!-- 警告弹窗 -->
     <Teleport to="body">
-      <div v-if="showWarning" class="warning-modal-overlay" @click.self="showWarning = false">
+      <div v-if="showWarning" class="warning-modal-overlay">
         <div class="warning-modal">
           <div class="warning-header">
             <span class="warning-icon">⚠️</span>

--- a/frontend/src/components/common/UserPicker.vue
+++ b/frontend/src/components/common/UserPicker.vue
@@ -23,7 +23,7 @@
 
     <!-- Modal 弹窗 -->
     <Teleport to="body">
-      <div v-if="showModal" class="user-picker-overlay" @click.self="closeModal">
+      <div v-if="showModal" class="user-picker-overlay">
         <div class="user-picker-modal">
           <div class="modal-header">
             <h3>{{ $t('settings.selectUser') }}</h3>
@@ -91,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { userApi } from '@/api/services'
 import { useToastStore } from '@/stores/toast'
@@ -195,13 +195,6 @@ const clearSelection = () => {
   closeModal()
 }
 
-// ESC 键关闭
-const handleKeydown = (event: KeyboardEvent) => {
-  if (event.key === 'Escape' && showModal.value) {
-    closeModal()
-  }
-}
-
 // 监听 modelValue 变化
 watch(() => props.modelValue, (newVal) => {
   if (newVal && users.value.length > 0) {
@@ -211,12 +204,7 @@ watch(() => props.modelValue, (newVal) => {
   }
 })
 
-onMounted(() => {
-  document.addEventListener('keydown', handleKeydown)
-})
-
 onUnmounted(() => {
-  document.removeEventListener('keydown', handleKeydown)
   // 确保恢复滚动
   document.body.style.overflow = ''
 })

--- a/frontend/src/components/settings/InvitationTab.vue
+++ b/frontend/src/components/settings/InvitationTab.vue
@@ -99,7 +99,7 @@
     </div>
 
     <!-- 链接显示弹窗 -->
-    <div v-if="showLinkModal" class="modal-overlay" @click.self="closeLinkModal">
+    <div v-if="showLinkModal" class="modal-overlay">
       <div class="modal-content link-modal">
         <div class="modal-header">
           <h3>{{ $t('invitation.inviteLink') }}</h3>
@@ -122,7 +122,7 @@
     </div>
 
     <!-- 使用记录弹窗 -->
-    <div v-if="showUsageModal" class="modal-overlay" @click.self="closeUsageModal">
+    <div v-if="showUsageModal" class="modal-overlay">
       <div class="modal-content">
         <div class="modal-header">
           <h3>{{ $t('invitation.usageTitle') }}</h3>


### PR DESCRIPTION
## 变更说明

将系统中所有 Modal 改为 static 模式，防止用户误点击背景或按 ESC 键导致表单数据丢失。

## 修改内容

- 移除所有 Modal 的 `@click.self` 事件，防止点击背景关闭
- 移除 UserPicker 的 ESC 键监听，防止按 ESC 键关闭
- 清理未使用的 `onMounted` 导入

## 修改的文件

| 文件 | 修改内容 |
|------|----------|
| `frontend/src/components/SkillParametersModal.vue` | 移除 `@click.self="close"` |
| `frontend/src/components/MySkillParametersModal.vue` | 移除 `@click.self="close"` |
| `frontend/src/components/common/UserPicker.vue` | 移除 `@click.self` 和 ESC 键监听 |
| `frontend/src/components/assistant/AssistantResult.vue` | 移除 `@click.self="showWarning = false"` |
| `frontend/src/components/assistant/AssistantRequestCard.vue` | 移除 `@click.self="showDetail = false"` |
| `frontend/src/components/settings/InvitationTab.vue` | 移除两个 Modal 的 `@click.self` 事件 |

## 测试

- [x] 所有 Modal 仍可通过关闭按钮正常关闭
- [x] 点击背景不会关闭 Modal
- [x] 按 ESC 键不会关闭 Modal

Closes #394