### PR TITLE
fix: 修复专家上下文拼接程序历史消息顺序混乱问题

### DIFF
--- a/lib/memory-system.js
+++ b/lib/memory-system.js
@@ -13,18 +13,13 @@ class MemorySystem {
    * @param {Database} db - 数据库实例
    * @param {string} expertId - 专家ID
    * @param {LLMClient} llmClient - LLM客户端（用于总结）
-   * @param {object} options - 可选配置
+   * @param {object} options - 可选配置（保留参数兼容性）
    */
   constructor(db, expertId, llmClient, options = {}) {
     this.db = db;
     this.expertId = expertId;
     this.llmClient = llmClient;
-
-    // 内存缓存配置
-    this.messageCache = new Map(); // userId -> recentMessages
-    this.cacheMaxSize = options.cacheMaxSize || 100; // 每个用户的最大消息数
-    this.maxCachedUsers = options.maxCachedUsers || 50; // 最大缓存用户数量
-    this.lruList = []; // LRU 访问顺序追踪
+    // 注：已弃用内存缓存，直接从数据库读取，确保数据一致性
   }
 
   /**
@@ -35,18 +30,10 @@ class MemorySystem {
    * 获取最近消息
    * @param {string} userId - 用户ID
    * @param {number} limit - 数量限制
-   * @returns {Promise<Array>} 消息列表
+   * @returns {Promise<Array>} 消息列表（DESC 顺序：最新的在前）
    */
   async getRecentMessages(userId, limit = 20) {
-    // 先检查缓存
-    const cached = this.messageCache.get(userId);
-    if (cached && cached.length >= limit) {
-      // 更新 LRU 顺序
-      this.updateLRU(userId);
-      return cached.slice(-limit);
-    }
-
-    // 从数据库加载
+    // 直接从数据库加载（DESC 顺序：最新的在前）
     const messages = await this.db.getRecentMessages(this.expertId, userId, limit);
 
     // 安全解析 JSON
@@ -60,7 +47,7 @@ class MemorySystem {
     };
 
     // 转换格式（保持数据库字段名一致，不做驼峰转换）
-    const formatted = messages.map(m => ({
+    return messages.map(m => ({
       id: m.id,
       role: m.role,
       content: m.content,
@@ -69,11 +56,6 @@ class MemorySystem {
       tool_calls: safeParseJSON(m.tool_calls),
       topic_id: m.topic_id,
     }));
-
-    // 更新缓存
-    this.messageCache.set(userId, formatted);
-
-    return formatted;
   }
 
   /**
@@ -961,73 +943,6 @@ ${JSON.stringify(existingTopics.map(t => ({
     return Utils.newID(20);
   }
 
-  /**
-   * 更新消息缓存
-   * @param {string} userId - 用户ID
-   * @param {object} message - 消息对象
-   */
-  updateMessageCache(userId, message) {
-    // 更新 LRU 顺序
-    this.updateLRU(userId);
-
-    // 检查是否需要清理旧用户
-    if (!this.messageCache.has(userId) &&
-        this.messageCache.size >= this.maxCachedUsers) {
-      this.evictLRU();
-    }
-
-    if (!this.messageCache.has(userId)) {
-      this.messageCache.set(userId, []);
-    }
-
-    const cache = this.messageCache.get(userId);
-    cache.push(message);
-
-    // 限制单个用户的缓存大小
-    if (cache.length > this.cacheMaxSize) {
-      cache.shift();
-    }
-  }
-
-  /**
-   * 更新 LRU 访问顺序
-   * @param {string} userId - 用户ID
-   */
-  updateLRU(userId) {
-    // 从列表中移除（如果存在）
-    const index = this.lruList.indexOf(userId);
-    if (index > -1) {
-      this.lruList.splice(index, 1);
-    }
-    // 添加到末尾（最近使用）
-    this.lruList.push(userId);
-  }
-
-  /**
-   * 清理最久未使用的用户缓存
-   */
-  evictLRU() {
-    if (this.lruList.length === 0) return;
-    
-    // 移除列表第一个（最久未使用）
-    const oldestUser = this.lruList.shift();
-    if (oldestUser && this.messageCache.has(oldestUser)) {
-      this.messageCache.delete(oldestUser);
-      logger.debug(`[MemorySystem] 缓存清理: ${oldestUser}`);
-    }
-  }
-
-  /**
-   * 清除缓存
-   * @param {string} userId - 用户ID（可选）
-   */
-  clearCache(userId = null) {
-    if (userId) {
-      this.messageCache.delete(userId);
-    } else {
-      this.messageCache.clear();
-    }
-  }
 }
 
 export default MemorySystem;

--- a/lib/reflective-mind.js
+++ b/lib/reflective-mind.js
@@ -142,7 +142,7 @@ ${triggerMessage?.content || '(无)'}
 ${myResponse?.content || '(无)'}
 
 ## 最近对话上下文
-${context?.slice(-5).map(m => `${m.role}: ${m.content}`).join('\n') || '(无)'}
+${context?.slice(0, 5).map(m => `${m.role}: ${m.content}`).join('\n') || '(无)'}
 
 请进行自我反思，返回 JSON 格式：`;
 


### PR DESCRIPTION
## 问题描述

专家上下文拼接程序在提取历史消息时存在顺序混乱问题。

## 修复内容

1. **移除未使用的缓存机制**：`MemorySystem` 中的内存缓存从未被更新，直接从数据库读取消息确保数据一致性
2. **修复 ReflectiveMind 中的 slice 问题**：`context.slice(-5)` 在 DESC 顺序下会取到最旧的 5 条消息，修正为 `context.slice(0, 5)` 取最新的 5 条

## 数据流确认

```
数据库查询 (DESC: 最新在前)
    ↓
MemorySystem.getRecentMessages() (DESC: 最新在前)
    ↓
Context Organizer 调用 .reverse() (ASC: 最旧在前)
    ↓
OpenAI API (符合标准格式)
```

## 修改文件

- `lib/memory-system.js` - 移除缓存属性和方法，简化 `getRecentMessages()`
- `lib/reflective-mind.js` - 修复 `slice(-5)` → `slice(0, 5)`

## 影响评估

| 风险项 | 等级 | 说明 |
|--------|------|------|
| 消息顺序混乱 | 已解决 | 移除缓存后直接从数据库读取，顺序一致 |
| 性能影响 | 低 | 数据库已有索引，查询效率可接受 |
| 向后兼容 | 无影响 | `options` 参数保留，接口签名不变 |

Closes #398