### PR TITLE
fix: 更新 xlsx SKILL.md 示例代码中的工具名

### DIFF
--- a/data/skills/xlsx/SKILL.md
+++ b/data/skills/xlsx/SKILL.md
@@ -21,10 +21,10 @@ description: "Excel 文件处理。用于读取、写入、编辑 .xlsx/.xls/.cs
 **示例**：
 ```javascript
 // 相对路径（推荐）
-excel_read({ path: 'input/data.xlsx', scope: 'workbook' })
+read({ path: 'input/data.xlsx', scope: 'workbook' })
 
 // 绝对路径（仅管理员）
-excel_read({ path: '/absolute/path/to/data.xlsx', scope: 'workbook' })
+read({ path: '/absolute/path/to/data.xlsx', scope: 'workbook' })
 ```
 
 ## 工具


### PR DESCRIPTION
补充修复 xlsx/SKILL.md 中遗漏的示例代码更新：`excel_read` → `read`