### PR TITLE
feat: 自主任务完成判断与错误状态处理

### DIFF
--- a/lib/autonomous-task-executor.js
+++ b/lib/autonomous-task-executor.js
@@ -51,6 +51,7 @@ export function createAutonomousTaskExecutor(options = {}) {
     rateLimitCooldownMs = 60000,
     contextMessagesCount = 6,  // 默认获取最近 6 条消息（约 3 轮对话）
     maxNoResponseCount = 2,    // 连续无响应最大次数
+    maxPMFailureCount = 3,     // PM 连续失败最大次数
   } = options;
 
   // 速率限制状态
@@ -61,6 +62,9 @@ export function createAutonomousTaskExecutor(options = {}) {
 
   // 跟踪每个任务的连续无响应次数（内存缓存）
   const noResponseCountMap = new Map();  // taskId -> count
+
+  // 跟踪每个任务的 PM 连续失败次数（内存缓存）
+  const pmFailureCountMap = new Map();  // taskId -> count
 
   /**
    * 确保模型已初始化
@@ -359,21 +363,70 @@ export function createAutonomousTaskExecutor(options = {}) {
       }
 
       // 【两步调用流程】
-      // 步骤 1: 用 InternalLLMService 生成 PM 指导建议
+      // 步骤 1: 用 InternalLLMService 的 judge 方法让 PM 判断任务状态并生成指导建议
       const internalLLM = new InternalLLMService(db);
       const pmPrompt = buildPMPrompt(task, contextMessages, readmeContent);
       
+      let pmResult;
       let guidanceMessage;
+      let isTaskCompleted = false;
+      
       try {
-        guidanceMessage = await internalLLM.generate(
-          '你是一个项目管理助手（PM），负责监督 AI 专家的工作进展。你的任务是给出简洁、具体的指导建议，帮助专家继续推进任务。',
+        pmResult = await internalLLM.judge(
+          '你是一个项目管理助手（PM），负责监督 AI 专家的工作进展。你需要判断任务是否完成，并给出指导建议。',
           pmPrompt,
-          { expertId: task.expert_id }
+          {
+            expertId: task.expert_id,
+            defaultValue: {
+              is_completed: false,
+              guidance: buildDefaultGuidance(task),
+              completion_reason: null
+            }
+          }
         );
-        logger.info(`[AutonomousExecutor] PM 生成指导建议: ${guidanceMessage.substring(0, 100)}...`);
+        
+        isTaskCompleted = pmResult.is_completed === true;
+        guidanceMessage = pmResult.guidance || buildDefaultGuidance(task);
+        
+        // PM 成功，重置失败计数
+        pmFailureCountMap.set(task.id, 0);
+        
+        if (isTaskCompleted) {
+          console.log(`[AutonomousExecutor] ✅ PM 判断任务 ${task.id} 已完成: ${pmResult.completion_reason || '未提供原因'}`);
+          logger.info(`[AutonomousExecutor] PM 判断任务 ${task.id} 已完成: ${pmResult.completion_reason}`);
+        } else {
+          logger.info(`[AutonomousExecutor] PM 生成指导建议: ${guidanceMessage.substring(0, 100)}...`);
+        }
       } catch (error) {
-        logger.warn(`[AutonomousExecutor] PM 生成失败，使用默认指导: ${error.message}`);
+        logger.warn(`[AutonomousExecutor] PM 判断失败，使用默认指导: ${error.message}`);
         guidanceMessage = buildDefaultGuidance(task);
+        
+        // 增加 PM 失败计数
+        const pmFailureCount = (pmFailureCountMap.get(task.id) || 0) + 1;
+        pmFailureCountMap.set(task.id, pmFailureCount);
+        console.log(`[AutonomousExecutor] ⚠️ 任务 ${task.id} PM 失败计数: ${pmFailureCount}/${maxPMFailureCount}`);
+        
+        // 如果 PM 连续失败次数达到上限，将任务标记为 error
+        if (pmFailureCount >= maxPMFailureCount) {
+          await models.Task.update(
+            { status: 'error' },
+            { where: { id: task.id } }
+          );
+          console.log(`[AutonomousExecutor] ❌ 任务 ${task.id} PM 连续失败 ${pmFailureCount} 次，标记为 error 状态`);
+          logger.error(`[AutonomousExecutor] Task ${task.id} marked as error: ${pmFailureCount} consecutive PM failures`);
+          return { success: false, pmFailed: true };
+        }
+      }
+
+      // 如果 PM 判断任务已完成，更新状态为 active 并跳过专家调用
+      if (isTaskCompleted) {
+        await models.Task.update(
+          { status: 'active' },
+          { where: { id: task.id } }
+        );
+        console.log(`[AutonomousExecutor] 🏁 任务 ${task.id} 已标记为完成，状态更新为 active`);
+        logger.info(`[AutonomousExecutor] Task ${task.id} marked as completed, status changed to active`);
+        return { success: true, completed: true };
       }
 
       // 步骤 2: 把指导建议发给专家继续工作
@@ -467,7 +520,7 @@ export function createAutonomousTaskExecutor(options = {}) {
    * PM 角色说明：
    * - PM 是项目管理助手，监督专家的工作进展
    * - PM 根据历史对话了解项目状态
-   * - PM 给出简洁、具体的指导建议
+   * - PM 判断任务是否完成，并给出指导建议
    *
    * @param {Object} task 任务对象
    * @param {Array} contextMessages 历史上下文消息
@@ -518,15 +571,23 @@ ${formattedHistory}
 
 当前任务：${taskDescription}
 ${readmeSection}${historySection}
---------
-请根据上述任务要求和专家的工作进展，给出简洁的提示（不超过 100 字），帮助专家保持正确的方向。
 
-重要原则：
-1. 只做方向性提示，不给出具体解决方案或操作步骤
-2. 不干预专家的技术判断和决策
-3. 可以提醒专家关注任务目标，但不要告诉专家具体该怎么做
-4. 如果专家看起来在正确方向上工作，可以只给予肯定，无需额外指导
-5. 如果专家长时间没有进展，可以提醒其考虑其他思路，但不指定具体方案`;
+--------
+请分析上述任务要求和专家的工作进展，返回 JSON 格式的判断结果。
+
+**任务完成判断标准**：
+1. 任务目标已明确达成（如：文件已生成、报告已完成、代码已实现）
+2. 专家明确表示任务已完成或无法继续
+3. 任务目标已无法实现（如：资源不可用、需求冲突）
+
+**注意**：如果专家正在积极工作、遇到问题正在解决、或任务目标尚未达成，请返回 is_completed: false
+
+请返回以下 JSON 格式：
+{
+  "is_completed": boolean,  // 任务是否已完成
+  "guidance": string,       // 给专家的指导建议（不超过 100 字），任务完成时可简短总结
+  "completion_reason": string | null  // 如果任务完成，说明完成原因；否则为 null
+}`;
 
     return prompt;
   }
@@ -621,8 +682,13 @@ ${readmeSection}${historySection}
         // 检查连续无响应次数
         const noResponseCount = noResponseCountMap.get(task.id) || 0;
         if (noResponseCount >= maxNoResponseCount) {
-          console.log(`[AutonomousExecutor] ⏹️ 任务 ${task.id} 已连续 ${noResponseCount} 次无响应，跳过`);
-          logger.warn(`[AutonomousExecutor] Task ${task.id} skipped: ${noResponseCount} consecutive no-response`);
+          console.log(`[AutonomousExecutor] ❌ 任务 ${task.id} 已连续 ${noResponseCount} 次无响应，标记为 error 状态`);
+          logger.warn(`[AutonomousExecutor] Task ${task.id} marked as error: ${noResponseCount} consecutive no-response`);
+          // 将任务状态设为 error
+          await models.Task.update(
+            { status: 'error' },
+            { where: { id: task.id } }
+          );
           continue;
         }
         
@@ -655,8 +721,9 @@ ${readmeSection}${historySection}
         
         if (result.success) {
           successCount++;
-          // 成功响应，重置无响应计数
+          // 成功响应，重置所有失败计数
           noResponseCountMap.set(task.id, 0);
+          pmFailureCountMap.set(task.id, 0);
         } else {
           failCount++;
           

--- a/scripts/init-database.js
+++ b/scripts/init-database.js
@@ -250,7 +250,7 @@ const TABLES = [
     topic_id VARCHAR(32) NULL COMMENT '关联的话题ID（自主任务执行时的对话）',
     last_executed_at DATETIME NULL COMMENT '最后执行时间（自主任务执行器更新）',
     solution_id VARCHAR(32) NULL COMMENT '关联的解决方案ID',
-    status ENUM('active', 'autonomous_wait', 'autonomous_working', 'archived', 'deleted') DEFAULT 'active',
+    status ENUM('active', 'autonomous_wait', 'autonomous_working', 'error', 'archived', 'deleted') DEFAULT 'active',
     created_by VARCHAR(32) NOT NULL COMMENT '创建者 user_id',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -202,6 +202,32 @@ const MIGRATIONS = [
       console.log('  ✓ Removed deprecated autonomous from tasks.status ENUM');
     }
   },
+
+  // ==================== 添加 error 状态 ====================
+  // Issue #410: 自主任务错误处理增强
+  // 当 LLM 连续无响应或 PM 判断失败时，将任务标记为 error 状态
+  {
+    name: 'tasks.status add error state',
+    check: async (conn) => {
+      const columnType = await getColumnType(conn, 'tasks', 'status');
+      // 检查是否已包含 error
+      return columnType && columnType.includes('error');
+    },
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE tasks
+        MODIFY COLUMN status ENUM(
+          'active',
+          'autonomous_wait',
+          'autonomous_working',
+          'error',
+          'archived',
+          'deleted'
+        ) NOT NULL DEFAULT 'active' COMMENT '任务状态'
+      `);
+      console.log('  ✓ Added error to tasks.status ENUM');
+    }
+  },
 ];
 
 /**


### PR DESCRIPTION
## 变更说明

### 1. PM 任务完成判断
- 使用 `InternalLLMService.judge()` 让 PM 返回结构化 JSON
- JSON 包含 `is_completed`、`guidance`、`completion_reason` 字段
- 当 PM 判断任务完成时，状态更新为 `active`，停止自主执行

### 2. 添加 `error` 状态
- 新增 `error` 状态到任务状态枚举
- 数据库迁移脚本已添加

### 3. 失败计数机制
- **LLM 无响应计数**：连续 2 次无响应 → 标记为 `error`
- **PM 失败计数**：连续 3 次失败 → 标记为 `error`
- 成功执行后重置所有计数

## 任务状态流转

```
active → autonomous_wait → autonomous_working → active (完成)
                                                → error (失败)
                                                → autonomous_wait (继续)
```

## 修改文件

- `lib/autonomous-task-executor.js` - 核心逻辑
- `scripts/upgrade-database.js` - 数据库迁移
- `scripts/init-database.js` - 初始化脚本

## 测试说明

- [ ] PM 判断任务完成时，状态正确更新为 `active`
- [ ] LLM 连续 2 次无响应，状态更新为 `error`
- [ ] PM 连续 3 次失败，状态更新为 `error`
- [ ] 成功执行后计数器正确重置

Closes #413