### PR TITLE
fix: 更新 net-operations 注释中的工具名

### DIFF
--- a/data/skills/net-operations/index.js
+++ b/data/skills/net-operations/index.js
@@ -5,8 +5,8 @@
  * All operations are designed to be LLM-friendly with clear error messages.
  * 
  * Tools:
- * - net_check: Unified check tool (DNS, SSL, HTTP headers)
- * - net_connect: TCP connectivity testing
+ * - check: Unified check tool (DNS, SSL, HTTP headers)
+ * - connect: TCP connectivity testing
  * - port_scan: Port scanning
  * - http_request: HTTP/HTTPS requests
  * 


### PR DESCRIPTION
## 变更说明

修复 net-operations 技能 index.js 文件头注释中的旧工具名：
- `net_check` → `check`
- `net_connect` → `connect`

## 关联 Issue

Closes #440