### PR TITLE
refactor: 重命名 file-operations 技能为 fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ touwaka-mate-v2/
 
 | 技能 | 说明 |
 |------|------|
-| `file-operations` | 文件读写、搜索、管理 |
+| `fs` | 文件读写、搜索、管理 |
 | `compression` | ZIP 压缩/解压 |
 | `http-client` | HTTP GET/POST 请求 |
 | `skill-manager` | 技能注册、删除、分配 |

--- a/data/skills/fs/SKILL.md
+++ b/data/skills/fs/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: file-operations
-description: "文件系统操作。用于读取、写入、搜索、管理文件。当需要在数据目录中操作文件时触发。"
-argument-hint: "[read|write|grep|info|action] [path]"
+name: fs
+description: "文件系统操作。⚠️读取前先调用info获取文件信息：图片用read_file(mode='data_url')，大文件用from/lines分块。"
+argument-hint: "[info|read|write|grep|action] [path]"
 user-invocable: true
 ---
 
-# File Operations - 文件系统操作
+# FS - 文件系统操作
 
 完整的文件系统操作，用于读取、写入、搜索和管理文件。
 

--- a/data/skills/fs/index.js
+++ b/data/skills/fs/index.js
@@ -1,10 +1,10 @@
  /**
- * File Operations Skill - Node.js Implementation
+ * FS Skill - Node.js Implementation
  * 
  * File system operations including read, write, search, and manage files.
  * All operations are restricted to allowed directories for security.
  * 
- * @module file-operations-skill
+ * @module fs-skill
  */
 
 const fs = require('fs');
@@ -45,7 +45,7 @@ if (IS_ADMIN) {
 }
 
 // 调试输出
-console.error('[file-operations] 环境变量诊断:');
+console.error('[fs] 环境变量诊断:');
 console.error(`  IS_ADMIN: ${IS_ADMIN}`);
 console.error(`  IS_SKILL_CREATOR: ${IS_SKILL_CREATOR}`);
 console.error(`  DATA_BASE_PATH: ${DATA_BASE_PATH}`);
