### PR TITLE
refactor: 消除工具名与技能标记的语义重复

### DIFF
--- a/data/skills/file-operations/SKILL.md
+++ b/data/skills/file-operations/SKILL.md
@@ -13,18 +13,18 @@ user-invocable: true
 
 | 工具 | 说明 | 关键参数 |
 |------|------|----------|
-| `fs_info` | 获取文件/目录信息 | `path`, `include_content_preview`, `hash` |
+| `info` | 获取文件/目录信息 | `path`, `include_content_preview`, `hash` |
 | `read_file` | 读取文件 | `path`, `mode`, `from`, `lines` |
 | `list_files` | 列出目录内容 | `path`, `recursive` |
-| `fs_grep` | 搜索文本 | `pattern`, `path`, `use_regex` |
+| `grep` | 搜索文本 | `pattern`, `path`, `use_regex` |
 | `write_file` | 写入文件 | `path`, `content`, `mode` |
 | `replace_in_file` | 替换文本 | `path`, `old`, `new` |
 | `edit_lines` | 编辑行 | `path`, `operation`, `line`, `content` |
-| `fs_action` | 文件操作 | `operation`, `source`, `destination`, `path` |
+| `action` | 文件操作 | `operation`, `source`, `destination`, `path` |
 
 ## 文件信息
 
-### fs_info
+### info
 
 获取文件或目录的详细元数据。**建议在其他操作前先调用**。
 
@@ -131,7 +131,7 @@ read_file(path="tasks/screenshot.png", mode="data_url")
 
 ## 搜索
 
-### fs_grep
+### grep
 
 跨文件搜索文本。
 
@@ -181,7 +181,7 @@ read_file(path="tasks/screenshot.png", mode="data_url")
 
 ## 文件操作
 
-### fs_action
+### action
 
 统一的文件系统操作。
 
@@ -200,7 +200,7 @@ read_file(path="tasks/screenshot.png", mode="data_url")
 
 ## 最佳实践
 
-1. **先调用 `fs_info`** 检查文件是否存在、类型、大小
+1. **先调用 `info`** 检查文件是否存在、类型、大小
 2. **使用 `include_content_preview`** 快速了解文件结构
 3. **处理大文件时** 检查 `size`，使用 `from`/`lines` 分块读取
 4. **内容替换** 使用 `replace_in_file`，行操作使用 `edit_lines`

--- a/data/skills/file-operations/index.js
+++ b/data/skills/file-operations/index.js
@@ -945,7 +945,7 @@ async function execute(toolName, params, context = {}) {
     case 'list_files':
       return await listFiles(params);
       
-    case 'fs_grep':
+    case 'grep':
       return await grep(params);
       
     case 'write_file':
@@ -957,14 +957,14 @@ async function execute(toolName, params, context = {}) {
     case 'edit_lines':
       return await editLines(params);
       
-    case 'fs_action':
+    case 'action':
       return await fsAction(params);
       
-    case 'fs_info':
+    case 'info':
       return await getFileInfo(params);
       
     default:
-      throw new Error(`Unknown tool: ${toolName}`);
+      throw new Error(`Unknown tool: ${toolName}. Supported tools: read_file, list_files, grep, write_file, replace_in_file, edit_lines, action, info`);
   }
 }
 

--- a/data/skills/kb-editor/SKILL.md
+++ b/data/skills/kb-editor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-editor
 description: "知识库编辑技能。用于创建和管理知识库、文章、节、段落、标签。当知识专家需要整理知识、导入文档、构建知识结构时触发。"
-argument-hint: "[kb|article|section|paragraph|tag] --action=xxx"
+argument-hint: "[knowledge_base|article|section|paragraph|tag] --action=xxx"
 user-invocable: false
 allowed-tools: []
 ---
@@ -26,13 +26,13 @@ knowledge_bases (知识库)
 
 | 工具 | 操作（action） | 说明 |
 |------|----------------|------|
-| `kb` | list, list_models, get, create, update, delete | 知识库操作 |
+| `knowledge_base` | list, list_models, get, create, update, delete | 知识库操作 |
 | `article` | list, get, get_tree, create, update, delete | 文章操作 |
 | `section` | list, create, update, move, delete | 节操作（支持无限层级） |
 | `paragraph` | list, create, update, move, delete | 段落操作 |
 | `tag` | list, create, update, delete | 标签操作 |
 
