### PR TITLE
fix: 为自主任务跳过执行添加详细的 console 日志

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -82,7 +82,7 @@ export function createAutonomousTaskExecutor(options = {}) {
    *
    * 状态机设计：
    * ┌─────────────────────────────────────────────────────────────┐
-   * │  autonomous_wait  ──(有新消息)──▶  autonomous_working       │
+   * │  autonomous_wait  ──(轮询触发)──▶  autonomous_working       │
    * │        ▲                               │                    │
    * │        │                               │ (执行完成/EOF)      │
    * │        │                               │ (或超时自动恢复)    │
@@ -90,26 +90,29 @@ export function createAutonomousTaskExecutor(options = {}) {
    * └─────────────────────────────────────────────────────────────┘
    *
    * 状态说明：
-   * - autonomous_wait: LLM 处理完毕，等待新消息
+   * - autonomous_wait: LLM 处理完毕，等待下次轮询
    * - autonomous_working: LLM 正在处理中，跳过轮询
    *
    * 执行条件：
    * 1. 状态必须是 autonomous_wait（不能是 autonomous_working）
-   * 2. 有新消息（lastMessageTime > last_executed_at）或者从未执行过
+   * 2. 连续无响应次数 < maxNoResponseCount
+   *
+   * 注意：自动运行模式下用户不能输入消息，所以不需要检查"新消息"
+   * 执行频率由轮询间隔和速率限制控制
    *
    * 超时保护：
    * - 如果任务在 autonomous_working 状态超过 WORKING_TIMEOUT_MS，自动恢复为 autonomous_wait
    * - 这可以防止因异常导致 EOF 未触发而造成的死锁
    *
    * @param {Object} task 任务对象
-   * @param {Date|null} lastMessageTime 最后一条消息时间
    * @returns {Promise<boolean>} 是否需要执行
    */
-  async function shouldExecute(task, lastMessageTime) {
+  async function shouldExecute(task) {
     // 超时保护：如果任务在 autonomous_working 状态超过阈值，自动恢复
     if (task.status === 'autonomous_working') {
       const workingDuration = Date.now() - new Date(task.last_executed_at).getTime();
       if (workingDuration > WORKING_TIMEOUT_MS) {
+        console.log(`[AutonomousExecutor] ⚠️ 任务 ${task.id} 在 autonomous_working 状态超时 (${Math.round(workingDuration / 1000)}s)，自动恢复为 autonomous_wait`);
         logger.warn(`[AutonomousExecutor] 任务 ${task.id} 在 autonomous_working 状态超时 (${Math.round(workingDuration / 1000)}s)，自动恢复为 autonomous_wait`);
         await models.Task.update(
           { status: 'autonomous_wait' },
@@ -118,57 +121,22 @@ export function createAutonomousTaskExecutor(options = {}) {
         // 恢复后继续检查是否需要执行
       } else {
         // 正在执行中且未超时，跳过
+        console.log(`[AutonomousExecutor] ⏭️ 跳过任务 ${task.id}: 正在执行中 (autonomous_working)，已执行 ${Math.round(workingDuration / 1000)}s`);
         return false;
       }
     }
 
     // 状态必须是 autonomous_wait 才能执行
     if (task.status !== 'autonomous_wait') {
+      console.log(`[AutonomousExecutor] ⏭️ 跳过任务 ${task.id}: 状态不是 autonomous_wait (当前: ${task.status})`);
       return false;
     }
 
-    // 如果从未执行过，立即执行（新创建的任务）
-    if (!task.last_executed_at) {
-      return true;
-    }
-
-    // 检查是否有新消息（消息时间晚于上次执行时间）
-    // 这是触发执行的核心条件：用户发了新消息，或者 LLM 上一轮执行后产生了新消息
-    if (lastMessageTime) {
-      const lastExecTime = new Date(task.last_executed_at);
-      const lastMsgTime = new Date(lastMessageTime);
-      return lastMsgTime > lastExecTime;
-    }
-
-    // 没有消息记录，不执行
-    return false;
-  }
-
-  /**
-   * 获取任务的最后一条消息时间
-   * @param {string} expertId - 专家ID
-   * @param {string} userId - 用户ID
-   * @returns {Promise<Date|null>} 最后消息时间
-   */
-  async function getLastMessageTime(expertId, userId) {
-    if (!expertId || !userId) return null;
-    
-    try {
-      const lastMessage = await models.Message.findOne({
-        where: {
-          expert_id: expertId,
-          user_id: userId,
-        },
-        attributes: ['created_at'],
-        order: [['created_at', 'DESC']],
-        raw: true,
-      });
-      
-      return lastMessage ? new Date(lastMessage.created_at) : null;
-    } catch (error) {
-      logger.error(`[AutonomousExecutor] 获取最后消息时间失败: ${error.message}`);
-      return null;
-    }
+    // autonomous_wait 状态下直接执行
+    // 注意：自动运行模式下用户不能输入，所以不需要检查"新消息"
+    // 执行频率由轮询间隔和速率限制控制
+    console.log(`[AutonomousExecutor] ▶️ 任务 ${task.id}: 状态为 autonomous_wait，准备执行`);
+    return true;
   }
 
   /**
@@ -647,7 +615,7 @@ ${readmeSection}${historySection}
 
       console.log(`[AutonomousExecutor] 📝 发现 ${autonomousTasks.length} 个自主任务`);
 
-      // 过滤出需要执行的任务（基于最后消息时间）
+      // 过滤出需要执行的任务
       const tasksToExecute = [];
       for (const task of autonomousTasks) {
         // 检查连续无响应次数
@@ -657,18 +625,15 @@ ${readmeSection}${historySection}
           logger.warn(`[AutonomousExecutor] Task ${task.id} skipped: ${noResponseCount} consecutive no-response`);
           continue;
         }
-
-        // 获取最后一条消息时间
-        const lastMessageTime = await getLastMessageTime(task.expert_id, task.created_by);
         
         // 检查是否需要执行（async 函数，可能触发超时恢复）
-        if (await shouldExecute(task, lastMessageTime)) {
-          tasksToExecute.push({ task, lastMessageTime });
+        if (await shouldExecute(task)) {
+          tasksToExecute.push(task);
         }
       }
 
       if (tasksToExecute.length === 0) {
-        console.log('[AutonomousExecutor] ⏳ 所有自主任务都在执行间隔内，跳过');
+        console.log('[AutonomousExecutor] ⏳ 没有需要执行的任务');
         return;
       }
 
@@ -679,7 +644,7 @@ ${readmeSection}${historySection}
       let successCount = 0;
       let failCount = 0;
 
-      for (const { task, lastMessageTime } of batch) {
+      for (const task of batch) {
         // 在执行每个任务前检查速率限制
         if (isRateLimited()) {
           console.log(`[AutonomousExecutor] ⏸️ 批次执行中断：检测到速率限制`);


### PR DESCRIPTION
## 修改内容

为 [`lib/autonomous-task-executor.js`](lib/autonomous-task-executor.js) 中的 `shouldExecute` 函数添加详细的 console 日志，记录每次跳过任务执行的具体原因。

## 新增日志

| 跳过原因 | 日志示例 |
|---------|---------|
| 正在执行中 (autonomous_working) | `⏭️ 跳过任务 xxx: 正在执行中 (autonomous_working)，已执行 30s` |
| 状态不是 autonomous_wait | `⏭️ 跳过任务 xxx: 状态不是 autonomous_wait (当前: active)` |
| 没有新消息 | `⏭️ 跳过任务 xxx: 没有新消息 (最后消息: 2026-03-26T..., 上次执行: 2026-03-26T...)` |
| 没有消息记录 | `⏭️ 跳过任务 xxx: 没有消息记录` |
| 连续无响应次数过多 | `⏹️ 任务 xxx 已连续 2 次无响应，跳过` |
| 速率限制暂停 | `⏸️ 速率限制暂停中，剩余 30 秒` |

## 目的

方便调试和监控自主任务执行器的行为，快速定位任务为何没有被触发执行。