### PR TITLE
refactor: 重命名 unifuncs-web-reader 技能并移除硬编码映射

### DIFF
--- a/data/skills/unifuncs/SKILL.md
+++ b/data/skills/unifuncs/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: unifuncs-web-reader
-description: 网页内容提取服务，通过 Unifuncs API 获取网页正文内容。支持微信公众号、知乎、头条等主流平台。
+name: unifuncs
+description: Unifuncs API 服务集成，提供网页内容提取等多种能力。支持微信公众号、知乎、头条等主流平台。
 argument-hint: "[url]"
 user-invocable: true
 allowed-tools: []
@@ -10,9 +10,9 @@ env-variables:
     required: true
 ---
 
-# Unifuncs Web Reader
+# Unifuncs
 
-网页内容提取服务，通过 Unifuncs API 获取网页正文内容。
+Unifuncs API 服务集成，提供网页内容提取等多种能力。
 
 ## 功能特点
 

--- a/data/skills/unifuncs/index.js
+++ b/data/skills/unifuncs/index.js
@@ -1,10 +1,10 @@
 /**
- * Unifuncs Web Reader Skill
+ * Unifuncs Skill
  *
- * 网页内容提取服务，通过 Unifuncs API 获取网页正文内容。
+ * Unifuncs API 服务集成，提供网页内容提取等多种能力。
  * 支持微信公众号、知乎、头条等主流平台。
  *
- * @module unifuncs-web-reader
+ * @module unifuncs
  */
 
 const https = require('https');