-## kb - 知识库操作
+## knowledge_base - 知识库操作
 
 ### 参数
 
@@ -247,7 +247,7 @@ knowledge_bases (知识库)
 
 ### 导入新文档
 
-1. `kb` action=list - 查看知识库列表
+1. `knowledge_base` action=list - 查看知识库列表
 2. `article` action=create - 创建文章，设置标题和标签
 3. `section` action=create - 根据文档结构创建节（章→节→小节）
 4. `paragraph` action=create - 创建段落，标记知识点（`is_knowledge_point: true`）

--- a/data/skills/kb-editor/index.js
+++ b/data/skills/kb-editor/index.js
@@ -372,7 +372,7 @@ async function execute(toolName, params, context = {}) {
 
   // 处理器映射
   const handlers = {
-    'kb': handleKb,
+    'knowledge_base': handleKb,
     'article': handleArticle,
     'section': handleSection,
     'paragraph': handleParagraph,
@@ -408,7 +408,7 @@ function getTools() {
   return [
     // ==================== 新工具（5个） ====================
     {
-      name: 'kb',
+      name: 'knowledge_base',
       description: '知识库操作。通过 action 参数区分具体操作：list（列出知识库）、list_models（列出嵌入模型）、get（获取详情）、create（创建）、update（更新）、delete（删除）。',
       parameters: {
         type: 'object',

--- a/data/skills/kb-search/SKILL.md
+++ b/data/skills/kb-search/SKILL.md
@@ -14,8 +14,8 @@ allowed-tools: []
 
 | 工具 | 说明 | 关键参数 |
 |------|------|----------|
-| `list_my_kbs` | 列出我的知识库 | `page`, `pageSize` |
-| `get_kb` | 获取知识库详情 | `id` |
+| `list_mine` | 列出我的知识库 | `page`, `pageSize` |
+| `get` | 获取知识库详情 | `id` |
 | `list_articles` | 列出文章 | `kb_id`, `page`, `status`, `search` |
 | `get_article` | 获取文章详情 | `kb_id`, `id` |
 | `get_article_tree` | 获取文章完整结构 | `kb_id`, `article_id` |
@@ -29,7 +29,7 @@ allowed-tools: []
 
 ## 知识库查询
 
-### list_my_kbs
+### list_mine
 
 列出当前用户可访问的知识库。
 
@@ -37,7 +37,7 @@ allowed-tools: []
 - `page` (integer, optional): 页码，默认 1
 - `pageSize` (integer, optional): 每页数量，默认 20
 
-### get_kb
+### get
 
 获取知识库详情。
 
@@ -123,7 +123,7 @@ allowed-tools: []
 
 ### 问答检索
 
-1. `list_my_kbs` - 确认可访问的知识库
+1. `list_mine` - 确认可访问的知识库
 2. `search` 或 `global_search` - 语义搜索相关知识点
 3. `get_article_tree` - 如果需要更多上下文
 

--- a/data/skills/kb-search/index.js
+++ b/data/skills/kb-search/index.js
@@ -330,8 +330,8 @@ async function execute(toolName, params, context = {}) {
 
   const tools = {
     // 知识库查询
-    'list_my_kbs': listMyKnowledgeBases,
-    'get_kb': getKnowledgeBase,
+    'list_mine': listMyKnowledgeBases,
+    'get': getKnowledgeBase,
 
     // 文章查询
     'list_articles': listArticles,
@@ -386,7 +386,7 @@ function getTools() {
   return [
     // 知识库查询
     {
-      name: 'list_my_kbs',
+      name: 'list_mine',
       description: '列出当前用户可访问的知识库',
       parameters: {
         type: 'object',
@@ -397,7 +397,7 @@ function getTools() {
       },
     },
     {
-      name: 'get_kb',
+      name: 'get',
       description: '获取知识库详情',
       parameters: {
         type: 'object',

--- a/data/skills/net-operations/SKILL.md
+++ b/data/skills/net-operations/SKILL.md
@@ -11,7 +11,7 @@ Network utilities for DNS lookup, SSL analysis, HTTP headers analysis, connectiv
 
 ## Tools
 
-### net_check
+### check
 
 Unified check tool for DNS, SSL, and HTTP analysis. Use `type` parameter to specify check type.
 
@@ -33,16 +33,16 @@ Unified check tool for DNS, SSL, and HTTP analysis. Use `type` parameter to spec
 **Examples:**
 ```javascript
 // DNS lookup - A records (IPv4)
-{ "tool": "net_check", "params": { "hostname": "example.com" } }
+{ "tool": "check", "params": { "hostname": "example.com" } }
 
 // DNS lookup - MX records (mail servers)
-{ "tool": "net_check", "params": { "hostname": "gmail.com", "type": "dns", "record_type": "MX" } }
+{ "tool": "check", "params": { "hostname": "gmail.com", "type": "dns", "record_type": "MX" } }
 
 // SSL certificate analysis
-{ "tool": "net_check", "params": { "hostname": "example.com", "type": "ssl" } }
+{ "tool": "check", "params": { "hostname": "example.com", "type": "ssl" } }
 
 // HTTP headers analysis (security & performance)
-{ "tool": "net_check", "params": { "url": "https://example.com", "type": "http" } }
+{ "tool": "check", "params": { "url": "https://example.com", "type": "http" } }
 ```
 
 **DNS Response:**
@@ -96,7 +96,7 @@ Unified check tool for DNS, SSL, and HTTP analysis. Use `type` parameter to spec
 }
 ```
 
-### net_connect
+### connect
 
 TCP connectivity testing - test if a host and port is reachable.
 
@@ -108,13 +108,13 @@ TCP connectivity testing - test if a host and port is reachable.
 **Examples:**
 ```javascript
 // Test web server connectivity
-{ "tool": "net_connect", "params": { "host": "example.com", "port": 80 } }
+{ "tool": "connect", "params": { "host": "example.com", "port": 80 } }
 
 // Test SSH port
-{ "tool": "net_connect", "params": { "host": "server.example.com", "port": 22 } }
+{ "tool": "connect", "params": { "host": "server.example.com", "port": 22 } }
 
 // Test database port
-{ "tool": "net_connect", "params": { "host": "db.example.com", "port": 3306 } }
+{ "tool": "connect", "params": { "host": "db.example.com", "port": 3306 } }
 ```
 
 **Response:**
@@ -230,13 +230,13 @@ Make HTTP/HTTPS requests.
 
 ```javascript
 // 1. Check DNS resolution
-{ "tool": "net_check", "params": { "hostname": "example.com" } }
+{ "tool": "check", "params": { "hostname": "example.com" } }
 
 // 2. Test connectivity
-{ "tool": "net_connect", "params": { "host": "example.com", "port": 443 } }
+{ "tool": "connect", "params": { "host": "example.com", "port": 443 } }
 
 // 3. Check SSL certificate
-{ "tool": "net_check", "params": { "hostname": "example.com", "type": "ssl" } }
+{ "tool": "check", "params": { "hostname": "example.com", "type": "ssl" } }
 
 // 4. Test HTTP endpoint
 { "tool": "http_request", "params": { "url": "https://example.com" } }
@@ -246,10 +246,10 @@ Make HTTP/HTTPS requests.
 
 ```javascript
 // Check HTTP security headers
-{ "tool": "net_check", "params": { "url": "https://example.com", "type": "http" } }
+{ "tool": "check", "params": { "url": "https://example.com", "type": "http" } }
 
 // Check SSL certificate
-{ "tool": "net_check", "params": { "hostname": "example.com", "type": "ssl" } }
+{ "tool": "check", "params": { "hostname": "example.com", "type": "ssl" } }
 
 // Scan common ports
 { "tool": "port_scan", "params": { "host": "example.com" } }
@@ -262,10 +262,10 @@ Make HTTP/HTTPS requests.
 { "tool": "port_scan", "params": { "host": "myserver.com", "ports": "web" } }
 
 // Check database server
-{ "tool": "net_connect", "params": { "host": "db.myserver.com", "port": 3306 } }
+{ "tool": "connect", "params": { "host": "db.myserver.com", "port": 3306 } }
 
 // Check SSH access
-{ "tool": "net_connect", "params": { "host": "myserver.com", "port": 22 } }
+{ "tool": "connect", "params": { "host": "myserver.com", "port": 22 } }
 ```
 
 ## Security
@@ -288,8 +288,8 @@ All tools return a consistent error format:
 
 ## Best Practices for LLM
 
-1. **Start with DNS** - If a host is unreachable, check DNS first with `net_check`
-2. **Use `net_check` for all checks** - DNS, SSL, and HTTP analysis in one unified tool
+1. **Start with DNS** - If a host is unreachable, check DNS first with `check`
+2. **Use `check` for all checks** - DNS, SSL, and HTTP analysis in one unified tool
 3. **Use appropriate timeouts** - Increase timeout for slow networks
 4. **Check common ports** - Use `port_scan` with port groups for quick assessment
 5. **Handle errors gracefully** - Network operations can fail for many reasons

--- a/data/skills/net-operations/index.js
+++ b/data/skills/net-operations/index.js
@@ -666,10 +666,10 @@ async function httpRequest(params) {
  */
 async function execute(toolName, params, context = {}) {
   switch (toolName) {
-    case 'net_check':
+    case 'check':
       return await netCheck(params);
     
-    case 'net_connect':
+    case 'connect':
       return await netConnect(params);
     
     case 'port_scan':
@@ -679,7 +679,7 @@ async function execute(toolName, params, context = {}) {
       return await httpRequest(params);
     
     default:
-      throw new Error(`Unknown tool: ${toolName}`);
+      throw new Error(`Unknown tool: ${toolName}. Supported tools: check, connect, port_scan, http_request`);
   }
 }
 

--- a/data/skills/pptx/SKILL.md
+++ b/data/skills/pptx/SKILL.md
@@ -30,14 +30,14 @@ user-invocable: true
 
 | 工具 | 最终名称 | 说明 |
 |------|----------|------|
-| `pptx_file` | `pptx__file` | 文件级操作（读取、创建、提取） |
-| `pptx_slide` | `pptx__slide` | 幻灯片创建（仅限新建演示文稿） |
-| `pptx_object` | `pptx__object` | 内容对象操作（添加、提取） |
-| `pptx_master` | `pptx__master` | 模板母版（定义、列出） |
+| `file` | `pptx__file` | 文件级操作（读取、创建、提取） |
+| `slide` | `pptx__slide` | 幻灯片创建（仅限新建演示文稿） |
+| `object` | `pptx__object` | 内容对象操作（添加、提取） |
+| `master` | `pptx__master` | 模板母版（定义、列出） |
 
 ---
 
-## pptx_file - 文件级操作
+## file - 文件级操作
 
 通过 `action` 参数区分具体操作：
 
@@ -128,7 +128,7 @@ pptx__file({
 
 ---
 
-## pptx_slide - 幻灯片创建
+## slide - 幻灯片创建
 
 创建新的演示文稿并添加幻灯片。
 
@@ -165,7 +165,7 @@ pptx__slide({
 
 ---
 
-## pptx_object - 内容对象操作
+## object - 内容对象操作
 
 通过 `action` 参数区分具体操作：
 
@@ -272,7 +272,7 @@ pptx__object({
 
 ---
 
-## pptx_master - 模板母版
+## master - 模板母版
 
 通过 `action` 参数区分具体操作：
 

--- a/data/skills/pptx/index.js
+++ b/data/skills/pptx/index.js
@@ -1345,20 +1345,20 @@ function finalizeMarkdownSlide(pptx, slideInfo, content) {
  */
 async function execute(toolName, params, context = {}) {
   switch (toolName) {
-    case 'pptx_file':
+    case 'file':
       return await pptxFile(params);
       
-    case 'pptx_slide':
+    case 'slide':
       return await pptxSlide(params);
       
-    case 'pptx_object':
+    case 'object':
       return await pptxObject(params);
       
-    case 'pptx_master':
+    case 'master':
       return await pptxMaster(params);
       
     default:
-      throw new Error(`Unknown tool: ${toolName}. Supported tools: pptx_file, pptx_slide, pptx_object, pptx_master`);
+      throw new Error(`Unknown tool: ${toolName}. Supported tools: file, slide, object, master`);
   }
 }
 

--- a/data/skills/xlsx/SKILL.md
+++ b/data/skills/xlsx/SKILL.md
@@ -31,105 +31,105 @@ excel_read({ path: '/absolute/path/to/data.xlsx', scope: 'workbook' })
 
 | 工具 | 说明 | 关键参数 |
 |------|------|----------|
-| `excel_read` | 读取 Excel | `scope`: workbook/sheet/cell |
-| `excel_write` | 写入 Excel | `scope`: workbook/sheet/cell |
-| `excel_sheet` | 工作表管理 | `action`: add/delete/rename/copy |
-| `excel_format` | 格式化 | `type`: column/cell |
-| `excel_query` | 数据查询 | `action`: filter/sort/find |
-| `excel_convert` | 格式转换 | `format`: json/csv, `direction`: to/from |
-| `excel_calc` | 公式计算 | - |
+| `read` | 读取 Excel | `scope`: workbook/sheet/cell |
+| `write` | 写入 Excel | `scope`: workbook/sheet/cell |
+| `sheet` | 工作表管理 | `action`: add/delete/rename/copy |
+| `format` | 格式化 | `type`: column/cell |
+| `query` | 数据查询 | `action`: filter/sort/find |
+| `convert` | 格式转换 | `format`: json/csv, `direction`: to/from |
+| `calc` | 公式计算 | - |
 
-## excel_read
+## read
 
 ```javascript
 // 读取工作簿
-excel_read({ path: 'data.xlsx', scope: 'workbook' })
-excel_read({ path: 'data.xlsx', scope: 'workbook', includeData: true })
+read({ path: 'data.xlsx', scope: 'workbook' })
+read({ path: 'data.xlsx', scope: 'workbook', includeData: true })
 
 // 读取工作表
-excel_read({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1' })
-excel_read({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', header: 'json', range: 'A1:C10' })
+read({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1' })
+read({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', header: 'json', range: 'A1:C10' })
 
 // 读取单元格
-excel_read({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1' })
+read({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1' })
 ```
 
-## excel_write
+## write
 
 ```javascript
 // 创建工作簿
-excel_write({
+write({
   path: 'new.xlsx',
   scope: 'workbook',
   sheets: [{ name: 'Sheet1', data: [['A', 'B'], [1, 2]] }]
 })
 
 // 写入工作表
-excel_write({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'overwrite' })
-excel_write({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'append' })
+write({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'overwrite' })
+write({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'append' })
 
 // 写入单元格
-excel_write({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1', value: 'Hello' })
-excel_write({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'C1', formula: '=SUM(A1:B1)' })
+write({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1', value: 'Hello' })
+write({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'C1', formula: '=SUM(A1:B1)' })
 ```
 
-## excel_sheet
+## sheet
 
 ```javascript
-excel_sheet({ path: 'data.xlsx', action: 'add', name: 'NewSheet' })
-excel_sheet({ path: 'data.xlsx', action: 'delete', sheet: 'Sheet2' })
-excel_sheet({ path: 'data.xlsx', action: 'rename', sheet: 'Sheet1', newName: 'Summary' })
-excel_sheet({ path: 'data.xlsx', action: 'copy', sourceSheet: 'Template', targetSheet: 'Copy1' })
+sheet({ path: 'data.xlsx', action: 'add', name: 'NewSheet' })
+sheet({ path: 'data.xlsx', action: 'delete', sheet: 'Sheet2' })
+sheet({ path: 'data.xlsx', action: 'rename', sheet: 'Sheet1', newName: 'Summary' })
+sheet({ path: 'data.xlsx', action: 'copy', sourceSheet: 'Template', targetSheet: 'Copy1' })
 ```
 
-## excel_format
+## format
 
 ```javascript
 // 列宽
-excel_format({
+format({
   path: 'data.xlsx', type: 'column', sheet: 'Sheet1',
   columns: [{ column: 'A', width: 20 }, { column: 'B', width: 15 }]
 })
 
 // 单元格样式
-excel_format({
+format({
   path: 'data.xlsx', type: 'cell', sheet: 'Sheet1',
   cells: ['A1', 'B1'],
   style: { font: { bold: true }, fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFF00' } } }
 })
 ```
 
-## excel_query
+## query
 
 ```javascript
 // 筛选
-excel_query({ path: 'data.xlsx', action: 'filter', column: 'status', condition: 'equals', value: 'active' })
+query({ path: 'data.xlsx', action: 'filter', column: 'status', condition: 'equals', value: 'active' })
 
 // 排序
-excel_query({ path: 'data.xlsx', action: 'sort', column: 'amount', order: 'desc' })
+query({ path: 'data.xlsx', action: 'sort', column: 'amount', order: 'desc' })
 
 // 查找
-excel_query({ path: 'data.xlsx', action: 'find', query: 'error' })
+query({ path: 'data.xlsx', action: 'find', query: 'error' })
 ```
 
 **筛选条件**: `equals`, `not_equals`, `greater`, `less`, `contains`, `starts_with`, `ends_with`, `is_empty`, `is_not_empty`
 
-## excel_convert
+## convert
 
 ```javascript
 // Excel ↔ JSON
-excel_convert({ path: 'data.xlsx', format: 'json', direction: 'to' })
-excel_convert({ path: 'output.xlsx', format: 'json', direction: 'from', data: [{ name: 'Alice' }] })
+convert({ path: 'data.xlsx', format: 'json', direction: 'to' })
+convert({ path: 'output.xlsx', format: 'json', direction: 'from', data: [{ name: 'Alice' }] })
 
 // Excel ↔ CSV
-excel_convert({ path: 'data.xlsx', format: 'csv', direction: 'to', output: 'data.csv' })
-excel_convert({ path: 'data.csv', format: 'csv', direction: 'from', output: 'data.xlsx' })
+convert({ path: 'data.xlsx', format: 'csv', direction: 'to', output: 'data.csv' })
+convert({ path: 'data.csv', format: 'csv', direction: 'from', output: 'data.xlsx' })
 ```
 
-## excel_calc
+## calc
 
 ```javascript
-excel_calc({ path: 'data.xlsx', sheet: 'Sheet1' })
+calc({ path: 'data.xlsx', sheet: 'Sheet1' })
 // 返回: { formulas: [{ cell: 'C1', formula: 'SUM(A1:B1)', value: 15 }] }
 ```
 

--- a/data/skills/xlsx/index.js
+++ b/data/skills/xlsx/index.js
@@ -1289,29 +1289,29 @@ async function excelCalc(params) {
  */
 async function execute(toolName, params, context = {}) {
   switch (toolName) {
-    case 'excel_read':
+    case 'read':
       return await excelRead(params);
       
-    case 'excel_write':
+    case 'write':
       return await excelWrite(params);
       
-    case 'excel_sheet':
+    case 'sheet':
       return await excelSheet(params);
       
-    case 'excel_format':
+    case 'format':
       return await excelFormat(params);
       
-    case 'excel_query':
+    case 'query':
       return await excelQuery(params);
       
-    case 'excel_convert':
+    case 'convert':
       return await excelConvert(params);
       
-    case 'excel_calc':
+    case 'calc':
       return await excelCalc(params);
       
     default:
-      throw new Error(`Unknown tool: ${toolName}. Supported tools: excel_read, excel_write, excel_sheet, excel_format, excel_query, excel_convert, excel_calc`);
+      throw new Error(`Unknown tool: ${toolName}. Supported tools: read, write, sheet, format, query, convert, calc`);
   }
 }
 


### PR DESCRIPTION
## 变更概述

消除工具名与技能标记（skill_mark）的语义重复问题。

## 问题背景

工具注册时，最终 `tool_name` = `skill_mark + '__' + tool_name_in_code`

当 `skill_mark` 已经表明领域时，工具名又重复相同语义，导致冗余：
- `xlsx__excel_read` → xlsx 和 excel 语义重复
- `pptx__pptx_file` → pptx 重复
- `kb-search__get_kb` → kb 重复

## 变更内容

| 技能 | 原工具名 | 新工具名 |
|------|----------|----------|
| xlsx | `excel_read`, `excel_write` 等 7 个 | `read`, `write` 等 |
| pptx | `pptx_file`, `pptx_slide` 等 4 个 | `file`, `slide` 等 |
| file-operations | `fs_grep`, `fs_action`, `fs_info` | `grep`, `action`, `info` |
| net-operations | `net_check`, `net_connect` | `check`, `connect` |
| kb-editor | `kb` | `knowledge_base` |
| kb-search | `get_kb`, `list_my_kbs` | `get`, `list_mine` |

## 修改文件

- 6 个技能的 `index.js`（工具定义和 execute 函数）
- 6 个技能的 `SKILL.md`（文档）

## 效果

修改后，最终 tool_name 更加简洁清晰：
- `xlsx__read` (而非 `xlsx__excel_read`)
- `pptx__file` (而非 `pptx__pptx_file`)
- `kb-search__get` (而非 `kb-search__get_kb`)

Closes #440