### PR TITLE
fix: 修复开启自动运行模式时覆盖已有 expert_id 的问题

### DIFF
--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -595,16 +595,20 @@ const toggleAutonomousMode = async () => {
     const newStatus: TaskStatus = isAutonomousMode.value ? 'active' : 'autonomous_wait'
     const updateData: { status: TaskStatus; expert_id?: string } = { status: newStatus }
     
-    // 开启自主模式时，设置当前专家ID
+    // 开启自主模式时，检查专家ID
     if (newStatus === 'autonomous_wait') {
-      const expertId = route.params.expertId as string
-      if (expertId) {
-        updateData.expert_id = expertId
-      } else {
-        // 没有专家ID，无法开启自主模式
-        toast.warning(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
-        return
+      // 优先使用任务已有的专家ID，避免覆盖
+      if (!taskStore.currentTask.expert_id) {
+        const expertId = route.params.expertId as string
+        if (expertId) {
+          updateData.expert_id = expertId
+        } else {
+          // 没有专家ID，无法开启自主模式
+          toast.warning(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
+          return
+        }
       }
+      // 如果任务已有 expert_id，不覆盖
     }
     
     await taskStore.updateTask(taskStore.currentTask.id, updateData)
@@ -626,10 +630,19 @@ const handleToggleAutonomousFromList = async (task: Task, event: Event) => {
   
   // 开启自主模式需要专家ID
   if (newStatus === 'autonomous_wait') {
-    const expertId = route.params.expertId as string
-    if (!expertId) {
-      toast.warning(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
-      return
+    // 优先使用任务已有的专家ID，避免覆盖
+    let expertIdToUse: string | undefined
+    if (task.expert_id) {
+      // 任务已有专家ID，保持不变
+      expertIdToUse = undefined  // 不在 updateData 中设置 expert_id
+    } else {
+      // 任务没有专家ID，尝试从路由获取
+      const expertId = route.params.expertId as string
+      if (!expertId) {
+        toast.warning(t('tasks.noExpertForAutonomous') || '请先选择一个专家再开启自动运行模式')
+        return
+      }
+      expertIdToUse = expertId
     }
     
     // 确认对话框
@@ -638,10 +651,11 @@ const handleToggleAutonomousFromList = async (task: Task, event: Event) => {
     
     isTogglingAutonomous.value = true
     try {
-      await taskStore.updateTask(task.id, {
-        status: newStatus,
-        expert_id: expertId
-      })
+      const updateData: { status: TaskStatus; expert_id?: string } = { status: newStatus }
+      if (expertIdToUse) {
+        updateData.expert_id = expertIdToUse
+      }
+      await taskStore.updateTask(task.id, updateData)
     } catch (error) {
       console.error('Failed to enable autonomous mode:', error)
       toast.error(t('tasks.toggleAutonomousFailed') || '切换自动运行模式失败')


### PR DESCRIPTION
## 问题描述

当任务已有 `expert_id` 时，开启自动运行模式会错误地用路由参数中的 `expertId` 覆盖已有的 `expert_id`。

## 修复内容

修改了 [`TasksTab.vue`](frontend/src/components/panel/TasksTab.vue) 中的两个函数：

1. **`toggleAutonomousMode`** (行 589-621) - 任务详情页切换自动运行模式
2. **`handleToggleAutonomousFromList`** (行 623-683) - 任务列表切换自动运行模式

### 修复逻辑

```javascript
// 开启自主模式时，检查专家ID
if (newStatus === 'autonomous_wait') {
  // 优先使用任务已有的专家ID，避免覆盖
  if (!task.expert_id) {
    const expertId = route.params.expertId as string
    if (expertId) {
      updateData.expert_id = expertId
    } else {
      // 没有专家ID，无法开启自主模式
      toast.warning(...)
      return
    }
  }
  // 如果任务已有 expert_id，不覆盖
}
```

## 测试场景

1. 任务无 `expert_id`，从专家对话页开启自动运行 → 使用路由中的专家ID
2. 任务已有 `expert_id`，从任意页面开启自动运行 → 保持原有专家ID不变
3. 任务无 `expert_id`，不在专家对话页开启自动运行 → 显示警告提示