### PR TITLE
refactor: 移除 kb-editor 旧工具名向后兼容

### DIFF
--- a/data/skills/kb-editor/SKILL.md
+++ b/data/skills/kb-editor/SKILL.md
@@ -24,8 +24,6 @@ knowledge_bases (知识库)
 
 ## 工具（5个）
 
-> **重构说明**：原 25 个工具已合并为 5 个，使用 `action` 参数区分具体操作。旧工具名仍可使用（向后兼容）。
-
 | 工具 | 操作（action） | 说明 |
 |------|----------------|------|
 | `kb` | list, list_models, get, create, update, delete | 知识库操作 |
@@ -260,39 +258,6 @@ knowledge_bases (知识库)
 1. `article` action=get_tree - 查看当前结构
 2. `section` action=move / `paragraph` action=move - 调整顺序
 3. `section` action=update / `paragraph` action=update - 修改内容
-
-## 向后兼容
-
-旧工具名仍可使用，内部自动映射到新工具：
-
-| 旧工具名 | 新工具 + action |
-|----------|-----------------|
-| list_my_kbs | kb + list |
-| list_embedding_models | kb + list_models |
-| get_kb | kb + get |
-| create_kb | kb + create |
-| update_kb | kb + update |
-| delete_kb | kb + delete |
-| list_articles | article + list |
-| get_article | article + get |
-| get_article_tree | article + get_tree |
-| create_article | article + create |
-| update_article | article + update |
-| delete_article | article + delete |
-| list_sections | section + list |
-| create_section | section + create |
-| update_section | section + update |
-| move_section | section + move |
-| delete_section | section + delete |
-| list_paragraphs | paragraph + list |
-| create_paragraph | paragraph + create |
-| update_paragraph | paragraph + update |
-| move_paragraph | paragraph + move |
-| delete_paragraph | paragraph + delete |
-| list_tags | tag + list |
-| create_tag | tag + create |
-| update_tag | tag + update |
-| delete_tag | tag + delete |
 
 ## 权限说明
 

--- a/data/skills/kb-editor/index.js
+++ b/data/skills/kb-editor/index.js
@@ -354,50 +354,13 @@ async function handleTag(params) {
   }
 }
 
-// ==================== 向后兼容：旧工具名映射 ====================
-
-/**
- * 旧工具名到新工具的映射表
- */
-const LEGACY_TOOL_MAP = {
-  // 知识库
-  'list_my_kbs': { tool: 'kb', action: 'list' },
-  'list_embedding_models': { tool: 'kb', action: 'list_models' },
-  'get_kb': { tool: 'kb', action: 'get' },
-  'create_kb': { tool: 'kb', action: 'create' },
-  'update_kb': { tool: 'kb', action: 'update' },
-  'delete_kb': { tool: 'kb', action: 'delete' },
-  // 文章
-  'list_articles': { tool: 'article', action: 'list' },
-  'get_article': { tool: 'article', action: 'get' },
-  'get_article_tree': { tool: 'article', action: 'get_tree' },
-  'create_article': { tool: 'article', action: 'create' },
-  'update_article': { tool: 'article', action: 'update' },
-  'delete_article': { tool: 'article', action: 'delete' },
-  // 节
-  'list_sections': { tool: 'section', action: 'list' },
-  'create_section': { tool: 'section', action: 'create' },
-  'update_section': { tool: 'section', action: 'update' },
-  'move_section': { tool: 'section', action: 'move' },
-  'delete_section': { tool: 'section', action: 'delete' },
-  // 段落
-  'list_paragraphs': { tool: 'paragraph', action: 'list' },
-  'create_paragraph': { tool: 'paragraph', action: 'create' },
-  'update_paragraph': { tool: 'paragraph', action: 'update' },
-  'move_paragraph': { tool: 'paragraph', action: 'move' },
-  'delete_paragraph': { tool: 'paragraph', action: 'delete' },
-  // 标签
-  'list_tags': { tool: 'tag', action: 'list' },
-  'create_tag': { tool: 'tag', action: 'create' },
-  'update_tag': { tool: 'tag', action: 'update' },
-  'delete_tag': { tool: 'tag', action: 'delete' },
-};
+// ==================== 执行入口 ====================
 
 /**
  * Skill execute function - 被 skill-runner 调用
  *
- * @param {string} toolName - 工具名称（新工具名或旧工具名）
- * @param {object} params - 工具参数
+ * @param {string} toolName - 工具名称（kb/article/section/paragraph/tag）
+ * @param {object} params - 工具参数（必须包含 action 字段）
  * @param {object} context - 执行上下文（由 skill-loader 注入环境变量，context 可为空）
  * @returns {Promise<object>} 执行结果
  */
@@ -416,26 +379,20 @@ async function execute(toolName, params, context = {}) {
     'tag': handleTag,
   };
 
-  // 检查是否为旧工具名
-  let actualTool = toolName;
-  let actualParams = params;
-
-  if (LEGACY_TOOL_MAP[toolName]) {
-    const mapping = LEGACY_TOOL_MAP[toolName];
-    actualTool = mapping.tool;
-    actualParams = { ...params, action: mapping.action };
-  }
-
   // 获取处理器
-  const handler = handlers[actualTool];
+  const handler = handlers[toolName];
   if (!handler) {
     const availableTools = Object.keys(handlers).join(', ');
-    const legacyTools = Object.keys(LEGACY_TOOL_MAP).join(', ');
-    throw new Error(`未知工具: ${toolName}. 可用工具: ${availableTools}（或旧工具名: ${legacyTools}）`);
+    throw new Error(`未知工具: ${toolName}. 可用工具: ${availableTools}`);
+  }
+
+  // 验证 action 参数
+  if (!params.action) {
+    throw new Error('缺少 action 参数。请指定操作类型。');
   }
 
   // 执行操作
-  const result = await handler(actualParams);
+  const result = await handler(params);
 
   return {
     success: true,


### PR DESCRIPTION
## 变更说明

移除 kb-editor 技能的旧工具名向后兼容代码，只保留新的 5 个工具格式。

### 变更内容

1. **index.js**:
   - 删除 `LEGACY_TOOL_MAP` 常量（38 行）
   - 简化 `execute` 函数，移除旧工具名映射逻辑
   - 添加 `action` 参数验证

2. **SKILL.md**:
   - 移除"向后兼容"章节
   - 移除重构说明注释

### 代码变化

- 删除 89 行，新增 11 行
- 代码更简洁，职责更清晰

## 测试

- [x] 语法检查通过 (`node --check`)

Closes #421