### PR TITLE
fix: PDF 技能代码审计问题修复

### DIFF
--- a/data/skills/pdf/SKILL.md
+++ b/data/skills/pdf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pdf
-description: "PDF 文件处理。用于读取、提取文本/表格、合并、拆分、旋转、水印、加密/解密、表单填写、图片提取、转换为图片。当用户提到 .pdf 文件或需要操作 PDF 时触发。"
+description: "PDF 文件处理。用于读取、提取文本/表格/图片、合并、拆分、旋转、水印、加密/解密、表单填写、页面渲染。当用户提到 .pdf 文件或需要操作 PDF 时触发。"
 license: Proprietary. LICENSE.txt has complete terms
 argument-hint: "[operation] [path]"
 user-invocable: true
@@ -8,18 +8,21 @@ user-invocable: true
 
 # PDF - PDF 文件处理
 
+> **依赖**：pdf-lib (PDF 操作) + pdf-parse v2.4+ (文本/表格/图片提取、页面渲染)
+
 ## 工具
 
 | 工具 | 说明 | 关键参数 |
 |------|------|----------|
-| `read_pdf` | 读取 PDF 元数据 | `path` |
-| `extract_text` | 提取文本 | `path`, `from_page`, `to_page` |
-| `extract_tables` | 提取表格 | `path`, `page` |
+| `read_pdf` | 读取 PDF 元数据 | `path`, `parse_page_info` |
+| `extract_text` | 提取文本 | `path`, `from_page`, `to_page`, `suppress_warnings` |
+| `extract_tables` | 提取表格 | `path`, `from_page`, `to_page` |
+| `extract_images` | 提取图片 | `path`, `from_page`, `to_page`, `image_threshold` |
+| `convert_to_images` | 渲染页面为图片 | `path`, `output_dir`, `scale`, `from_page`, `to_page` |
 | `merge_pdfs` | 合并 PDF | `paths[]`, `output` |
 | `split_pdf` | 拆分 PDF | `path`, `output_dir`, `pages_per_file` |
 | `rotate_pages` | 旋转页面 | `path`, `output`, `pages[]`, `degrees` |
 | `create_pdf` | 创建 PDF | `output`, `content[]` |
-| `convert_to_images` | 转为图片 | `path`, `output_dir`, `dpi`, `format` |
 | `pdf_to_markdown` | 转为 Markdown | `path`, `output` |
 | `encrypt_pdf` | 加密 PDF | `path`, `output`, `user_password` |
 | `decrypt_pdf` | 解密 PDF | `path`, `output`, `password` |
@@ -27,10 +30,6 @@ user-invocable: true
 | `check_fillable_fields` | 检查可填写字段 | `path` |
 | `extract_form_field_info` | 提取表单字段信息 | `path`, `output` |
 | `fill_fillable_fields` | 填写表单字段 | `path`, `field_values`, `output` |
-| `extract_form_structure` | 提取表单结构 | `path`, `output` |
-| `fill_pdf_form_with_annotations` | 用注释填写表单 | `path`, `fields_json`, `output` |
-| `check_bounding_boxes` | 验证边界框 | `fields_json` |
-| `extract_images` | 提取图片 | `path`, `output_dir` |
 
 ## 基本操作
 
@@ -40,8 +39,10 @@ user-invocable: true
 
 **参数：**
 - `path` (string, required): PDF 文件路径
+- `parse_page_info` (boolean, optional): 解析每页详细信息（默认: false）
+- `suppress_warnings` (boolean, optional): 抑制警告输出（默认: true）
 
-**返回：** 页数、元数据（标题、作者、主题、创建者）、加密状态
+**返回：** 页数、元数据（标题、作者、主题、创建者）、加密状态、每页尺寸
 
 ### extract_text
 
@@ -51,15 +52,28 @@ user-invocable: true
 - `path` (string, required): PDF 文件路径
 - `from_page` (number, optional): 起始页（从1开始，默认: 1）
 - `to_page` (number, optional): 结束页（包含）
-- `preserve_layout` (boolean, optional): 保留布局（默认: false）
+- `suppress_warnings` (boolean, optional): 抑制警告输出（默认: true）
 
 ### extract_tables
 
-使用 pdfplumber 从 PDF 提取表格。
+从 PDF 提取表格数据（使用 pdf-parse v2 的 getTable 方法）。
 
 **参数：**
 - `path` (string, required): PDF 文件路径
-- `page` (number, optional): 指定页码（从1开始，不指定则提取所有）
+- `from_page` (number, optional): 起始页（从1开始）
+- `to_page` (number, optional): 结束页（包含）
+- `suppress_warnings` (boolean, optional): 抑制警告输出（默认: true）
+
+### extract_images
+
+从 PDF 中提取嵌入的图片（使用 pdf-parse v2 的 getImage 方法）。
+
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `from_page` (number, optional): 起始页（从1开始）
+- `to_page` (number, optional): 结束页（包含）
+- `image_threshold` (number, optional): 图片最小尺寸阈值，像素（默认: 80）
+- `suppress_warnings` (boolean, optional): 抑制警告输出（默认: true）
 
 ## 编辑操作
 
@@ -109,11 +123,13 @@ user-invocable: true
 
 **参数：**
 - `path` (string, required): PDF 文件路径
-- `output_dir` (string, required): 输出目录
-- `dpi` (number, optional): 分辨率 DPI（默认: 150）
-- `format` (string, optional): 图片格式 - "png" 或 "jpeg"（默认: "png"）
+- `output_dir` (string, optional): 输出目录（不指定则只返回 dataUrl）
+- `scale` (number, optional): 缩放比例（默认: 1.5，相当于 150 DPI）
+- `desired_width` (number, optional): 期望宽度（像素），设置后将忽略 scale
+- `prefix` (string, optional): 输出文件名前缀（默认: "page"）
 - `from_page` (number, optional): 起始页（从1开始）
 - `to_page` (number, optional): 结束页（包含）
+- `suppress_warnings` (boolean, optional): 抑制警告输出（默认: true）
 
 ### pdf_to_markdown
 
@@ -171,7 +187,7 @@ user-invocable: true
 
 **参数：**
 - `path` (string, required): PDF 文件路径
-- `output` (string, required): 输出 JSON 文件路径
+- `output` (string, optional): 输出 JSON 文件路径（不指定则只返回结果）
 
 ### fill_fillable_fields
 
@@ -179,42 +195,8 @@ user-invocable: true
 
 **参数：**
 - `path` (string, required): PDF 文件路径
-- `field_values` (string, required): 包含字段值的 JSON 文件
+- `field_values` (object, required): 字段名和值的键值对
 - `output` (string, required): 输出 PDF 文件路径
-
-### extract_form_structure
-
-为不可填写的表单提取表单结构。
-
-**参数：**
-- `path` (string, required): PDF 文件路径
-- `output` (string, required): 输出 JSON 文件路径
-
-### fill_pdf_form_with_annotations
-
-使用文本注释填写不可填写的 PDF 表单。
-
-**参数：**
-- `path` (string, required): PDF 文件路径
-- `fields_json` (string, required): 字段 JSON 文件路径
-- `output` (string, required): 输出 PDF 文件路径
-
-### check_bounding_boxes
-
-验证表单字段的边界框。
-
-**参数：**
-- `fields_json` (string, required): 字段 JSON 文件路径
-
-## 其他操作
-
-### extract_images
-
-从 PDF 中提取嵌入的图片。
-
-**参数：**
-- `path` (string, required): PDF 文件路径
-- `output_dir` (string, required): 输出目录
 
 ## 常见任务
 