@@ -78,7 +78,7 @@ function isPathAllowed(targetPath) {
   const resolvedLower = resolved.toLowerCase();
   
   // 调试输出
-  console.error(`[file-operations] isPathAllowed: checking "${resolved}"`);
+  console.error(`[fs] isPathAllowed: checking "${resolved}"`);
   
   const result = ALLOWED_BASE_PATHS.some(basePath => {
     let resolvedBase = path.resolve(basePath);
@@ -97,11 +97,11 @@ function isPathAllowed(targetPath) {
     // 1. 路径必须以 basePath + path.sep 开头（子目录/文件）
     // 2. 或者路径完全等于 basePath（目录本身）
     const isAllowed = resolvedLower.startsWith(resolvedBaseLower + path.sep) || resolvedLower === resolvedBaseLower;
-    console.error(`[file-operations]   vs "${resolvedBase}": ${isAllowed}`);
+    console.error(`[fs]   vs "${resolvedBase}": ${isAllowed}`);
     return isAllowed;
   });
   
-  console.error(`[file-operations] isPathAllowed result: ${result}`);
+  console.error(`[fs] isPathAllowed result: ${result}`);
   return result;
 }
 

--- a/docs/function-calling-best-practices.md
+++ b/docs/function-calling-best-practices.md
@@ -53,7 +53,7 @@
 | `kb-search` | 知识库搜索 | 查询知识库内容、搜索专业知识 | `kb-search__search`, `kb-search__global_search` |
 | `docx` | Word 文档处理 | 创建或编辑 .docx 文件 | `docx__create`, `docx__read` |
 | `pdf` | PDF 处理 | 读取或转换 PDF 文件 | `pdf__read`, `pdf__to_images` |
-| `file-operations` | 文件操作 | 文件系统操作、文件信息查询 | `file-operations__fs_info`, `file-operations__read_file` |
+| `fs` | 文件操作 | 文件系统操作、文件信息查询 | `fs__info`, `fs__read_file` |
 
 ### 使用建议
 
@@ -65,7 +65,7 @@
 ### 注意事项
 
 - 如果信息不足，先询问用户再调用工具
-- 文件操作前必须先用 `file-operations__fs_info` 检查文件类型
+- 文件操作前必须先用 `fs__info` 检查文件类型
 - 技能工具的详细参数说明在各自的工具描述中
 ```
 
@@ -170,7 +170,7 @@ System Prompt 应该包含**无法在 tools 参数中表达的信息**：
 **使用建议**：
 - 需要搜索知识库时，使用 `kb-search` 技能
 - 需要处理文档时，优先使用 `docx` 或 `pdf` 技能
-- 不确定文件类型时，先用 `file-operations` 的 `fs_info` 工具获取文件信息
+- 不确定文件类型时，先用 `fs` 技能的 `info` 工具获取文件信息
 
 **注意事项**：
 - 技能工具需要明确的参数，如果信息不足请询问用户
@@ -278,7 +278,7 @@ OpenAI 文档推荐：
 
 - `kb-search__search` - 知识库搜索技能的搜索工具
 - `kb-search__insert` - 知识库搜索技能的插入工具
-- `file-operations__fs_info` - 文件操作技能的文件信息工具
+- `fs__info` - 文件操作技能的文件信息工具
 - `docx__create` - DOCX 技能的创建文档工具
 
 **优势**：

--- a/docs/guides/development/quick-start.md
+++ b/docs/guides/development/quick-start.md
@@ -72,7 +72,7 @@ node scripts/init-core-skills.js
 
 | 技能 | 说明 |
 |------|------|
-| `file-operations` | 文件读写、搜索、管理 |
+| `fs` | 文件读写、搜索、管理 |
 | `compression` | ZIP 压缩/解压 |
 | `http-client` | HTTP GET/POST 请求 |
 | `skill-manager` | 技能注册、删除、分配 |
@@ -140,7 +140,7 @@ touwaka-mate-v2/
 │   └── sandboxie/         # Sandboxie 沙箱配置
 ├── data/                  # 数据目录
 │   ├── skills/            # 技能存储
-│   │   ├── file-operations/
+│   │   ├── fs/            # 文件系统操作
 │   │   ├── compression/
 │   │   ├── http-client/
 │   │   ├── skill-manager/

--- a/issue-body.md
+++ b/issue-body.md
@@ -1,0 +1,23 @@
+# refactor: 重命名 file-operations 技能为 fs
+
+## 问题描述
+`file-operations` 技能名称过长（15 字符），且不够精确（包含目录操作）。
+
+## 解决方案
+- 重命名技能目录：`file-operations` → `fs`
+- 更新工具命名：`file-operations__xxx` → `fs__xxx`
+- 将技能使用提示从代码硬编码移到 SKILL.md description 字段
+
+## 变更内容
+- `data/skills/file-operations/` → `data/skills/fs/`
+- `data/skills/fs/SKILL.md` - 更新 name 和 description
+- `data/skills/fs/index.js` - 更新模块注释和调试标识
+- `lib/context-manager.js` - 移除硬编码检测
+- `lib/context-organizer/base-organizer.js` - 移除硬编码检测
+- `README.md`, `docs/` - 更新文档引用
+
+## 优势
+1. 更短更简洁：`fs` (2 字符) vs `file-operations` (15 字符)
+2. 更准确：`fs` 代表 "file system"，涵盖文件和目录操作
+3. 更优雅：技能提示通过 description 自动注入，无需硬编码
+4. 易于维护：新增或修改技能提示只需编辑 SKILL.md

--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -290,6 +290,7 @@ class ContextManager {
    * - tools 参数已包含工具名称、描述、参数定义，无需在 System Prompt 中重复
    * - System Prompt 只需提供：命名空间解释、技能场景映射、使用指导
    * - 让 LLM 能够根据 skill_mark 在 tools 数组中找到对应工具
+   * - 技能特定的使用提示应在 SKILL.md 的 description 字段中定义，自动注入
    *
    * @param {Array} skills - 技能列表
    * @returns {string|null} 技能段落内容
@@ -318,39 +319,12 @@ class ContextManager {
     validSkills.forEach(s => logger.info(`[ContextManager] - ${s.id}: ${s.name} (mark: ${s.mark})`));
 
     // 生成技能映射表（技能标识 → 使用场景）
+    // description 来自数据库，技能特定的使用提示已在 SKILL.md 中定义
     const skillsTable = validSkills.map(skill => {
       const mark = skill.mark || skill.id;
-      const useCase = this.getSkillUseCase(mark) || skill.description || '暂无描述';
+      const useCase = skill.description || '暂无描述';
       return `| \`${mark}\` | ${skill.name} | ${useCase} |`;
     }).join('\n');