@@ -102,12 +102,12 @@ async function readWebPage(params) {
   const apiKey = process.env.SKILL_UNIFUNCS_API_KEY || process.env.UNIFUNCS_API_KEY;
 
   // 🔍 调试日志：输出环境变量和参数信息
-  console.log('[unifuncs-web-reader] ========== DEBUG INFO ==========');
-  console.log('[unifuncs-web-reader] params:', JSON.stringify(params, null, 2));
-  console.log('[unifuncs-web-reader] SKILL_UNIFUNCS_API_KEY:', process.env.SKILL_UNIFUNCS_API_KEY ? `${process.env.SKILL_UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
-  console.log('[unifuncs-web-reader] UNIFUNCS_API_KEY:', process.env.UNIFUNCS_API_KEY ? `${process.env.UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
-  console.log('[unifuncs-web-reader] resolved apiKey:', apiKey ? `${apiKey.substring(0, 8)}...` : '(not set)');
-  console.log('[unifuncs-web-reader] ==============================');
+  console.log('[unifuncs] ========== DEBUG INFO ==========');
+  console.log('[unifuncs] params:', JSON.stringify(params, null, 2));
+  console.log('[unifuncs] SKILL_UNIFUNCS_API_KEY:', process.env.SKILL_UNIFUNCS_API_KEY ? `${process.env.SKILL_UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
+  console.log('[unifuncs] UNIFUNCS_API_KEY:', process.env.UNIFUNCS_API_KEY ? `${process.env.UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
+  console.log('[unifuncs] resolved apiKey:', apiKey ? `${apiKey.substring(0, 8)}...` : '(not set)');
+  console.log('[unifuncs] ==============================');
 
   if (!url) {
     throw new Error('URL is required');
@@ -124,16 +124,16 @@ async function readWebPage(params) {
     const urlPath = `${API_PATH}${encodedUrl}?apiKey=${apiKey}`;
 
     // 🔍 调试日志：输出请求信息（隐藏完整 API Key）
-    console.log('[unifuncs-web-reader] Request URL:', `https://${API_BASE}${API_PATH}${encodedUrl}?apiKey=${apiKey.substring(0, 8)}...`);
-    console.log('[unifuncs-web-reader] Timeout:', timeout);
+    console.log('[unifuncs] Request URL:', `https://${API_BASE}${API_PATH}${encodedUrl}?apiKey=${apiKey.substring(0, 8)}...`);
+    console.log('[unifuncs] Timeout:', timeout);
 
     const result = await makeRequest(urlPath, timeout);
 
     // 🔍 调试日志：输出响应信息
-    console.log('[unifuncs-web-reader] Response status:', result.statusCode, result.statusMessage);
-    console.log('[unifuncs-web-reader] Response size:', result.size, 'bytes');
+    console.log('[unifuncs] Response status:', result.statusCode, result.statusMessage);
+    console.log('[unifuncs] Response size:', result.size, 'bytes');
     if (!result.success) {
-      console.log('[unifuncs-web-reader] Response body:', JSON.stringify(result.body).substring(0, 500));
+      console.log('[unifuncs] Response body:', JSON.stringify(result.body).substring(0, 500));
     }
 
     return {
@@ -146,7 +146,7 @@ async function readWebPage(params) {
       originalUrl: url,
     };
   } catch (error) {
-    console.log('[unifuncs-web-reader] Error:', error.message);
+    console.log('[unifuncs] Error:', error.message);
     return {
       success: false,
       error: error.message,
@@ -178,6 +178,6 @@ async function execute(toolName, params, context = {}) {
 module.exports = {
   execute,
   readWebPage,
-  name: 'unifuncs-web-reader',
-  description: '网页内容提取服务，通过 Unifuncs API 获取网页正文内容',
+  name: 'unifuncs',
+  description: 'Unifuncs API 服务集成，提供网页内容提取等多种能力',
 };

--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -379,32 +379,19 @@ ${fileOperationsGuidance}
 
   /**
    * 根据技能 mark 获取使用场景描述
+   *
+   * 重构说明：
+   * - 运行时技能信息应从数据库 skills 表获取
+   * - 此方法已废弃，保留仅为向后兼容
+   * - 实际使用 skill.description 字段（来自数据库）
+   *
    * @param {string} mark - 技能标识
-   * @returns {string|null} 使用场景描述
+   * @returns {string|null} 使用场景描述（始终返回 null，使用数据库中的 description）
+   * @deprecated 使用数据库中的 skill.description 字段
    */
   getSkillUseCase(mark) {
-    const useCaseMap = {
-      'kb-search': '查询知识库内容、搜索专业知识',
-      'kb-editor': '编辑知识库内容、管理知识条目',
-      'docx': '创建或编辑 Word 文档',
-      'xlsx': '处理 Excel 电子表格',
-      'pptx': '创建或编辑 PowerPoint 演示文稿',
-      'pdf': '读取或转换 PDF 文件',
-      'file-operations': '文件系统操作、文件信息查询',
-      'compression': '压缩或解压文件',
-      'searxng': '网络搜索',
-      'hacknews': '获取 Hacker News 资讯',
-      'remote-llm': '调用远程 LLM 服务',
-      'echarts-chart': '生成 ECharts 图表',
-      'wikijs': '与 Wiki.js 知识库交互',
-      'erix-ssh': 'SSH 远程连接和命令执行',
-      'user-code-executor': '执行用户自定义代码',
-      'net-operations': '网络操作、HTTP 请求',
-      'skill-manager': '技能管理、工具列表查询',
-      'unifuncs-web-reader': '读取网页内容',
-      'prompt-editor': '编辑和优化提示词',
-    };
-    return useCaseMap[mark] || null;
+    // 硬编码已移除，使用数据库中的 skill.description 字段
+    return null;
   }
 
   /**

--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -265,32 +265,19 @@ ${fileOperationsGuidance}
 
   /**
    * 根据技能 mark 获取使用场景描述
+   *
+   * 重构说明：
+   * - 运行时技能信息应从数据库 skills 表获取
+   * - 此方法已废弃，保留仅为向后兼容
+   * - 实际使用 skill.description 字段（来自数据库）
+   *
    * @param {string} mark - 技能标识
-   * @returns {string|null} 使用场景描述
+   * @returns {string|null} 使用场景描述（始终返回 null，使用数据库中的 description）
+   * @deprecated 使用数据库中的 skill.description 字段
    */
   getSkillUseCase(mark) {
-    const useCaseMap = {
-      'kb-search': '查询知识库内容、搜索专业知识',
-      'kb-editor': '编辑知识库内容、管理知识条目',
-      'docx': '创建或编辑 Word 文档',
-      'xlsx': '处理 Excel 电子表格',
-      'pptx': '创建或编辑 PowerPoint 演示文稿',
-      'pdf': '读取或转换 PDF 文件',
-      'file-operations': '文件系统操作、文件信息查询',
-      'compression': '压缩或解压文件',
-      'searxng': '网络搜索',
-      'hacknews': '获取 Hacker News 资讯',
-      'remote-llm': '调用远程 LLM 服务',
-      'echarts-chart': '生成 ECharts 图表',
-      'wikijs': '与 Wiki.js 知识库交互',
-      'erix-ssh': 'SSH 远程连接和命令执行',
-      'user-code-executor': '执行用户自定义代码',
-      'net-operations': '网络操作、HTTP 请求',
-      'skill-manager': '技能管理、工具列表查询',
-      'unifuncs-web-reader': '读取网页内容',
-      'prompt-editor': '编辑和优化提示词',
-    };
-    return useCaseMap[mark] || null;
+    // 硬编码已移除，使用数据库中的 skill.description 字段
+    return null;
   }
 
   /**


### PR DESCRIPTION
## 变更概述

Closes #435

1. **技能目录重命名**：`unifuncs-web-reader` → `unifuncs`
2. **移除硬编码技能映射**：删除 `useCaseMap`，改用数据库 `skills.description` 字段

## 变更详情

### 1. 技能目录重命名

将 `data/skills/unifuncs-web-reader` 重命名为 `data/skills/unifuncs`，原因：
- Unifuncs 公司不止 web-reader 一个产品
- 后续会将其他产品（如 screenshot 等）合并进来
- 技能名称更通用，便于扩展

### 2. 移除硬编码技能映射

**问题**：`lib/context-manager.js` 和 `lib/context-organizer/base-organizer.js` 中存在硬编码的 `useCaseMap` 对象，包含 20+ 个技能的使用场景描述。

**解决方案**：删除 `useCaseMap`，让 `getSkillUseCase()` 返回 `null`，直接使用数据库中的 `skill.description` 字段。

**修改文件**：
- `lib/context-manager.js` - `getSkillUseCase()` 方法
- `lib/context-organizer/base-organizer.js` - `getSkillUseCase()` 方法

**改进后的逻辑**：
```javascript
const useCase = this.getSkillUseCase(mark) || skill.description || '暂无描述';
// getSkillUseCase 返回 null → 直接使用数据库中的 skill.description
```

## 代码审计

- [x] `npm run lint` 通过
- [x] ES 模块导入验证通过
- [x] 技能语法检查通过

## 影响范围

- 技能使用场景描述现在完全从数据库获取
- 需要确保 `skills` 表的 `description` 字段已正确填充