### PR TITLE
fix: 用户代码执行器 Illegal return statement 错误

### DIFF
--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -645,11 +645,12 @@ async function executeUserCodeDirectly(code, source = 'inline') {
   const VM_TIMEOUT = parseInt(process.env.VM_TIMEOUT || '30000', 10);
   
   // 包装用户代码为异步函数
+  // 注意：return 必须在函数体内，vm.runInContext 在全局作用域执行
   const wrappedCode = `
-    "use strict";
-    return (async function() {
+    (async function() {
+      "use strict";
       ${code}
-    })();
+    })()
   `;
   
   try {


### PR DESCRIPTION
## 问题描述

用户代码执行器（`user-code-executor` 技能）在执行用户代码时报错：

```
User code execution failed: Illegal return statement
```

## 修复内容

修改 [`lib/skill-runner.js:648`](lib/skill-runner.js:648) 中的代码包装方式，将 `return` 语句从全局作用域移到函数体内。

**修改前：**
```javascript
const wrappedCode = `
  "use strict";
  return (async function() {
    ${code}
  })();
`;
```

**修改后：**
```javascript
const wrappedCode = `
  (async function() {
    "use strict";
    ${code}
  })()
`;
```

## 安全分析

修改后的代码没有引入新的安全隐患：
- 严格模式在函数体内同样有效
- VM 上下文隔离保持不变
- 原型链逃逸攻击仍然被阻止

Closes #415