@@ -223,13 +205,13 @@ user-invocable: true
 对于扫描版 PDF 或基于图片的 PDF，文本提取可能失败。使用 `convert_to_images` 转换为图片，然后发送给 VL（视觉语言）模型进行文字识别。
 
 **工作流程：**
-1. 使用 `convert_to_images` 将 PDF 页面转换为 PNG/JPEG 图片
+1. 使用 `convert_to_images` 将 PDF 页面转换为 PNG 图片
 2. 将生成的图片发送给 VL 模型（如 GPT-4V、Claude Vision、Qwen-VL）
 3. VL 模型将识别并提取图片中的文字
 
 **示例：**
 ```javascript
-convert_to_images({ path: "scanned.pdf", output_dir: "./images", dpi: 200 })
+convert_to_images({ path: "scanned.pdf", output_dir: "./images", scale: 1.5 })
 ```
 
 ## 快速参考
@@ -240,11 +222,12 @@ convert_to_images({ path: "scanned.pdf", output_dir: "./images", dpi: 200 })
 | 拆分 PDF | `split_pdf` | 按页拆分 |
 | 提取文本 | `extract_text` | 获取文本内容 |
 | 提取表格 | `extract_tables` | 获取表格数据 |
+| 提取图片 | `extract_images` | 获取嵌入图片 |
+| 渲染页面 | `convert_to_images` | 页面转 PNG |
 | 创建 PDF | `create_pdf` | 从文本创建 |
 | 扫描版 PDF | `convert_to_images` + VL 模型 | 先转图片再识别 |
-| 填写表单 | `fill_fillable_fields` | 见 FORMS.md |
+| 填写表单 | `fill_fillable_fields` | 填写表单字段 |
 
-## 更多资源
+## 更新日志
 
-- **表单填写**: 详见 [`FORMS.md`](./forms.md)
-- **高级用法**: 详见 [`REFERENCE.md`](./reference.md)
+- **2026-03-26**: 升级 pdf-parse 到 v2.4.5，新增表格提取、图片提取、页面渲染功能

--- a/data/skills/pdf/index.js
+++ b/data/skills/pdf/index.js
@@ -4,6 +4,9 @@
  * 功能：
  * - 读取 PDF 元数据和基本信息
  * - 提取文本内容
+ * - 提取图片
+ * - 提取表格
+ * - 渲染页面为图片
  * - 合并多个 PDF
  * - 拆分 PDF
  * - 旋转页面
@@ -14,20 +17,24 @@
  * 
  * 依赖：
  * - pdf-lib: PDF 操作核心库
- * - pdf-parse: 文本提取
+ * - pdf-parse v2.4+: 文本提取、图片提取、表格提取、页面渲染
  */
 
 const { PDFDocument, StandardFonts, rgb, degrees } = require('pdf-lib');
 const fs = require('fs');
 const path = require('path');
 
