### PR TITLE
fix: 任务状态被错误地从 active 改为 autonomous_wait

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -860,7 +860,8 @@ class ChatService {
    * 当任务有关的消息（用户消息、助手消息、工具消息）保存时调用
    *
    * 状态转换说明：
-   * - 当 ChatService 完成处理（EOF）后，将状态设为 autonomous_wait
+   * - 只有在自主运行状态（autonomous/autonomous_wait/autonomous_working）时才更新为 autonomous_wait
+   * - active 状态的任务保持 active，只更新 last_executed_at
    * - autonomous_wait 表示 LLM 处理完毕，等待中，可以响应新消息
    * - 自主任务执行器会在开始执行时将状态设为 autonomous_working
    *
@@ -874,7 +875,26 @@ class ChatService {
         this.Task = this.db.getModel('task');
       }
       
-      // 更新 last_executed_at 并将状态设为 autonomous_wait
+      // 先获取当前任务状态
+      const task = await this.Task.findByPk(task_id, { raw: true });
+      if (!task) {
+        logger.warn(`[ChatService] 任务不存在: ${task_id}`);
+        return;
+      }
+      
+      // 只有在自主运行相关状态时才更新为 autonomous_wait
+      const autonomousStatuses = ['autonomous', 'autonomous_wait', 'autonomous_working'];
+      if (!autonomousStatuses.includes(task.status)) {
+        // 非自主运行状态（如 active），只更新 last_executed_at，不改变状态
+        await this.Task.update(
+          { last_executed_at: new Date() },
+          { where: { id: task_id } }
+        );
+        logger.debug(`[ChatService] 任务 last_executed_at 已更新（状态保持 ${task.status}）: ${task_id}`);
+        return;
+      }
+      
+      // 自主运行状态，更新 last_executed_at 并设为 autonomous_wait
       // 这样自主任务执行器就知道 LLM 已处理完毕，可以响应新消息
       await this.Task.update(
         {


### PR DESCRIPTION
## 问题描述

任务创建后，初始状态为 `active`。但当用户发送消息后，任务状态被错误地从 `active` 改为 `autonomous_wait`。

这是因为 `updateTaskLastExecuted` 方法在更新 `last_executed_at` 时，无条件将状态设为 `autonomous_wait`，没有检查当前状态是否为自主运行状态。

## 修复内容

修改 [`lib/chat-service.js`](lib/chat-service.js:869) 的 `updateTaskLastExecuted` 方法：

1. 先获取当前任务状态
2. 只有在自主运行相关状态（`autonomous`、`autonomous_wait`、`autonomous_working`）时才更新为 `autonomous_wait`
3. `active` 状态的任务保持 `active`，只更新 `last_executed_at`

## 状态转换逻辑

| 当前状态 | 修复前 | 修复后 |
|---------|--------|--------|
| `active` | → `autonomous_wait` ❌ | → `active` ✅ |
| `autonomous` | → `autonomous_wait` ✅ | → `autonomous_wait` ✅ |
| `autonomous_wait` | → `autonomous_wait` ✅ | → `autonomous_wait` ✅ |
| `autonomous_working` | → `autonomous_wait` ✅ | → `autonomous_wait` ✅ |

Closes #401