### PR TITLE
fix: 自动执行按钮设置正确的 autonomous_wait 状态

### DIFF
--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -592,11 +592,11 @@ const toggleAutonomousMode = async () => {
 
   isTogglingAutonomous.value = true
   try {
-    const newStatus: TaskStatus = isAutonomousMode.value ? 'active' : 'autonomous'
+    const newStatus: TaskStatus = isAutonomousMode.value ? 'active' : 'autonomous_wait'
     const updateData: { status: TaskStatus; expert_id?: string } = { status: newStatus }
     
     // 开启自主模式时，设置当前专家ID
-    if (newStatus === 'autonomous') {
+    if (newStatus === 'autonomous_wait') {
       const expertId = route.params.expertId as string
       if (expertId) {
         updateData.expert_id = expertId
@@ -622,10 +622,10 @@ const handleToggleAutonomousFromList = async (task: Task, event: Event) => {
   
   if (isTogglingAutonomous.value) return
   
-  const newStatus: TaskStatus = task.status === 'autonomous' ? 'active' : 'autonomous'
+  const newStatus: TaskStatus = isAutonomousStatus(task.status) ? 'active' : 'autonomous_wait'
   
   // 开启自主模式需要专家ID
-  if (newStatus === 'autonomous') {
+  if (newStatus === 'autonomous_wait') {
     const expertId = route.params.expertId as string
     if (!expertId) {
       toast.warning(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')


### PR DESCRIPTION
## 问题描述

点击"自动执行"按钮时，任务状态被设置为 `autonomous`，但这个状态应该被废弃。正确的状态应该是：
- `autonomous_wait` - 自动模式，等待执行（LLM 空闲）
- `autonomous_working` - 自动模式，正在执行（LLM 处理中）

## 修改内容

修改 `frontend/src/components/panel/TasksTab.vue` 中的两个函数：

1. **`toggleAutonomousMode`** - 任务详情页的自动执行按钮
   - 将 `'autonomous'` 改为 `'autonomous_wait'`

2. **`handleToggleAutonomousFromList`** - 任务列表的自动执行按钮
   - 将判断条件从 `task.status === 'autonomous'` 改为 `isAutonomousStatus(task.status)`
   - 将设置的状态从 `'autonomous'` 改为 `'autonomous_wait'`

## 测试

- [x] 点击自动执行按钮，状态变为 `autonomous_wait`
- [x] 再次点击，状态恢复为 `active`

Closes #403