-// pdf-parse 延迟加载
-let pdfParse = null;
+// pdf-parse v2 延迟加载
+let PDFParse = null;
+let VerbosityLevel = null;
+
 function getPdfParse() {
-  if (!pdfParse) {
-    pdfParse = require('pdf-parse');
+  if (!PDFParse) {
+    const pdfParseModule = require('pdf-parse');
+    PDFParse = pdfParseModule.PDFParse;
+    VerbosityLevel = pdfParseModule.VerbosityLevel;
   }
-  return pdfParse;
+  return { PDFParse, VerbosityLevel };
 }
 
 // 用户角色检查
@@ -132,14 +139,16 @@ function savePdfFile(filePath, pdfBytes) {
 
 /**
  * 读取 PDF 元数据和基本信息
+ * 使用 pdf-parse v2 的 getInfo() 方法获取更丰富的信息
  */
 async function readPdf(params) {
-  const { path: filePath } = params;
+  const { path: filePath, parsePageInfo = false, suppressWarnings = true } = params;
   
   const pdfBytes = await readPdfFile(filePath);
   const pdfDoc = await PDFDocument.load(pdfBytes);
   
-  const metadata = {
+  // 使用 pdf-lib 获取基础信息
+  const basicMetadata = {
     title: pdfDoc.getTitle() || null,
     author: pdfDoc.getAuthor() || null,
     subject: pdfDoc.getSubject() || null,
@@ -154,10 +163,42 @@ async function readPdf(params) {
   const pageCount = pages.length;
   const isEncrypted = pdfDoc.isEncrypted;
   
+  // 使用 pdf-parse v2 获取更丰富的信息
+  let extendedInfo = null;
+  let parser;
+  
+  try {
+    const { PDFParse, VerbosityLevel } = getPdfParse();
+    const loadParams = {
+      data: pdfBytes,
+      verbosity: suppressWarnings ? VerbosityLevel.ERRORS : VerbosityLevel.WARNINGS
+    };
+    
+    parser = new PDFParse(loadParams);
+    const infoResult = await parser.getInfo({ parsePageInfo });
+    
+    extendedInfo = {
+      total: infoResult.total,
+      infoData: infoResult.infoData,
+      dates: infoResult.getDateNode ? infoResult.getDateNode() : null,
+      pages: parsePageInfo ? infoResult.pages : undefined
+    };
+  } catch (e) {
+    // 如果 pdf-parse 失败，仍然返回基础信息
+    console.error('pdf-parse getInfo failed:', e.message);
+  } finally {
+    // 确保释放内存
+    if (parser) {
+      await parser.destroy();
+    }
+  }
+  
   return {
     success: true,
     pageCount,
-    metadata,
+    metadata: extendedInfo?.infoData || basicMetadata,
+    basicMetadata,
+    extendedInfo,
     isEncrypted,
     pages: pages.map((page, index) => ({
       number: index + 1,
@@ -169,55 +210,111 @@ async function readPdf(params) {
 
 /**
  * 提取文本内容
+ * 使用 pdf-parse v2 API，支持 verbosity 参数抑制警告输出
  */
 async function extractText(params) {
-  const { path: filePath, fromPage, toPage } = params;
+  const { path: filePath, fromPage, toPage, suppressWarnings = true } = params;
   
-  const pdfParseLib = getPdfParse();
+  const { PDFParse, VerbosityLevel } = getPdfParse();
   const pdfBytes = await readPdfFile(filePath);
   
-  const data = await pdfParseLib(pdfBytes);
-  
-  let text = data.text;
-  const totalPages = data.numpages;
-  
-  if (fromPage || toPage) {
-    const start = (fromPage || 1) - 1;
-    const end = toPage || totalPages;
-    
-    const pdfDoc = await PDFDocument.load(pdfBytes);
-    const pages = pdfDoc.getPages();
-    
-    const newDoc = await PDFDocument.create();
-    const indices = [];
-    for (let i = start; i < end && i < pages.length; i++) {
-      indices.push(i);
-    }
-    const copiedPages = await newDoc.copyPages(pdfDoc, indices);
-    copiedPages.forEach(page => newDoc.addPage(page));
-    
-    const newBytes = await newDoc.save();
-    const newData = await pdfParseLib(newBytes);
-    text = newData.text;
-  }
-  
-  return {
-    success: true,
-    text,
-    pageCount: data.numpages,
-    info: data.info
+  // 创建解析器实例，设置 verbosity 抑制警告
+  const loadParams = {
+    data: pdfBytes,
+    // 设置 verbosity 为 ERRORS 只显示错误，抑制 WARNING 输出
+    verbosity: suppressWarnings ? VerbosityLevel.ERRORS : VerbosityLevel.WARNINGS
   };
+  
+  const parser = new PDFParse(loadParams);
+  
+  try {
+    // 处理分页提取
+    if (fromPage || toPage) {
+      const pdfDoc = await PDFDocument.load(pdfBytes);
+      const totalPages = pdfDoc.getPageCount();
+      const start = (fromPage || 1);
+      const end = toPage || totalPages;
+      
+      // 构建 partial 数组（页码从 1 开始）
+      const partial = [];
+      for (let i = start; i <= end && i <= totalPages; i++) {
+        partial.push(i);
+      }
+      
+      const result = await parser.getText({ partial });
+      return {
+        success: true,
+        text: result.text,
+        pageCount: totalPages,
+        extractedPages: partial,
+        info: result.info
+      };
+    }
+    
+    // 提取全部文本
+    const result = await parser.getText();
+    
+    return {
+      success: true,
+      text: result.text,
+      pageCount: result.total || result.numpages,
+      info: result.info
+    };
+  } finally {
+    // 始终释放内存
+    await parser.destroy();
+  }
 }
 
 /**
- * 提取表格（简化版本）
+ * 提取表格
+ * 使用 pdf-parse v2 的 getTable() 方法
  */
 async function extractTables(params) {
-  return {
-    success: false,
-    error: 'Table extraction is not fully supported in Node.js. Consider using VL models (GPT-4V, Claude Vision) for table recognition.',
-    alternative: 'Use convert_to_images to convert PDF to images, then send to VL model for table extraction.'
+  const { path: filePath, fromPage, toPage, suppressWarnings = true } = params;
+  
+  const { PDFParse, VerbosityLevel } = getPdfParse();
+  const pdfBytes = await readPdfFile(filePath);
+  
+  const loadParams = {
+    data: pdfBytes,
+    verbosity: suppressWarnings ? VerbosityLevel.ERRORS : VerbosityLevel.WARNINGS
   };
+  
+  const parser = new PDFParse(loadParams);
+  
+  try {
+    // 构建分页参数
+    const parseParams = {};
+    if (fromPage || toPage) {
+      const pdfDoc = await PDFDocument.load(pdfBytes);
+      const totalPages = pdfDoc.getPageCount();
+      const start = fromPage || 1;
+      const end = toPage || totalPages;
+      
+      const partial = [];
+      for (let i = start; i <= end && i <= totalPages; i++) {
+        partial.push(i);
+      }
+      parseParams.partial = partial;
+    }
+    
+    const result = await parser.getTable(parseParams);
+    
+    // 格式化表格数据
+    const tables = result.pages.map((page, pageIndex) => ({
+      pageNumber: pageIndex + 1,
+      tables: page.tables || []
+    }));
+    
+    return {
+      success: true,
+      tables,
+      totalTables: tables.reduce((sum, p) => sum + p.tables.length, 0)
+    };
+  } finally {
+    await parser.destroy();
+  }
 }
 
 // ==================== 编辑操作 ====================
@@ -418,18 +515,85 @@ function wrapText(text, maxWidth, font, fontSize) {
 }
 
 /**
- * 转换 PDF 为图片（需要外部工具）
+ * 转换 PDF 为图片
+ * 使用 pdf-parse v2 的 getScreenshot() 方法
  */
 async function convertToImages(params) {
-  return {
-    success: false,
-    error: 'PDF to image conversion requires external tools.',
-    alternatives: [
-      'Use poppler-utils: pdftoppm -png input.pdf output',
-      'Use pdf2pic (requires GraphicsMagick or ImageMagick)',
-      'Use canvas + pdf.js for rendering'
-    ]
+  const { 
+    path: filePath, 
+    outputDir, 
+    fromPage, 
+    toPage, 
+    scale = 1.5, 
+    desiredWidth,
+    prefix = 'page',
+    suppressWarnings = true 
+  } = params;
+  
+  const { PDFParse, VerbosityLevel } = getPdfParse();
+  const pdfBytes = await readPdfFile(filePath);
+  
+  const loadParams = {
+    data: pdfBytes,
+    verbosity: suppressWarnings ? VerbosityLevel.ERRORS : VerbosityLevel.WARNINGS
   };
+  
+  const parser = new PDFParse(loadParams);
+  
+  try {
+    // 构建分页参数
+    const parseParams = { scale };
+    if (desiredWidth) {
+      parseParams.desiredWidth = desiredWidth;
+    }
+    
+    if (fromPage || toPage) {
+      const pdfDoc = await PDFDocument.load(pdfBytes);
+      const totalPages = pdfDoc.getPageCount();
+      const start = fromPage || 1;
+      const end = toPage || totalPages;
+      
+      const partial = [];
+      for (let i = start; i <= end && i <= totalPages; i++) {
+        partial.push(i);
+      }
+      parseParams.partial = partial;
+    }
+    
+    const result = await parser.getScreenshot(parseParams);
+    
+    // 保存图片
+    const resolvedOutputDir = outputDir ? resolvePath(outputDir) : null;
+    const savedFiles = [];
+    
+    if (resolvedOutputDir) {
+      if (!fs.existsSync(resolvedOutputDir)) {
+        fs.mkdirSync(resolvedOutputDir, { recursive: true });
+      }
+      
+      for (let i = 0; i < result.pages.length; i++) {
+        const page = result.pages[i];
+        const outputPath = path.join(resolvedOutputDir, `${prefix}_${i + 1}.png`);
+        fs.writeFileSync(outputPath, page.data);
+        savedFiles.push(outputPath);
+      }
+    }
+    
+    return {
+      success: true,
+      pages: result.pages.map((page, index) => ({
+        pageNumber: index + 1,
+        width: page.width,
+        height: page.height,
+        dataUrl: page.dataUrl,
+        savedPath: savedFiles[index] || null
+      })),
+      savedFiles: savedFiles.length > 0 ? savedFiles : undefined,
+      outputDir: resolvedOutputDir
+    };
+  } finally {
+    await parser.destroy();
+  }
 }
 
 /**
@@ -688,17 +852,60 @@ async function fillFillableFields(params) {
 
 /**
  * 提取图片
+ * 使用 pdf-parse v2 的 getImage() 方法
  */
 async function extractImages(params) {
-  return {
-    success: false,
-    error: 'Image extraction is not directly supported by pdf-lib.',
-    alternatives: [
-      'Use pdfimages from poppler-utils: pdfimages -j input.pdf output',
-      'Use pdf.js for image extraction',
-      'Use Python pypdf or pdfplumber for image extraction'
-    ]
+  const { path: filePath, fromPage, toPage, imageThreshold = 80, suppressWarnings = true } = params;
+  
+  const { PDFParse, VerbosityLevel } = getPdfParse();
+  const pdfBytes = await readPdfFile(filePath);
+  
+  const loadParams = {
+    data: pdfBytes,
+    verbosity: suppressWarnings ? VerbosityLevel.ERRORS : VerbosityLevel.WARNINGS
   };
+  
+  const parser = new PDFParse(loadParams);
+  
+  try {
+    // 构建分页参数
+    const parseParams = { imageThreshold };
+    if (fromPage || toPage) {
+      const pdfDoc = await PDFDocument.load(pdfBytes);
+      const totalPages = pdfDoc.getPageCount();
+      const start = fromPage || 1;
+      const end = toPage || totalPages;
+      
+      const partial = [];
+      for (let i = start; i <= end && i <= totalPages; i++) {
+        partial.push(i);
+      }
+      parseParams.partial = partial;
+    }
+    
+    const result = await parser.getImage(parseParams);
+    
+    // 格式化图片数据
+    const images = result.pages.map((page, pageIndex) => ({
+      pageNumber: pageIndex + 1,
+      images: (page.images || []).map((img, imgIndex) => ({
+        index: imgIndex + 1,
+        width: img.width,
+        height: img.height,
+        // 图片数据为 Buffer
+        data: img.data,
+        dataUrl: img.dataUrl
+      }))
+    }));
+    
+    return {
+      success: true,
+      images,
+      totalImages: images.reduce((sum, p) => sum + p.images.length, 0)
+    };
+  } finally {
+    await parser.destroy();
+  }
 }
 
 // ==================== 技能入口 ====================

--- a/docs/core/tasks/2026-03-26-pdf-skill-code-review.md
+++ b/docs/core/tasks/2026-03-26-pdf-skill-code-review.md
@@ -1,0 +1,352 @@
+# PDF Skill 代码审计报告
+
+**审计日期**: 2026-03-26
+**审计范围**: `data/skills/pdf/index.js` + `data/skills/pdf/SKILL.md`
+**审计人**: Maria
+
+---
+
+## 📋 审计摘要
+
+| 类别 | 问题数 | 严重程度 |
+|------|--------|----------|
+| 🔴 严重问题 | 1 | 高 |
+| 🟡 中等问题 | 4 | 中 |
+| 🟢 轻微问题 | 3 | 低 |
+
+---
+
+## 🔴 严重问题
+
+### 1. SKILL.md 与代码参数不一致 - `convert_to_images`
+
+**位置**: 
+- SKILL.md 第 127-128 行
+- index.js 第 516-525 行
+
+**问题描述**:
+SKILL.md 文档描述的参数与实际代码实现不一致：
+
+| 参数 | SKILL.md | 代码实现 |
+|------|----------|----------|
+| 分辨率 | `dpi` (number, 默认: 150) | `scale` (number, 默认: 1.5) |
+| 图片格式 | `format` ("png" \| "jpeg") | ❌ 未实现 |
+| 宽度控制 | ❌ 未文档化 | `desiredWidth` (可选) |
+
+**影响**: LLM 调用技能时可能传递错误参数，导致功能异常。
+
+**建议修复**:
+```javascript
+// 方案 A: 更新 SKILL.md 匹配代码
+- `dpi` (number, optional): 分辨率 DPI（默认: 150）
+- `format` (string, optional): 图片格式 - "png" 或 "jpeg"（默认: "png"）
++ `scale` (number, optional): 缩放比例（默认: 1.5）
++ `desired_width` (number, optional): 期望宽度（像素）
+
+// 方案 B: 更新代码支持 dpi 参数（推荐）
+// dpi 150 ≈ scale 1.5, dpi 300 ≈ scale 3.0
+const scale = params.dpi ? params.dpi / 100 : (params.scale || 1.5);
+```
+
+---
+
+## 🟡 中等问题
+
+### 2. `readPdf` 函数内存管理不完整
+
+**位置**: index.js 第 168-188 行
+
+**问题描述**:
+`readPdf` 函数中创建了 `PDFParse` 实例，但如果 `getInfo()` 抛出异常，`parser.destroy()` 不会被调用。
+
+**当前代码**:
+```javascript
+try {
+  const parser = new PDFParse(loadParams);
+  const infoResult = await parser.getInfo({ parsePageInfo });
+  await parser.destroy();  // ❌ 如果 getInfo 抛异常，这行不会执行
+  // ...
+} catch (e) {
+  console.error('pdf-parse getInfo failed:', e.message);
+  // ❌ 没有 destroy 调用
+}
+```
+
+**建议修复**:
+```javascript
+let parser;
+try {
+  parser = new PDFParse(loadParams);
+  const infoResult = await parser.getInfo({ parsePageInfo });
+  // ...
+} catch (e) {
+  console.error('pdf-parse getInfo failed:', e.message);
+} finally {
+  if (parser) {
+    await parser.destroy();
+  }
+}
+```
+
+### 3. 冗余的 PDF 加载
+
+**位置**: 
+- `extractText` 第 227 行
+- `extractTables` 第 284 行
+- `extractImages` 第 868 行
+- `convertToImages` 第 545 行
+
+**问题描述**:
+在处理分页提取时，代码先使用 `PDFDocument.load` 加载 PDF 获取总页数，然后 `PDFParse` 内部又会再次加载同一个 PDF。
+
+**当前代码**:
+```javascript
+const pdfBytes = await readPdfFile(filePath);  // 第一次读取
+// ...
+if (fromPage || toPage) {
+  const pdfDoc = await PDFDocument.load(pdfBytes);  // 第二次解析
+  const totalPages = pdfDoc.getPageCount();
+  // ...
+  const result = await parser.getText({ partial });  // PDFParse 内部第三次解析
+}
+```
+
+**影响**: 性能损耗，内存占用增加。
+
+**建议修复**:
+```javascript
+// 方案 A: 使用 pdf-parse 的 info 获取页数
+const info = await parser.getInfo();
+const totalPages = info.total;
+
+// 方案 B: 只在需要时加载 PDFDocument
+// （当前实现可接受，但建议添加注释说明原因）
+```
+
+### 4. `extract_form_field_info` 参数文档不一致
+
+**位置**: 
+- SKILL.md 第 188 行
+- index.js 第 758-800 行
+
+**问题描述**:
+SKILL.md 标注 `output` 为 required，但代码中 `output` 是可选的。
+
+**SKILL.md**:
+```
+- `output` (string, required): 输出 JSON 文件路径
+```
+
+**代码**:
+```javascript
+if (output) {  // output 是可选的
+  const resolvedPath = resolvePath(output);
+  fs.writeFileSync(resolvedPath, JSON.stringify(result, null, 2), 'utf-8');
+  result.path = resolvedPath;
+}
+```
+
+**建议修复**:
+更新 SKILL.md：
+```markdown
+- `output` (string, optional): 输出 JSON 文件路径（不指定则只返回结果）
+```
+
+### 5. 缺少参数范围验证
+
+**位置**: 多处
+
+**问题描述**:
+多个函数缺少参数范围验证：
+
+| 函数 | 缺少验证的参数 |
+|------|----------------|
+| `extractText` | `fromPage < 1`, `toPage > totalPages`, `fromPage > toPage` |
+| `extractTables` | 同上 |
+| `extractImages` | 同上，`imageThreshold < 0` |
+| `rotatePages` | `degrees` 不是 90/180/270 |
+| `createPdf` | `content` 为空数组 |
+
+**建议修复**:
+```javascript
+// extractText 示例
+if (fromPage !== undefined && fromPage < 1) {
+  throw new Error('fromPage must be >= 1');
+}
+if (toPage !== undefined && toPage < fromPage) {
+  throw new Error('toPage must be >= fromPage');
+}
+```
+
+---
+
+## 🟢 轻微问题
+
+### 6. `extractImages` 返回大量数据
+
+**位置**: index.js 第 883-893 行
+
+**问题描述**:
+`extractImages` 返回的图片数据包含完整的 Buffer 和 dataUrl，可能导致 JSON 响应过大。
+
+**当前代码**:
+```javascript
+images: (page.images || []).map((img, imgIndex) => ({
+  index: imgIndex + 1,
+  width: img.width,
+  height: img.height,
+  data: img.data,      // Buffer 数据
+  dataUrl: img.dataUrl  // Base64 数据 URL
+}))
+```
+
+**建议**:
+1. 添加 `saveToDir` 参数，将图片保存到文件而非返回数据
+2. 或添加 `maxImageSize` 参数限制返回数据大小
+
+### 7. 模块级变量初始化
+
+**位置**: index.js 第 28-38 行
+
+**问题描述**:
+`getPdfParse()` 函数使用模块级变量延迟加载，虽然 Node.js 单线程下问题不大，但代码风格可改进。
+
+**当前代码**:
+```javascript
+let PDFParse = null;
+let VerbosityLevel = null;
+
+function getPdfParse() {
+  if (!PDFParse) {
+    const pdfParseModule = require('pdf-parse');
+    PDFParse = pdfParseModule.PDFParse;
+    VerbosityLevel = pdfParseModule.VerbosityLevel;
+  }
+  return { PDFParse, VerbosityLevel };
+}
+```
+
+**建议**:
+```javascript
+// 使用更清晰的单例模式
+const getPdfParse = (() => {
+  let cached = null;
+  return () => {
+    if (!cached) {
+      const { PDFParse, VerbosityLevel } = require('pdf-parse');
+      cached = { PDFParse, VerbosityLevel };
+    }
+    return cached;
+  };
+})();
+```
+
+### 8. 缺少 TypeScript 类型定义
+
+**位置**: 整个文件
+
+**问题描述**:
+技能代码缺少 TypeScript 类型定义或 JSDoc 类型注释，不利于代码维护和 IDE 支持。
+
+**建议**:
+添加 JSDoc 类型注释：
+```javascript
+/**
+ * @typedef {Object} ExtractTextParams
+ * @property {string} path - PDF 文件路径
+ * @property {number} [fromPage] - 起始页
+ * @property {number} [toPage] - 结束页
+ * @property {boolean} [suppressWarnings=true] - 抑制警告
+ */
+```
+
+---
+
+## ✅ 代码优点
+
+1. **良好的错误处理**: 大部分函数都有 try-catch 包裹
+2. **内存管理意识**: `extractText`, `extractTables`, `extractImages`, `convertToImages` 都正确使用了 `finally` 块调用 `parser.destroy()`
+3. **路径安全检查**: `isPathAllowed()` 和 `resolvePath()` 实现了完善的路径访问控制
+4. **角色权限分离**: 根据用户角色（管理员/技能创建者/普通用户）设置不同的访问权限
+5. **代码结构清晰**: 按功能分组（基础操作、编辑操作、创建转换、安全操作、表单操作）
+
+---
+
+## 📝 修复优先级
+
+| 优先级 | 问题 | 建议 |
+|--------|------|------|
+| P0 | `convert_to_images` 参数不一致 | 立即修复 SKILL.md |
+| P1 | `readPdf` 内存管理 | 尽快修复 |
+| P1 | 参数文档不一致 | 更新 SKILL.md |
+| P2 | 参数范围验证 | 添加验证逻辑 |
+| P3 | 其他轻微问题 | 后续优化 |
+
+---
+
+## 🔧 建议的修复代码
+
+### 修复 1: 更新 SKILL.md 中 `convert_to_images` 参数
+
+```markdown
+### convert_to_images
+
+将 PDF 页面转换为图片。
+
+**参数：**
+- `path` (string, required): PDF 文件路径
+- `output_dir` (string, optional): 输出目录（不指定则只返回 dataUrl）
+- `scale` (number, optional): 缩放比例（默认: 1.5，相当于 150 DPI）
+- `desired_width` (number, optional): 期望宽度（像素），设置后将忽略 scale
+- `prefix` (string, optional): 输出文件名前缀（默认: "page"）
+- `from_page` (number, optional): 起始页（从1开始）
+- `to_page` (number, optional): 结束页（包含）
+- `suppress_warnings` (boolean, optional): 抑制警告输出（默认: true）
+```
+
+### 修复 2: `readPdf` 内存管理
+
+```javascript
+async function readPdf(params) {
+  const { path: filePath, parsePageInfo = false, suppressWarnings = true } = params;
+  
+  const pdfBytes = await readPdfFile(filePath);
+  const pdfDoc = await PDFDocument.load(pdfBytes);
+  
+  // ... 基础信息获取 ...
+  
+  // 使用 pdf-parse v2 获取更丰富的信息
+  let extendedInfo = null;
+  let parser;
+  
+  try {
+    const { PDFParse, VerbosityLevel } = getPdfParse();
+    const loadParams = {
+      data: pdfBytes,
+      verbosity: suppressWarnings ? VerbosityLevel.ERRORS : VerbosityLevel.WARNINGS
+    };
+    
+    parser = new PDFParse(loadParams);
+    const infoResult = await parser.getInfo({ parsePageInfo });
+    
+    extendedInfo = {
+      total: infoResult.total,
+      infoData: infoResult.infoData,
+      dates: infoResult.getDateNode ? infoResult.getDateNode() : null,
+      pages: parsePageInfo ? infoResult.pages : undefined
+    };
+  } catch (e) {
+    console.error('pdf-parse getInfo failed:', e.message);
+  } finally {
+    if (parser) {
+      await parser.destroy();
+    }
+  }
+  
+  // ... 返回结果 ...
+}
+```
+
+---
+
+**审计完成** ✌Bazinga！亲爱的

--- a/docs/skills/pdf-parse-upgrade.md
+++ b/docs/skills/pdf-parse-upgrade.md
@@ -1,0 +1,186 @@
+# pdf-parse 升级指南
+
+## 问题背景
+
+在使用 pdf-parse 解析 PDF 时，遇到以下错误：
+
+```
+Failed to parse skill output: Unexpected token 'W', "Warning: T"... is not valid JSON
+```
+
+**原因分析：**
+1. pdf-parse 旧版本 (v1.x) 会输出 Warning 信息到 stdout
+2. 技能执行器期望输出是纯 JSON 格式
+3. Warning 信息导致 JSON 解析失败
+
+## 解决方案
+
+### 1. 升级 pdf-parse
+
+```bash
+npm install pdf-parse@latest
+```
+
+当前版本：`^2.4.5`（从 `^1.1.1` 升级）
+
+### 2. 使用 verbosity 参数抑制警告
+
+新版本 pdf-parse 提供 `VerbosityLevel` 枚举来控制输出级别：
+
+```javascript
+const { PDFParse, VerbosityLevel } = require('pdf-parse');
+
+const parser = new PDFParse({
+  data: pdfBuffer,
+  verbosity: VerbosityLevel.ERRORS  // 只显示错误，抑制警告
+});
+
+const result = await parser.getText();
+await parser.destroy();  // 记得释放内存
+```
+
+**VerbosityLevel 选项：**
+
+| 值 | 说明 |
+|---|---|
+| `VerbosityLevel.ERRORS` | 只显示错误信息 |
+| `VerbosityLevel.WARNINGS` | 显示警告和错误 |
+| `VerbosityLevel.INFOS` | 显示信息、警告和错误 |
+
+## pdf-parse v1 vs v2 API 对比
+
+### v1 API（旧版）
+
+```javascript
+// v1 - 函数式调用
+const pdfParse = require('pdf-parse');
+const data = await pdfParse(buffer);
+console.log(data.text);
+```
+
+### v2 API（新版）
+
+```javascript
+// v2 - 类实例调用
+const { PDFParse, VerbosityLevel } = require('pdf-parse');
+
+const parser = new PDFParse({
+  data: buffer,
+  verbosity: VerbosityLevel.ERRORS
+});
+
+const result = await parser.getText();
+console.log(result.text);
+
+// 释放内存
+await parser.destroy();
+```
+
+## 新版本新功能
+
+### 1. `getText()` - 提取文本
+
+```javascript
+const result = await parser.getText({
+  partial: [1, 3, 5]  // 只提取第 1、3、5 页
+});
+```
+
+### 2. `getInfo()` - 获取元数据
+
+```javascript
+const result = await parser.getInfo({
+  parsePageInfo: true  // 解析每页信息
+});
+console.log(result.total);        // 总页数
+console.log(result.infoData);     // 元数据
+console.log(result.pages);        // 每页信息
+```
+
+### 3. `getTable()` - 提取表格（新功能）
+
+```javascript
+const result = await parser.getTable();
+result.pages.forEach((page, i) => {
+  console.log(`Page ${i + 1} tables:`, page.tables);
+});
+```
+
+### 4. `getImage()` - 提取图片（新功能）
+
+```javascript
+const result = await parser.getImage({
+  imageThreshold: 80  // 过滤小于 80px 的图片
+});
+result.pages.forEach((page, i) => {
+  page.images.forEach((img, j) => {
+    console.log(`Image ${j}: ${img.width}x${img.height}`);
+    // img.data 是 Buffer
+  });
+});
+```
+
+### 5. `getScreenshot()` - 渲染页面为图片（新功能）
+
+```javascript
+const result = await parser.getScreenshot({
+  scale: 1.5,           // 缩放比例
+  desiredWidth: 1024,   // 或指定目标宽度
+  partial: [1, 2]       // 只渲染第 1、2 页
+});
+
+result.pages.forEach((page, i) => {
+  // page.data 是 PNG Buffer
+  // page.dataUrl 是 base64 Data URL
+});
+```
+
+### 6. `getHeader()` - 获取远程 PDF 头信息（Node.js 专用）
+
+```javascript
+const { getHeader } = require('pdf-parse/node');
+
+const header = await getHeader('https://example.com/doc.pdf', true);
+console.log(header.status);    // HTTP 状态
+console.log(header.size);      // 文件大小
+console.log(header.isPdf);     // 是否为 PDF
+```
+
+## 技能代码更新
+
+### 更新的函数
+
+| 函数 | 更新内容 |
+|---|---|
+| `extractText()` | 使用 `PDFParse` 类 + `verbosity` 参数 |
+| `extractTables()` | 使用 `getTable()` 实现真正的表格提取 |
+| `extractImages()` | 使用 `getImage()` 实现图片提取 |
+| `convertToImages()` | 使用 `getScreenshot()` 实现页面渲染 |
+| `readPdf()` | 使用 `getInfo()` 获取更丰富的元数据 |
+
+### 新增参数
+
+所有使用 pdf-parse 的函数都支持 `suppressWarnings` 参数：
+
+```javascript
+await extractText({
+  path: 'document.pdf',
+  suppressWarnings: true  // 默认为 true
+});
+```
+
+## 注意事项
+
+1. **内存管理**：v2 API 需要手动调用 `parser.destroy()` 释放内存
+2. **Node.js 版本**：v2 要求 Node.js >= 20.16.0 或 >= 22.3.0
+3. **异常处理**：v2 提供了更多异常类型：
+   - `PasswordException` - 密码错误
+   - `InvalidPDFException` - 无效 PDF
+   - `FormatError` - 格式错误
+   - `ResponseException` - 网络响应错误
+
+## 参考链接
+
+- [pdf-parse npm](https://www.npmjs.com/package/pdf-parse)
+- [pdf-parse GitHub](https://github.com/mehmet-kozan/pdf-parse)
+- [pdf.js 文档](https://mozilla.github.io/pdf.js/)

--- a/docs/skills/pdf-skill-refactor-plan.md
+++ b/docs/skills/pdf-skill-refactor-plan.md
@@ -1,0 +1,272 @@
+# PDF 技能重构方案
+
+## 当前问题
+
+当前 PDF 技能有 **16 个工具**，工具数量过多导致：
+1. LLM 选择困难 - 需要从大量工具中选择
+2. 维护成本高 - 每个工具都需要单独维护
+3. 用户体验差 - 需要记住多个工具名称
+4. **职责不清** - 混合了基本操作和组合技能
+
+## 技能分类原则
+
+### 基本技能 vs 组合技能
+
+| 类型 | 定义 | 示例 |
+|------|------|------|
+| **基本技能** | 单一原子操作，不可再分 | 提取文本、提取图片、合并 PDF |
+| **组合技能** | 由多个基本技能组合而成 | PDF 转 Markdown（提取文本 + 格式转换） |
+
+### 当前工具分类
+
+#### 基本技能 - 读取类（Read）
+
+| 工具 | 功能 | 保留 |
+|------|------|------|
+| `read_pdf` | 读取元数据 | ✅ |
+| `extract_text` | 提取文本 | ✅ |
+| `extract_tables` | 提取表格 | ✅ |
+| `extract_images` | 提取图片 | ✅ |
+| `convert_to_images` | 渲染为图片 | ✅ |
+| `check_fillable_fields` | 检查可填写字段 | ✅ |
+| `extract_form_field_info` | 提取表单字段信息 | ✅ |
+
+#### 基本技能 - 写入类（Write）
+
+| 工具 | 功能 | 保留 |
+|------|------|------|
+| `merge_pdfs` | 合并 PDF | ✅ |
+| `split_pdf` | 拆分 PDF | ✅ |
+| `rotate_pages` | 旋转页面 | ✅ |
+| `create_pdf` | 创建 PDF | ✅ |
+| `encrypt_pdf` | 加密 | ✅ |
+| `decrypt_pdf` | 解密 | ✅ |
+| `add_watermark` | 添加水印 | ✅ |
+| `fill_fillable_fields` | 填写表单字段 | ✅ |
+
+#### 组合技能 - 应移除或独立
+
+| 工具 | 功能 | 处理方式 |
+|------|------|----------|
+| `pdf_to_markdown` | 转为 Markdown | ❌ 移除，作为独立组合技能 |
+
+## 重构方案：两大工具
+
+### 方案：`read_pdf` + `write_pdf`
+
+### 充分利用新版 pdf-parse v2.4.5 特性
+
+新版 pdf-parse 提供了丰富的功能，重构方案应充分利用：
+
+| 新版特性 | 当前利用 | 重构方案 |
+|----------|----------|----------|
+| `getText({ partial })` | ✅ 已用 | 支持分页提取 |
+| `getInfo({ parsePageInfo })` | ✅ 已用 | 获取丰富元数据 |
+| `getTable()` | ✅ 已用 | 表格提取 |
+| `getImage({ imageThreshold })` | ✅ 已用 | 图片提取 |
+| `getScreenshot({ scale, desiredWidth })` | ✅ 已用 | 页面渲染 |
+| `getHeader(url, validatePdf)` | ❌ 未用 | **新增**：远程 PDF 验证 |
+| `verbosity: VerbosityLevel.ERRORS` | ✅ 已用 | 抑制警告 |
+| `password` 参数 | ❌ 未用 | **新增**：密码保护 PDF |
+| `url` 加载方式 | ❌ 未用 | **新增**：直接从 URL 加载 |
+
+#### `read_pdf` - 统一读取接口
+
+```javascript
+await read_pdf({
+  path: "document.pdf",  // 本地路径或 URL
+  action: "text",  // text | tables | images | metadata | form | screenshot | header
+  // 可选参数
+  from_page: 1,
+  to_page: 10,
+  output_dir: "./output",  // 用于 screenshot/images
+  scale: 1.5,  // 用于 screenshot
+  desired_width: 1024,  // 用于 screenshot（替代 scale）
+  image_threshold: 80,  // 用于 images
+  password: "xxx",  // 用于密码保护的 PDF
+  suppress_warnings: true  // 抑制警告输出
+});
+```
+
+**action 参数说明：**
+
+| action | 功能 | 额外参数 | pdf-parse 方法 |
+|--------|------|----------|----------------|
+| `metadata` | 读取元数据（默认） | `parse_page_info` | `getInfo()` |
+| `text` | 提取文本 | `from_page`, `to_page` | `getText({ partial })` |
+| `tables` | 提取表格 | `from_page`, `to_page` | `getTable()` |
+| `images` | 提取图片 | `from_page`, `to_page`, `image_threshold`, `output_dir` | `getImage()` |
+| `screenshot` | 渲染为图片 | `from_page`, `to_page`, `scale`, `desired_width`, `output_dir` | `getScreenshot()` |
+| `form` | 提取表单字段 | - | pdf-lib |
+| `header` | 获取远程 PDF 头信息 | `validate_pdf` | `getHeader()` **(新)** |
+
+> **注意**：`markdown` 不作为基本 action，因为 PDF 转 Markdown 是组合技能（提取文本 + 格式转换），应作为独立技能实现。
+
+#### 新增功能详解
+
+##### 1. `header` action - 远程 PDF 验证
+
+```javascript
+// 在下载前验证远程 PDF
+const result = await read_pdf({
+  path: "https://example.com/document.pdf",
+  action: "header",
+  validate_pdf: true  // 验证是否为有效 PDF
+});
+
+// 返回
+{
+  success: true,
+  status: 200,
+  size: 1024000,  // 文件大小（字节）
+  is_pdf: true,   // 是否为 PDF
+  headers: { ... } // HTTP 头信息
+}
+```
+
+##### 2. URL 直接加载
+
+```javascript
+// 直接从 URL 加载 PDF，无需先下载
+const result = await read_pdf({
+  path: "https://example.com/document.pdf",
+  action: "text"
+});
+```
+
+##### 3. 密码保护 PDF
+
+```javascript
+// 读取密码保护的 PDF
+const result = await read_pdf({
+  path: "protected.pdf",
+  action: "text",
+  password: "secret123"
+});
+```
+
+#### `write_pdf` - 统一写入接口
+
+```javascript
+await write_pdf({
+  action: "merge",  // merge | split | rotate | create | encrypt | decrypt | watermark | fill_form
+  // 根据 action 不同参数
+  paths: ["a.pdf", "b.pdf"],  // merge
+  output: "merged.pdf",
+  
+  // 或其他 action 的参数
+  // split: path, output_dir, pages_per_file
+  // rotate: path, output, pages, degrees
+  // create: output, title, content
+  // encrypt: path, output, user_password
+  // decrypt: path, output, password
+  // watermark: path, output, watermark
+  // fill_form: path, field_values, output
+});
+```
+
+**action 参数说明：**
+
+| action | 功能 | 必需参数 |
+|--------|------|----------|
+| `merge` | 合并 PDF | `paths[]`, `output` |
+| `split` | 拆分 PDF | `path`, `output_dir`, `pages_per_file?` |
+| `rotate` | 旋转页面 | `path`, `output`, `pages[]?`, `degrees?` |
+| `create` | 创建 PDF | `output`, `title?`, `content[]` |
+| `encrypt` | 加密 | `path`, `output`, `user_password` |
+| `decrypt` | 解密 | `path`, `output`, `password` |
+| `watermark` | 添加水印 | `path`, `output`, `watermark` |
+| `fill_form` | 填写表单 | `path`, `field_values`, `output` |
+
+## 优势对比
+
+| 指标 | 当前方案 | 重构方案 |
+|------|----------|----------|
+| 工具数量 | 16 个 | 2 个 |
+| LLM 选择复杂度 | 高 | 低 |
+| 参数设计 | 分散 | 统一 |
+| 代码复用 | 低 | 高 |
+| 扩展性 | 需新增工具 | 只需新增 action |
+
+## 实现建议
+
+### 1. 保持向后兼容
+
+```javascript
+// 新 API
+await read_pdf({ path: "doc.pdf", action: "text" });
+
+// 旧 API 仍然可用（内部转发到新 API）
+await extract_text({ path: "doc.pdf" });
+```
+
+### 2. 统一错误处理
+
+```javascript
+{
+  success: false,
+  error: "Invalid action: xxx",
+  available_actions: ["metadata", "text", "tables", ...]
+}
+```
+
+### 3. 智能默认值
+
+```javascript
+// action 默认为 metadata
+await read_pdf({ path: "doc.pdf" });  // 等同于 read_pdf({ path: "doc.pdf", action: "metadata" })
+```
+
+## 迁移计划
+
+### 阶段 1：添加新工具（不删除旧工具）
+- 实现 `read_pdf` 和 `write_pdf`
+- 更新 SKILL.md 文档
+- 旧工具标记为 deprecated
+
+### 阶段 2：测试验证
+- 使用新工具测试所有功能
+- 确保 LLM 能正确选择新工具
+
+### 阶段 3：移除旧工具
+- 删除旧工具定义
+- 清理代码
+
+## 示例对比
+
+### 当前方式
+
+```javascript
+// 提取文本
+await extract_text({ path: "doc.pdf", from_page: 1, to_page: 5 });
+
+// 提取表格
+await extract_tables({ path: "doc.pdf" });
+
+// 合并 PDF
+await merge_pdfs({ paths: ["a.pdf", "b.pdf"], output: "merged.pdf" });
+```
+
+### 重构后
+
+```javascript
+// 提取文本
+await read_pdf({ path: "doc.pdf", action: "text", from_page: 1, to_page: 5 });
+
+// 提取表格
+await read_pdf({ path: "doc.pdf", action: "tables" });
+
+// 合并 PDF
+await write_pdf({ action: "merge", paths: ["a.pdf", "b.pdf"], output: "merged.pdf" });
+```
+
+## 结论
+
+推荐采用 **read_pdf + write_pdf** 两工具方案，理由：
+
+1. **简化 LLM 决策** - 只需选择读或写
+2. **降低维护成本** - 代码集中，易于维护
+3. **提升扩展性** - 新功能只需添加 action
+4. **保持兼容性** - 旧 API 可继续使用
+
+是否需要我开始实现这个重构方案？

--- a/docs/skills/pdf-skill-summary.md
+++ b/docs/skills/pdf-skill-summary.md
@@ -1,0 +1,148 @@
+# PDF 技能升级与重构总结
+
+## 1. pdf-parse 升级
+
+### 版本变更
+- **旧版本**：`^1.1.1`
+- **新版本**：`^2.4.5`
+
+### 关键参数：抑制警告输出
+
+```javascript
+const { PDFParse, VerbosityLevel } = require('pdf-parse');
+
+const parser = new PDFParse({
+  data: pdfBuffer,
+  verbosity: VerbosityLevel.ERRORS  // 只显示错误，抑制警告
+});
+```
+
+### VerbosityLevel 选项
+
+| 值 | 说明 |
+|---|---|
+| `VerbosityLevel.ERRORS` | 只显示错误信息 |
+| `VerbosityLevel.WARNINGS` | 显示警告和错误 |
+| `VerbosityLevel.INFOS` | 显示信息、警告和错误 |
+
+---
+
+## 2. PDF 技能代码更新
+
+### 更新的函数
+
+| 函数 | 文件位置 | 更新内容 |
+|------|----------|----------|
+| `extractText()` | [index.js:209](../../data/skills/pdf/index.js#L209) | 使用 `PDFParse` 类 + `verbosity` 参数 |
+| `extractTables()` | [index.js:267](../../data/skills/pdf/index.js#L267) | 使用 `getTable()` 实现真正的表格提取 |
+| `extractImages()` | [index.js:851](../../data/skills/pdf/index.js#L851) | 使用 `getImage()` 实现图片提取 |
+| `convertToImages()` | [index.js:515](../../data/skills/pdf/index.js#L515) | 使用 `getScreenshot()` 实现页面渲染 |
+| `readPdf()` | [index.js:144](../../data/skills/pdf/index.js#L144) | 使用 `getInfo()` 获取更丰富的元数据 |
+
+---
+
+## 3. 新版本 pdf-parse 新功能
+
+| 方法 | 功能 | 示例 |
+|------|------|------|
+| `getText()` | 提取文本 | 支持 `partial` 分页提取 |
+| `getInfo()` | 获取元数据 | 支持 `parsePageInfo` |
+| `getTable()` | 提取表格 | **新功能** |
+| `getImage()` | 提取图片 | **新功能** |
+| `getScreenshot()` | 渲染为 PNG | **新功能** |
+| `getHeader()` | 获取远程 PDF 头信息 | **新功能** (Node.js 专用) |
+
+---
+
+## 4. 重构方案：read_pdf + write_pdf
+
+### 充分利用新版 pdf-parse v2.4.5 特性
+
+| 新版特性 | 当前利用 | 重构方案 |
+|----------|----------|----------|
+| `getText({ partial })` | ✅ 已用 | 支持分页提取 |
+| `getInfo({ parsePageInfo })` | ✅ 已用 | 获取丰富元数据 |
+| `getTable()` | ✅ 已用 | 表格提取 |
+| `getImage({ imageThreshold })` | ✅ 已用 | 图片提取 |
+| `getScreenshot({ scale, desiredWidth })` | ✅ 已用 | 页面渲染 |
+| `getHeader(url, validatePdf)` | ❌ 未用 | **新增**：远程 PDF 验证 |
+| `verbosity: VerbosityLevel.ERRORS` | ✅ 已用 | 抑制警告 |
+| `password` 参数 | ❌ 未用 | **新增**：密码保护 PDF |
+| `url` 加载方式 | ❌ 未用 | **新增**：直接从 URL 加载 |
+
+### 技能分类原则
+
+| 类型 | 定义 | 示例 |
+|------|------|------|
+| **基本技能** | 单一原子操作，不可再分 | 提取文本、提取图片、合并 PDF |
+| **组合技能** | 由多个基本技能组合而成 | PDF 转 Markdown（提取文本 + 格式转换） |
+
+### `read_pdf` - 统一读取接口
+
+```javascript
+await read_pdf({
+  path: "document.pdf",  // 本地路径或 URL
+  action: "text",  // metadata | text | tables | images | screenshot | form | header
+  from_page: 1,
+  to_page: 10,
+  password: "xxx",  // 密码保护 PDF
+  suppress_warnings: true
+});
+```
+
+| action | 功能 | pdf-parse 方法 |
+|--------|------|----------------|
+| `metadata` | 读取元数据 | `getInfo()` |
+| `text` | 提取文本 | `getText({ partial })` |
+| `tables` | 提取表格 | `getTable()` |
+| `images` | 提取图片 | `getImage()` |
+| `screenshot` | 渲染为图片 | `getScreenshot()` |
+| `form` | 提取表单字段 | pdf-lib |
+| `header` | 远程 PDF 验证 | `getHeader()` **(新)** |
+
+> **注意**：`markdown` 不作为基本 action，因为 PDF 转 Markdown 是组合技能。
+
+### `write_pdf` - 统一写入接口
+
+```javascript
+await write_pdf({
+  action: "merge",  // merge | split | rotate | create | encrypt | decrypt | watermark | fill_form
+  paths: ["a.pdf", "b.pdf"],
+  output: "merged.pdf"
+});
+```
+
+| action | 功能 |
+|--------|------|
+| `merge` | 合并 PDF |
+| `split` | 拆分 PDF |
+| `rotate` | 旋转页面 |
+| `create` | 创建 PDF |
+| `encrypt` | 加密 PDF |
+| `decrypt` | 解密 PDF |
+| `watermark` | 添加水印 |
+| `fill_form` | 填写表单 |
+
+### 优势对比
+
+| 指标 | 当前方案 | 重构方案 |
+|------|----------|----------|
+| 工具数量 | 16 个 | 2 个 |
+| LLM 选择难度 | 高 | 低 |
+| 代码复用 | 分散 | 统一 |
+| 扩展性 | 需新增工具 | 只需新增 action |
+
+---
+
+## 5. 相关文档
+
+- [pdf-parse 升级指南](./pdf-parse-upgrade.md)
+- [PDF 技能重构方案](./pdf-skill-refactor-plan.md)
+
+## 6. GitHub Issue
+
+- **Issue #408**: [refactor: PDF 技能工具重构为 read_pdf + write_pdf 两大类](https://github.com/ErixWong/touwaka-ai-mate/issues/408)
+
+---
+
+*最后更新：2026-03-26*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "touwaka-mate",
-  "version": "2.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "touwaka-mate",
-      "version": "2.0.0",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -30,7 +30,7 @@
         "mysql2": "^3.11.3",
         "numpy": "^0.0.1",
         "pdf-lib": "^1.17.1",
-        "pdf-parse": "^1.1.1",
+        "pdf-parse": "^2.4.5",
         "pptxgenjs": "^3.12.0",
         "sequelize": "^6.37.7",
         "sharp": "^0.34.5",
@@ -635,6 +635,190 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@pdf-lib/standard-fonts": {
@@ -2790,12 +2974,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
-      "license": "MIT"
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2893,19 +3071,35 @@
       "license": "0BSD"
     },
     "node_modules/pdf-parse": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
-      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
-      "license": "MIT",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "node-ensure": "^0.0.0"
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=6.8.1"
+        "node": ">=20.16.0 <21 || >=22.3.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/pg-connection-string": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mysql2": "^3.11.3",
     "numpy": "^0.0.1",
     "pdf-lib": "^1.17.1",
-    "pdf-parse": "^1.1.1",
+    "pdf-parse": "^2.4.5",
     "pptxgenjs": "^3.12.0",
     "sequelize": "^6.37.7",
     "sharp": "^0.34.5",


### PR DESCRIPTION
## 问题描述

代码审计发现以下问题需要修复：

### 🔴 严重问题
- `convert_to_images` 参数文档与代码实现不一致（`dpi` vs `scale`）

### 🟡 中等问题
- `readPdf` 函数内存管理不完整，异常时未调用 `parser.destroy()`
- `extract_form_field_info` 参数文档标注 `output` 为 required，但代码中为 optional

## 修复内容

- [x] 升级 pdf-parse 从 v1.1.1 到 v2.4.5
- [x] 更新 SKILL.md 中 `convert_to_images` 参数说明（`dpi` -> `scale`）
- [x] 更新 SKILL.md 中 `extract_form_field_info` 参数说明（`output` 改为 optional）
- [x] 修复 `readPdf` 函数内存管理，添加 `finally` 块确保 `parser.destroy()` 被调用
- [x] 创建代码审计报告
- [x] 添加 pdf-parse 升级文档和重构计划文档

## 相关文件

- `data/skills/pdf/index.js` - PDF 技能主代码
- `data/skills/pdf/SKILL.md` - 技能文档
- `package.json` - 依赖升级
- `docs/core/tasks/2026-03-26-pdf-skill-code-review.md` - 代码审计报告
- `docs/skills/pdf-parse-upgrade.md` - 升级指南
- `docs/skills/pdf-skill-refactor-plan.md` - 重构计划

## 测试

```bash
# 测试 PDF 技能
node tests/run-skill.js pdf read_pdf --path=test.pdf
node tests/run-skill.js pdf extract_text --path=test.pdf
```

Closes #411