### PR TITLE
refactor: 清理技能工具名别名

### DIFF
--- a/data/skills/docx/SKILL.md
+++ b/data/skills/docx/SKILL.md
@@ -29,8 +29,6 @@ read({ path: '/absolute/path/to/document.docx', scope: 'text' })
 
 ## 工具列表
 
-### 简化工具名（推荐）
-
 | 工具 | 说明 | 关键参数 |
 |------|------|----------|
 | `read` | 读取文档 | `scope`: info/text/paragraphs/tables/comments/images/headers/footers |
@@ -41,19 +39,6 @@ read({ path: '/absolute/path/to/document.docx', scope: 'text' })
 | `image` | 图片操作 | `action`: extract/insert/list |
 | `link` | 超链接操作 | `action`: add/list |
 | `toc` | 目录操作 | `action`: insert/update |
-
-### 兼容旧工具名
-
-| 旧工具名 | 新工具名 |
-|----------|----------|
-| `docx_read` | `read` |
-| `docx_write` | `write` |
-| `docx_edit` | `edit` |
-| `docx_convert` | `convert` |
-| `docx_image` | `image` |
-| `docx_patch` (新增) | `patch` |
-| `docx_link` (新增) | `link` |
-| `docx_toc` (新增) | `toc` |
 
 ---
 