-
-    // 检查是否有 file-operations 技能（使用过滤后的 validSkills）
-    const hasFileOperations = validSkills.some(s => s.mark === 'file-operations' || s.name === 'file-operations');
-    const fileOperationsGuidance = hasFileOperations ? `
-
-### ⚠️ 文件操作重要提示
-
-**在读取文件之前，必须先了解文件信息！**
-
-直接读取图片、压缩包、二进制文件对 LLM 是无意义的（会被截断）。正确做法：
-
-1. **先调用 \`file-operations__fs_info\`** 获取文件信息：
-   - \`size\` / \`sizeHuman\`: 文件大小
-   - \`mimeType\`: 文件类型（image/png, application/zip 等）
-   - \`isTextFile\`: 是否为文本文件
-
-2. **根据文件信息选择处理方式**：
-   - **图片文件** → 使用 \`file-operations__read_file(mode="data_url")\` 传给多模态模型
-   - **压缩包** → 委托助理处理，或使用解压工具
-   - **二进制文件** → 委托助理处理，或使用专门工具
-   - **大文本文件** → 使用 \`from\` / \`lines\` 参数分块读取
-   - **普通文本文件** → 正常读取
-
-**示例流程**：
-\`\`\`
-1. file-operations__fs_info(path="input/screenshot.png")  → 得知是图片，大小 500KB
-2. file-operations__read_file(path="input/screenshot.png", mode="data_url")  → 转为 base64 供多模态模型处理
-\`\`\`` : '';
 
     return `## 技能使用指南
 
@@ -366,7 +340,7 @@ class ContextManager {
 | 技能标识 | 技能名称 | 使用场景 |
 |---------|---------|---------|
 ${skillsTable}
-${fileOperationsGuidance}
+
 ### 使用建议
 
 1. **识别场景** → 确定需要哪个技能（如：用户要搜索知识库 → \`kb-search\`）

--- a/lib/context-organizer/base-organizer.js
+++ b/lib/context-organizer/base-organizer.js
@@ -206,6 +206,7 @@ export class BaseContextOrganizer extends IContextOrganizer {
    * - tools 参数已包含工具名称、描述、参数定义，无需在 System Prompt 中重复
    * - System Prompt 只需提供：命名空间解释、技能场景映射、使用指导
    * - 让 LLM 能够根据 skill_mark 在 tools 数组中找到对应工具
+   * - 技能特定的使用提示应在 SKILL.md 的 description 字段中定义，自动注入
    *
    * @param {Array} skills - 技能列表
    * @returns {string|null} 技能段落内容
@@ -216,27 +217,12 @@ export class BaseContextOrganizer extends IContextOrganizer {
     }
 
     // 生成技能映射表（技能标识 → 使用场景）
+    // description 字段来自数据库，包含技能特定的使用提示
     const skillsTable = skills.map(skill => {
       const mark = skill.mark || skill.id;
-      const useCase = this.getSkillUseCase(mark) || skill.description || '暂无描述';
+      const useCase = skill.description || '暂无描述';
       return `| \`${mark}\` | ${skill.name} | ${useCase} |`;
     }).join('\n');
-
-    // 检查是否有 file-operations 技能
-    const hasFileOperations = skills.some(s => s.mark === 'file-operations' || s.name === 'file-operations');
-    const fileOperationsGuidance = hasFileOperations ? `
-
-### ⚠️ 文件操作重要提示
-
-**在读取文件之前，必须先了解文件信息！**
-
-直接读取图片、压缩包、二进制文件对 LLM 是无意义的（会被截断）。正确做法：
-
-1. **先调用 \`file-operations__fs_info\`** 获取文件信息
-2. **根据文件信息选择处理方式**：
-   - 图片文件 → 使用 \`file-operations__read_file(mode="data_url")\`
-   - 压缩包/二进制文件 → 委托助理处理
-   - 大文本文件 → 使用 \`from\` / \`lines\` 参数分块读取` : '';
 
     return `## 技能使用指南
 
@@ -252,7 +238,7 @@ export class BaseContextOrganizer extends IContextOrganizer {
 | 技能标识 | 技能名称 | 使用场景 |
 |---------|---------|---------|
 ${skillsTable}
-${fileOperationsGuidance}
+
 ### 使用建议
 
 1. **识别场景** → 确定需要哪个技能（如：用户要搜索知识库 → \`kb-search\`）


### PR DESCRIPTION
## 变更概述
重命名 `file-operations` 技能为 `fs`，简化命名并优化技能提示注入方式。

## 变更详情

### 技能重命名
- **目录**：`data/skills/file-operations` → `data/skills/fs`
- **技能标识**：`file-operations` → `fs`
- **工具命名**：`file-operations__xxx` → `fs__xxx`

### 设计改进
将技能特定的使用提示从代码硬编码移到 SKILL.md 的 `description` 字段：

**新的 description**：
```
"文件系统操作。⚠️读取前先调用 info 获取文件信息：图片用 read_file(mode='data_url')，大文件用 from/lines 分块。"
```

这样提示会自动出现在 System Prompt 的技能表格中，无需在 `context-manager.js` 和 `base-organizer.js` 中硬编码检测。

### 修改的文件
- `data/skills/fs/SKILL.md` - 更新 name 和 description
- `data/skills/fs/index.js` - 更新模块注释和调试标识
- `lib/context-manager.js` - 移除硬编码检测
- `lib/context-organizer/base-organizer.js` - 移除硬编码检测
- `README.md` - 更新技能名称
- `docs/function-calling-best-practices.md` - 更新工具名称示例
- `docs/guides/development/quick-start.md` - 更新技能名称和目录结构

## 优势
1. **更短更简洁**：`fs` (2 字符) vs `file-operations` (15 字符)
2. **更准确**：`fs` 代表 "file system"，涵盖文件和目录操作
3. **更优雅**：技能提示通过 description 自动注入，无需硬编码
4. **易于维护**：新增或修改技能提示只需编辑 SKILL.md

Closes #446
