### PR TITLE
refactor: 移除已废弃的 autonomous 状态

### DIFF
--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -557,7 +557,7 @@ const isTogglingAutonomous = ref(false)
 // 计算属性：是否为自动运行模式（包括等待和执行中状态）
 const isAutonomousMode = computed(() => {
   const status = taskStore.currentTask?.status
-  return status === 'autonomous' || status === 'autonomous_wait' || status === 'autonomous_working'
+  return status === 'autonomous_wait' || status === 'autonomous_working'
 })
 
 // 计算属性：是否正在执行中（用于 UI 指示器）
@@ -567,12 +567,12 @@ const isAutonomousWorking = computed(() => {
 
 // 辅助函数：判断是否为自动运行相关状态
 const isAutonomousStatus = (status: string): boolean => {
-  return status === 'autonomous' || status === 'autonomous_wait' || status === 'autonomous_working'
+  return status === 'autonomous_wait' || status === 'autonomous_working'
 }
 
 // 辅助函数：获取任务状态指示器的 CSS 类名
 const getTaskStatusClass = (status: string): string => {
-  if (status === 'autonomous' || status === 'autonomous_wait' || status === 'autonomous_working') {
+  if (status === 'autonomous_wait' || status === 'autonomous_working') {
     return 'autonomous'
   }
   return status

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -730,13 +730,12 @@ export interface ExpertSimple {
 /**
  * 任务状态
  * - active: 正常活跃状态
- * - autonomous: 自动运行模式（旧状态，兼容）
  * - autonomous_wait: 自动运行等待中（LLM 处理完毕，等待新消息）
  * - autonomous_working: 自动运行执行中（LLM 正在处理）
  * - archived: 已归档
  * - deleted: 已删除
  */
-export type TaskStatus = 'active' | 'autonomous' | 'autonomous_wait' | 'autonomous_working' | 'archived' | 'deleted'
+export type TaskStatus = 'active' | 'autonomous_wait' | 'autonomous_working' | 'archived' | 'deleted'
 
 /**
  * 任务（匹配后端 tasks 表）

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -212,9 +212,10 @@ const currentModel = computed(() => {
   return undefined
 })
 
-// 自主运行模式 - 当任务状态为 autonomous 时禁用用户输入
+// 自主运行模式 - 当任务状态为 autonomous_wait 或 autonomous_working 时禁用用户输入
 const isAutonomousMode = computed(() => {
-  return taskStore.currentTask?.status === 'autonomous'
+  const status = taskStore.currentTask?.status
+  return status === 'autonomous_wait' || status === 'autonomous_working'
 })
 
 // 自主运行模式下的提示文字

--- a/issue-body-403.md
+++ b/issue-body-403.md
@@ -1,0 +1,27 @@
+## 问题描述
+
+当用户点击"自动执行"按钮时，任务状态被设置为 `autonomous`，但这个状态是旧设计，应该使用 `autonomous_wait` 代替。
+
+## 当前行为
+
+```javascript
+// frontend/src/components/panel/TasksTab.vue
+const newStatus: TaskStatus = isAutonomousMode.value ? 'active' : 'autonomous'
+```
+
+## 期望行为
+
+点击"自动执行"按钮后，状态应该设为 `autonomous_wait`（等待执行），而不是 `autonomous`。
+
+## 状态定义
+
+- `active`: 手动模式，用户控制
+- `autonomous_wait`: 自动模式，等待执行（LLM 空闲）
+- `autonomous_working`: 自动模式，正在执行（LLM 处理中）
+- ~~`autonomous`~~: 旧状态，已废弃
+
+## 修复位置
+
+`frontend/src/components/panel/TasksTab.vue`:
+- 第 595 行: `toggleAutonomousMode` 函数
+- 第 625 行: `handleToggleAutonomousFromList` 函数

--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -2,10 +2,10 @@
  * Autonomous Task Executor - 自主任务执行器
  *
  * 作为 BackgroundTaskScheduler 的任务处理器
- * 定期扫描 status='autonomous' 的任务，自动触发 AI 执行
+ * 定期扫描 status='autonomous_wait' 的任务，自动触发 AI 执行
  *
  * 工作流程：
- * 1. 查找所有 status='autonomous' 的任务
+ * 1. 查找所有 status='autonomous_wait' 或 'autonomous_working' 的任务
  * 2. 检查任务是否需要执行（根据 last_executed_at 和执行间隔）
  * 3. 获取任务的历史上下文（最近 N 条消息）
  * 4. 调用 ChatService 生成 AI 回复
@@ -90,12 +90,11 @@ export function createAutonomousTaskExecutor(options = {}) {
    * └─────────────────────────────────────────────────────────────┘
    *
    * 状态说明：
-   * - autonomous: 旧状态，视为等待中（兼容旧数据）
    * - autonomous_wait: LLM 处理完毕，等待新消息
    * - autonomous_working: LLM 正在处理中，跳过轮询
    *
    * 执行条件：
-   * 1. 状态必须是 autonomous 或 autonomous_wait（不能是 autonomous_working）
+   * 1. 状态必须是 autonomous_wait（不能是 autonomous_working）
    * 2. 有新消息（lastMessageTime > last_executed_at）或者从未执行过
    *
    * 超时保护：
@@ -123,8 +122,8 @@ export function createAutonomousTaskExecutor(options = {}) {
       }
     }
 
-    // 状态必须是 autonomous_wait 或 autonomous（旧状态兼容）才能执行
-    if (task.status !== 'autonomous_wait' && task.status !== 'autonomous') {
+    // 状态必须是 autonomous_wait 才能执行
+    if (task.status !== 'autonomous_wait') {
       return false;
     }
 
@@ -628,11 +627,10 @@ ${readmeSection}${historySection}
     }
 
     try {
-      // 查找所有 status='autonomous' 或 'autonomous_wait' 的任务
-      // 注：autonomous 是旧状态，autonomous_wait 是新状态，需要兼容
+      // 查找所有 status='autonomous_wait' 或 'autonomous_working' 的任务
       const autonomousTasks = await models.Task.findAll({
         where: {
-          status: { [Op.in]: ['autonomous', 'autonomous_wait', 'autonomous_working'] },
+          status: { [Op.in]: ['autonomous_wait', 'autonomous_working'] },
         },
         attributes: [
           'id', 'task_id', 'title', 'description', 'status',

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -883,7 +883,7 @@ class ChatService {
       }
       
       // 只有在自主运行相关状态时才更新为 autonomous_wait
-      const autonomousStatuses = ['autonomous', 'autonomous_wait', 'autonomous_working'];
+      const autonomousStatuses = ['autonomous_wait', 'autonomous_working'];
       if (!autonomousStatuses.includes(task.status)) {
         // 非自主运行状态（如 active），只更新 last_executed_at，不改变状态
         await this.Task.update(

--- a/models/task.js
+++ b/models/task.js
@@ -63,7 +63,7 @@ export default class task extends Model {
       }
     },
     status: {
-      type: DataTypes.ENUM('active','autonomous','autonomous_wait','autonomous_working','archived','deleted'),
+      type: DataTypes.ENUM('active','autonomous_wait','autonomous_working','archived','deleted'),
       allowNull: false,
       defaultValue: "active",
       comment: "任务状态"

--- a/pr-body-403.md
+++ b/pr-body-403.md
@@ -1,0 +1,23 @@
+## 问题描述
+
+点击"自动执行"按钮时，任务状态被设置为 `autonomous`，但这个状态应该被废弃。正确的状态应该是：
+- `autonomous_wait` - 自动模式，等待执行（LLM 空闲）
+- `autonomous_working` - 自动模式，正在执行（LLM 处理中）
+
+## 修改内容
+
+修改 `frontend/src/components/panel/TasksTab.vue` 中的两个函数：
+
+1. **`toggleAutonomousMode`** - 任务详情页的自动执行按钮
+   - 将 `'autonomous'` 改为 `'autonomous_wait'`
+
+2. **`handleToggleAutonomousFromList`** - 任务列表的自动执行按钮
+   - 将判断条件从 `task.status === 'autonomous'` 改为 `isAutonomousStatus(task.status)`
+   - 将设置的状态从 `'autonomous'` 改为 `'autonomous_wait'`
+
+## 测试
+
+- [x] 点击自动执行按钮，状态变为 `autonomous_wait`
+- [x] 再次点击，状态恢复为 `active`
+
+Closes #403

--- a/scripts/init-database.js
+++ b/scripts/init-database.js
@@ -250,7 +250,7 @@ const TABLES = [
     topic_id VARCHAR(32) NULL COMMENT '关联的话题ID（自主任务执行时的对话）',
     last_executed_at DATETIME NULL COMMENT '最后执行时间（自主任务执行器更新）',
     solution_id VARCHAR(32) NULL COMMENT '关联的解决方案ID',
-    status ENUM('active', 'autonomous', 'archived', 'deleted') DEFAULT 'active',
+    status ENUM('active', 'autonomous_wait', 'autonomous_working', 'archived', 'deleted') DEFAULT 'active',
     created_by VARCHAR(32) NOT NULL COMMENT '创建者 user_id',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -171,6 +171,37 @@ const MIGRATIONS = [
       console.log('  ✓ Added autonomous_wait and autonomous_working to tasks.status ENUM');
     }
   },
+
+  // ==================== 移除废弃的 autonomous 状态 ====================
+  // Issue #405: 清理已废弃的 autonomous 状态
+  {
+    name: 'tasks.status remove deprecated autonomous',
+    check: async (conn) => {
+      const columnType = await getColumnType(conn, 'tasks', 'status');
+      // 检查是否已移除 autonomous（只包含 autonomous_wait）
+      return columnType && columnType.includes('autonomous_wait') && !columnType.includes("'autonomous'");
+    },
+    migrate: async (conn) => {
+      // 1. 将现有的 autonomous 状态数据迁移为 autonomous_wait
+      await conn.execute(`
+        UPDATE tasks SET status = 'autonomous_wait' WHERE status = 'autonomous'
+      `);
+      console.log('  ✓ Migrated autonomous -> autonomous_wait');
+
+      // 2. 修改 ENUM 类型，移除 autonomous
+      await conn.execute(`
+        ALTER TABLE tasks
+        MODIFY COLUMN status ENUM(
+          'active',
+          'autonomous_wait',
+          'autonomous_working',
+          'archived',
+          'deleted'
+        ) NOT NULL DEFAULT 'active' COMMENT '任务状态'
+      `);
+      console.log('  ✓ Removed deprecated autonomous from tasks.status ENUM');
+    }
+  },
 ];
 
 /**


### PR DESCRIPTION
## 变更概述

移除已废弃的 `autonomous` 任务状态，统一使用 `autonomous_wait` 和 `autonomous_working` 状态。

## 变更内容

### 数据库迁移
- 添加迁移脚本，将现有 `autonomous` 状态数据迁移为 `autonomous_wait`
- 从 ENUM 定义中移除 `autonomous` 值

### 后端修改
- `models/task.js`: 更新 ENUM 定义
- `lib/autonomous-task-executor.js`: 移除对 `autonomous` 的兼容处理
- `lib/chat-service.js`: 移除 `autonomous` 状态

### 前端修改
- `frontend/src/types/index.ts`: 更新 `TaskStatus` 类型定义
- `frontend/src/views/ChatView.vue`: 更新状态检查逻辑
- `frontend/src/components/panel/TasksTab.vue`: 更新状态检查函数

### 初始化脚本
- `scripts/init-database.js`: 更新初始化 ENUM 定义

## 任务状态说明

| 状态 | 说明 |
|------|------|
| `active` | 正常活跃状态 |
| `autonomous_wait` | 自动运行等待中（LLM 空闲，等待执行） |
| `autonomous_working` | 自动运行执行中（LLM 正在处理） |
| `archived` | 已归档 |
| `deleted` | 已删除 |

## 测试建议

1. 运行数据库迁移：`node scripts/upgrade-database.js`
2. 验证现有 `autonomous` 状态数据已迁移为 `autonomous_wait`
3. 测试任务自动执行功能正常工作

Closes #405