@@ -443,4 +428,3 @@ write({
 - **占位符格式**：默认 `{{placeholder}}`，可自定义分隔符
 - **目录更新**：插入目录后需在 Word 中手动更新（F9）
 - **图片插入**：推荐使用占位符方式，可保留格式
-- **兼容性**：旧工具名（`docx_read` 等）仍然支持

--- a/data/skills/docx/index.js
+++ b/data/skills/docx/index.js
@@ -1466,7 +1466,6 @@ async function docxToc(params) {
  */
 async function execute(toolName, params, context = {}) {
   switch (toolName) {
-    // 新工具名（简化版）
     case 'read':
       return await docxRead(params);
       
@@ -1490,78 +1489,6 @@ async function execute(toolName, params, context = {}) {
       
     case 'toc':
       return await docxToc(params);
-      
-    // 旧工具名（兼容）
-    case 'docx_read':
-      return await docxRead(params);
-      
-    case 'docx_write':
-      return await docxWrite(params);
-      
-    case 'docx_patch':
-      return await docxPatch(params);
-      
-    case 'docx_edit':
-      return await docxEdit(params);
-      
-    case 'docx_convert':
-      return await docxConvert(params);
-      
-    case 'docx_image':
-      return await docxImage(params);
-      
-    case 'docx_link':
-      return await docxLink(params);
-      
-    case 'docx_toc':
-      return await docxToc(params);
-      
-    // 更旧的兼容名
-    case 'read_document':
-      return await docxRead({ ...params, scope: 'info' });
-      
-    case 'extract_text':
-      return await docxRead({ ...params, scope: 'text' });
-      
-    case 'extract_paragraphs':
-      return await docxRead({ ...params, scope: 'paragraphs' });
-      
-    case 'extract_tables':
-      return await docxRead({ ...params, scope: 'tables' });
-      
-    case 'extract_comments':
-      return await docxRead({ ...params, scope: 'comments' });
-      
-    case 'create_document':
-    case 'create':
-      return await docxWrite({ ...params, source: 'data' });
-      
-    case 'from_markdown':
-      return await docxWrite({ ...params, source: 'markdown' });
-      
-    case 'add_paragraph':
-      return await docxEdit({ ...params, action: 'append' });
-      
-    case 'replace_text':
-      return await docxEdit({ ...params, action: 'replace' });
-      
-    case 'add_table':
-      return await docxEdit({ ...params, action: 'insert' });
-      
-    case 'to_markdown':
-      return await docxConvert({ ...params, format: 'markdown' });
-      
-    case 'to_html':
-      return await docxConvert({ ...params, format: 'html' });
-      
-    case 'extract_images':
-      return await docxImage({ ...params, action: 'extract' });
-      
-    case 'insert_image':
-      return await docxImage({ ...params, action: 'insert' });
-      
-    case 'template_fill':
-      return await docxPatch(params);
       
     default:
       throw new Error(`Unknown tool: ${toolName}. Supported tools: read, write, patch, edit, convert, image, link, toc`);

--- a/data/skills/searxng/index.js
+++ b/data/skills/searxng/index.js
@@ -190,8 +190,7 @@ function formatResultsTable(data, query) {
  */
 async function execute(toolName, params, context = {}) {
   switch (toolName) {
-    case 'web_search':
-    case 'search': {
+    case 'web_search': {
       const searchParams = {
         query: params.query,
         n: params.n || params.limit || 10,

--- a/data/skills/unifuncs/index.js
+++ b/data/skills/unifuncs/index.js
@@ -166,8 +166,6 @@ async function readWebPage(params) {
 async function execute(toolName, params, context = {}) {
   switch (toolName) {
     case 'read_web_page':
-    case 'readWebPage':
-    case 'read':
       return await readWebPage(params);
 
     default:

--- a/data/skills/xlsx/index.js
+++ b/data/skills/xlsx/index.js
@@ -1310,69 +1310,6 @@ async function execute(toolName, params, context = {}) {
     case 'excel_calc':
       return await excelCalc(params);
       
-    // 兼容旧工具名（映射到新工具）
-    case 'read_workbook':
-    case 'read':
-      return await excelRead({ ...params, scope: 'workbook' });
-      
-    case 'read_sheet':
-      return await excelRead({ ...params, scope: 'sheet' });
-      
-    case 'read_cell':
-      return await excelRead({ ...params, scope: 'cell' });
-      
-    case 'create_workbook':
-    case 'create':
-      return await excelWrite({ ...params, scope: 'workbook' });
-      
-    case 'write_sheet':
-      return await excelWrite({ ...params, scope: 'sheet' });
-      
-    case 'write_cell':
-      return await excelWrite({ ...params, scope: 'cell' });
-      
-    case 'add_sheet':
-      return await excelSheet({ ...params, action: 'add', name: params.name || params.sheet });
-      
-    case 'delete_sheet':
-      return await excelSheet({ ...params, action: 'delete' });
-      
-    case 'rename_sheet':
-      return await excelSheet({ ...params, action: 'rename', newName: params.newName });
-      
-    case 'copy_sheet':
-      return await excelSheet({ ...params, action: 'copy' });
-      
-    case 'set_column_width':
-      return await excelFormat({ ...params, type: 'column' });
-      
-    case 'set_cell_style':
-      return await excelFormat({ ...params, type: 'cell' });
-      
-    case 'filter_data':
-      return await excelQuery({ ...params, action: 'filter' });
-      
-    case 'sort_data':
-      return await excelQuery({ ...params, action: 'sort' });
-      
-    case 'find_data':
-      return await excelQuery({ ...params, action: 'find' });
-      
-    case 'to_json':
-      return await excelConvert({ ...params, format: 'json', direction: 'to' });
-      
-    case 'from_json':
-      return await excelConvert({ ...params, format: 'json', direction: 'from' });
-      
-    case 'to_csv':
-      return await excelConvert({ ...params, format: 'csv', direction: 'to' });
-      
-    case 'from_csv':
-      return await excelConvert({ ...params, format: 'csv', direction: 'from' });
-      
-    case 'calculate_formulas':
-      return await excelCalc(params);
-      
     default:
       throw new Error(`Unknown tool: ${toolName}. Supported tools: excel_read, excel_write, excel_sheet, excel_format, excel_query, excel_convert, excel_calc`);
   }


### PR DESCRIPTION
## 变更说明

清理技能工具名别名，确保工具名明确、无歧义。

## 变更内容

### 已清理的技能

| 技能 | 移除的别名 | 保留的工具名 |
|------|------------|--------------|
| searxng | `search` | `web_search` |
| docx | 24 个旧工具名 | `read`, `write`, `patch`, `edit`, `convert`, `image`, `link`, `toc` |
| xlsx | 22 个旧工具名 | `excel_read`, `excel_write`, `excel_sheet`, `excel_format`, `excel_query`, `excel_convert`, `excel_calc` |
| unifuncs | `readWebPage`, `read` | `read_web_page` |

### 详细变更

- **searxng/index.js**: 移除 `search` 别名
- **docx/index.js**: 移除 24 个旧工具名（docx_xxx 变体和旧命名）
- **docx/SKILL.md**: 移除"兼容旧工具名"章节
- **xlsx/index.js**: 移除 22 个旧工具名
- **unifuncs/index.js**: 移除 `readWebPage` 和 `read` 别名

## 影响范围

- 仅影响使用旧工具名调用技能的代码
- 新工具名调用不受影响
- 建议检查专家的 prompt_template 中是否使用了旧工具名

Closes #438