### PR TITLE
fix: 为 kb-editor 子资源操作添加权限校验

### DIFF
--- a/docs/guides/development/code-review-checklist.md
+++ b/docs/guides/development/code-review-checklist.md
@@ -99,6 +99,7 @@ ctx.success(buildPaginatedResponse(rows, count, pagination));
 | **路由顺序** | 动态路由 `/:id` 是否在静态路由之后？ |
 | **ID 类型匹配** | 自增 ID 字段是否误用手动指定（如 `Utils.newID()`）？检查 Model 定义中 `autoIncrement: true` 的字段 |
 | **数据库方法选择** | SELECT 用 `db.query()`，INSERT 用 `db.insert()`，UPDATE/DELETE 用 `db.execute()` |
+| **API 权限校验** | 所有写操作是否校验用户权限？详见下方专项检查 |
 
 ### 前端错误处理专项检查
 
@@ -145,6 +146,93 @@ grep -rn "// 错误已在" frontend/src/views/ frontend/src/components/
    ```
 
 3. **删除/保存等关键操作必须给用户明确的成功/失败反馈**
+
+---
+
+### API 权限校验专项检查
+
+> **来源**：Issue #426 知识库权限控制遗漏教训
+> **核心原则**：认证 ≠ 权限校验，所有写操作必须校验用户是否有操作权限
+
+#### 权限校验原则
+
+| 原则 | 说明 |
+|------|------|
+| **认证 ≠ 授权** | 用户已登录不代表有权限操作所有资源 |
+| **最小权限原则** | 默认拒绝，只授予必要权限 |
+| **层级权限继承** | 子资源操作必须校验父资源权限 |
+
+#### 检查清单
+
+**每个 API 端点必须检查**：
+
+| 操作类型 | 权限校验要求 |
+|----------|-------------|
+| **创建（POST）** | 校验用户是否有权限在该父资源下创建子资源 |
+| **更新（PUT）** | 校验用户是否有权限编辑该资源 |
+| **删除（DELETE）** | 校验用户是否有权限删除该资源 |
+| **查询（GET）** | 校验用户是否有权限访问该资源（或过滤结果） |
+
+**层级资源权限校验**：
+
+```
+知识库 (kb)           → canEditKb() / canAccessKb()
+  └── 文章 (article)  → 必须校验 kb 权限
+      └── 节 (section) → 必须校验 kb 权限
+          └── 段落 (paragraph) → 必须校验 kb 权限
+  └── 标签 (tag)      → 必须校验 kb 权限
+```
+
+#### 代码模板
+
+```javascript
+// ✅ 正确 - 写操作前校验权限
+async createArticle(ctx) {
+  const { kb_id } = ctx.params;
+  const userId = ctx.state.session.id;
+
+  // 权限检查：只有 owner 或 admin 可以编辑
+  const canEdit = await canEditKb(this.db, kb_id, userId);
+  if (!canEdit) {
+    ctx.throw(403, '无权编辑此知识库');
+  }
+
+  // 执行业务逻辑...
+}
+
+// ❌ 错误 - 只验证资源存在，未校验权限
+async createArticle(ctx) {
+  const { kb_id } = ctx.params;
+
+  // 只验证知识库存在，未校验用户是否有权限
+  const kb = await this.KnowledgeBase.findByPk(kb_id);
+  if (!kb) {
+    ctx.throw(404, 'Knowledge base not found');
+  }
+
+  // 直接执行业务逻辑 - 安全漏洞！
+}
+```
+
+#### 快速检查命令
+
+```bash
+# 检查所有写操作是否缺少权限校验
+# 查找 POST/PUT/DELETE 路由定义
+grep -rn "router\.\(post\|put\|delete\)" server/routes/
+
+# 对照检查对应的 controller 方法是否包含权限校验
+grep -rn "canEdit\|canAccess\|canDelete" server/controllers/
+```
+
+#### 常见遗漏场景
+
+| 场景 | 问题 | 修复 |
+|------|------|------|
+| 子资源 CRUD | 只验证父资源存在，未校验编辑权限 | 添加 `canEditKb()` 校验 |
+| 批量操作 | 只校验部分资源权限 | 所有涉及资源都必须校验 |
+| 嵌套资源 | 只校验直接父资源，忽略祖先资源 | 递归校验祖先权限 |
+| 公开资源 | 误认为公开=可编辑 | 读权限 ≠ 写权限，分别校验 |
 
 ---
 

--- a/server/controllers/kb.controller.js
+++ b/server/controllers/kb.controller.js
@@ -484,11 +484,18 @@ class KbController {
       this.ensureModels();
       const { kb_id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
 
       // 验证知识库存在
       const kb = await this.KnowledgeBase.findByPk(kb_id);
       if (!kb) {
         ctx.throw(404, 'Knowledge base not found');
+      }
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
       }
 
       const id = Utils.newID(20);
@@ -531,6 +538,13 @@ class KbController {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const article = await this.KbArticle.findOne({ where: { id, kb_id } });
       if (!article) {
@@ -572,6 +586,13 @@ class KbController {
     try {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const article = await this.KbArticle.findOne({ where: { id, kb_id } });
       if (!article) {
@@ -709,6 +730,13 @@ class KbController {
       this.ensureModels();
       const { kb_id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       // 验证文章存在且属于该知识库
       const article = await this.KbArticle.findOne({
@@ -769,6 +797,13 @@ class KbController {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const section = await this.KbSection.findByPk(id, {
         include: [{ model: this.KbArticle, as: 'article' }],
@@ -797,6 +832,13 @@ class KbController {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
       const { direction } = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       if (!['up', 'down'].includes(direction)) {
         ctx.throw(400, 'Invalid direction, must be "up" or "down"');
@@ -850,6 +892,13 @@ class KbController {
     try {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const section = await this.KbSection.findByPk(id, {
         include: [{ model: this.KbArticle, as: 'article' }],
@@ -938,6 +987,13 @@ class KbController {
       this.ensureModels();
       const { kb_id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       // 验证节存在且属于该知识库
       const section = await this.KbSection.findByPk(data.section_id, {
@@ -981,6 +1037,13 @@ class KbController {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const paragraph = await this.KbParagraph.findByPk(id, {
         include: [{
@@ -1019,6 +1082,13 @@ class KbController {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
       const { direction } = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       if (!['up', 'down'].includes(direction)) {
         ctx.throw(400, 'Invalid direction, must be "up" or "down"');
@@ -1076,6 +1146,13 @@ class KbController {
     try {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const paragraph = await this.KbParagraph.findByPk(id, {
         include: [{
@@ -1147,6 +1224,13 @@ class KbController {
       this.ensureModels();
       const { kb_id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       // 验证知识库存在
       const kb = await this.KnowledgeBase.findByPk(kb_id);
@@ -1188,6 +1272,13 @@ class KbController {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
       const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const tag = await this.KbTag.findOne({ where: { id, kb_id } });
       if (!tag) {
@@ -1224,6 +1315,13 @@ class KbController {
     try {
       this.ensureModels();
       const { kb_id, id } = ctx.params;
+      const userId = ctx.state.session.id;
+
+      // 权限检查：只有 owner 或 admin 可以编辑
+      const canEdit = await canEditKb(this.db, kb_id, userId);
+      if (!canEdit) {
+        ctx.throw(403, '无权编辑此知识库');
+      }
 
       const tag = await this.KbTag.findOne({ where: { id, kb_id } });
       if (!tag) {


### PR DESCRIPTION
## 变更摘要

为 kb-editor 技能的子资源操作添加完整的权限校验，修复安全漏洞。

## 问题背景

Issue #426 实现了知识库权限控制，但遗漏了子资源（文章/节/段落/标签）的权限校验。任何登录用户只要知道 `kb_id`，就可以操作该知识库中的子资源，即使该用户没有编辑权限。

## 修复内容

在所有子资源的写操作中添加 `canEditKb()` 权限校验：

| 资源 | 修复的方法 |
|------|-----------|
| 文章 | `createArticle`, `updateArticle`, `deleteArticle` |
| 节 | `createSection`, `updateSection`, `moveSection`, `deleteSection` |
| 段落 | `createParagraph`, `updateParagraph`, `moveParagraph`, `deleteParagraph` |
| 标签 | `createTag`, `updateTag`, `deleteTag` |

## 权限校验逻辑

```javascript
// 示例：createArticle 方法
async createArticle(ctx) {
  const { kb_id } = ctx.params;
  const userId = ctx.state.session.id;

  // 权限检查：只有 owner 或 admin 可以编辑
  const canEdit = await canEditKb(this.db, kb_id, userId);
  if (!canEdit) {
    ctx.throw(403, '无权编辑此知识库');
  }

  // 执行业务逻辑...
}
```

## 涉及文件

- `data/skills/kb-editor/index.js` - 添加权限校验逻辑

## 安全提升

- ✅ 防止未授权用户操作他人知识库的子资源
- ✅ 与知识库级别的权限控制保持一致
- ✅ 符合最小权限原则

Closes #431