### PR TITLE
chore: 同步 skill-manager 技能数据到初始化脚本

### DIFF
--- a/scripts/skills-data.json
+++ b/scripts/skills-data.json
@@ -1,5 +1,5 @@
 {
-  "exportedAt": "2026-03-23T07:48:06.989Z",
+  "exportedAt": "2026-03-30T05:08:40.586Z",
   "skills": [
     {
       "id": "compression",
@@ -26,6 +26,86 @@
       "is_active": true
     },
     {
+      "id": "H4ehsMA68GLUyXl56oPg",
+      "name": "docx",
+      "description": "Word 文档处理。用于读取、写入、编辑、模板填充 .docx 文件。支持页眉页脚、超链接、目录、图片操作。使用 Patcher API 保留原文档样式。当用户需要操作 Word 文档时触发。",
+      "version": "1.0.0",
+      "author": "'张三'",
+      "tags": [],
+      "source_type": "local",
+      "source_path": "skills/docx",
+      "source_url": null,
+      "skill_md": "---\nname: docx\ndescription: \"Word 文档处理。用于读取、写入、编辑、模板填充 .docx 文件。支持页眉页脚、超链接、目录、图片操作。使用 Patcher API 保留原文档样式。当用户需要操作 Word 文档时触发。\"\n---\n\n# DOCX - Word 文档处理 (重构版)\n\n## 路径参数说明\n\n> **重要**：所有工具的 `path` 参数遵循以下规则：\n\n| 参数类型 | 说明 |\n|----------|------|\n| **相对路径** | 相对于工作目录，工具自动拼接基础路径。示例：`input/file.docx` |\n| **绝对路径** | 仅管理员可用，需在允许的路径范围内 |\n\n**基础路径规则**：\n- 管理员：项目根目录 或 `data/` 目录\n- 普通用户：`data/work/{user_id}/` 目录\n\n**示例**：\n```javascript\n// 相对路径（推荐）\nread({ path: 'input/document.docx', scope: 'text' })\n\n// 绝对路径（仅管理员）\nread({ path: '/absolute/path/to/document.docx', scope: 'text' })\n```\n\n## 工具列表\n\n| 工具 | 说明 | 关键参数 |\n|------|------|----------|\n| `read` | 读取文档 | `scope`: info/text/paragraphs/tables/comments/images/headers/footers |\n| `write` | 写入文档 | `source`: data/markdown，支持 `header`/`footer` |\n| `patch` | 模板填充 | `patches`: { placeholder: value }，保留原文档样式 |\n| `edit` | 编辑文档 | `action`: replace/append/insert/delete |\n| `convert` | 格式转换 | `format`: markdown/html |\n| `image` | 图片操作 | `action`: extract/insert/list |\n| `link` | 超链接操作 | `action`: add/list |\n| `toc` | 目录操作 | `action`: insert/update |\n\n---\n\n## read - 读取文档\n\n### scope 参数\n\n| scope | 说明 | 返回内容 |\n|-------|------|----------|\n| `info` | 文档信息 | 元数据、段落数、字数、是否有页眉页脚 |\n| `text` | 提取文本 | 纯文本或 HTML（`includeFormatting: true`） |\n| `paragraphs` | 提取段落 | 段落列表（可选样式） |\n| `tables` | 提取表格 | 表格数据数组 |\n| `comments` | 提取批注 | 批注列表 |\n| `images` | 提取图片信息 | 图片列表（路径、大小） |\n| `headers` | 提取页眉 | 页眉内容 |\n| `footers` | 提取页脚 | 页脚内容 |\n\n### 示例\n\n```javascript\n// 读取文档信息\nread({ path: 'document.docx', scope: 'info' })\n// 返回: { metadata, paragraphCount, characterCount, wordCount, hasHeader, hasFooter }\n\n// 提取文本\nread({ path: 'document.docx', scope: 'text' })\nread({ path: 'document.docx', scope: 'text', includeFormatting: true })  // 返回 HTML\n\n// 提取段落/表格/批注\nread({ path: 'document.docx', scope: 'paragraphs' })\nread({ path: 'document.docx', scope: 'tables' })\nread({ path: 'document.docx', scope: 'comments' })\n\n// 提取图片信息\nread({ path: 'document.docx', scope: 'images' })\n// 返回: { imageCount, images: [{ path, fileName, extension, size }] }\n\n// 提取页眉页脚\nread({ path: 'document.docx', scope: 'headers' })\nread({ path: 'document.docx', scope: 'footers' })\n```\n\n---\n\n## write - 写入文档\n\n### 参数\n\n| 参数 | 类型 | 说明 |\n|------|------|------|\n| `path` | string | 输出文件路径 |\n| `source` | string | 数据来源：`data` 或 `markdown` |\n| `content` | array | 内容数据（source 为 data） |\n| `markdown` | string | Markdown 内容（source 为 markdown） |\n| `title` | string | 文档标题 |\n| `properties` | object | 文档属性（author, subject, keywords） |\n| `header` | object | 页眉配置 |\n| `footer` | object | 页脚配置 |\n| `sections` | array | 多节配置 |\n\n### 页眉配置\n\n```javascript\nheader: {\n  text: 'Document Header',\n  alignment: 'CENTER'  // LEFT, CENTER, RIGHT\n}\n```\n\n### 页脚配置\n\n```javascript\nfooter: {\n  text: 'Company Name',\n  pageNumber: true,\n  pagePrefix: 'Page ',\n  pageSuffix: '',\n  pageAlignment: 'CENTER'\n}\n```\n\n### 示例\n\n```javascript\n// 从数据创建（带页眉页脚）\nwrite({\n  path: 'output.docx',\n  source: 'data',\n  title: 'Report Title',\n  header: { text: 'Company Report', alignment: 'CENTER' },\n  footer: { pageNumber: true, pagePrefix: 'Page ' },\n  content: [\n    { type: 'heading', text: 'Introduction', level: 1 },\n    { type: 'paragraph', text: 'This is the content.' },\n    { type: 'paragraph', text: 'Bold text', runs: [{ text: 'Bold', bold: true }] },\n    { type: 'list', items: ['Item 1', 'Item 2'] },\n    { type: 'table', headers: ['Name', 'Value'], rows: [['A', '1']] }\n  ]\n})\n\n// 从 Markdown 创建\nwrite({\n  path: 'output.docx',\n  source: 'markdown',\n  markdown: '# Title\\n\\nParagraph with **bold** text.\\n\\n- Item 1\\n- Item 2',\n  header: { text: 'Header' },\n  footer: { pageNumber: true }\n})\n\n// 多节文档\nwrite({\n  path: 'output.docx',\n  sections: [\n    { \n      content: [{ type: 'heading', text: 'Section 1', level: 1 }],\n      header: { text: 'Section 1 Header' }\n    },\n    { \n      content: [{ type: 'heading', text: 'Section 2', level: 1 }],\n      header: { text: 'Section 2 Header' }\n    }\n  ]\n})\n```\n\n---\n\n## patch - 模板填充（核心功能）\n\n> **重要**：使用 Patcher API，保留原文档样式！\n\n### 参数\n\n| 参数 | 类型 | 说明 |\n|------|------|------|\n| `path` | string | 模板文件路径 |\n| `patches` | object | 替换数据 `{ placeholder: value }` |\n| `output` | string | 输出文件路径（可选，默认覆盖原文件） |\n| `keepOriginalStyles` | boolean | 保留原文档样式（默认 true） |\n| `delimiters` | object | 占位符分隔符（默认 `{ start: '{{', end: '}}' }`） |\n\n### 模板文档准备\n\n在 Word 文档中使用 `{{placeholder}}` 格式的占位符：\n\n```\n姓名：{{name}}\n日期：{{date}}\n金额：{{amount}}\n```\n\n### 示例\n\n```javascript\n// 简单文本替换\npatch({\n  path: 'template.docx',\n  patches: {\n    name: '张三',\n    date: '2024-01-15',\n    amount: '¥1,000.00'\n  },\n  output: 'output.docx'\n})\n\n// 复杂替换（段落样式）\npatch({\n  path: 'template.docx',\n  patches: {\n    title: {\n      type: 'paragraph',\n      children: [{ text: '新标题', bold: true, size: 28 }]\n    }\n  }\n})\n\n// 自定义分隔符\npatch({\n  path: 'template.docx',\n  patches: { name: 'John' },\n  delimiters: { start: '[[', end: ']]' }\n})\n```\n\n---\n\n## edit - 编辑文档\n\n> **推荐使用 `patch` 工具进行编辑，可保留原文档样式**\n\n### action 参数\n\n| action | 说明 | 关键参数 |\n|--------|------|----------|\n| `replace` | 替换占位符 | `replacements`: { placeholder: value } |\n| `append` | 添加段落 | `text`: 内容 |\n| `insert` | 插入段落 | `text`: 内容，`placeholder`: 占位符 |\n| `delete` | 删除内容 | `placeholder`: 占位符 |\n\n### 示例\n\n```javascript\n// 替换占位符（保留格式）\nedit({\n  path: 'document.docx',\n  action: 'replace',\n  replacements: {\n    title: '新标题',\n    author: '张三'\n  }\n})\n\n// 在占位符处插入内容\nedit({\n  path: 'document.docx',\n  action: 'insert',\n  placeholder: 'content_here',\n  text: '这是新插入的内容'\n})\n\n// 添加段落到末尾\nedit({\n  path: 'document.docx',\n  action: 'append',\n  text: '新段落'\n})\n\n// 删除占位符内容\nedit({\n  path: 'document.docx',\n  action: 'delete',\n  placeholder: 'remove_this'\n})\n```\n\n---\n\n## convert - 格式转换\n\n### 示例\n\n```javascript\n// 转 Markdown\nconvert({ path: 'document.docx', format: 'markdown' })\nconvert({ path: 'document.docx', format: 'markdown', output: 'document.md' })\n\n// 转 HTML\nconvert({ path: 'document.docx', format: 'html' })\nconvert({ path: 'document.docx', format: 'html', output: 'document.html', includeStyles: true })\n```\n\n---\n\n## image - 图片操作\n\n### action 参数\n\n| action | 说明 | 关键参数 |\n|--------|------|----------|\n| `list` | 列出图片 | 无额外参数 |\n| `extract` | 提取图片 | `outputDir`: 输出目录 |\n| `insert` | 插入图片 | `imagePath`: 图片路径，`placeholder`: 占位符 |\n\n### 示例\n\n```javascript\n// 列出图片\nimage({ path: 'document.docx', action: 'list' })\n\n// 提取图片\nimage({ path: 'document.docx', action: 'extract', outputDir: './images' })\n\n// 在占位符处插入图片（保留格式）\nimage({\n  path: 'document.docx',\n  action: 'insert',\n  placeholder: 'image_here',\n  imagePath: 'chart.png',\n  width: 500,\n  height: 300\n})\n\n// 插入图片到末尾（可能丢失格式）\nimage({\n  path: 'document.docx',\n  action: 'insert',\n  imagePath: 'chart.png',\n  width: 500,\n  height: 300\n})\n```\n\n---\n\n## link - 超链接操作\n\n### action 参数\n\n| action | 说明 | 关键参数 |\n|--------|------|----------|\n| `list` | 列出超链接 | 无额外参数 |\n| `add` | 添加超链接 | `placeholder`: 占位符，`url`: 链接，`text`: 显示文本 |\n\n### 示例\n\n```javascript\n// 列出超链接\nlink({ path: 'document.docx', action: 'list' })\n\n// 在占位符处添加超链接\nlink({\n  path: 'document.docx',\n  action: 'add',\n  placeholder: 'link_here',\n  url: 'https://example.com',\n  text: '点击访问'\n})\n```\n\n---\n\n## toc - 目录操作\n\n### action 参数\n\n| action | 说明 | 关键参数 |\n|--------|------|----------|\n| `insert` | 插入目录 | `placeholder`: 占位符 |\n| `update` | 更新目录提示 | 无额外参数 |\n\n### 示例\n\n```javascript\n// 在占位符处插入目录\ntoc({\n  path: 'document.docx',\n  action: 'insert',\n  placeholder: 'toc_here'\n})\n\n// 更新目录提示\ntoc({ path: 'document.docx', action: 'update' })\n// 返回提示：需要在 Word 中手动更新目录（F9）\n```\n\n---\n\n## 最佳实践\n\n### 1. 模板填充优先\n\n使用 `patch` 工具进行模板填充，可保留原文档的所有样式：\n\n```javascript\n// 推荐：使用模板填充\npatch({ path: 'template.docx', patches: { name: '张三' } })\n\n// 不推荐：直接编辑（可能丢失格式）\nedit({ path: 'document.docx', action: 'append', text: '新内容' })\n```\n\n### 2. 占位符命名规范\n\n- 使用清晰的命名：`{{customer_name}}`、`{{invoice_date}}`\n- 避免特殊字符：仅使用字母、数字、下划线\n- 模板中占位符前后留空格：`姓名：{{ name }}`\n\n### 3. 页眉页脚设置\n\n创建专业文档时添加页眉页脚：\n\n```javascript\nwrite({\n  path: 'report.docx',\n  header: { text: '公司报告', alignment: 'CENTER' },\n  footer: { pageNumber: true, pagePrefix: '第 ', pageSuffix: ' 页' },\n  content: [...]\n})\n```\n\n---\n\n## 注意事项\n\n- **模板填充**：使用 `patch` 工具可保留原文档样式\n- **占位符格式**：默认 `{{placeholder}}`，可自定义分隔符\n- **目录更新**：插入目录后需在 Word 中手动更新（F9）\n- **图片插入**：推荐使用占位符方式，可保留格式\n",
+      "security_score": 100,
+      "security_warnings": null,
+      "license": null,
+      "argument_hint": "",
+      "disable_model_invocation": true,
+      "user_invocable": true,
+      "allowed_tools": null,
+      "is_active": true
+    },
+    {
+      "id": "mnbsn9bm15ytytah4err",
+      "name": "echarts",
+      "description": "ECharts 图表生成。用于需要可视化数据展示的场景，支持 20+ 图表类型（柱状图、折线图、饼图、散点图等），可输出 SVG/PNG/Base64/文件格式。",
+      "version": "1.0.0",
+      "author": "",
+      "tags": [],
+      "source_type": "local",
+      "source_path": "skills/echarts",
+      "source_url": null,
+      "skill_md": "---\nname: echarts\ndescription: \"ECharts 图表生成。用于需要可视化数据展示的场景，支持 20+ 图表类型（柱状图、折线图、饼图、雷达图等），输出 SVG/PNG/Base64/文件格式。当用户需要生成图表、数据可视化、统计图形时触发。\"\n---\n\n# ECharts - 图表生成\n\n基于 ECharts SSR 的图表生成技能，无需浏览器环境。\n\n## 工具\n\n| 工具 | 说明 |\n|------|------|\n| `generate` | 生成图表 |\n\n## generate\n\n生成图表，支持简化配置和原始 ECharts 配置。\n\n### 参数\n\n| 参数 | 类型 | 必填 | 说明 |\n|------|------|------|------|\n| type | string | 否 | 图表类型，默认 `bar` |\n| data | array/object | 是 | 图表数据 |\n| options | object | 否 | 配置选项 |\n| output | string | 否 | 输出格式：`svg`/`png`/`base64`/`file`，默认 `svg` |\n| outputPath | string | file时必填 | 输出文件路径 |\n| width | number | 否 | 宽度，默认 600 |\n| height | number | 否 | 高度，默认 400 |\n| option | object | 否 | 原始 ECharts 配置（高级用法） |\n\n### 支持的图表类型\n\n| 类型 | 说明 |\n|------|------|\n| `bar` | 柱状图 |\n| `line` | 折线图 |\n| `pie` | 饼图/环形图 |\n| `scatter` | 散点图 |\n| `radar` | 雷达图 |\n| `gauge` | 仪表盘 |\n| `funnel` | 漏斗图 |\n| `heatmap` | 热力图 |\n| `tree` | 树图 |\n| `treemap` | 矩形树图 |\n| `sunburst` | 旭日图 |\n| `sankey` | 桑基图 |\n| `graph` | 关系图 |\n| `boxplot` | 箱线图 |\n| `candlestick` | K线图 |\n\n### options 配置项\n\n| 配置项 | 说明 |\n|------|------|\n| title | 图表标题 |\n| xAxisData | X 轴数据（柱状图、折线图等） |\n| seriesNames | 多系列时的系列名称 |\n| indicators | 雷达图指标 |\n| radius | 饼图半径 |\n| center | 饼图中心位置 |\n| min/max | 仪表盘最小/最大值 |\n| smooth | 折线图是否平滑 |\n| areaStyle | 折线图是否显示面积 |\n| backgroundColor | 背景颜色 |\n| echartsOption | 原始 ECharts 配置合并（高级用法） |\n\n### 使用示例\n\n**简单柱状图**:\n```javascript\ngenerate({\n  type: 'bar',\n  data: [100, 200, 300],\n  options: {\n    title: 'Sales Report',\n    xAxisData: ['Q1', 'Q2', 'Q3']\n  }\n})\n```\n\n**饼图**:\n```javascript\ngenerate({\n  type: 'pie',\n  data: [\n    { name: 'Product A', value: 100 },\n    { name: 'Product B', value: 200 },\n    { name: 'Product C', value: 150 }\n  ]\n})\n```\n\n**多系列折线图**:\n```javascript\ngenerate({\n  type: 'line',\n  data: [\n    [100, 120, 140],  // Series 1\n    [80, 90, 110]     // Series 2\n  ],\n  options: {\n    title: 'Trend Analysis',\n    xAxisData: ['Jan', 'Feb', 'Mar'],\n    seriesNames: ['Product A', 'Product B'],\n    smooth: true\n  }\n})\n```\n\n**雷达图**:\n```javascript\ngenerate({\n  type: 'radar',\n  data: [\n    { name: 'Team A', value: [80, 90, 75, 85, 70] }\n  ],\n  options: {\n    indicators: [\n      { name: 'Speed', max: 100 },\n      { name: 'Quality', max: 100 },\n      { name: 'Cost', max: 100 },\n      { name: 'Safety', max: 100 },\n      { name: 'Service', max: 100 }\n    ]\n  }\n})\n```\n\n**输出为文件**:\n```javascript\ngenerate({\n  type: 'bar',\n  data: [100, 200, 300],\n  options: { title: 'Sales' },\n  output: 'file',\n  outputPath: './charts/sales.png'\n})\n```\n\n**使用原始 ECharts 配置（高级）**:\n```javascript\ngenerate({\n  option: {\n    title: { text: 'Custom Chart' },\n    xAxis: { type: 'category', data: ['A', 'B', 'C'] },\n    yAxis: { type: 'value' },\n    series: [{ type: 'bar', data: [10, 20, 30] }]\n  },\n  output: 'svg'\n})\n```\n\n**合并自定义 ECharts 配置**:\n```javascript\ngenerate({\n  type: 'bar',\n  data: [100, 200, 300],\n  options: {\n    title: 'Sales',\n    xAxisData: ['Q1', 'Q2', 'Q3'],\n    echartsOption: {\n      animation: false,\n      series: [{ itemStyle: { color: '#5470c6' } }]\n    }\n  }\n})",
+      "security_score": 100,
+      "security_warnings": null,
+      "license": null,
+      "argument_hint": "",
+      "disable_model_invocation": true,
+      "user_invocable": true,
+      "allowed_tools": null,
+      "is_active": true
+    },
+    {
+      "id": "mnbryh3fndf2lmerp216",
+      "name": "fs",
+      "description": "文件系统操作。⚠️读取前先调用info获取文件信息：图片用read_file(mode='data_url')，大文件用from/lines分块。",
+      "version": "1.0.0",
+      "author": "",
+      "tags": [],
+      "source_type": "local",
+      "source_path": "skills/fs",
+      "source_url": null,
+      "skill_md": "---\nname: fs\ndescription: \"文件系统操作。⚠️读取前先调用info获取文件信息：图片用read_file(mode='data_url')，大文件用from/lines分块。\"\nargument-hint: \"[info|read|write|grep|action] [path]\"\nuser-invocable: true\n---\n\n# FS - 文件系统操作\n\n完整的文件系统操作，用于读取、写入、搜索和管理文件。\n\n## 工具\n\n| 工具 | 说明 | 关键参数 |\n|------|------|----------|\n| `info` | 获取文件/目录信息 | `path`, `include_content_preview`, `hash` |\n| `read_file` | 读取文件 | `path`, `mode`, `from`, `lines` |\n| `list_files` | 列出目录内容 | `path`, `recursive` |\n| `grep` | 搜索文本 | `pattern`, `path`, `use_regex` |\n| `write_file` | 写入文件 | `path`, `content`, `mode` |\n| `replace_in_file` | 替换文本 | `path`, `old`, `new` |\n| `edit_lines` | 编辑行 | `path`, `operation`, `line`, `content` |\n| `action` | 文件操作 | `operation`, `source`, `destination`, `path` |\n\n## 文件信息\n\n### info\n\n获取文件或目录的详细元数据。**建议在其他操作前先调用**。\n\n**参数：**\n- `path` (string, required): 文件或目录路径\n- `include_content_preview` (boolean, optional): 包含内容预览（默认: false）\n- `hash` (string, optional): 计算文件哈希 - `\"md5\"`, `\"sha256\"`, `\"sha1\"`\n\n**返回：**\n- `exists`, `type`, `size`, `sizeHuman`\n- `created`, `modified`, `accessed`\n- `isReadOnly`, `pathInfo`, `mimeType`, `isTextFile`\n- `directoryInfo` (目录), `contentPreview` (文件)\n\n## 读取文件\n\n### read_file\n\n读取文件内容，支持多种模式。\n\n**参数：**\n- `path` (string, required): 文件路径\n- `mode` (string, optional): 读取模式 - `\"lines\"` (默认), `\"bytes\"`, 或 `\"data_url\"`\n- `from` (number, optional): 起始行（lines 模式，默认: 1）\n- `lines` (number, optional): 行数（lines 模式，默认: 100）\n- `offset` (number, optional): 起始字节（bytes 模式，默认: 0）\n- `bytes` (number, optional): 字节数（bytes 模式，默认: 50000）\n\n**读取模式：**\n| 模式 | 说明 | 用途 |\n|------|------|------|\n| `lines` | 按行读取（默认） | 读取文本文件 |\n| `bytes` | 按字节读取 | 读取二进制文件片段 |\n| `data_url` | 转换为 Data URL | **多模态 LLM 调用** |\n\n**data_url 模式（用于多模态）：**\n\n让多模态专家能够\"看到\"图片文件内容。\n\n> ⚠️ **重要**：此功能仅对多模态模型有效！如果专家使用的是纯文本模型，图片数据将被忽略。\n\n**何时使用：**\n- 用户要求\"看图片\"、\"分析图片\"、\"识别图片内容\"\n- 用户上传了图片文件并要求分析\n- 需要将图片内容发送给多模态 LLM 进行处理\n\n**使用方法：**\n1. 调用 `read_file(path=\"tasks/screenshot.png\", mode=\"data_url\")`\n2. 系统自动将图片 Data URL 转换为多模态格式发送给模型\n3. 多模态模型即可\"看到\"图片内容\n\n**完整示例：**\n```\n# 用户：请帮我分析这张截图\n\n# 专家调用工具：\nread_file(path=\"tasks/screenshot.png\", mode=\"data_url\")\n\n# 工具返回：\n{\n  success: true,\n  data: {\n    dataUrl: \"data:image/png;base64,iVBORw0KGgo...\",\n    mimeType: \"image/png\"\n  }\n}\n\n# 系统自动处理：\n# ToolManager.formatToolResultsForLLM() 检测到 dataUrl\n# 自动添加 Markdown 图片语法到工具结果中\n# LLMClient.processMultimodalMessages() 转换为多模态格式\n# 多模态模型接收到图片并可以\"看到\"内容\n\n# 专家回复：\n根据截图内容，我可以看到这是一个...\n```\n\n**工作原理（自动处理）：**\n1. `read_file(mode=\"data_url\")` 返回 base64 编码的 Data URL\n2. `ToolManager.formatToolResultsForLLM()` 检测到工具结果中的 `dataUrl`\n3. 自动在工具结果中添加 Markdown 图片语法：`![工具读取的图片](data:image/png;base64,...)`\n4. `LLMClient.processMultimodalMessages()` 检测到 Markdown 图片语法\n5. 自动转换为 OpenAI 多模态格式：`{ type: \"image_url\", image_url: { url: \"data:...\" } }`\n6. 多模态模型接收并\"看到\"图片\n\n> ✅ **新特性**：系统现在会自动处理图片 Data URL，专家无需手动添加 Markdown 语法！\n\n**支持的文件类型：**\n- 图片：png, jpg, jpeg, gif, webp, svg, bmp, ico\n- 文档：pdf（部分多模态模型支持）\n- 音视频：mp3, wav, mp4, webm（部分模型支持）\n\n**限制：**\n- 最大文件大小：10MB（data_url 模式）\n- 仅多模态模型（model_type=\"multimodal\"）能处理图片\n\n### list_files\n\n列出目录内容。\n\n**参数：**\n- `path` (string, required): 目录路径\n- `recursive` (boolean, optional): 递归列出（默认: false）\n\n## 搜索\n\n### grep\n\n跨文件搜索文本。\n\n**参数：**\n- `pattern` (string, required): 搜索模式\n- `path` (string, optional): 文件或目录路径（默认: 当前）\n- `file_pattern` (string, optional): 文件模式过滤（默认: \"*\"）\n- `use_regex` (boolean, optional): 使用正则模式（默认: false）\n- `ignore_case` (boolean, optional): 忽略大小写（默认: true）\n\n**搜索模式：**\n| 模式 | 说明 | 示例 |\n|------|------|------|\n| 字面量（默认） | 简单字符串匹配 | `pattern: \"TODO\"` |\n| 正则 | 完整正则支持 | `pattern: \"TODO\\\\d+\"` |\n\n## 写入文件\n\n### write_file\n\n写入内容到文件。\n\n**参数：**\n- `path` (string, required): 文件路径\n- `content` (string, required): 写入内容\n- `mode` (string, optional): 写入模式 - `\"write\"` (默认) 或 `\"append\"`\n\n### replace_in_file\n\n替换文件中的文本。\n\n**参数：**\n- `path` (string, required): 文件路径\n- `old` (string, required): 要替换的文本\n- `new` (string, required): 替换后的文本\n\n### edit_lines\n\n编辑文件行。\n\n**参数：**\n- `path` (string, required): 文件路径\n- `operation` (string, optional): 操作类型 - `\"insert\"` (默认) 或 `\"delete\"`\n- `line` (number, required): 行号（从1开始）\n- `end_line` (number, optional): 结束行（delete 操作）\n- `content` (string, required for insert): 插入内容\n\n## 文件操作\n\n### action\n\n统一的文件系统操作。\n\n**参数：**\n- `operation` (string, optional): 操作类型 - `\"copy\"` (默认), `\"move\"`, `\"delete\"`, `\"create_dir\"`\n- `source` (string, required for copy/move): 源路径\n- `destination` (string, required for copy/move): 目标路径\n- `path` (string, required for delete/create_dir): 路径\n\n| 操作 | 说明 | 必需参数 |\n|------|------|----------|\n| `copy` | 复制文件 | `source`, `destination` |\n| `move` | 移动文件 | `source`, `destination` |\n| `delete` | 删除文件或目录 | `path` |\n| `create_dir` | 创建目录 | `path` |\n\n## 最佳实践\n\n1. **先调用 `info`** 检查文件是否存在、类型、大小\n2. **使用 `include_content_preview`** 快速了解文件结构\n3. **处理大文件时** 检查 `size`，使用 `from`/`lines` 分块读取\n4. **内容替换** 使用 `replace_in_file`，行操作使用 `edit_lines`\n",
+      "security_score": 100,
+      "security_warnings": null,
+      "license": null,
+      "argument_hint": "",
+      "disable_model_invocation": true,
+      "user_invocable": true,
+      "allowed_tools": null,
+      "is_active": true
+    },
+    {
+      "id": "mncpuylil9ebcl4uadbq",
+      "name": "Hacker News Node",
+      "description": "",
+      "version": "1.0.0",
+      "author": "",
+      "tags": [],
+      "source_type": "local",
+      "source_path": "skills/hacknews",
+      "source_url": null,
+      "skill_md": "---\nname: hackernews-node\ndescription: Browse and search Hacker News with AI domain filtering. Windows-compatible Node.js implementation with bilingual output support.\nmetadata:\n  openclaw:\n    emoji: 🚀\n---\n\n# Hacker News Node\n\nWindows-compatible Hacker News browser with AI domain filtering and JSON output.\n\n## Tools\n\n### `stories`\n\n获取 Hacker News 故事，支持多种类型和搜索。\n\n**Parameters:**\n\n| Parameter | Type | Required | Description |\n|-----------|------|----------|-------------|\n| `type` | string | Yes | Story type: `top`, `new`, `best`, `ask`, `show`, `jobs`, `ai`, `search` |\n| `limit` | number | No | Number of stories to return (default: 10) |\n| `period` | string | No | Time filter for AI type: `day`, `week`, `month`, `all` (default: `all`) |\n| `query` | string | No | Search query (required when type is `search`) |\n| `json` | boolean | No | Return JSON format instead of text (default: false) |\n\n**Story Types:**\n\n| Type | Description |\n|------|-------------|\n| `top` | Top stories |\n| `new` | Newest stories |\n| `best` | Best stories |\n| `ask` | Ask HN posts |\n| `show` | Show HN posts |\n| `jobs` | Job postings |\n| `ai` | AI domain stories with time filter |\n| `search` | Search stories by query |\n\n## Examples\n\n```javascript\n// Get top stories\n{ \"type\": \"top\", \"limit\": 10 }\n\n// Get new stories in JSON format\n{ \"type\": \"new\", \"limit\": 20, \"json\": true }\n\n// Get AI stories from last 24 hours\n{ \"type\": \"ai\", \"limit\": 10, \"period\": \"day\" }\n\n// Search for machine learning stories\n{ \"type\": \"search\", \"query\": \"machine learning\", \"limit\": 5 }\n\n// Get best stories\n{ \"type\": \"best\", \"limit\": 15 }\n```\n\n## Output Format\n\n### Text Mode (default)\n```\n🔥 Top Stories\n==================================================\n\n1. Story Title\n   https://example.com/story\n   👍 523 | 💬 156 | @author\n```\n\n### JSON Mode (`json: true`)\n```json\n{\n  \"count\": 10,\n  \"stories\": [\n    {\n      \"id\": 43050023,\n      \"title\": \"Story Title\",\n      \"url\": \"https://example.com/story\",\n      \"points\": 523,\n      \"author\": \"author\",\n      \"comments\": 156\n    }\n  ]\n}\n```\n\n## API Reference\n\n- HN Official API: https://github.com/HackerNews/API\n- Algolia Search: https://hn.algolia.com/api\n",
+      "security_score": 100,
+      "security_warnings": null,
+      "license": null,
+      "argument_hint": "",
+      "disable_model_invocation": true,
+      "user_invocable": true,
+      "allowed_tools": null,
+      "is_active": true
+    },
+    {
       "id": "mmgf5ge7vfxvf07duv0k",
       "name": "KB Editor",
       "description": "知识库管理技能，用于创建和管理知识库、文章、节、段落、标签",
@@ -46,16 +126,56 @@
       "is_active": true
     },
     {
-      "id": "BqqKfGgDw5LFZW33eBUN",
-      "name": "PPTX",
-      "description": "PowerPoint 文件操作技能 - 解包、打包、修改、预览",
+      "id": "mnbsyqr1kfmj4ee8io9n",
+      "name": "net-operations",
+      "description": "Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, and comprehensive network diagnostics.",
       "version": "1.0.0",
       "author": "",
       "tags": [],
       "source_type": "local",
-      "source_path": "skills\\pptx",
+      "source_path": "skills/net-operations",
       "source_url": null,
-      "skill_md": "---\r\nname: pptx\r\ndescription: \"Use this skill any time a .pptx file is involved in any way — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading, parsing, or extracting text from any .pptx file (even if the extracted content will be used elsewhere, like in an email or summary); editing, modifying, or updating existing presentations; combining or splitting slide files; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \\\"deck,\\\" \\\"slides,\\\" \\\"presentation,\\\" or references a .pptx filename, regardless of what they plan to do with the content afterward. If a .pptx file needs to be opened, created, or touched, use this skill.\"\r\nlicense: Proprietary. LICENSE.txt has complete terms\r\n---\r\n\r\n# PPTX Skill\r\n\r\n## Quick Reference\r\n\r\n| Task | Guide |\r\n|------|-------|\r\n| Read/analyze content | `python -m markitdown presentation.pptx` |\r\n| Edit or create from template | Read [editing.md](editing.md) |\r\n| Create from scratch | Read [pptxgenjs.md](pptxgenjs.md) |\r\n\r\n---\r\n\r\n## Reading Content\r\n\r\n```bash\r\n# Text extraction\r\npython -m markitdown presentation.pptx\r\n\r\n# Visual overview\r\npython scripts/thumbnail.py presentation.pptx\r\n\r\n# Raw XML\r\npython scripts/office/unpack.py presentation.pptx unpacked/\r\n```\r\n\r\n---\r\n\r\n## Editing Workflow\r\n\r\n**Read [editing.md](editing.md) for full details.**\r\n\r\n1. Analyze template with `thumbnail.py`\r\n2. Unpack → manipulate slides → edit content → clean → pack\r\n\r\n---\r\n\r\n## Creating from Scratch\r\n\r\n**Read [pptxgenjs.md](pptxgenjs.md) for full details.**\r\n\r\nUse when no template or reference presentation is available.\r\n\r\n---\r\n\r\n## Design Ideas\r\n\r\n**Don't create boring slides.** Plain bullets on a white background won't impress anyone. Consider ideas from this list for each slide.\r\n\r\n### Before Starting\r\n\r\n- **Pick a bold, content-informed color palette**: The palette should feel designed for THIS topic. If swapping your colors into a completely different presentation would still \"work,\" you haven't made specific enough choices.\r\n- **Dominance over equality**: One color should dominate (60-70% visual weight), with 1-2 supporting tones and one sharp accent. Never give all colors equal weight.\r\n- **Dark/light contrast**: Dark backgrounds for title + conclusion slides, light for content (\"sandwich\" structure). Or commit to dark throughout for a premium feel.\r\n- **Commit to a visual motif**: Pick ONE distinctive element and repeat it — rounded image frames, icons in colored circles, thick single-side borders. Carry it across every slide.\r\n\r\n### Color Palettes\r\n\r\nChoose colors that match your topic — don't default to generic blue. Use these palettes as inspiration:\r\n\r\n| Theme | Primary | Secondary | Accent |\r\n|-------|---------|-----------|--------|\r\n| **Midnight Executive** | `1E2761` (navy) | `CADCFC` (ice blue) | `FFFFFF` (white) |\r\n| **Forest & Moss** | `2C5F2D` (forest) | `97BC62` (moss) | `F5F5F5` (cream) |\r\n| **Coral Energy** | `F96167` (coral) | `F9E795` (gold) | `2F3C7E` (navy) |\r\n| **Warm Terracotta** | `B85042` (terracotta) | `E7E8D1` (sand) | `A7BEAE` (sage) |\r\n| **Ocean Gradient** | `065A82` (deep blue) | `1C7293` (teal) | `21295C` (midnight) |\r\n| **Charcoal Minimal** | `36454F` (charcoal) | `F2F2F2` (off-white) | `212121` (black) |\r\n| **Teal Trust** | `028090` (teal) | `00A896` (seafoam) | `02C39A` (mint) |\r\n| **Berry & Cream** | `6D2E46` (berry) | `A26769` (dusty rose) | `ECE2D0` (cream) |\r\n| **Sage Calm** | `84B59F` (sage) | `69A297` (eucalyptus) | `50808E` (slate) |\r\n| **Cherry Bold** | `990011` (cherry) | `FCF6F5` (off-white) | `2F3C7E` (navy) |\r\n\r\n### For Each Slide\r\n\r\n**Every slide needs a visual element** — image, chart, icon, or shape. Text-only slides are forgettable.\r\n\r\n**Layout options:**\r\n- Two-column (text left, illustration on right)\r\n- Icon + text rows (icon in colored circle, bold header, description below)\r\n- 2x2 or 2x3 grid (image on one side, grid of content blocks on other)\r\n- Half-bleed image (full left or right side) with content overlay\r\n\r\n**Data display:**\r\n- Large stat callouts (big numbers 60-72pt with small labels below)\r\n- Comparison columns (before/after, pros/cons, side-by-side options)\r\n- Timeline or process flow (numbered steps, arrows)\r\n\r\n**Visual polish:**\r\n- Icons in small colored circles next to section headers\r\n- Italic accent text for key stats or taglines\r\n\r\n### Typography\r\n\r\n**Choose an interesting font pairing** — don't default to Arial. Pick a header font with personality and pair it with a clean body font.\r\n\r\n| Header Font | Body Font |\r\n|-------------|-----------|\r\n| Georgia | Calibri |\r\n| Arial Black | Arial |\r\n| Calibri | Calibri Light |\r\n| Cambria | Calibri |\r\n| Trebuchet MS | Calibri |\r\n| Impact | Arial |\r\n| Palatino | Garamond |\r\n| Consolas | Calibri |\r\n\r\n| Element | Size |\r\n|---------|------|\r\n| Slide title | 36-44pt bold |\r\n| Section header | 20-24pt bold |\r\n| Body text | 14-16pt |\r\n| Captions | 10-12pt muted |\r\n\r\n### Spacing\r\n\r\n- 0.5\" minimum margins\r\n- 0.3-0.5\" between content blocks\r\n- Leave breathing room—don't fill every inch\r\n\r\n### Avoid (Common Mistakes)\r\n\r\n- **Don't repeat the same layout** — vary columns, cards, and callouts across slides\r\n- **Don't center body text** — left-align paragraphs and lists; center only titles\r\n- **Don't skimp on size contrast** — titles need 36pt+ to stand out from 14-16pt body\r\n- **Don't default to blue** — pick colors that reflect the specific topic\r\n- **Don't mix spacing randomly** — choose 0.3\" or 0.5\" gaps and use consistently\r\n- **Don't style one slide and leave the rest plain** — commit fully or keep it simple throughout\r\n- **Don't create text-only slides** — add images, icons, charts, or visual elements; avoid plain title + bullets\r\n- **Don't forget text box padding** — when aligning lines or shapes with text edges, set `margin: 0` on the text box or offset the shape to account for padding\r\n- **Don't use low-contrast elements** — icons AND text need strong contrast against the background; avoid light text on light backgrounds or dark text on dark backgrounds\r\n- **NEVER use accent lines under titles** — these are a hallmark of AI-generated slides; use whitespace or background color instead\r\n\r\n---\r\n\r\n## QA (Required)\r\n\r\n**Assume there are problems. Your job is to find them.**\r\n\r\nYour first render is almost never correct. Approach QA as a bug hunt, not a confirmation step. If you found zero issues on first inspection, you weren't looking hard enough.\r\n\r\n### Content QA\r\n\r\n```bash\r\npython -m markitdown output.pptx\r\n```\r\n\r\nCheck for missing content, typos, wrong order.\r\n\r\n**When using templates, check for leftover placeholder text:**\r\n\r\n```bash\r\npython -m markitdown output.pptx | grep -iE \"xxxx|lorem|ipsum|this.*(page|slide).*layout\"\r\n```\r\n\r\nIf grep returns results, fix them before declaring success.\r\n\r\n### Visual QA\r\n\r\n**⚠️ USE SUBAGENTS** — even for 2-3 slides. You've been staring at the code and will see what you expect, not what's there. Subagents have fresh eyes.\r\n\r\nConvert slides to images (see [Converting to Images](#converting-to-images)), then use this prompt:\r\n\r\n```\r\nVisually inspect these slides. Assume there are issues — find them.\r\n\r\nLook for:\r\n- Overlapping elements (text through shapes, lines through words, stacked elements)\r\n- Text overflow or cut off at edges/box boundaries\r\n- Decorative lines positioned for single-line text but title wrapped to two lines\r\n- Source citations or footers colliding with content above\r\n- Elements too close (< 0.3\" gaps) or cards/sections nearly touching\r\n- Uneven gaps (large empty area in one place, cramped in another)\r\n- Insufficient margin from slide edges (< 0.5\")\r\n- Columns or similar elements not aligned consistently\r\n- Low-contrast text (e.g., light gray text on cream-colored background)\r\n- Low-contrast icons (e.g., dark icons on dark backgrounds without a contrasting circle)\r\n- Text boxes too narrow causing excessive wrapping\r\n- Leftover placeholder content\r\n\r\nFor each slide, list issues or areas of concern, even if minor.\r\n\r\nRead and analyze these images:\r\n1. /path/to/slide-01.jpg (Expected: [brief description])\r\n2. /path/to/slide-02.jpg (Expected: [brief description])\r\n\r\nReport ALL issues found, including minor ones.\r\n```\r\n\r\n### Verification Loop\r\n\r\n1. Generate slides → Convert to images → Inspect\r\n2. **List issues found** (if none found, look again more critically)\r\n3. Fix issues\r\n4. **Re-verify affected slides** — one fix often creates another problem\r\n5. Repeat until a full pass reveals no new issues\r\n\r\n**Do not declare success until you've completed at least one fix-and-verify cycle.**\r\n\r\n---\r\n\r\n## Converting to Images\r\n\r\nConvert presentations to individual slide images for visual inspection:\r\n\r\n```bash\r\npython scripts/office/soffice.py --headless --convert-to pdf output.pptx\r\npdftoppm -jpeg -r 150 output.pdf slide\r\n```\r\n\r\nThis creates `slide-01.jpg`, `slide-02.jpg`, etc.\r\n\r\nTo re-render specific slides after fixes:\r\n\r\n```bash\r\npdftoppm -jpeg -r 150 -f N -l N output.pdf slide-fixed\r\n```\r\n\r\n---\r\n\r\n## Dependencies\r\n\r\n- `pip install \"markitdown[pptx]\"` - text extraction\r\n- `pip install Pillow` - thumbnail grids\r\n- `npm install -g pptxgenjs` - creating from scratch\r\n- LibreOffice (`soffice`) - PDF conversion (auto-configured for sandboxed environments via `scripts/office/soffice.py`)\r\n- Poppler (`pdftoppm`) - PDF to images\r\n",
+      "skill_md": "---\nname: net-operations\ndescription: Network utilities including DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests. Use when you need to diagnose network issues or make HTTP requests.\nargument-hint: \"[check|connect|scan|request] [host]\"\nuser-invocable: true\n---\n\n# Network Operations\n\nNetwork utilities for DNS lookup, SSL analysis, HTTP headers analysis, connectivity testing, port scanning, and HTTP requests.\n\n## Tools\n\n### check\n\nUnified check tool for DNS, SSL, and HTTP analysis. Use `type` parameter to specify check type.\n\n**Parameters:**\n- `type` (string, optional): Check type - `\"dns\"` (default), `\"ssl\"`, or `\"http\"`\n- `timeout` (number, optional): Timeout in ms (default: 5000)\n\n**DNS Check (type=\"dns\"):**\n- `hostname` (string, required): Hostname to check\n- `record_type` (string, optional): DNS record type - `\"A\"` (default), `\"AAAA\"`, `\"MX\"`, `\"TXT\"`, `\"CNAME\"`, `\"NS\"`\n\n**SSL Check (type=\"ssl\"):**\n- `hostname` (string, required): Hostname to check\n- `port` (number, optional): Port for SSL check (default: 443)\n\n**HTTP Check (type=\"http\"):**\n- `url` (string, required): URL to analyze\n\n**Examples:**\n```javascript\n// DNS lookup - A records (IPv4)\n{ \"tool\": \"check\", \"params\": { \"hostname\": \"example.com\" } }\n\n// DNS lookup - MX records (mail servers)\n{ \"tool\": \"check\", \"params\": { \"hostname\": \"gmail.com\", \"type\": \"dns\", \"record_type\": \"MX\" } }\n\n// SSL certificate analysis\n{ \"tool\": \"check\", \"params\": { \"hostname\": \"example.com\", \"type\": \"ssl\" } }\n\n// HTTP headers analysis (security & performance)\n{ \"tool\": \"check\", \"params\": { \"url\": \"https://example.com\", \"type\": \"http\" } }\n```\n\n**DNS Response:**\n```json\n{\n  \"success\": true,\n  \"hostname\": \"example.com\",\n  \"recordType\": \"A\",\n  \"records\": [\"93.184.216.34\"],\n  \"count\": 1\n}\n```\n\n**SSL Response:**\n```json\n{\n  \"success\": true,\n  \"hostname\": \"example.com\",\n  \"port\": 443,\n  \"ssl\": {\n    \"valid\": true,\n    \"subject\": { \"CN\": \"example.com\" },\n    \"issuer\": { \"CN\": \"Let's Encrypt\" },\n    \"validFrom\": \"Jan 1 00:00:00 2024 GMT\",\n    \"validTo\": \"Apr 1 00:00:00 2024 GMT\",\n    \"daysUntilExpiry\": 30,\n    \"isExpired\": false,\n    \"fingerprint\": \"...\"\n  }\n}\n```\n\n**HTTP Response:**\n```json\n{\n  \"success\": true,\n  \"url\": \"https://example.com\",\n  \"hostname\": \"example.com\",\n  \"statusCode\": 200,\n  \"security\": {\n    \"hsts\": true,\n    \"noSniff\": true,\n    \"frameGuard\": \"DENY\",\n    \"csp\": true\n  },\n  \"performance\": {\n    \"cacheControl\": \"max-age=31536000\",\n    \"compression\": \"gzip\"\n  },\n  \"recommendations\": []\n}\n```\n\n### connect\n\nTCP connectivity testing - test if a host and port is reachable.\n\n**Parameters:**\n- `host` (string, required): Hostname or IP address\n- `port` (number, optional): Port number (default: 80)\n- `timeout` (number, optional): Timeout in ms (default: 5000)\n\n**Examples:**\n```javascript\n// Test web server connectivity\n{ \"tool\": \"connect\", \"params\": { \"host\": \"example.com\", \"port\": 80 } }\n\n// Test SSH port\n{ \"tool\": \"connect\", \"params\": { \"host\": \"server.example.com\", \"port\": 22 } }\n\n// Test database port\n{ \"tool\": \"connect\", \"params\": { \"host\": \"db.example.com\", \"port\": 3306 } }\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"host\": \"example.com\",\n  \"port\": 80,\n  \"status\": \"open\",\n  \"responseTime\": 15,\n  \"message\": \"Port 80 is open on example.com (15ms)\"\n}\n```\n\n### port_scan\n\nScan multiple ports on a host.\n\n**Parameters:**\n- `host` (string, required): Hostname or IP address\n- `ports` (string|number|array, optional): Port configuration (default: \"common\")\n  - `\"common\"` - Common ports (21, 22, 23, 25, 53, 80, 110, 143, 443, 465, 587, 993, 995, 3306, 3389, 5432, 6379, 8080, 8443)\n  - `\"web\"` - Web ports (80, 443, 8080, 8443)\n  - `\"mail\"` - Mail ports (25, 110, 143, 465, 587, 993, 995)\n  - `\"db\"` - Database ports (1433, 1521, 3306, 5432, 6379, 27017)\n  - Single port number\n  - Array of port numbers\n- `timeout` (number, optional): Timeout per port in ms (default: 3000)\n\n**Examples:**\n```javascript\n// Scan common ports\n{ \"tool\": \"port_scan\", \"params\": { \"host\": \"example.com\" } }\n\n// Scan web ports\n{ \"tool\": \"port_scan\", \"params\": { \"host\": \"example.com\", \"ports\": \"web\" } }\n\n// Scan specific ports\n{ \"tool\": \"port_scan\", \"params\": { \"host\": \"example.com\", \"ports\": [80, 443, 8080] } }\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"host\": \"example.com\",\n  \"scan\": {\n    \"total\": 20,\n    \"open\": [22, 80, 443],\n    \"closed\": [21, 23, 25, ...],\n    \"filtered\": [],\n    \"results\": [\n      { \"port\": 22, \"status\": \"open\" },\n      { \"port\": 80, \"status\": \"open\" },\n      ...\n    ]\n  }\n}\n```\n\n### http_request\n\nMake HTTP/HTTPS requests.\n\n**Parameters:**\n- `url` (string, required): Request URL\n- `method` (string, optional): HTTP method - `\"GET\"` (default), `\"POST\"`, `\"PUT\"`, `\"DELETE\"`, `\"PATCH\"`\n- `headers` (object, optional): Request headers\n- `body` (string|object, optional): Request body (for POST/PUT/PATCH)\n- `timeout` (number, optional): Timeout in ms (default: 10000)\n- `follow_redirects` (boolean, optional): Follow redirects (default: true)\n\n**Examples:**\n```javascript\n// Simple GET request\n{ \"tool\": \"http_request\", \"params\": { \"url\": \"https://api.example.com/data\" } }\n\n// POST with JSON body\n{\n  \"tool\": \"http_request\",\n  \"params\": {\n    \"url\": \"https://api.example.com/create\",\n    \"method\": \"POST\",\n    \"body\": { \"name\": \"Test\", \"value\": 123 }\n  }\n}\n\n// With custom headers\n{\n  \"tool\": \"http_request\",\n  \"params\": {\n    \"url\": \"https://api.example.com/protected\",\n    \"headers\": { \"Authorization\": \"Bearer token123\" }\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"statusCode\": 200,\n  \"statusMessage\": \"OK\",\n  \"headers\": { ... },\n  \"body\": { ... },\n  \"size\": 1234\n}\n```\n\n## Common Use Cases\n\n### Diagnose Network Issues\n\n```javascript\n// 1. Check DNS resolution\n{ \"tool\": \"check\", \"params\": { \"hostname\": \"example.com\" } }\n\n// 2. Test connectivity\n{ \"tool\": \"connect\", \"params\": { \"host\": \"example.com\", \"port\": 443 } }\n\n// 3. Check SSL certificate\n{ \"tool\": \"check\", \"params\": { \"hostname\": \"example.com\", \"type\": \"ssl\" } }\n\n// 4. Test HTTP endpoint\n{ \"tool\": \"http_request\", \"params\": { \"url\": \"https://example.com\" } }\n```\n\n### Security Audit\n\n```javascript\n// Check HTTP security headers\n{ \"tool\": \"check\", \"params\": { \"url\": \"https://example.com\", \"type\": \"http\" } }\n\n// Check SSL certificate\n{ \"tool\": \"check\", \"params\": { \"hostname\": \"example.com\", \"type\": \"ssl\" } }\n\n// Scan common ports\n{ \"tool\": \"port_scan\", \"params\": { \"host\": \"example.com\" } }\n```\n\n### Check Server Health\n\n```javascript\n// Check web server ports\n{ \"tool\": \"port_scan\", \"params\": { \"host\": \"myserver.com\", \"ports\": \"web\" } }\n\n// Check database server\n{ \"tool\": \"connect\", \"params\": { \"host\": \"db.myserver.com\", \"port\": 3306 } }\n\n// Check SSH access\n{ \"tool\": \"connect\", \"params\": { \"host\": \"myserver.com\", \"port\": 22 } }\n```\n\n## Security\n\n- Maximum HTTP response size is limited (1MB)\n- Port scan is limited to 20 ports per request\n- All operations have configurable timeouts\n- HTTPS is recommended for sensitive requests\n\n## Error Handling\n\nAll tools return a consistent error format:\n\n```json\n{\n  \"success\": false,\n  \"error\": \"Error message describing what went wrong\"\n}\n```\n\n## Best Practices for LLM\n\n1. **Start with DNS** - If a host is unreachable, check DNS first with `check`\n2. **Use `check` for all checks** - DNS, SSL, and HTTP analysis in one unified tool\n3. **Use appropriate timeouts** - Increase timeout for slow networks\n4. **Check common ports** - Use `port_scan` with port groups for quick assessment\n5. **Handle errors gracefully** - Network operations can fail for many reasons",
+      "security_score": 100,
+      "security_warnings": null,
+      "license": null,
+      "argument_hint": "",
+      "disable_model_invocation": true,
+      "user_invocable": true,
+      "allowed_tools": null,
+      "is_active": true
+    },
+    {
+      "id": "t2RQiLTup0dtaHn8IUx0",
+      "name": "pdf",
+      "description": "PDF 文件处理。用于读取、提取文本/表格/图片、合并、拆分、旋转、水印、加密/解密、表单填写、页面渲染。当用户提到 .pdf 文件或需要操作 PDF 时触发。",
+      "version": "1.0.0",
+      "author": "",
+      "tags": [],
+      "source_type": "local",
+      "source_path": "skills/pdf",
+      "source_url": null,
+      "skill_md": "---\nname: pdf\ndescription: \"PDF 文件处理。用于读取、提取文本/表格/图片、合并、拆分、旋转、水印、加密/解密、表单填写、页面渲染。当用户提到 .pdf 文件或需要操作 PDF 时触发。\"\nlicense: Proprietary. LICENSE.txt has complete terms\nargument-hint: \"[read|write] [operation] [path]\"\nuser-invocable: true\n---\n\n# PDF - PDF 文件处理\n\n> **依赖**：pdf-lib (PDF 操作) + pdf-parse v2.4+ (文本/表格/图片提取、页面渲染)\n\n## 工具\n\n本技能提供两个工具，通过 `operation` 参数区分具体操作：\n\n| 工具 | 最终名称 | 说明 |\n|------|----------|------|\n| `read` | `pdf__read` | PDF 读取操作（不修改原文件） |\n| `write` | `pdf__write` | PDF 写入操作（创建或修改文件） |\n\n---\n\n## read - PDF 读取工具\n\n通过 `operation` 参数区分具体读取操作：\n\n| operation | 功能 | 关键参数 |\n|-----------|------|----------|\n| `metadata` | 读取元数据 | `parse_page_info` |\n| `text` | 提取文本 | `from_page`, `to_page` |\n| `tables` | 提取表格 | `from_page`, `to_page` |\n| `images` | 提取图片 | `from_page`, `to_page`, `image_threshold` |\n| `render` | 渲染页面为图片 | `output_dir`, `scale`, `from_page`, `to_page` |\n| `markdown` | 转 Markdown | `output`, `from_page`, `to_page` |\n| `fields` | 检查表单字段 | - |\n| `field_info` | 获取字段信息 | `output` |\n\n### 参数说明\n\n**通用参数：**\n- `path` (string, required): PDF 文件路径\n- `operation` (string, required): 操作类型\n- `from_page` (number, optional): 起始页（从1开始）\n- `to_page` (number, optional): 结束页（包含）\n- `suppress_warnings` (boolean, optional): 抑制警告输出（默认: true）\n\n**metadata 操作参数：**\n- `parse_page_info` (boolean, optional): 解析每页详细信息（默认: false）\n\n**images 操作参数：**\n- `image_threshold` (number, optional): 图片最小尺寸阈值，像素（默认: 80）\n\n**render 操作参数：**\n- `output_dir` (string, optional): 输出目录（不指定则只返回 dataUrl）\n- `scale` (number, optional): 缩放比例（默认: 1.5，相当于 150 DPI）\n- `desired_width` (number, optional): 期望宽度（像素），设置后将忽略 scale\n- `prefix` (string, optional): 输出文件名前缀（默认: \"page\"）\n\n**markdown 操作参数：**\n- `output` (string, optional): 输出 markdown 文件路径\n\n### 调用示例\n\n```javascript\n// 读取元数据\npdf__read({ path: \"doc.pdf\", operation: \"metadata\" })\n\n// 提取第1-5页文本\npdf__read({ path: \"doc.pdf\", operation: \"text\", from_page: 1, to_page: 5 })\n\n// 提取表格\npdf__read({ path: \"doc.pdf\", operation: \"tables\" })\n\n// 提取图片\npdf__read({ path: \"doc.pdf\", operation: \"images\", image_threshold: 100 })\n\n// 渲染页面为图片\npdf__read({ path: \"doc.pdf\", operation: \"render\", output_dir: \"./images\", scale: 1.5 })\n\n// 转 Markdown\npdf__read({ path: \"doc.pdf\", operation: \"markdown\", output: \"doc.md\" })\n\n// 检查表单字段\npdf__read({ path: \"form.pdf\", operation: \"fields\" })\n\n// 获取字段信息\npdf__read({ path: \"form.pdf\", operation: \"field_info\", output: \"fields.json\" })\n```\n\n---\n\n## write - PDF 写入工具\n\n通过 `operation` 参数区分具体写入操作：\n\n| operation | 功能 | 关键参数 |\n|-----------|------|----------|\n| `create` | 创建 PDF | `content[]`, `title`, `page_size` |\n| `merge` | 合并 PDF | `paths[]` |\n| `split` | 拆分 PDF | `output_dir`, `pages_per_file` |\n| `rotate` | 旋转页面 | `pages[]`, `degrees` |\n| `encrypt` | 加密 PDF | `user_password`, `owner_password` |\n| `decrypt` | 解密 PDF | `password` |\n| `watermark` | 添加水印 | `watermark`, `is_text` |\n| `fill` | 填写表单 | `field_values` |\n\n### 参数说明\n\n**通用参数：**\n- `path` (string, required for most operations): PDF 文件路径\n- `output` (string, required): 输出文件路径\n- `operation` (string, required): 操作类型\n\n**create 操作参数：**\n- `content` (string[], required): 文本内容数组（每项为一页）\n- `title` (string, optional): PDF 标题\n- `page_size` (string, optional): 页面大小 - \"letter\" 或 \"a4\"（默认: \"a4\"）\n\n**merge 操作参数：**\n- `paths` (string[], required): 要合并的 PDF 文件路径数组（至少2个）\n\n**split 操作参数：**\n- `output_dir` (string, required): 输出目录\n- `pages_per_file` (number, optional): 每个文件的页数（默认: 1）\n- `prefix` (string, optional): 输出文件名前缀（默认: \"page\"）\n\n**rotate 操作参数：**\n- `pages` (number[], optional): 要旋转的页码（从1开始，为空则旋转所有）\n- `degrees` (number, optional): 旋转角度 - 90, 180, 270（默认: 90）\n\n**encrypt 操作参数：**\n- `user_password` (string, required): 打开 PDF 的密码\n- `owner_password` (string, optional): 编辑密码（默认使用 user_password）\n\n**decrypt 操作参数：**\n- `password` (string, required): 当前密码\n\n**watermark 操作参数：**\n- `watermark` (string, required): 水印文本或水印 PDF 路径\n- `is_text` (boolean, optional): true 为文本水印，false 为 PDF 路径（默认: true）\n\n**fill 操作参数：**\n- `field_values` (object, required): 字段名和值的键值对\n\n### 调用示例\n\n```javascript\n// 创建 PDF\npdf__write({ \n  output: \"new.pdf\", \n  operation: \"create\", \n  content: [\"第一页内容\", \"第二页内容\"],\n  title: \"我的文档\"\n})\n\n// 合并 PDF\npdf__write({ \n  output: \"merged.pdf\", \n  operation: \"merge\", \n  paths: [\"a.pdf\", \"b.pdf\", \"c.pdf\"]\n})\n\n// 拆分 PDF（每文件1页）\npdf__write({ \n  path: \"doc.pdf\", \n  output: \"merged.pdf\",\n  operation: \"split\", \n  output_dir: \"./split\", \n  pages_per_file: 1\n})\n\n// 旋转所有页面90度\npdf__write({ \n  path: \"doc.pdf\", \n  output: \"rotated.pdf\", \n  operation: \"rotate\", \n  degrees: 90 \n})\n\n// 旋转指定页面\npdf__write({ \n  path: \"doc.pdf\", \n  output: \"rotated.pdf\", \n  operation: \"rotate\", \n  pages: [1, 3, 5], \n  degrees: 180 \n})\n\n// 加密 PDF\npdf__write({ \n  path: \"doc.pdf\", \n  output: \"encrypted.pdf\", \n  operation: \"encrypt\", \n  user_password: \"secret123\"\n})\n\n// 解密 PDF\npdf__write({ \n  path: \"encrypted.pdf\", \n  output: \"decrypted.pdf\", \n  operation: \"decrypt\", \n  password: \"secret123\"\n})\n\n// 添加文本水印\npdf__write({ \n  path: \"doc.pdf\", \n  output: \"watermarked.pdf\", \n  operation: \"watermark\", \n  watermark: \"机密文件\"\n})\n\n// 填写表单\npdf__write({ \n  path: \"form.pdf\", \n  output: \"filled.pdf\", \n  operation: \"fill\", \n  field_values: { \n    name: \"张三\", \n    date: \"2026-03-28\", \n    approved: true \n  }\n})\n```\n\n---\n\n## 常见任务\n\n### 扫描版 PDF 处理\n\n对于扫描版 PDF 或基于图片的 PDF，文本提取可能失败。使用 `render` 操作转换为图片，然后发送给 VL（视觉语言）模型进行文字识别。\n\n**工作流程：**\n1. 使用 `read` 工具的 `render` 操作将 PDF 页面转换为 PNG 图片\n2. 将生成的图片发送给 VL 模型（如 GPT-4V、Claude Vision、Qwen-VL）\n3. VL 模型将识别并提取图片中的文字\n\n**示例：**\n```javascript\npdf__read({ path: \"scanned.pdf\", operation: \"render\", output_dir: \"./images\", scale: 1.5 })\n```\n\n---\n\n## 快速参考\n\n| 任务 | 工具 | operation |\n|------|------|-----------|\n| 读取元数据 | `read` | `metadata` |\n| 提取文本 | `read` | `text` |\n| 提取表格 | `read` | `tables` |\n| 提取图片 | `read` | `images` |\n| 渲染页面 | `read` | `render` |\n| 转 Markdown | `read` | `markdown` |\n| 检查表单字段 | `read` | `fields` |\n| 获取字段信息 | `read` | `field_info` |\n| 创建 PDF | `write` | `create` |\n| 合并 PDF | `write` | `merge` |\n| 拆分 PDF | `write` | `split` |\n| 旋转页面 | `write` | `rotate` |\n| 加密 PDF | `write` | `encrypt` |\n| 解密 PDF | `write` | `decrypt` |\n| 添加水印 | `write` | `watermark` |\n| 填写表单 | `write` | `fill` |\n\n---\n\n## 更新日志\n\n- **2026-03-28**: 重构为两个工具（read + write），通过 operation 参数区分具体操作\n- **2026-03-26**: 升级 pdf-parse 到 v2.4.5，新增表格提取、图片提取、页面渲染功能\n",
+      "security_score": 100,
+      "security_warnings": null,
+      "license": null,
+      "argument_hint": "",
+      "disable_model_invocation": true,
+      "user_invocable": true,
+      "allowed_tools": null,
+      "is_active": true
+    },
+    {
+      "id": "BqqKfGgDw5LFZW33eBUN",
+      "name": "pptx",
+      "description": "PowerPoint 演示文稿处理。用于读取现有 PPTX 信息、创建新演示文稿、提取媒体文件。支持文本、图片、表格、图表、形状、媒体、演讲者备注。当用户提到 .pptx 文件或需要操作 PowerPoint 时触发。",
+      "version": "1.0.0",
+      "author": "",
+      "tags": [],
+      "source_type": "local",
+      "source_path": "skills/pptx",
+      "source_url": null,
+      "skill_md": "---\nname: pptx\ndescription: \"PowerPoint 演示文稿处理。用于读取现有 PPTX 信息、创建新演示文稿、提取媒体文件。支持文本、图片、表格、图表、形状、媒体、演讲者备注。当用户提到 .pptx 文件或需要操作 PowerPoint 时触发。\"\nlicense: MIT\nargument-hint: \"[file|slide|object|master] [action] [path]\"\nuser-invocable: true\n---\n\n# PPTX - PowerPoint 演示文稿处理\n\n> **依赖**：pptxgenjs 4.0+ (创建演示文稿) + adm-zip (读取现有 PPTX)\n\n## ⚠️ 重要限制\n\n**pptxgenjs 4.0 只能创建新演示文稿，无法编辑现有文件！**\n\n- ✅ **支持**：创建新演示文稿、读取现有文件信息、提取内容\n- ❌ **不支持**：编辑现有 PPTX 文件（添加/修改/删除幻灯片或对象）\n\n**编辑现有文件的替代方案**：\n1. 使用 `file read` 读取现有文件内容\n2. 使用 `file create` 创建新文件，添加修改后的内容\n3. 删除原文件，重命名新文件\n\n---\n\n## 工具\n\n本技能提供四个工具：\n\n| 工具 | 最终名称 | 说明 |\n|------|----------|------|\n| `file` | `pptx__file` | 文件级操作（读取、创建、提取） |\n| `slide` | `pptx__slide` | 幻灯片创建（仅限新建演示文稿） |\n| `object` | `pptx__object` | 内容对象操作（添加、提取） |\n| `master` | `pptx__master` | 模板母版（定义、列出） |\n\n---\n\n## file - 文件级操作\n\n通过 `action` 参数区分具体操作：\n\n| action | 功能 | 关键参数 |\n|--------|------|----------|\n| `read` | 读取演示文稿信息 | `scope`, `slideNumbers` |\n| `create` | 创建演示文稿 | `source`, `slides`, `markdown` |\n| `extract` | 提取媒体文件 | `outputDir`, `extractType` |\n\n### read - 读取演示文稿\n\n**参数**：\n- `action` (string, required): `\"read\"`\n- `path` (string, required): PPTX 文件路径\n- `scope` (string, optional): 读取范围\n  - `info`: 基本信息（幻灯片数量、元数据）\n  - `text`: 提取所有文本内容\n  - `structure`: 提取结构信息（形状、图片等）\n  - `media`: 提取媒体信息（图片、视频列表）\n- `slideNumbers` (number[], optional): 指定幻灯片编号\n\n**示例**：\n```javascript\n// 读取基本信息\npptx__file({ action: \"read\", path: \"presentation.pptx\", scope: \"info\" })\n\n// 提取文本\npptx__file({ action: \"read\", path: \"presentation.pptx\", scope: \"text\" })\n\n// 提取结构\npptx__file({ action: \"read\", path: \"presentation.pptx\", scope: \"structure\" })\n```\n\n### create - 创建演示文稿\n\n**参数**：\n- `action` (string, required): `\"create\"`\n- `path` (string, required): 输出文件路径\n- `source` (string, optional): 创建来源 - `data` 或 `markdown`（默认: `data`）\n- `slides` (object[], optional): 幻灯片数据数组\n- `markdown` (string, optional): Markdown 内容\n- `properties` (object, optional): 文档属性\n  - `title`: 标题\n  - `author`: 作者\n  - `company`: 公司\n  - `layout`: 布局（`LAYOUT_16x9`, `LAYOUT_4x3`, `LAYOUT_WIDE`）\n\n**示例**：\n```javascript\n// 从数据创建\npptx__file({\n  action: \"create\",\n  path: \"new.pptx\",\n  slides: [\n    { title: \"第一章\", content: \"这是内容\" },\n    { title: \"第二章\", texts: [\"要点一\", \"要点二\"] }\n  ],\n  properties: { title: \"我的演示\", author: \"张三\" }\n})\n\n// 从 Markdown 创建\npptx__file({\n  action: \"create\",\n  path: \"markdown.pptx\",\n  source: \"markdown\",\n  markdown: \"# 标题页\\n\\n## 内容\\n- 要点一\\n- 要点二\"\n})\n```\n\n### extract - 提取媒体文件\n\n**参数**：\n- `action` (string, required): `\"extract\"`\n- `path` (string, required): PPTX 文件路径\n- `outputDir` (string, optional): 输出目录\n- `extractType` (string, optional): 提取类型 - `images`, `media`, `all`\n\n**示例**：\n```javascript\n// 提取图片\npptx__file({\n  action: \"extract\",\n  path: \"presentation.pptx\",\n  outputDir: \"images\",\n  extractType: \"images\"\n})\n```\n\n---\n\n## slide - 幻灯片创建\n\n创建新的演示文稿并添加幻灯片。\n\n**参数**：\n- `action` (string, required): `\"add\"`\n- `output` (string, required): 输出文件路径\n- `title` (string, optional): 幻灯片标题\n- `content` (string | string[], optional): 幻灯片内容\n- `slides` (object[], optional): 多个幻灯片数据\n- `background` (object, optional): 背景配置\n- `master` (object, optional): 母版配置\n- `properties` (object, optional): 文档属性\n\n**示例**：\n```javascript\n// 创建单个幻灯片\npptx__slide({\n  action: \"add\",\n  output: \"single.pptx\",\n  title: \"演示标题\",\n  content: [\"要点一\", \"要点二\"]\n})\n\n// 创建多个幻灯片\npptx__slide({\n  action: \"add\",\n  output: \"multi.pptx\",\n  slides: [\n    { title: \"第一页\", content: \"内容一\" },\n    { title: \"第二页\", texts: [\"要点A\", \"要点B\"] }\n  ]\n})\n```\n\n---\n\n## object - 内容对象操作\n\n通过 `action` 参数区分具体操作：\n\n| action | 功能 | 关键参数 |\n|--------|------|----------|\n| `add` | 创建包含对象的演示文稿 | `type`, `text`, `image`, `chart` 等 |\n| `extract` | 提取对象内容 | `type`, `outputDir` |\n\n### add - 添加对象到新演示文稿\n\n**参数**：\n- `action` (string, required): `\"add\"`\n- `output` (string, required): 输出文件路径\n- `type` (string, required): 对象类型\n  - `text`: 文本\n  - `image`: 图片\n  - `table`: 表格\n  - `chart`: 图表\n  - `shape`: 形状\n  - `media`: 视频/音频\n  - `notes`: 演讲者备注\n- `properties` (object, optional): 文档属性\n\n**文本示例**：\n```javascript\npptx__object({\n  action: \"add\",\n  output: \"text.pptx\",\n  type: \"text\",\n  text: \"Hello World\",\n  options: { fontSize: 24, bold: true, color: \"FF0000\" }\n})\n```\n\n**图片示例**：\n```javascript\npptx__object({\n  action: \"add\",\n  output: \"image.pptx\",\n  type: \"image\",\n  image: { path: \"photo.jpg\", x: 1, y: 1, w: 4, h: 3 }\n})\n```\n\n**表格示例**：\n```javascript\npptx__object({\n  action: \"add\",\n  output: \"table.pptx\",\n  type: \"table\",\n  table: {\n    rows: [\n      [{ text: \"姓名\" }, { text: \"年龄\" }],\n      [{ text: \"张三\" }, { text: \"25\" }]\n    ],\n    x: 0.5, y: 1, w: 9\n  }\n})\n```\n\n**图表示例**：\n```javascript\npptx__object({\n  action: \"add\",\n  output: \"chart.pptx\",\n  type: \"chart\",\n  chart: {\n    type: \"bar\",\n    data: [\n      { name: \"销售额\", labels: [\"一月\", \"二月\"], values: [100, 150] }\n    ],\n    title: \"月度销售额\"\n  }\n})\n```\n\n**支持的图表类型**：\n- `bar`, `bar3D`: 柱状图\n- `line`, `line3D`: 折线图\n- `pie`, `pie3D`: 饼图\n- `doughnut`: 环形图\n- `area`, `area3D`: 面积图\n- `scatter`: 散点图\n- `radar`, `radar3D`: 雷达图\n- `bubble`, `bubble3D`: 气泡图\n\n### extract - 提取对象内容\n\n**参数**：\n- `action` (string, required): `\"extract\"`\n- `path` (string, required): PPTX 文件路径\n- `type` (string, required): 提取类型 - `images`, `media`, `text`\n- `outputDir` (string, optional): 输出目录\n\n**示例**：\n```javascript\npptx__object({\n  action: \"extract\",\n  path: \"presentation.pptx\",\n  type: \"images\",\n  outputDir: \"extracted\"\n})\n```\n\n---\n\n## master - 模板母版\n\n通过 `action` 参数区分具体操作：\n\n| action | 功能 | 关键参数 |\n|--------|------|----------|\n| `define` | 定义母版并创建演示文稿 | `name`, `background`, `objects` |\n| `list` | 列出母版布局 | `path` |\n\n### define - 定义母版\n\n**参数**：\n- `action` (string, required): `\"define\"`\n- `output` (string, required): 输出文件路径\n- `name` (string, required): 母版名称\n- `background` (object, optional): 背景配置\n- `objects` (object[], optional): 母版上的固定对象\n- `slideNumber` (object, optional): 幻灯片编号配置\n- `properties` (object, optional): 文档属性\n\n**示例**：\n```javascript\npptx__master({\n  action: \"define\",\n  output: \"template.pptx\",\n  name: \"CompanyTemplate\",\n  background: { color: \"F5F5F5\" },\n  objects: [\n    { text: \"公司名称\", options: { x: 0.5, y: 0.2 } }\n  ]\n})\n```\n\n### list - 列出母版\n\n**参数**：\n- `action` (string, required): `\"list\"`\n- `path` (string, required): PPTX 文件路径\n\n**示例**：\n```javascript\npptx__master({\n  action: \"list\",\n  path: \"template.pptx\"\n})\n```\n\n---\n\n## 幻灯片数据结构\n\n创建演示文稿时，每个幻灯片支持以下字段：\n\n```typescript\ninterface SlideData {\n  title?: string;              // 标题\n  content?: string;            // 内容文本\n  texts?: (string | TextItem)[];  // 文本列表\n  images?: ImageItem[];        // 图片列表\n  tables?: TableItem[];        // 表格列表\n  charts?: ChartItem[];        // 图表列表\n  shapes?: ShapeItem[];        // 形状列表\n  background?: Background;     // 背景\n  notes?: string;              // 演讲者备注\n}\n```\n\n---\n\n## 快速参考\n\n| 任务 | 工具 | action |\n|------|------|--------|\n| 读取基本信息 | `file` | `read` (scope: `info`) |\n| 提取文本 | `file` | `read` (scope: `text`) |\n| 提取结构 | `file` | `read` (scope: `structure`) |\n| 提取媒体信息 | `file` | `read` (scope: `media`) |\n| 创建演示文稿 | `file` | `create` |\n| 提取媒体文件 | `file` | `extract` |\n| 创建幻灯片 | `slide` | `add` |\n| 添加文本 | `object` | `add` (type: `text`) |\n| 添加图片 | `object` | `add` (type: `image`) |\n| 添加表格 | `object` | `add` (type: `table`) |\n| 添加图表 | `object` | `add` (type: `chart`) |\n| 添加形状 | `object` | `add` (type: `shape`) |\n| 添加媒体 | `object` | `add` (type: `media`) |\n| 添加备注 | `object` | `add` (type: `notes`) |\n| 提取对象 | `object` | `extract` |\n| 定义母版 | `master` | `define` |\n| 列出母版 | `master` | `list` |\n\n---\n\n## 更新日志\n\n- **2026-03-28**: 升级到 pptxgenjs 4.0.1，重新设计工具架构（4 个工具）\n- **2026-03-28**: **重要变更**：移除编辑现有文件的功能（pptxgenjs 4.0 不支持）\n- **2026-03-28**: 新增图表类型支持（14 种图表）\n- **2026-03-28**: 新增演讲者备注、媒体、母版定义功能\n- **2026-03-28**: 新增 Markdown 创建支持\n",
       "security_score": 100,
       "security_warnings": null,
       "license": null,
@@ -86,123 +206,23 @@
       "is_active": true
     },
     {
-      "id": "H4ehsMA68GLUyXl56oPg",
-      "name": "docx",
-      "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of \"Word doc\", \"word document\", \".docx\", or requests to produce professional documents with formatting.",
-      "version": "1.0.0",
-      "author": "",
-      "tags": [],
-      "source_type": "local",
-      "source_path": "skills\\docx",
-      "source_url": null,
-      "skill_md": "---\r\nname: docx\r\ndescription: \"Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of \\\"Word doc\\\", \\\"word document\\\", \\\".docx\\\", or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, or converting content into a polished Word document. If the user asks for a \\\"report\\\", \\\"memo\\\", \\\"letter\\\", \\\"template\\\", or similar deliverable as a Word or .docx file, use this skill. Do NOT use for PDFs, spreadsheets, Google Docs, or general coding tasks unrelated to document generation.\"\r\nlicense: Proprietary. LICENSE.txt has complete terms\r\n---\r\n\r\n# DOCX creation, editing, and analysis\r\n\r\n## Overview\r\n\r\nA .docx file is a ZIP archive containing XML files.\r\n\r\n## Quick Reference\r\n\r\n| Task | Approach |\r\n|------|----------|\r\n| Read/analyze content | `pandoc` or unpack for raw XML |\r\n| Create new document | Use `docx-js` - see Creating New Documents below |\r\n| Edit existing document | Unpack → edit XML → repack - see Editing Existing Documents below |\r\n\r\n### Converting .doc to .docx\r\n\r\nLegacy `.doc` files must be converted before editing:\r\n\r\n```bash\r\npython scripts/office/soffice.py --headless --convert-to docx document.doc\r\n```\r\n\r\n### Reading Content\r\n\r\n```bash\r\n# Text extraction with tracked changes\r\npandoc --track-changes=all document.docx -o output.md\r\n\r\n# Raw XML access\r\npython scripts/office/unpack.py document.docx unpacked/\r\n```\r\n\r\n### Converting to Images\r\n\r\n```bash\r\npython scripts/office/soffice.py --headless --convert-to pdf document.docx\r\npdftoppm -jpeg -r 150 document.pdf page\r\n```\r\n\r\n### Accepting Tracked Changes\r\n\r\nTo produce a clean document with all tracked changes accepted (requires LibreOffice):\r\n\r\n```bash\r\npython scripts/accept_changes.py input.docx output.docx\r\n```\r\n\r\n---\r\n\r\n## Creating New Documents\r\n\r\nGenerate .docx files with JavaScript, then validate. Install: `npm install -g docx`\r\n\r\n### Setup\r\n```javascript\r\nconst { Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell, ImageRun,\r\n        Header, Footer, AlignmentType, PageOrientation, LevelFormat, ExternalHyperlink,\r\n        TableOfContents, HeadingLevel, BorderStyle, WidthType, ShadingType,\r\n        VerticalAlign, PageNumber, PageBreak } = require('docx');\r\n\r\nconst doc = new Document({ sections: [{ children: [/* content */] }] });\r\nPacker.toBuffer(doc).then(buffer => fs.writeFileSync(\"doc.docx\", buffer));\r\n```\r\n\r\n### Validation\r\nAfter creating the file, validate it. If validation fails, unpack, fix the XML, and repack.\r\n```bash\r\npython scripts/office/validate.py doc.docx\r\n```\r\n\r\n### Page Size\r\n\r\n```javascript\r\n// CRITICAL: docx-js defaults to A4, not US Letter\r\n// Always set page size explicitly for consistent results\r\nsections: [{\r\n  properties: {\r\n    page: {\r\n      size: {\r\n        width: 12240,   // 8.5 inches in DXA\r\n        height: 15840   // 11 inches in DXA\r\n      },\r\n      margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } // 1 inch margins\r\n    }\r\n  },\r\n  children: [/* content */]\r\n}]\r\n```\r\n\r\n**Common page sizes (DXA units, 1440 DXA = 1 inch):**\r\n\r\n| Paper | Width | Height | Content Width (1\" margins) |\r\n|-------|-------|--------|---------------------------|\r\n| US Letter | 12,240 | 15,840 | 9,360 |\r\n| A4 (default) | 11,906 | 16,838 | 9,026 |\r\n\r\n**Landscape orientation:** docx-js swaps width/height internally, so pass portrait dimensions and let it handle the swap:\r\n```javascript\r\nsize: {\r\n  width: 12240,   // Pass SHORT edge as width\r\n  height: 15840,  // Pass LONG edge as height\r\n  orientation: PageOrientation.LANDSCAPE  // docx-js swaps them in the XML\r\n},\r\n// Content width = 15840 - left margin - right margin (uses the long edge)\r\n```\r\n\r\n### Styles (Override Built-in Headings)\r\n\r\nUse Arial as the default font (universally supported). Keep titles black for readability.\r\n\r\n```javascript\r\nconst doc = new Document({\r\n  styles: {\r\n    default: { document: { run: { font: \"Arial\", size: 24 } } }, // 12pt default\r\n    paragraphStyles: [\r\n      // IMPORTANT: Use exact IDs to override built-in styles\r\n      { id: \"Heading1\", name: \"Heading 1\", basedOn: \"Normal\", next: \"Normal\", quickFormat: true,\r\n        run: { size: 32, bold: true, font: \"Arial\" },\r\n        paragraph: { spacing: { before: 240, after: 240 }, outlineLevel: 0 } }, // outlineLevel required for TOC\r\n      { id: \"Heading2\", name: \"Heading 2\", basedOn: \"Normal\", next: \"Normal\", quickFormat: true,\r\n        run: { size: 28, bold: true, font: \"Arial\" },\r\n        paragraph: { spacing: { before: 180, after: 180 }, outlineLevel: 1 } },\r\n    ]\r\n  },\r\n  sections: [{\r\n    children: [\r\n      new Paragraph({ heading: HeadingLevel.HEADING_1, children: [new TextRun(\"Title\")] }),\r\n    ]\r\n  }]\r\n});\r\n```\r\n\r\n### Lists (NEVER use unicode bullets)\r\n\r\n```javascript\r\n// ❌ WRONG - never manually insert bullet characters\r\nnew Paragraph({ children: [new TextRun(\"• Item\")] })  // BAD\r\nnew Paragraph({ children: [new TextRun(\"\\u2022 Item\")] })  // BAD\r\n\r\n// ✅ CORRECT - use numbering config with LevelFormat.BULLET\r\nconst doc = new Document({\r\n  numbering: {\r\n    config: [\r\n      { reference: \"bullets\",\r\n        levels: [{ level: 0, format: LevelFormat.BULLET, text: \"•\", alignment: AlignmentType.LEFT,\r\n          style: { paragraph: { indent: { left: 720, hanging: 360 } } } }] },\r\n      { reference: \"numbers\",\r\n        levels: [{ level: 0, format: LevelFormat.DECIMAL, text: \"%1.\", alignment: AlignmentType.LEFT,\r\n          style: { paragraph: { indent: { left: 720, hanging: 360 } } } }] },\r\n    ]\r\n  },\r\n  sections: [{\r\n    children: [\r\n      new Paragraph({ numbering: { reference: \"bullets\", level: 0 },\r\n        children: [new TextRun(\"Bullet item\")] }),\r\n      new Paragraph({ numbering: { reference: \"numbers\", level: 0 },\r\n        children: [new TextRun(\"Numbered item\")] }),\r\n    ]\r\n  }]\r\n});\r\n\r\n// ⚠️ Each reference creates INDEPENDENT numbering\r\n// Same reference = continues (1,2,3 then 4,5,6)\r\n// Different reference = restarts (1,2,3 then 1,2,3)\r\n```\r\n\r\n### Tables\r\n\r\n**CRITICAL: Tables need dual widths** - set both `columnWidths` on the table AND `width` on each cell. Without both, tables render incorrectly on some platforms.\r\n\r\n```javascript\r\n// CRITICAL: Always set table width for consistent rendering\r\n// CRITICAL: Use ShadingType.CLEAR (not SOLID) to prevent black backgrounds\r\nconst border = { style: BorderStyle.SINGLE, size: 1, color: \"CCCCCC\" };\r\nconst borders = { top: border, bottom: border, left: border, right: border };\r\n\r\nnew Table({\r\n  width: { size: 9360, type: WidthType.DXA }, // Always use DXA (percentages break in Google Docs)\r\n  columnWidths: [4680, 4680], // Must sum to table width (DXA: 1440 = 1 inch)\r\n  rows: [\r\n    new TableRow({\r\n      children: [\r\n        new TableCell({\r\n          borders,\r\n          width: { size: 4680, type: WidthType.DXA }, // Also set on each cell\r\n          shading: { fill: \"D5E8F0\", type: ShadingType.CLEAR }, // CLEAR not SOLID\r\n          margins: { top: 80, bottom: 80, left: 120, right: 120 }, // Cell padding (internal, not added to width)\r\n          children: [new Paragraph({ children: [new TextRun(\"Cell\")] })]\r\n        })\r\n      ]\r\n    })\r\n  ]\r\n})\r\n```\r\n\r\n**Table width calculation:**\r\n\r\nAlways use `WidthType.DXA` — `WidthType.PERCENTAGE` breaks in Google Docs.\r\n\r\n```javascript\r\n// Table width = sum of columnWidths = content width\r\n// US Letter with 1\" margins: 12240 - 2880 = 9360 DXA\r\nwidth: { size: 9360, type: WidthType.DXA },\r\ncolumnWidths: [7000, 2360]  // Must sum to table width\r\n```\r\n\r\n**Width rules:**\r\n- **Always use `WidthType.DXA`** — never `WidthType.PERCENTAGE` (incompatible with Google Docs)\r\n- Table width must equal the sum of `columnWidths`\r\n- Cell `width` must match corresponding `columnWidth`\r\n- Cell `margins` are internal padding - they reduce content area, not add to cell width\r\n- For full-width tables: use content width (page width minus left and right margins)\r\n\r\n### Images\r\n\r\n```javascript\r\n// CRITICAL: type parameter is REQUIRED\r\nnew Paragraph({\r\n  children: [new ImageRun({\r\n    type: \"png\", // Required: png, jpg, jpeg, gif, bmp, svg\r\n    data: fs.readFileSync(\"image.png\"),\r\n    transformation: { width: 200, height: 150 },\r\n    altText: { title: \"Title\", description: \"Desc\", name: \"Name\" } // All three required\r\n  })]\r\n})\r\n```\r\n\r\n### Page Breaks\r\n\r\n```javascript\r\n// CRITICAL: PageBreak must be inside a Paragraph\r\nnew Paragraph({ children: [new PageBreak()] })\r\n\r\n// Or use pageBreakBefore\r\nnew Paragraph({ pageBreakBefore: true, children: [new TextRun(\"New page\")] })\r\n```\r\n\r\n### Table of Contents\r\n\r\n```javascript\r\n// CRITICAL: Headings must use HeadingLevel ONLY - no custom styles\r\nnew TableOfContents(\"Table of Contents\", { hyperlink: true, headingStyleRange: \"1-3\" })\r\n```\r\n\r\n### Headers/Footers\r\n\r\n```javascript\r\nsections: [{\r\n  properties: {\r\n    page: { margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 } } // 1440 = 1 inch\r\n  },\r\n  headers: {\r\n    default: new Header({ children: [new Paragraph({ children: [new TextRun(\"Header\")] })] })\r\n  },\r\n  footers: {\r\n    default: new Footer({ children: [new Paragraph({\r\n      children: [new TextRun(\"Page \"), new TextRun({ children: [PageNumber.CURRENT] })]\r\n    })] })\r\n  },\r\n  children: [/* content */]\r\n}]\r\n```\r\n\r\n### Critical Rules for docx-js\r\n\r\n- **Set page size explicitly** - docx-js defaults to A4; use US Letter (12240 x 15840 DXA) for US documents\r\n- **Landscape: pass portrait dimensions** - docx-js swaps width/height internally; pass short edge as `width`, long edge as `height`, and set `orientation: PageOrientation.LANDSCAPE`\r\n- **Never use `\\n`** - use separate Paragraph elements\r\n- **Never use unicode bullets** - use `LevelFormat.BULLET` with numbering config\r\n- **PageBreak must be in Paragraph** - standalone creates invalid XML\r\n- **ImageRun requires `type`** - always specify png/jpg/etc\r\n- **Always set table `width` with DXA** - never use `WidthType.PERCENTAGE` (breaks in Google Docs)\r\n- **Tables need dual widths** - `columnWidths` array AND cell `width`, both must match\r\n- **Table width = sum of columnWidths** - for DXA, ensure they add up exactly\r\n- **Always add cell margins** - use `margins: { top: 80, bottom: 80, left: 120, right: 120 }` for readable padding\r\n- **Use `ShadingType.CLEAR`** - never SOLID for table shading\r\n- **TOC requires HeadingLevel only** - no custom styles on heading paragraphs\r\n- **Override built-in styles** - use exact IDs: \"Heading1\", \"Heading2\", etc.\r\n- **Include `outlineLevel`** - required for TOC (0 for H1, 1 for H2, etc.)\r\n\r\n---\r\n\r\n## Editing Existing Documents\r\n\r\n**Follow all 3 steps in order.**\r\n\r\n### Step 1: Unpack\r\n```bash\r\npython scripts/office/unpack.py document.docx unpacked/\r\n```\r\nExtracts XML, pretty-prints, merges adjacent runs, and converts smart quotes to XML entities (`&#x201C;` etc.) so they survive editing. Use `--merge-runs false` to skip run merging.\r\n\r\n### Step 2: Edit XML\r\n\r\nEdit files in `unpacked/word/`. See XML Reference below for patterns.\r\n\r\n**Use \"Claude\" as the author** for tracked changes and comments, unless the user explicitly requests use of a different name.\r\n\r\n**Use the Edit tool directly for string replacement. Do not write Python scripts.** Scripts introduce unnecessary complexity. The Edit tool shows exactly what is being replaced.\r\n\r\n**CRITICAL: Use smart quotes for new content.** When adding text with apostrophes or quotes, use XML entities to produce smart quotes:\r\n```xml\r\n<!-- Use these entities for professional typography -->\r\n<w:t>Here&#x2019;s a quote: &#x201C;Hello&#x201D;</w:t>\r\n```\r\n| Entity | Character |\r\n|--------|-----------|\r\n| `&#x2018;` | ‘ (left single) |\r\n| `&#x2019;` | ’ (right single / apostrophe) |\r\n| `&#x201C;` | “ (left double) |\r\n| `&#x201D;` | ” (right double) |\r\n\r\n**Adding comments:** Use `comment.py` to handle boilerplate across multiple XML files (text must be pre-escaped XML):\r\n```bash\r\npython scripts/comment.py unpacked/ 0 \"Comment text with &amp; and &#x2019;\"\r\npython scripts/comment.py unpacked/ 1 \"Reply text\" --parent 0  # reply to comment 0\r\npython scripts/comment.py unpacked/ 0 \"Text\" --author \"Custom Author\"  # custom author name\r\n```\r\nThen add markers to document.xml (see Comments in XML Reference).\r\n\r\n### Step 3: Pack\r\n```bash\r\npython scripts/office/pack.py unpacked/ output.docx --original document.docx\r\n```\r\nValidates with auto-repair, condenses XML, and creates DOCX. Use `--validate false` to skip.\r\n\r\n**Auto-repair will fix:**\r\n- `durableId` >= 0x7FFFFFFF (regenerates valid ID)\r\n- Missing `xml:space=\"preserve\"` on `<w:t>` with whitespace\r\n\r\n**Auto-repair won't fix:**\r\n- Malformed XML, invalid element nesting, missing relationships, schema violations\r\n\r\n### Common Pitfalls\r\n\r\n- **Replace entire `<w:r>` elements**: When adding tracked changes, replace the whole `<w:r>...</w:r>` block with `<w:del>...<w:ins>...` as siblings. Don't inject tracked change tags inside a run.\r\n- **Preserve `<w:rPr>` formatting**: Copy the original run's `<w:rPr>` block into your tracked change runs to maintain bold, font size, etc.\r\n\r\n---\r\n\r\n## XML Reference\r\n\r\n### Schema Compliance\r\n\r\n- **Element order in `<w:pPr>`**: `<w:pStyle>`, `<w:numPr>`, `<w:spacing>`, `<w:ind>`, `<w:jc>`, `<w:rPr>` last\r\n- **Whitespace**: Add `xml:space=\"preserve\"` to `<w:t>` with leading/trailing spaces\r\n- **RSIDs**: Must be 8-digit hex (e.g., `00AB1234`)\r\n\r\n### Tracked Changes\r\n\r\n**Insertion:**\r\n```xml\r\n<w:ins w:id=\"1\" w:author=\"Claude\" w:date=\"2025-01-01T00:00:00Z\">\r\n  <w:r><w:t>inserted text</w:t></w:r>\r\n</w:ins>\r\n```\r\n\r\n**Deletion:**\r\n```xml\r\n<w:del w:id=\"2\" w:author=\"Claude\" w:date=\"2025-01-01T00:00:00Z\">\r\n  <w:r><w:delText>deleted text</w:delText></w:r>\r\n</w:del>\r\n```\r\n\r\n**Inside `<w:del>`**: Use `<w:delText>` instead of `<w:t>`, and `<w:delInstrText>` instead of `<w:instrText>`.\r\n\r\n**Minimal edits** - only mark what changes:\r\n```xml\r\n<!-- Change \"30 days\" to \"60 days\" -->\r\n<w:r><w:t>The term is </w:t></w:r>\r\n<w:del w:id=\"1\" w:author=\"Claude\" w:date=\"...\">\r\n  <w:r><w:delText>30</w:delText></w:r>\r\n</w:del>\r\n<w:ins w:id=\"2\" w:author=\"Claude\" w:date=\"...\">\r\n  <w:r><w:t>60</w:t></w:r>\r\n</w:ins>\r\n<w:r><w:t> days.</w:t></w:r>\r\n```\r\n\r\n**Deleting entire paragraphs/list items** - when removing ALL content from a paragraph, also mark the paragraph mark as deleted so it merges with the next paragraph. Add `<w:del/>` inside `<w:pPr><w:rPr>`:\r\n```xml\r\n<w:p>\r\n  <w:pPr>\r\n    <w:numPr>...</w:numPr>  <!-- list numbering if present -->\r\n    <w:rPr>\r\n      <w:del w:id=\"1\" w:author=\"Claude\" w:date=\"2025-01-01T00:00:00Z\"/>\r\n    </w:rPr>\r\n  </w:pPr>\r\n  <w:del w:id=\"2\" w:author=\"Claude\" w:date=\"2025-01-01T00:00:00Z\">\r\n    <w:r><w:delText>Entire paragraph content being deleted...</w:delText></w:r>\r\n  </w:del>\r\n</w:p>\r\n```\r\nWithout the `<w:del/>` in `<w:pPr><w:rPr>`, accepting changes leaves an empty paragraph/list item.\r\n\r\n**Rejecting another author's insertion** - nest deletion inside their insertion:\r\n```xml\r\n<w:ins w:author=\"Jane\" w:id=\"5\">\r\n  <w:del w:author=\"Claude\" w:id=\"10\">\r\n    <w:r><w:delText>their inserted text</w:delText></w:r>\r\n  </w:del>\r\n</w:ins>\r\n```\r\n\r\n**Restoring another author's deletion** - add insertion after (don't modify their deletion):\r\n```xml\r\n<w:del w:author=\"Jane\" w:id=\"5\">\r\n  <w:r><w:delText>deleted text</w:delText></w:r>\r\n</w:del>\r\n<w:ins w:author=\"Claude\" w:id=\"10\">\r\n  <w:r><w:t>deleted text</w:t></w:r>\r\n</w:ins>\r\n```\r\n\r\n### Comments\r\n\r\nAfter running `comment.py` (see Step 2), add markers to document.xml. For replies, use `--parent` flag and nest markers inside the parent's.\r\n\r\n**CRITICAL: `<w:commentRangeStart>` and `<w:commentRangeEnd>` are siblings of `<w:r>`, never inside `<w:r>`.**\r\n\r\n```xml\r\n<!-- Comment markers are direct children of w:p, never inside w:r -->\r\n<w:commentRangeStart w:id=\"0\"/>\r\n<w:del w:id=\"1\" w:author=\"Claude\" w:date=\"2025-01-01T00:00:00Z\">\r\n  <w:r><w:delText>deleted</w:delText></w:r>\r\n</w:del>\r\n<w:r><w:t> more text</w:t></w:r>\r\n<w:commentRangeEnd w:id=\"0\"/>\r\n<w:r><w:rPr><w:rStyle w:val=\"CommentReference\"/></w:rPr><w:commentReference w:id=\"0\"/></w:r>\r\n\r\n<!-- Comment 0 with reply 1 nested inside -->\r\n<w:commentRangeStart w:id=\"0\"/>\r\n  <w:commentRangeStart w:id=\"1\"/>\r\n  <w:r><w:t>text</w:t></w:r>\r\n  <w:commentRangeEnd w:id=\"1\"/>\r\n<w:commentRangeEnd w:id=\"0\"/>\r\n<w:r><w:rPr><w:rStyle w:val=\"CommentReference\"/></w:rPr><w:commentReference w:id=\"0\"/></w:r>\r\n<w:r><w:rPr><w:rStyle w:val=\"CommentReference\"/></w:rPr><w:commentReference w:id=\"1\"/></w:r>\r\n```\r\n\r\n### Images\r\n\r\n1. Add image file to `word/media/`\r\n2. Add relationship to `word/_rels/document.xml.rels`:\r\n```xml\r\n<Relationship Id=\"rId5\" Type=\".../image\" Target=\"media/image1.png\"/>\r\n```\r\n3. Add content type to `[Content_Types].xml`:\r\n```xml\r\n<Default Extension=\"png\" ContentType=\"image/png\"/>\r\n```\r\n4. Reference in document.xml:\r\n```xml\r\n<w:drawing>\r\n  <wp:inline>\r\n    <wp:extent cx=\"914400\" cy=\"914400\"/>  <!-- EMUs: 914400 = 1 inch -->\r\n    <a:graphic>\r\n      <a:graphicData uri=\".../picture\">\r\n        <pic:pic>\r\n          <pic:blipFill><a:blip r:embed=\"rId5\"/></pic:blipFill>\r\n        </pic:pic>\r\n      </a:graphicData>\r\n    </a:graphic>\r\n  </wp:inline>\r\n</w:drawing>\r\n```\r\n\r\n---\r\n\r\n## Dependencies\r\n\r\n- **pandoc**: Text extraction\r\n- **docx**: `npm install -g docx` (new documents)\r\n- **LibreOffice**: PDF conversion (auto-configured for sandboxed environments via `scripts/office/soffice.py`)\r\n- **Poppler**: `pdftoppm` for images\r\n",
-      "security_score": 100,
-      "security_warnings": null,
-      "license": null,
-      "argument_hint": "",
-      "disable_model_invocation": true,
-      "user_invocable": true,
-      "allowed_tools": null,
-      "is_active": true
-    },
-    {
-      "id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "file-operations",
-      "description": "File system operations including read, write, search, and manage files. Use when you need to work with files in the data directory.",
-      "version": "1.0.0",
-      "author": "",
-      "tags": [],
-      "source_type": "local",
-      "source_path": "skills\\file-operations",
-      "source_url": null,
-      "skill_md": "---\nname: file-operations\ndescription: File system operations including read, write, search, and manage files. Use when you need to work with files in the data directory.\nargument-hint: \"[operation] [path]\"\nuser-invocable: true\nallowed-tools:\n  - Bash(cat *)\n  - Bash(ls *)\n  - Bash(grep *)\n  - Bash(find *)\n---\n\n# File Operations\n\nComplete file system operations for reading, writing, searching, and managing files.\n\n## Tools\n\n### File System Information\n\n#### fs_info\n\nGet detailed metadata about a file or directory. **Recommended to call before other operations** to understand what you're working with.\n\n**Parameters:**\n- `path` (string, required): File or directory path\n- `include_content_preview` (boolean, optional): Include content preview for text files (default: false)\n\n**Returns:**\n- `exists` (boolean): Whether the path exists\n- `type` (string): \"file\", \"directory\", or \"unknown\"\n- `size` (number): Size in bytes\n- `sizeHuman` (string): Human-readable size (e.g., \"1.5 MB\")\n- `created`, `modified`, `accessed` (Date): Timestamps\n- `isReadOnly` (boolean): Write permission check\n- `pathInfo` (object): Path components (fullPath, directory, baseName, extension, fileNameWithoutExt)\n- `mimeType` (string, files only): Inferred MIME type\n- `isTextFile` (boolean, files only): Whether the file is likely text\n- `directoryInfo` (object, directories only): Item counts and listing preview\n- `contentPreview` (object, files only): First 10 lines preview (if requested)\n- `warning` (string, optional): Large file warning\n\n**Use Cases:**\n- Check if a file exists before reading\n- Determine file type (text vs binary)\n- Get file size to decide how to read it\n- Preview content structure\n\n### Reading Files\n\n#### read_file\n\nRead file content with mode parameter.\n\n**Parameters:**\n- `path` (string, required): File path\n- `mode` (string, optional): Read mode - `\"lines\"` (default) or `\"bytes\"`\n- `from` (number, optional): Start line for lines mode (default: 1)\n- `lines` (number, optional): Number of lines for lines mode (default: 100)\n- `offset` (number, optional): Start byte for bytes mode (default: 0)\n- `bytes` (number, optional): Bytes to read for bytes mode (default: 50000)\n\n#### list_files\n\nList directory contents.\n\n**Parameters:**\n- `path` (string, required): Directory path\n- `recursive` (boolean, optional): List recursively (default: false)\n\n### Searching\n\n#### fs_grep\n\nSearch text across files. Supports both single file and multi-file search.\n\n**Parameters:**\n- `pattern` (string, required): Search pattern\n- `path` (string, optional): File or directory path (default: current)\n- `file_pattern` (string, optional): File pattern filter (default: \"*\")\n- `use_regex` (boolean, optional): Use regex mode (default: `false`, use literal string match)\n- `ignore_case` (boolean, optional): Case insensitive search (default: `true`)\n\n**Search Modes:**\n| Mode | Description | Example |\n|------|-------------|---------|\n| Literal (default) | Simple string match, no special characters | `pattern: \"TODO\"` matches \"TODO\" exactly |\n| Regex | Full regex support, set `use_regex: true` | `pattern: \"TODO\\\\d+\"` matches \"TODO1\", \"TODO123\" |\n\n**Note:** For single file search, pass the file path directly to `path` parameter.\n\n**Examples:**\n```javascript\n// Simple string search (default, recommended for LLM)\n{ \"tool\": \"fs_grep\", \"params\": { \"pattern\": \"function\", \"path\": \"src/\" } }\n\n// Regex search\n{ \"tool\": \"fs_grep\", \"params\": { \"pattern\": \"function\\\\s+\\\\w+\", \"path\": \"src/\", \"use_regex\": true } }\n\n// Case sensitive search\n{ \"tool\": \"fs_grep\", \"params\": { \"pattern\": \"TODO\", \"path\": \"src/\", \"ignore_case\": false } }\n```\n\n### Writing Files\n\n#### write_file\n\nWrite content to a file with optional append mode.\n\n**Parameters:**\n- `path` (string, required): File path\n- `content` (string, required): Content to write\n- `mode` (string, optional): Write mode - `\"write\"` (default, overwrite) or `\"append\"`\n\n#### replace_in_file\n\nReplace text in a file.\n\n**Parameters:**\n- `path` (string, required): File path\n- `old` (string, required): Text to replace\n- `new` (string, required): Replacement text\n\n#### edit_lines\n\nEdit lines in a file with insert or delete operations.\n\n**Parameters:**\n- `path` (string, required): File path\n- `operation` (string, optional): Operation type - `\"insert\"` (default) or `\"delete\"`\n- `line` (number, required): Line number (1-based)\n- `end_line` (number, optional): End line number for delete operation (defaults to `line`)\n- `content` (string, required for insert): Content to insert\n\n**Operations:**\n| Operation | Description | Required Params |\n|-----------|-------------|-----------------|\n| `insert` | Insert content before the specified line | `path`, `line`, `content` |\n| `delete` | Delete lines from `line` to `end_line` | `path`, `line`, `end_line` (optional) |\n\n**Examples:**\n```javascript\n// Insert a line at line 5\n{ \"tool\": \"edit_lines\", \"params\": { \"path\": \"file.txt\", \"line\": 5, \"content\": \"new line\" } }\n\n// Delete line 10\n{ \"tool\": \"edit_lines\", \"params\": { \"path\": \"file.txt\", \"operation\": \"delete\", \"line\": 10 } }\n\n// Delete lines 10-15\n{ \"tool\": \"edit_lines\", \"params\": { \"path\": \"file.txt\", \"operation\": \"delete\", \"line\": 10, \"end_line\": 15 } }\n```\n\n**Tip:** For content replacement (e.g., \"replace 'foo' with 'bar'\"), use `replace_in_file` tool instead.\n\n### File System Operations\n\n#### fs_action\n\nUnified file system operations: copy, move, delete, and create directory.\n\n**Parameters:**\n- `operation` (string, optional): Operation type - `\"copy\"` (default), `\"move\"`, `\"delete\"`, or `\"create_dir\"`\n- `source` (string, required for copy/move): Source path\n- `destination` (string, required for copy/move): Destination path\n- `path` (string, required for delete/create_dir): Path to delete or directory to create\n\n**Operations:**\n| Operation | Description | Required Params |\n|-----------|-------------|-----------------|\n| `copy` | Copy file to destination | `source`, `destination` |\n| `move` | Move file to destination | `source`, `destination` |\n| `delete` | Delete file or directory (recursive) | `path` |\n| `create_dir` | Create directory (recursive) | `path` |\n\n**Examples:**\n```javascript\n// Copy a file\n{ \"tool\": \"fs_action\", \"params\": { \"source\": \"file.txt\", \"destination\": \"backup.txt\" } }\n\n// Move a file\n{ \"tool\": \"fs_action\", \"params\": { \"operation\": \"move\", \"source\": \"old.txt\", \"destination\": \"new.txt\" } }\n\n// Delete a file or directory\n{ \"tool\": \"fs_action\", \"params\": { \"operation\": \"delete\", \"path\": \"unwanted.txt\" } }\n\n// Create a directory\n{ \"tool\": \"fs_action\", \"params\": { \"operation\": \"create_dir\", \"path\": \"new_folder\" } }\n```\n\n## Security\n\n### Path Restrictions\n\n| User Type | Relative Path | Absolute Path |\n|-----------|---------------|---------------|\n| Normal User | ✅ Allowed (relative to working directory) | ❌ Denied |\n| Admin | ✅ Allowed (relative to working directory) | ✅ Allowed (within permitted directories) |\n\n### Allowed Directories\n\n| User Type | Allowed Directories |\n|-----------|---------------------|\n| Normal User | Current working directory only (task or temp) |\n| Admin | Current working directory + `data/skills` directory |\n\n### Examples\n\n```javascript\n// Normal user - relative path (allowed)\nlist_files({ path: \".\" })  // Lists current working directory\n\n// Normal user - absolute path (denied)\nlist_files({ path: \"d:/projects/.../data/skills\" })  // Error!\n\n// Admin - relative path (allowed)\nlist_files({ path: \".\" })  // Lists current working directory\n\n// Admin - absolute path to skills (allowed)\nlist_files({ path: \"d:/projects/.../data/skills/file-operations\" })  // OK!\n```\n\n## Examples\n\n```javascript\n// Get file/directory information (recommended first step)\n{ \"tool\": \"fs_info\", \"params\": { \"path\": \"data/example.txt\" } }\n\n// Get file info with content preview\n{ \"tool\": \"fs_info\", \"params\": { \"path\": \"data/example.txt\", \"include_content_preview\": true } }\n\n// Check if a directory exists and see its contents\n{ \"tool\": \"fs_info\", \"params\": { \"path\": \"data/src\" } }\n\n// Read a file (lines mode)\n{ \"tool\": \"read_file\", \"params\": { \"path\": \"data/example.txt\" } }\n\n// Read file in bytes mode\n{ \"tool\": \"read_file\", \"params\": { \"path\": \"data/binary.bin\", \"mode\": \"bytes\", \"bytes\": 1000 } }\n\n// Search in files\n{ \"tool\": \"fs_grep\", \"params\": { \"pattern\": \"TODO\", \"path\": \"data/src\" } }\n\n// Write a file\n{ \"tool\": \"write_file\", \"params\": { \"path\": \"data/output.txt\", \"content\": \"Hello!\" } }\n\n// Append to a file\n{ \"tool\": \"write_file\", \"params\": { \"path\": \"data/log.txt\", \"content\": \"New entry\\n\", \"mode\": \"append\" } }\n\n// Copy a file\n{ \"tool\": \"fs_action\", \"params\": { \"source\": \"data/file.txt\", \"destination\": \"data/backup.txt\" } }\n\n// Move a file\n{ \"tool\": \"fs_action\", \"params\": { \"operation\": \"move\", \"source\": \"data/old.txt\", \"destination\": \"data/new.txt\" } }\n\n// Delete a file or directory\n{ \"tool\": \"fs_action\", \"params\": { \"operation\": \"delete\", \"path\": \"data/unwanted.txt\" } }\n\n// Create a directory\n{ \"tool\": \"fs_action\", \"params\": { \"operation\": \"create_dir\", \"path\": \"data/new_folder\" } }\n```\n\n## Best Practices for LLM\n\n1. **Always call `fs_info` first** when working with an unknown path:\n   - Check if the file exists\n   - Determine if it's a file or directory\n   - See the file size before reading\n   - Check if it's a text file\n\n2. **Use `include_content_preview`** to quickly understand file structure without reading the entire file\n\n3. **Handle large files carefully**:\n   - Check `size` or `sizeHuman` before reading\n   - Use `from` and `lines` parameters to read in chunks\n   - Watch for `warning` field in `fs_info` response\n\n4. **Example workflow**:\n   ```\n   1. fs_info(path) → Check existence, type, size\n   2. If text file and small: read_file(path)\n   3. If text file and large: read_file(path, from=1, lines=100)\n   4. If directory: list_files(path) for detailed listing\n   ```\n",
-      "security_score": 100,
-      "security_warnings": null,
-      "license": null,
-      "argument_hint": "",
-      "disable_model_invocation": true,
-      "user_invocable": true,
-      "allowed_tools": null,
-      "is_active": true
-    },
-    {
-      "id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hacknews",
-      "description": "Hacker News 浏览器，支持AI领域过滤和搜索",
-      "version": "1.0.0",
-      "author": "",
-      "tags": [],
-      "source_type": "local",
-      "source_path": "skills\\hacknews",
-      "source_url": null,
-      "skill_md": "---\nname: hackernews-node\ndescription: Browse and search Hacker News with AI domain filtering. Windows-compatible Node.js implementation with bilingual output support.\nmetadata:\n  openclaw:\n    emoji: 🚀\n---\n\n# Hacker News Node\n\nWindows-compatible Hacker News browser with AI domain filtering and JSON output.\n\n## Quick Start\n\n```bash\n# Top stories\nnode scripts/hn.js top\n\n# AI domain stories\nnode scripts/hn.js ai\n\n# Search\nnode scripts/hn.js search \"LLM\"\n```\n\n## Commands\n\n| Command | Description | Options |\n|---------|-------------|---------|\n| `top` | Top stories | `--limit`, `--json` |\n| `new` | Newest stories | `--limit`, `--json` |\n| `best` | Best stories | `--limit`, `--json` |\n| `ask` | Ask HN | `--limit`, `--json` |\n| `show` | Show HN | `--limit`, `--json` |\n| `jobs` | Job postings | `--limit`, `--json` |\n| `ai` | AI domain filter | `--limit`, `--period`, `--json` |\n| `search` | Search stories | `--limit`, `--sort`, `--json` |\n\n## Examples\n\n```bash\n# Top 10 AI stories from last 24 hours\nnode scripts/hn.js ai --limit 10 --period day\n\n# Search with JSON output\nnode scripts/hn.js search \"machine learning\" --limit 5 --json\n\n# Get best stories\nnode scripts/hn.js best --limit 20 --json\n```\n\n## Output Format\n\n### JSON Mode (`--json`)\n```json\n{\n  \"command\": \"ai\",\n  \"query\": \"AI OR artificial intelligence OR LLM\",\n  \"count\": 10,\n  \"stories\": [\n    {\n      \"id\": 43050023,\n      \"title\": \"OpenAI releases GPT-5\",\n      \"url\": \"https://openai.com/...\",\n      \"points\": 523,\n      \"author\": \"sama\",\n      \"time\": \"2026-02-06T08:30:00Z\",\n      \"comments\": 156\n    }\n  ]\n}\n```\n\n## API Reference\n\n- HN Official API: https://github.com/HackerNews/API\n- Algolia Search: https://hn.algolia.com/api\n",
-      "security_score": 100,
-      "security_warnings": null,
-      "license": null,
-      "argument_hint": "",
-      "disable_model_invocation": true,
-      "user_invocable": true,
-      "allowed_tools": null,
-      "is_active": true
-    },
-    {
-      "id": "mmsj2jsuqvbkjqx00ldt",
-      "name": "message-reader",
-      "description": "提供消息内容检索能力，用于上下文优化中的按需获取",
-      "version": "1.0.0",
-      "author": "",
-      "tags": [],
-      "source_type": "local",
-      "source_path": "skills\\message-reader",
-      "source_url": null,
-      "skill_md": "# Message Reader Skill\n\n提供消息内容检索能力，用于上下文优化中的按需获取。\n\n## 功能说明\n\n当工具消息被摘要后，AI 可以通过此技能获取完整消息内容。\n\n## 工具列表\n\n### get_message_content\n\n获取指定工具消息的完整内容。\n\n**参数：**\n\n| 参数 | 类型 | 必填 | 说明 |\n|------|------|------|------|\n| tool_call_id | string | 是 | 工具调用 ID，从上下文摘要中获取 |\n\n**返回值：**\n\n```json\n{\n  \"success\": true,\n  \"tool_call_id\": \"call_xxx\",\n  \"tool_name\": \"search\",\n  \"content\": \"完整的消息内容...\",\n  \"content_length\": 1234,\n  \"created_at\": \"2026-03-15T12:00:00.000Z\"\n}\n```\n\n## 使用场景\n\n在 Simple 上下文策略中，工具消息会被摘要为：\n\n```\nsearch → 1234 字符 | get_message_content(\"call_xxx\")\n```\n\nAI 看到此提示后，可以调用 `get_message_content` 工具获取完整结果。\n\n## 技术说明\n\n- 使用 `tool_call_id` 作为消息唯一标识\n- 查询 `messages` 表中 `role='tool'` 的消息\n- `tool_call_id` 存储在 `tool_calls` 字段的 JSON 中",
-      "security_score": 100,
-      "security_warnings": null,
-      "license": null,
-      "argument_hint": "",
-      "disable_model_invocation": true,
-      "user_invocable": true,
-      "allowed_tools": null,
-      "is_active": true
-    },
-    {
-      "id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "pdf",
-      "description": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and converting PDFs to images for VL model recognition. If the user mentions a .pdf file or asks to produce one, use this skill.",
-      "version": "1.0.0",
-      "author": "",
-      "tags": [],
-      "source_type": "local",
-      "source_path": "skills\\pdf",
-      "source_url": null,
-      "skill_md": "---\nname: pdf\ndescription: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and converting PDFs to images for VL model recognition. If the user mentions a .pdf file or asks to produce one, use this skill.\nlicense: Proprietary. LICENSE.txt has complete terms\nargument-hint: \"[operation] [path]\"\nuser-invocable: true\ntools:\n  - read_pdf\n  - extract_text\n  - extract_tables\n  - merge_pdfs\n  - split_pdf\n  - rotate_pages\n  - create_pdf\n  - convert_to_images\n  - pdf_to_markdown\n  - encrypt_pdf\n  - decrypt_pdf\n  - add_watermark\n  - check_fillable_fields\n  - extract_form_field_info\n  - fill_fillable_fields\n  - extract_form_structure\n  - fill_pdf_form_with_annotations\n  - check_bounding_boxes\n  - extract_images\n---\n\n# PDF Processing Guide\n\n## Overview\n\nThis guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.\n\n## Tools\n\n### Basic Operations\n\n#### read_pdf\n\nRead PDF metadata and basic information.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n\n**Returns:** Page count, metadata (title, author, subject, creator), encryption status\n\n#### extract_text\n\nExtract text content from PDF pages.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `from_page` (number, optional): Start page (1-based, default: 1)\n- `to_page` (number, optional): End page (inclusive)\n- `preserve_layout` (boolean, optional): Preserve layout (default: false)\n\n#### extract_tables\n\nExtract tables from PDF using pdfplumber.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `page` (number, optional): Specific page number (1-based, extracts all if not specified)\n\n### Editing Operations\n\n#### merge_pdfs\n\nMerge multiple PDF files into one.\n\n**Parameters:**\n- `paths` (string[], required): Array of PDF file paths (at least 2)\n- `output` (string, required): Output file path\n\n#### split_pdf\n\nSplit PDF into multiple files.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output_dir` (string, required): Output directory\n- `pages_per_file` (number, optional): Pages per output file (default: 1)\n- `prefix` (string, optional): Output filename prefix (default: \"page\")\n\n#### rotate_pages\n\nRotate pages in PDF.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output` (string, required): Output file path\n- `pages` (number[], optional): Page numbers to rotate (1-based, all if empty)\n- `degrees` (number, optional): Rotation degrees - 90, 180, 270 (default: 90)\n\n### Creation and Conversion\n\n#### create_pdf\n\nCreate a new PDF with text content.\n\n**Parameters:**\n- `output` (string, required): Output file path\n- `title` (string, optional): PDF title\n- `content` (string[], required): Array of text content (each item is a page)\n- `page_size` (string, optional): Page size - \"letter\" or \"a4\" (default: \"a4\")\n\n#### convert_to_images\n\nConvert PDF pages to images.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output_dir` (string, required): Output directory\n- `dpi` (number, optional): Resolution DPI (default: 150)\n- `format` (string, optional): Image format - \"png\" or \"jpeg\" (default: \"png\")\n- `from_page` (number, optional): Start page (1-based)\n- `to_page` (number, optional): End page (inclusive)\n\n#### pdf_to_markdown\n\nConvert PDF to Markdown format.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output` (string, optional): Output markdown file path\n- `from_page` (number, optional): Start page (1-based)\n- `to_page` (number, optional): End page (inclusive)\n\n### Security Operations\n\n#### encrypt_pdf\n\nEncrypt PDF with password protection.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output` (string, required): Output file path\n- `user_password` (string, required): Password to open the PDF\n- `owner_password` (string, optional): Password for editing (defaults to user_password)\n\n#### decrypt_pdf\n\nRemove password protection from PDF.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output` (string, required): Output file path\n- `password` (string, required): Current password\n\n#### add_watermark\n\nAdd watermark to PDF pages.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output` (string, required): Output file path\n- `watermark` (string, required): Watermark text or watermark PDF path\n- `is_text` (boolean, optional): True if watermark is text, false if PDF path (default: true)\n\n### Form Operations\n\n#### check_fillable_fields\n\nCheck if PDF has fillable form fields.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n\n#### extract_form_field_info\n\nExtract information about fillable form fields.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output` (string, required): Output JSON file path\n\n#### fill_fillable_fields\n\nFill fillable form fields in a PDF.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `field_values` (string, required): JSON file with field values\n- `output` (string, required): Output PDF file path\n\n#### extract_form_structure\n\nExtract form structure for non-fillable forms.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output` (string, required): Output JSON file path\n\n#### fill_pdf_form_with_annotations\n\nFill non-fillable PDF forms with text annotations.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `fields_json` (string, required): Fields JSON file path\n- `output` (string, required): Output PDF file path\n\n#### check_bounding_boxes\n\nValidate bounding boxes for form fields.\n\n**Parameters:**\n- `fields_json` (string, required): Fields JSON file path\n\n### Other Operations\n\n#### extract_images\n\nExtract embedded images from PDF.\n\n**Parameters:**\n- `path` (string, required): PDF file path\n- `output_dir` (string, required): Output directory\n\n## Quick Start\n\n```python\nfrom pypdf import PdfReader, PdfWriter\n\n# Read a PDF\nreader = PdfReader(\"document.pdf\")\nprint(f\"Pages: {len(reader.pages)}\")\n\n# Extract text\ntext = \"\"\nfor page in reader.pages:\n    text += page.extract_text()\n```\n\n## Python Libraries\n\n### pypdf - Basic Operations\n\n#### Merge PDFs\n\n```python\nfrom pypdf import PdfWriter, PdfReader\n\nwriter = PdfWriter()\nfor pdf_file in [\"doc1.pdf\", \"doc2.pdf\", \"doc3.pdf\"]:\n    reader = PdfReader(pdf_file)\n    for page in reader.pages:\n        writer.add_page(page)\n\nwith open(\"merged.pdf\", \"wb\") as output:\n    writer.write(output)\n```\n\n#### Split PDF\n\n```python\nreader = PdfReader(\"input.pdf\")\nfor i, page in enumerate(reader.pages):\n    writer = PdfWriter()\n    writer.add_page(page)\n    with open(f\"page_{i+1}.pdf\", \"wb\") as output:\n        writer.write(output)\n```\n\n#### Extract Metadata\n\n```python\nreader = PdfReader(\"document.pdf\")\nmeta = reader.metadata\nprint(f\"Title: {meta.title}\")\nprint(f\"Author: {meta.author}\")\nprint(f\"Subject: {meta.subject}\")\nprint(f\"Creator: {meta.creator}\")\n```\n\n#### Rotate Pages\n\n```python\nreader = PdfReader(\"input.pdf\")\nwriter = PdfWriter()\n\npage = reader.pages[0]\npage.rotate(90)  # Rotate 90 degrees clockwise\nwriter.add_page(page)\n\nwith open(\"rotated.pdf\", \"wb\") as output:\n    writer.write(output)\n```\n\n### pdfplumber - Text and Table Extraction\n\n#### Extract Text with Layout\n\n```python\nimport pdfplumber\n\nwith pdfplumber.open(\"document.pdf\") as pdf:\n    for page in pdf.pages:\n        text = page.extract_text()\n        print(text)\n```\n\n#### Extract Tables\n\n```python\nwith pdfplumber.open(\"document.pdf\") as pdf:\n    for i, page in enumerate(pdf.pages):\n        tables = page.extract_tables()\n        for j, table in enumerate(tables):\n            print(f\"Table {j+1} on page {i+1}:\")\n            for row in table:\n                print(row)\n```\n\n#### Advanced Table Extraction\n\n```python\nimport pandas as pd\n\nwith pdfplumber.open(\"document.pdf\") as pdf:\n    all_tables = []\n    for page in pdf.pages:\n        tables = page.extract_tables()\n        for table in tables:\n            if table:  # Check if table is not empty\n                df = pd.DataFrame(table[1:], columns=table[0])\n                all_tables.append(df)\n\n# Combine all tables\nif all_tables:\n    combined_df = pd.concat(all_tables, ignore_index=True)\n    combined_df.to_excel(\"extracted_tables.xlsx\", index=False)\n```\n\n### reportlab - Create PDFs\n\n#### Basic PDF Creation\n\n```python\nfrom reportlab.lib.pagesizes import letter\nfrom reportlab.pdfgen import canvas\n\nc = canvas.Canvas(\"hello.pdf\", pagesize=letter)\nwidth, height = letter\n\n# Add text\nc.drawString(100, height - 100, \"Hello World!\")\nc.drawString(100, height - 120, \"This is a PDF created with reportlab\")\n\n# Add a line\nc.line(100, height - 140, 400, height - 140)\n\n# Save\nc.save()\n```\n\n#### Create PDF with Multiple Pages\n\n```python\nfrom reportlab.lib.pagesizes import letter\nfrom reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak\nfrom reportlab.lib.styles import getSampleStyleSheet\n\ndoc = SimpleDocTemplate(\"report.pdf\", pagesize=letter)\nstyles = getSampleStyleSheet()\nstory = []\n\n# Add content\ntitle = Paragraph(\"Report Title\", styles['Title'])\nstory.append(title)\nstory.append(Spacer(1, 12))\n\nbody = Paragraph(\"This is the body of the report. \" * 20, styles['Normal'])\nstory.append(body)\nstory.append(PageBreak())\n\n# Page 2\nstory.append(Paragraph(\"Page 2\", styles['Heading1']))\nstory.append(Paragraph(\"Content for page 2\", styles['Normal']))\n\n# Build PDF\ndoc.build(story)\n```\n\n#### Subscripts and Superscripts\n\n**IMPORTANT**: Never use Unicode subscript/superscript characters (₀₁₂₃₄₅₆₇₈₉, ⁰¹²³⁴⁵⁶⁷⁸⁹) in ReportLab PDFs. The built-in fonts do not include these glyphs, causing them to render as solid black boxes.\n\nInstead, use ReportLab's XML markup tags in Paragraph objects:\n\n```python\nfrom reportlab.platypus import Paragraph\nfrom reportlab.lib.styles import getSampleStyleSheet\n\nstyles = getSampleStyleSheet()\n\n# Subscripts: use <sub> tag\nchemical = Paragraph(\"H<sub>2</sub>O\", styles['Normal'])\n\n# Superscripts: use <super> tag\nsquared = Paragraph(\"x<super>2</super> + y<super>2</super>\", styles['Normal'])\n```\n\nFor canvas-drawn text (not Paragraph objects), manually adjust font the size and position rather than using Unicode subscripts/superscripts.\n\n## Command-Line Tools\n\n### pdftotext (poppler-utils)\n\n```bash\n# Extract text\npdftotext input.pdf output.txt\n\n# Extract text preserving layout\npdftotext -layout input.pdf output.txt\n\n# Extract specific pages\npdftotext -f 1 -l 5 input.pdf output.txt  # Pages 1-5\n```\n\n### qpdf\n\n```bash\n# Merge PDFs\nqpdf --empty --pages file1.pdf file2.pdf -- merged.pdf\n\n# Split pages\nqpdf input.pdf --pages . 1-5 -- pages1-5.pdf\nqpdf input.pdf --pages . 6-10 -- pages6-10.pdf\n\n# Rotate pages\nqpdf input.pdf output.pdf --rotate=+90:1  # Rotate page 1 by 90 degrees\n\n# Remove password\nqpdf --password=mypassword --decrypt encrypted.pdf decrypted.pdf\n```\n\n### pdftk (if available)\n\n```bash\n# Merge\npdftk file1.pdf file2.pdf cat output merged.pdf\n\n# Split\npdftk input.pdf burst\n\n# Rotate\npdftk input.pdf rotate 1east output rotated.pdf\n```\n\n## Common Tasks\n\n### Convert Scanned PDFs to Images for VL Model Recognition\n\nFor scanned PDFs or image-based PDFs where text extraction fails, use `convert_to_images` tool to convert PDF pages to images, then send images to VL (Vision-Language) model for text recognition.\n\n**Workflow:**\n1. Use `convert_to_images` tool to convert PDF pages to PNG/JPEG images\n2. Send the generated images to VL model (e.g., GPT-4V, Claude Vision, Qwen-VL)\n3. VL model will recognize and extract text from the images\n\n**Example:**\n```\n# Step 1: Convert PDF to images\nTool: convert_to_images\nParams: { \"path\": \"scanned.pdf\", \"output_dir\": \"./images\", \"dpi\": 200 }\n\n# Step 2: Send images to VL model for recognition\n# The images are now ready for VL model processing\n```\n\n**Benefits of using VL model over traditional OCR:**\n- Better handling of complex layouts\n- Multi-language support without additional language packs\n- Understanding of tables, forms, and structured content\n- No need to install Tesseract or language packs\n\n### Add Watermark\n\n```python\nfrom pypdf import PdfReader, PdfWriter\n\n# Create watermark (or load existing)\nwatermark = PdfReader(\"watermark.pdf\").pages[0]\n\n# Apply to all pages\nreader = PdfReader(\"document.pdf\")\nwriter = PdfWriter()\n\nfor page in reader.pages:\n    page.merge_page(watermark)\n    writer.add_page(page)\n\nwith open(\"watermarked.pdf\", \"wb\") as output:\n    writer.write(output)\n```\n\n### Extract Images\n\n```bash\n# Using pdfimages (poppler-utils)\npdfimages -j input.pdf output_prefix\n\n# This extracts all images as output_prefix-000.jpg, output_prefix-001.jpg, etc.\n```\n\n### Password Protection\n\n```python\nfrom pypdf import PdfReader, PdfWriter\n\nreader = PdfReader(\"input.pdf\")\nwriter = PdfWriter()\n\nfor page in reader.pages:\n    writer.add_page(page)\n\n# Add password\nwriter.encrypt(\"userpassword\", \"ownerpassword\")\n\nwith open(\"encrypted.pdf\", \"wb\") as output:\n    writer.write(output)\n```\n\n## Quick Reference\n\n| Task               | Best Tool                       | Command/Code                 |\n| ------------------ | ------------------------------- | ---------------------------- |\n| Merge PDFs         | pypdf                           | `writer.add_page(page)`    |\n| Split PDFs         | pypdf                           | One page per file            |\n| Extract text       | pdfplumber                      | `page.extract_text()`      |\n| Extract tables     | pdfplumber                      | `page.extract_tables()`    |\n| Create PDFs        | reportlab                       | Canvas or Platypus           |\n| Command line merge | qpdf                            | `qpdf --empty --pages ...` |\n| Scanned PDFs       | convert_to_images + VL model    | Convert to image first       |\n| Fill PDF forms     | pdf-lib or pypdf (see FORMS.md) | See FORMS.md                 |\n\n## Next Steps\n\n- For advanced pypdfium2 usage, see REFERENCE.md\n- For JavaScript libraries (pdf-lib), see REFERENCE.md\n- If you need to fill out a PDF form, follow the instructions in FORMS.md\n- For troubleshooting guides, see REFERENCE.md\n\n---\n",
-      "security_score": 100,
-      "security_warnings": null,
-      "license": null,
-      "argument_hint": "",
-      "disable_model_invocation": true,
-      "user_invocable": true,
-      "allowed_tools": null,
-      "is_active": true
-    },
-    {
-      "id": "searxng",
+      "id": "mnbs681pqiej9tvgx1pd",
       "name": "searxng",
       "description": "Search the web using SearXNG. Use when you need current information, news, or web search. Triggers on \"search\", \"look up\", \"find online\", \"web search\".",
       "version": "1.0.0",
-      "author": "System",
+      "author": "",
       "tags": [],
       "source_type": "local",
       "source_path": "skills/searxng",
       "source_url": null,
-      "skill_md": "---\r\nname: searxng\r\ndescription: Search the web using SearXNG. Use when you need current information, news, or web search. Triggers on \"search\", \"look up\", \"find online\", \"web search\".\r\nargument-hint: \"[query]\"\r\nuser-invocable: true\r\nallowed-tools:\r\n  - Bash(curl *)\r\n---\r\n\r\n# SearXNG Search\r\n\r\nSearch the web using your local SearXNG instance - a privacy-respecting metasearch engine.\r\n\r\n## Quick Start\r\n\r\n```javascript\r\n// Basic search\r\n{ \"query\": \"machine learning basics\" }\r\n\r\n// Search with options\r\n{ \"query\": \"breaking news\", \"category\": \"news\", \"time_range\": \"day\", \"n\": 20 }\r\n```\r\n\r\n## Tools\r\n\r\n### web_search\r\n\r\nSearch the web using SearXNG.\r\n\r\n**Parameters:**\r\n- `query` (string, required): The search query\r\n- `n` (number, optional): Number of results (default: 10, max: 50)\r\n- `category` (string, optional): \"general\" | \"images\" | \"videos\" | \"news\" | \"map\" | \"music\" | \"files\" | \"it\" | \"science\"\r\n- `language` (string, optional): Language code like \"en\", \"zh\", \"auto\" (default: \"auto\")\r\n- `time_range` (string, optional): \"day\" | \"week\" | \"month\" | \"year\"\r\n- `format` (string, optional): \"json\" (default) or \"table\" for readable display\r\n\r\n**Examples:**\r\n```javascript\r\n// General search\r\n{ \"query\": \"node.js tutorial\" }\r\n\r\n// Image search\r\n{ \"query\": \"cute cats\", \"category\": \"images\" }\r\n\r\n// Recent news\r\n{ \"query\": \"AI news\", \"category\": \"news\", \"time_range\": \"day\" }\r\n\r\n// Get 30 results in table format\r\n{ \"query\": \"climate change\", \"n\": 30, \"format\": \"table\" }\r\n```\r\n\r\n## Configuration\r\n\r\nSet environment variable:\r\n```bash\r\nexport SEARXNG_URL=https://your-searxng-instance.com\r\n```\r\n\r\nDefault: `http://localhost:8080`\r\n\r\n## Output\r\n\r\nReturns JSON with search results:\r\n```json\r\n{\r\n  \"success\": true,\r\n  \"data\": {\r\n    \"query\": \"search term\",\r\n    \"number_of_results\": 1000,\r\n    \"results\": [\r\n      {\r\n        \"title\": \"Result Title\",\r\n        \"url\": \"https://example.com\",\r\n        \"content\": \"Snippet...\",\r\n        \"engines\": [\"google\", \"bing\"]\r\n      }\r\n    ]\r\n  }\r\n}\r\n```\r\n\r\nUse `format: \"table\"` for human-readable output.\r\n",
+      "skill_md": "---\nname: searxng\ndescription: Search the web using SearXNG. Use when you need current information, news, or web search. Triggers on \"search\", \"look up\", \"find online\", \"web search\".\nargument-hint: \"[query]\"\nuser-invocable: true\nallowed-tools:\n  - Bash(curl *)\n---\n\n# SearXNG Search\n\nSearch the web using your local SearXNG instance - a privacy-respecting metasearch engine.\n\n## Quick Start\n\n```javascript\n// Basic search\n{ \"query\": \"machine learning basics\" }\n\n// Search with options\n{ \"query\": \"breaking news\", \"category\": \"news\", \"time_range\": \"day\", \"n\": 20 }\n```\n\n## Tools\n\n### web_search\n\nSearch the web using SearXNG.\n\n**Parameters:**\n- `query` (string, required): The search query\n- `n` (number, optional): Number of results (default: 10, max: 50)\n- `category` (string, optional): \"general\" | \"images\" | \"videos\" | \"news\" | \"map\" | \"music\" | \"files\" | \"it\" | \"science\"\n- `language` (string, optional): Language code like \"en\", \"zh\", \"auto\" (default: \"auto\")\n- `time_range` (string, optional): \"day\" | \"week\" | \"month\" | \"year\"\n- `format` (string, optional): \"json\" (default) or \"table\" for readable display\n\n**Examples:**\n```javascript\n// General search\n{ \"query\": \"node.js tutorial\" }\n\n// Image search\n{ \"query\": \"cute cats\", \"category\": \"images\" }\n\n// Recent news\n{ \"query\": \"AI news\", \"category\": \"news\", \"time_range\": \"day\" }\n\n// Get 30 results in table format\n{ \"query\": \"climate change\", \"n\": 30, \"format\": \"table\" }\n```\n\n## Configuration\n\nSet environment variable:\n```bash\nexport SEARXNG_URL=https://your-searxng-instance.com\n```\n\nDefault: `http://localhost:8080`\n\n## Output\n\nReturns JSON with search results:\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"query\": \"search term\",\n    \"number_of_results\": 1000,\n    \"results\": [\n      {\n        \"title\": \"Result Title\",\n        \"url\": \"https://example.com\",\n        \"content\": \"Snippet...\",\n        \"engines\": [\"google\", \"bing\"]\n      }\n    ]\n  }\n}\n```\n\nUse `format: \"table\"` for human-readable output.\n",
       "security_score": 100,
       "security_warnings": null,
       "license": null,
       "argument_hint": "",
       "disable_model_invocation": true,
       "user_invocable": true,
-      "allowed_tools": "[]",
+      "allowed_tools": null,
       "is_active": true
     },
     {
@@ -218,7 +238,7 @@
       "source_type": "local",
       "source_path": "skills/skill-manager",
       "source_url": null,
-      "skill_md": "---\r\nname: skill-manager\r\ndescription: 技能管理工具，用于注册、删除、查询技能。技能专家通过文件系统读取 SKILL.md 后，使用此工具将技能注册到数据库。\r\nargument-hint: \"[register|delete|toggle|list] [skill_id]\"\r\nuser-invocable: false\r\nallowed-tools: []\r\n---\r\n\r\n# Skill Manager\r\n\r\n技能管理核心工具，提供以下功能：\r\n\r\n## 配置要求\r\n\r\n此技能需要数据库连接参数，通过 `skill_parameters` 表配置：\r\n\r\n| 参数名 | 说明 | 示例值 |\r\n|--------|------|--------|\r\n| `db_host` | 数据库主机 | `${DB_HOST}` |\r\n| `db_port` | 数据库端口 | `${DB_PORT}` |\r\n| `db_name` | 数据库名称 | `${DB_NAME}` |\r\n| `db_user` | 数据库用户 | `${DB_USER}` |\r\n| `db_password` | 数据库密码 | `${DB_PASSWORD}` |\r\n\r\n> 使用 `${ENV_VAR}` 格式会自动从环境变量读取值，避免敏感信息存储在数据库中。\r\n\r\n## 工具清单\r\n\r\n### register_skill\r\n从本地目录注册或更新技能到数据库。需要先读取 SKILL.md，理解工具定义后调用此工具。\r\n\r\n**参数：**\r\n- `source_path`: 技能目录相对于 dataBasePath 的路径。例如：`skills/searxng`（注意：必须包含 `skills/` 前缀）\r\n- `name`: 技能名称（可选）\r\n- `description`: 技能描述（可选）\r\n- `tools`: 工具定义数组，每个工具包含 name、description、parameters、script_path 字段\r\n\r\n### delete_skill\r\n从数据库中删除技能（谨慎使用）。\r\n\r\n**参数：**\r\n- `skill_id`: 技能ID或名称\r\n\r\n### toggle_skill\r\n启用或禁用技能。\r\n\r\n**参数：**\r\n- `skill_id`: 技能ID或名称\r\n- `is_active`: 是否启用\r\n\r\n### list_skills\r\n列出数据库中所有技能（精简列表，不含工具详情）。\r\n\r\n**参数：**\r\n- `is_active`: 过滤启用/禁用状态（可选，不传则返回所有）\r\n- `search`: 按名称搜索（可选，模糊匹配）\r\n\r\n### list_skill_details\r\n获取指定技能的完整详情，包括技能所有字段和工具定义列表。\r\n\r\n**参数：**\r\n- `skill_id`: 技能ID或名称\r\n\r\n## 使用流程\r\n\r\n1. 使用 `list_skills` 浏览已注册的技能精简列表\r\n2. 对感兴趣的技能，使用 `list_skill_details` 获取完整详情（含工具定义）\r\n3. 通过 `list_files` 和 `read_lines` 浏览本地技能目录\r\n4. 读取 SKILL.md 理解技能结构和工具定义\r\n5. 使用 `register_skill` 将技能注册到数据库\r\n6. 使用 `toggle_skill` 启用或禁用技能\r\n\r\n## 注意事项\r\n\r\n- 此技能仅供技能管理专家（如 skill-studio）使用\r\n- 注册技能时必须提供完整的 tools 数组\r\n- 删除技能会同时删除关联的工具定义\r\n- 技能分配给专家的操作需要在网页端手动完成\r\n- 此技能运行在沙箱中，使用独立的数据库连接池（最大2个连接）\r\n",
+      "skill_md": "---\nname: skill-manager\ndescription: 技能管理工具，用于注册、删除、查询技能。技能专家通过文件系统读取 SKILL.md 后，使用此工具将技能注册到数据库。\nargument-hint: \"[register|delete|toggle|list|details] [skill_id]\"\nuser-invocable: false\nallowed-tools: []\n---\n\n# Skill Manager\n\n技能管理核心工具，通过 API 调用后台服务执行操作。\n\n## 配置要求\n\n此技能通过 API 调用后台服务，需要以下环境变量：\n\n| 变量名 | 说明 | 必需 |\n|--------|------|------|\n| `USER_ACCESS_TOKEN` | 用户的 JWT access token | ✅ |\n| `API_BASE` | API 基础地址 | ✅ |\n| `NODE_ENV` | 运行环境（production/development） | 可选 |\n\n> 注意：此技能不再需要数据库连接参数，所有操作通过 API 完成。\n\n## 工具清单\n\n### list\n\n列出数据库中所有技能（精简列表，不含工具详情）。\n\n**参数：**\n- `is_active`: 过滤启用/禁用状态（可选，不传则返回所有）\n- `search`: 按名称搜索（可选，模糊匹配）\n\n**返回示例：**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"skills\": [\n      {\n        \"id\": \"abc123\",\n        \"name\": \"searxng\",\n        \"description\": \"互联网搜索技能\",\n        \"version\": \"1.0.0\",\n        \"is_active\": true,\n        \"source_path\": \"skills/searxng\"\n      }\n    ]\n  }\n}\n```\n\n### details\n\n获取指定技能的完整详情，包括技能所有字段和工具定义列表。\n\n**参数：**\n- `skill_id`: 技能ID或名称（必需）\n\n**返回示例：**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"skill\": {\n      \"id\": \"abc123\",\n      \"name\": \"searxng\",\n      \"description\": \"互联网搜索技能\",\n      \"version\": \"1.0.0\",\n      \"author\": \"Touwaka Team\",\n      \"tags\": [\"search\", \"web\"],\n      \"is_active\": true,\n      \"source_path\": \"skills/searxng\",\n      \"created_at\": \"2026-03-01T10:00:00Z\",\n      \"updated_at\": \"2026-03-02T15:30:00Z\"\n    },\n    \"tools\": [\n      {\n        \"id\": \"tool1\",\n        \"name\": \"web_search\",\n        \"description\": \"搜索互联网\",\n        \"parameters\": { \"type\": \"object\", \"properties\": {...} },\n        \"script_path\": \"index.js\"\n      }\n    ]\n  }\n}\n```\n\n### register\n\n从本地目录注册或更新技能到数据库。需要先读取 SKILL.md，理解工具定义后调用此工具。\n\n**参数：**\n- `source_path`: 技能目录路径。支持自动规范化：\n  - `skills/searxng`（推荐格式）\n  - `data/skills/searxng` → 自动转换为 `skills/searxng`\n  - `searxng` → 自动转换为 `skills/searxng`\n- `name`: 技能名称（可选，默认从 SKILL.md 的 name 字段提取）\n- `description`: 技能描述（可选，默认从 SKILL.md 的 description 字段提取）\n- `tools`: 工具定义数组，每个工具包含 name、description、parameters、script_path 字段\n\n### delete\n\n从数据库中删除技能（谨慎使用）。\n\n**参数：**\n- `skill_id`: 技能ID或名称\n\n### toggle\n\n启用或禁用技能。\n\n**参数：**\n- `skill_id`: 技能ID或名称\n- `is_active`: 是否启用（boolean）\n\n## 使用流程\n\n1. 使用 `list` 浏览已注册的技能精简列表\n2. 对感兴趣的技能，使用 `details` 获取完整详情（含工具定义）\n3. 通过 `list_files` 和 `read_lines` 浏览本地技能目录\n4. 读取 SKILL.md 理解技能结构和工具定义\n5. 使用 `register` 将技能注册到数据库\n6. 使用 `toggle` 启用或禁用技能\n\n## 架构说明\n\n此技能采用 API 调用模式：\n\n```\nskill-manager (沙箱)\n    ↓ HTTP API\nserver/controllers/skill.controller.js\n    ↓ Sequelize\nMySQL 数据库\n```\n\n**优点**：\n- 业务逻辑集中在后台服务\n- 使用用户 Token 认证，权限由 API 层统一控制\n- 无需在 skill 中暴露数据库凭证\n- 数据库结构变更不影响 skill 代码\n\n## 注意事项\n\n- 此技能仅供技能管理专家（如 skill-studio）使用\n- 注册技能时必须提供完整的 tools 数组\n- 删除技能会同时删除关联的工具定义\n- 所有操作需要用户已登录（有有效的 USER_ACCESS_TOKEN）\n\n---\n\n*重构时间: 2026-03-30 - 精简工具数量，移除 assign/unassign 功能*\n",
       "security_score": 100,
       "security_warnings": null,
       "license": null,
@@ -249,36 +269,16 @@
       "is_active": true
     },
     {
-      "id": "mmoasyw4iar2f9qi4z96",
-      "name": "unifuncs-web-reader",
-      "description": "网页内容提取服务，通过 Unifuncs API 获取网页正文内容。支持微信公众号、知乎、头条等主流平台。",
-      "version": "1.0.0",
-      "author": "",
-      "tags": [],
-      "source_type": "local",
-      "source_path": "skills\\unifuncs-web-reader",
-      "source_url": null,
-      "skill_md": "---\nname: unifuncs-web-reader\ndescription: 网页内容提取服务，通过 Unifuncs API 获取网页正文内容。支持微信公众号、知乎、头条等主流平台。\nargument-hint: \"[url]\"\nuser-invocable: true\nallowed-tools: []\nenv-variables:\n  - name: UNIFUNCS_API_KEY\n    description: Unifuncs API 密钥\n    required: true\n---\n\n# Unifuncs Web Reader\n\n网页内容提取服务，通过 Unifuncs API 获取网页正文内容。\n\n## 功能特点\n\n- 支持微信公众号文章\n- 支持知乎专栏/问答\n- 支持今日头条\n- 支持其他主流网站\n- 自动提取正文内容\n- 返回结构化数据\n\n## 配置要求\n\n此技能需要以下环境变量（由系统从 `skill_parameters` 表自动注入）：\n\n| 变量名 | 说明 | 必需 |\n|--------|------|------|\n| `UNIFUNCS_API_KEY` | Unifuncs API 密钥 | ✅ |\n\n## 工具清单\n\n### read_web_page\n\n读取网页内容并提取正文。\n\n**参数：**\n- `url` (string, required): 要读取的网页 URL\n- `timeout` (number, optional): 超时时间（毫秒），默认 30000\n\n**调用方式：**\n```\nGET https://api.unifuncs.com/api/web-reader/{path}?apiKey=API_KEY\n```\n\n**注意：** path 需要进行 URL 编码\n\n**示例：**\n```javascript\n// 读取微信公众号文章\n{\n  \"url\": \"https://mp.weixin.qq.com/s/wmoNh44A4ofkawPNVx_g6A\"\n}\n\n// 实际请求 URL\n// https://api.unifuncs.com/api/web-reader/https%3A%2F%2Fmp.weixin.qq.com%2Fs%2FwmoNh44A4ofkawPNVx_g6A?apiKey=API_KEY\n```\n\n**返回示例：**\n```json\n{\n  \"success\": true,\n  \"statusCode\": 200,\n  \"statusMessage\": \"OK\",\n  \"headers\": {\n    \"content-type\": \"text/markdown; charset=utf-8\",\n    \"x-unifuncs-status\": \"0\"\n  },\n  \"body\": \"Title: 文章标题\\n\\nURL Source: https://example.com\\n\\nMarkdown Content:\\n\\n正文内容...\",\n  \"size\": 12345,\n  \"originalUrl\": \"https://example.com\"\n}\n```\n\n**说明：** `body` 字段返回 Markdown 格式的文本内容，包含标题、来源 URL 和正文。\n\n## 错误处理\n\n| 状态码 | 说明 |\n|--------|------|\n| 200 | 成功 |\n| 400 | URL 格式错误 |\n| 401 | API Key 无效或缺失 |\n| 403 | 无权限访问 |\n| 404 | 网页不存在 |\n| 429 | 请求频率超限 |\n| 500 | 服务器错误 |\n\n## 安全说明\n\n- API Key 从环境变量获取，不在代码中硬编码\n- 使用 HTTPS 加密传输\n- 最大响应大小限制为 5MB\n- 默认超时 30 秒\n\n## 使用场景\n\n1. **内容分析**：提取网页正文用于 AI 分析\n2. **信息收集**：批量获取特定平台的内容\n3. **内容存档**：保存网页内容到本地\n\n## 注意事项\n\n- 请遵守目标网站的使用条款\n- 不要频繁请求同一网站\n- 部分网站可能有反爬机制",
-      "security_score": 100,
-      "security_warnings": null,
-      "license": null,
-      "argument_hint": "",
-      "disable_model_invocation": true,
-      "user_invocable": true,
-      "allowed_tools": null,
-      "is_active": true
-    },
-    {
-      "id": "mn1hcspll2vbjefyd9zo",
+      "id": "mnbdoe1alv92mmh4f28y",
       "name": "xlsx",
-      "description": "Excel 文件处理。用于读取、写入、编辑 .xlsx/.xls/.csv 文件，支持工作表管理、格式化、公式计算、数据查询和格式转换。",
+      "description": "Excel 文件处理。用于读取、写入、编辑 .xlsx/.xls/.csv 文件，支持工作表管理、格式化、公式计算、数据查询和格式转换。当用户需要操作电子表格文件时触发。",
       "version": "1.0.0",
       "author": "",
       "tags": [],
       "source_type": "local",
-      "source_path": "skills\\xlsx",
+      "source_path": "skills/xlsx",
       "source_url": null,
-      "skill_md": "---\nname: xlsx\ndescription: \"Excel 文件处理。用于读取、写入、编辑 .xlsx/.xls/.csv 文件，支持工作表管理、格式化、公式计算、数据查询和格式转换。当用户需要操作电子表格文件时触发。\"\n---\n\n# XLSX - Excel 文件处理\n\n## 工具\n\n| 工具 | 说明 | 关键参数 |\n|------|------|----------|\n| `excel_read` | 读取 Excel | `scope`: workbook/sheet/cell |\n| `excel_write` | 写入 Excel | `scope`: workbook/sheet/cell |\n| `excel_sheet` | 工作表管理 | `action`: add/delete/rename/copy |\n| `excel_format` | 格式化 | `type`: column/cell |\n| `excel_query` | 数据查询 | `action`: filter/sort/find |\n| `excel_convert` | 格式转换 | `format`: json/csv, `direction`: to/from |\n| `excel_calc` | 公式计算 | - |\n\n## excel_read\n\n```javascript\n// 读取工作簿\nexcel_read({ path: 'data.xlsx', scope: 'workbook' })\nexcel_read({ path: 'data.xlsx', scope: 'workbook', includeData: true })\n\n// 读取工作表\nexcel_read({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1' })\nexcel_read({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', header: 'json', range: 'A1:C10' })\n\n// 读取单元格\nexcel_read({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1' })\n```\n\n## excel_write\n\n```javascript\n// 创建工作簿\nexcel_write({\n  path: 'new.xlsx',\n  scope: 'workbook',\n  sheets: [{ name: 'Sheet1', data: [['A', 'B'], [1, 2]] }]\n})\n\n// 写入工作表\nexcel_write({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'overwrite' })\nexcel_write({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'append' })\n\n// 写入单元格\nexcel_write({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1', value: 'Hello' })\nexcel_write({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'C1', formula: '=SUM(A1:B1)' })\n```\n\n## excel_sheet\n\n```javascript\nexcel_sheet({ path: 'data.xlsx', action: 'add', name: 'NewSheet' })\nexcel_sheet({ path: 'data.xlsx', action: 'delete', sheet: 'Sheet2' })\nexcel_sheet({ path: 'data.xlsx', action: 'rename', sheet: 'Sheet1', newName: 'Summary' })\nexcel_sheet({ path: 'data.xlsx', action: 'copy', sourceSheet: 'Template', targetSheet: 'Copy1' })\n```\n\n## excel_format\n\n```javascript\n// 列宽\nexcel_format({\n  path: 'data.xlsx', type: 'column', sheet: 'Sheet1',\n  columns: [{ column: 'A', width: 20 }, { column: 'B', width: 15 }]\n})\n\n// 单元格样式\nexcel_format({\n  path: 'data.xlsx', type: 'cell', sheet: 'Sheet1',\n  cells: ['A1', 'B1'],\n  style: { font: { bold: true }, fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFF00' } } }\n})\n```\n\n## excel_query\n\n```javascript\n// 筛选\nexcel_query({ path: 'data.xlsx', action: 'filter', column: 'status', condition: 'equals', value: 'active' })\n\n// 排序\nexcel_query({ path: 'data.xlsx', action: 'sort', column: 'amount', order: 'desc' })\n\n// 查找\nexcel_query({ path: 'data.xlsx', action: 'find', query: 'error' })\n```\n\n**筛选条件**: `equals`, `not_equals`, `greater`, `less`, `contains`, `starts_with`, `ends_with`, `is_empty`, `is_not_empty`\n\n## excel_convert\n\n```javascript\n// Excel ↔ JSON\nexcel_convert({ path: 'data.xlsx', format: 'json', direction: 'to' })\nexcel_convert({ path: 'output.xlsx', format: 'json', direction: 'from', data: [{ name: 'Alice' }] })\n\n// Excel ↔ CSV\nexcel_convert({ path: 'data.xlsx', format: 'csv', direction: 'to', output: 'data.csv' })\nexcel_convert({ path: 'data.csv', format: 'csv', direction: 'from', output: 'data.xlsx' })\n```\n\n## excel_calc\n\n```javascript\nexcel_calc({ path: 'data.xlsx', sheet: 'Sheet1' })\n// 返回: { formulas: [{ cell: 'C1', formula: 'SUM(A1:B1)', value: 15 }] }\n```\n\n## 兼容旧工具名\n\n| 旧名称 | 新名称 |\n|--------|--------|\n| `read_workbook`, `read` | `excel_read(scope: 'workbook')` |\n| `read_sheet` | `excel_read(scope: 'sheet')` |\n| `read_cell` | `excel_read(scope: 'cell')` |\n| `create_workbook`, `create` | `excel_write(scope: 'workbook')` |\n| `write_sheet` | `excel_write(scope: 'sheet')` |\n| `write_cell` | `excel_write(scope: 'cell')` |\n| `add_sheet` | `excel_sheet(action: 'add')` |\n| `delete_sheet` | `excel_sheet(action: 'delete')` |\n| `rename_sheet` | `excel_sheet(action: 'rename')` |\n| `copy_sheet` | `excel_sheet(action: 'copy')` |\n| `set_column_width` | `excel_format(type: 'column')` |\n| `set_cell_style` | `excel_format(type: 'cell')` |\n| `filter_data` | `excel_query(action: 'filter')` |\n| `sort_data` | `excel_query(action: 'sort')` |\n| `find_data` | `excel_query(action: 'find')` |\n| `to_json` | `excel_convert(format: 'json', direction: 'to')` |\n| `from_json` | `excel_convert(format: 'json', direction: 'from')` |\n| `to_csv` | `excel_convert(format: 'csv', direction: 'to')` |\n| `from_csv` | `excel_convert(format: 'csv', direction: 'from')` |\n| `calculate_formulas` | `excel_calc()` |\n\n## 输出规范\n\n- **字体**: 使用专业字体（Arial, Times New Roman）\n- **公式错误**: 必须确保零错误（#REF!, #DIV/0!, #VALUE!, #N/A, #NAME?）\n- **财务模型颜色**: 蓝色=输入，黑色=公式，绿色=跨表引用，红色=外部链接，黄色=关键假设\n- **数字格式**: 年份用文本，货币用 $#,##0，负数用括号",
+      "skill_md": "---\nname: xlsx\ndescription: \"Excel 文件处理。用于读取、写入、编辑 .xlsx/.xls/.csv 文件，支持工作表管理、格式化、公式计算、数据查询和格式转换。当用户需要操作电子表格文件时触发。\"\n---\n\n# XLSX - Excel 文件处理\n\n## 路径参数说明\n\n> **重要**：所有工具的 `path` 参数遵循以下规则：\n\n| 参数类型 | 说明 |\n|----------|------|\n| **相对路径** | 相对于工作目录，工具自动拼接基础路径。示例：`input/file.xlsx` |\n| **绝对路径** | 仅管理员可用，需在允许的路径范围内 |\n\n**基础路径规则**：\n- 管理员：项目根目录 或 `data/` 目录\n- 普通用户：`data/work/{user_id}/` 目录\n\n**示例**：\n```javascript\n// 相对路径（推荐）\nexcel_read({ path: 'input/data.xlsx', scope: 'workbook' })\n\n// 绝对路径（仅管理员）\nexcel_read({ path: '/absolute/path/to/data.xlsx', scope: 'workbook' })\n```\n\n## 工具\n\n| 工具 | 说明 | 关键参数 |\n|------|------|----------|\n| `read` | 读取 Excel | `scope`: workbook/sheet/cell |\n| `write` | 写入 Excel | `scope`: workbook/sheet/cell |\n| `sheet` | 工作表管理 | `action`: add/delete/rename/copy |\n| `format` | 格式化 | `type`: column/cell |\n| `query` | 数据查询 | `action`: filter/sort/find |\n| `convert` | 格式转换 | `format`: json/csv, `direction`: to/from |\n| `calc` | 公式计算 | - |\n\n## read\n\n```javascript\n// 读取工作簿\nread({ path: 'data.xlsx', scope: 'workbook' })\nread({ path: 'data.xlsx', scope: 'workbook', includeData: true })\n\n// 读取工作表\nread({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1' })\nread({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', header: 'json', range: 'A1:C10' })\n\n// 读取单元格\nread({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1' })\n```\n\n## write\n\n```javascript\n// 创建工作簿\nwrite({\n  path: 'new.xlsx',\n  scope: 'workbook',\n  sheets: [{ name: 'Sheet1', data: [['A', 'B'], [1, 2]] }]\n})\n\n// 写入工作表\nwrite({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'overwrite' })\nwrite({ path: 'data.xlsx', scope: 'sheet', sheet: 'Sheet1', data: [[...]], mode: 'append' })\n\n// 写入单元格\nwrite({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'A1', value: 'Hello' })\nwrite({ path: 'data.xlsx', scope: 'cell', sheet: 'Sheet1', cell: 'C1', formula: '=SUM(A1:B1)' })\n```\n\n## sheet\n\n```javascript\nsheet({ path: 'data.xlsx', action: 'add', name: 'NewSheet' })\nsheet({ path: 'data.xlsx', action: 'delete', sheet: 'Sheet2' })\nsheet({ path: 'data.xlsx', action: 'rename', sheet: 'Sheet1', newName: 'Summary' })\nsheet({ path: 'data.xlsx', action: 'copy', sourceSheet: 'Template', targetSheet: 'Copy1' })\n```\n\n## format\n\n```javascript\n// 列宽\nformat({\n  path: 'data.xlsx', type: 'column', sheet: 'Sheet1',\n  columns: [{ column: 'A', width: 20 }, { column: 'B', width: 15 }]\n})\n\n// 单元格样式\nformat({\n  path: 'data.xlsx', type: 'cell', sheet: 'Sheet1',\n  cells: ['A1', 'B1'],\n  style: { font: { bold: true }, fill: { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFFFF00' } } }\n})\n```\n\n## query\n\n```javascript\n// 筛选\nquery({ path: 'data.xlsx', action: 'filter', column: 'status', condition: 'equals', value: 'active' })\n\n// 排序\nquery({ path: 'data.xlsx', action: 'sort', column: 'amount', order: 'desc' })\n\n// 查找\nquery({ path: 'data.xlsx', action: 'find', query: 'error' })\n```\n\n**筛选条件**: `equals`, `not_equals`, `greater`, `less`, `contains`, `starts_with`, `ends_with`, `is_empty`, `is_not_empty`\n\n## convert\n\n```javascript\n// Excel ↔ JSON\nconvert({ path: 'data.xlsx', format: 'json', direction: 'to' })\nconvert({ path: 'output.xlsx', format: 'json', direction: 'from', data: [{ name: 'Alice' }] })\n\n// Excel ↔ CSV\nconvert({ path: 'data.xlsx', format: 'csv', direction: 'to', output: 'data.csv' })\nconvert({ path: 'data.csv', format: 'csv', direction: 'from', output: 'data.xlsx' })\n```\n\n## calc\n\n```javascript\ncalc({ path: 'data.xlsx', sheet: 'Sheet1' })\n// 返回: { formulas: [{ cell: 'C1', formula: 'SUM(A1:B1)', value: 15 }] }\n```\n\n## 输出规范\n\n- **字体**: 使用专业字体（Arial, Times New Roman）\n- **公式错误**: 必须确保零错误（#REF!, #DIV/0!, #VALUE!, #N/A, #NAME?）\n- **财务模型颜色**: 蓝色=输入，黑色=公式，绿色=跨表引用，红色=外部链接，黄色=关键假设\n- **数字格式**: 年份用文本，货币用 $#,##0，负数用括号",
       "security_score": 100,
       "security_warnings": null,
       "license": null,
@@ -291,334 +291,260 @@
   ],
   "tools": [
     {
-      "id": "Q9FLvucouzVB1XWYhbDE",
+      "id": "mnbe33wlfmsgmwfq5q04",
       "skill_id": "BqqKfGgDw5LFZW33eBUN",
-      "name": "pptx_add_slide",
-      "description": "向已解压的PPTX目录添加幻灯片（复制现有幻灯片或从布局创建）",
+      "name": "file",
+      "description": "PowerPoint 文件级操作。支持读取、创建、提取功能。通过 action 参数区分：read（读取演示文稿信息）、create（创建演示文稿）、extract（提取媒体文件）。",
       "parameters": {
         "type": "object",
         "properties": {
-          "unpacked_dir": {
+          "action": {
             "type": "string",
-            "description": "已解压的PPTX目录路径"
+            "enum": [
+              "read",
+              "create",
+              "extract"
+            ],
+            "description": "操作类型：read=读取，create=创建，extract=提取"
+          },
+          "path": {
+            "type": "string",
+            "description": "PPTX 文件路径"
+          },
+          "output": {
+            "type": "string",
+            "description": "输出文件路径（create时）"
+          },
+          "outputDir": {
+            "type": "string",
+            "description": "输出目录（extract时）"
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "info",
+              "text",
+              "structure",
+              "media"
+            ],
+            "description": "读取范围：info=基本信息，text=文本内容，structure=结构信息，media=媒体信息"
           },
           "source": {
             "type": "string",
-            "description": "源文件: slideN.xml (复制) 或 slideLayoutN.xml (从布局创建)"
+            "enum": [
+              "data",
+              "markdown"
+            ],
+            "description": "创建来源：data=数据，markdown=Markdown内容"
+          },
+          "slides": {
+            "type": "array",
+            "description": "幻灯片数据数组"
+          },
+          "markdown": {
+            "type": "string",
+            "description": "Markdown内容"
+          },
+          "properties": {
+            "type": "object",
+            "description": "文档属性：title, author, company, layout"
+          },
+          "slideNumbers": {
+            "type": "array",
+            "description": "指定幻灯片编号"
+          },
+          "extractType": {
+            "type": "string",
+            "enum": [
+              "images",
+              "media",
+              "all"
+            ],
+            "description": "提取类型"
           }
         },
         "required": [
-          "unpacked_dir",
-          "source"
+          "action"
         ]
       },
-      "script_path": "scripts/add_slide.py",
+      "script_path": "index.js",
       "is_resident": false
     },
     {
-      "id": "ID4wxiMXVIUScWXjGqTw",
+      "id": "mnbe33yi8elfgomd2vr9",
       "skill_id": "BqqKfGgDw5LFZW33eBUN",
-      "name": "pptx_clean",
-      "description": "清理已解压PPTX目录中的未引用文件（孤立幻灯片、媒体等）",
+      "name": "master",
+      "description": "PowerPoint 模板母版操作。支持定义母版和列出母版布局。通过 action 参数区分：define（定义母版并创建演示文稿）、list（列出母版布局）。",
       "parameters": {
         "type": "object",
         "properties": {
-          "unpacked_dir": {
+          "action": {
             "type": "string",
-            "description": "已解压的PPTX目录路径"
+            "enum": [
+              "define",
+              "list"
+            ],
+            "description": "操作类型：define=定义母版，list=列出母版"
+          },
+          "output": {
+            "type": "string",
+            "description": "输出文件路径（define时）"
+          },
+          "path": {
+            "type": "string",
+            "description": "PPTX 文件路径（list时）"
+          },
+          "name": {
+            "type": "string",
+            "description": "母版名称"
+          },
+          "background": {
+            "type": "object",
+            "description": "背景配置"
+          },
+          "objects": {
+            "type": "array",
+            "description": "母版上的固定对象"
+          },
+          "slideNumber": {
+            "type": "object",
+            "description": "幻灯片编号配置"
+          },
+          "properties": {
+            "type": "object",
+            "description": "文档属性"
           }
         },
         "required": [
-          "unpacked_dir"
+          "action"
         ]
       },
-      "script_path": "scripts/clean.py",
+      "script_path": "index.js",
       "is_resident": false
     },
     {
-      "id": "l0UxbdHrJnEdZpt4dYmZ",
+      "id": "mnbe33y0isptajezpfe4",
       "skill_id": "BqqKfGgDw5LFZW33eBUN",
-      "name": "pptx_pack",
-      "description": "将目录打包为PPTX/DOCX/XLSX文件，支持验证和自动修复",
+      "name": "object",
+      "description": "PowerPoint 内容对象操作。支持添加和提取对象。通过 action 参数区分：add（添加对象到新演示文稿）、extract（提取对象内容）。",
       "parameters": {
         "type": "object",
         "properties": {
-          "input_directory": {
+          "action": {
             "type": "string",
-            "description": "输入目录路径"
+            "enum": [
+              "add",
+              "extract"
+            ],
+            "description": "操作类型：add=添加，extract=提取"
           },
-          "output_file": {
+          "output": {
             "type": "string",
-            "description": "输出Office文件路径"
+            "description": "输出文件路径（add时）"
           },
-          "original_file": {
+          "path": {
             "type": "string",
-            "description": "原始文件路径 (用于验证)"
+            "description": "PPTX 文件路径（extract时）"
           },
-          "validate": {
-            "type": "boolean",
-            "description": "是否验证 (默认true)"
-          }
-        },
-        "required": [
-          "input_directory",
-          "output_file"
-        ]
-      },
-      "script_path": "scripts/office/pack.py",
-      "is_resident": false
-    },
-    {
-      "id": "HwqlNpPok2YSP2fTbl2Q",
-      "skill_id": "BqqKfGgDw5LFZW33eBUN",
-      "name": "pptx_thumbnail",
-      "description": "生成PPTX文件的幻灯片缩略图网格，用于快速视觉分析",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "input": {
+          "type": {
             "type": "string",
-            "description": "输入PPTX文件路径"
-          },
-          "output_prefix": {
-            "type": "string",
-            "description": "输出图片前缀 (默认: thumbnails)"
-          },
-          "cols": {
-            "type": "integer",
-            "description": "列数 (默认3, 最大6)"
-          }
-        },
-        "required": [
-          "input"
-        ]
-      },
-      "script_path": "scripts/thumbnail.py",
-      "is_resident": false
-    },
-    {
-      "id": "wDyCn2H8CaLAveD7hmi6",
-      "skill_id": "BqqKfGgDw5LFZW33eBUN",
-      "name": "pptx_unpack",
-      "description": "解压PPTX/DOCX/XLSX文件到目录，格式化XML便于编辑",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "input_file": {
-            "type": "string",
-            "description": "Office文件路径 (.pptx/.docx/.xlsx)"
-          },
-          "output_directory": {
-            "type": "string",
-            "description": "输出目录路径"
-          },
-          "merge_runs": {
-            "type": "boolean",
-            "description": "合并相邻格式相同的runs (仅DOCX, 默认true)"
-          },
-          "simplify_redlines": {
-            "type": "boolean",
-            "description": "简化相邻修订标记 (仅DOCX, 默认true)"
-          }
-        },
-        "required": [
-          "input_file",
-          "output_directory"
-        ]
-      },
-      "script_path": "scripts/office/unpack.py",
-      "is_resident": false
-    },
-    {
-      "id": "lj8u0ydlATHTCguow9BD",
-      "skill_id": "H4ehsMA68GLUyXl56oPg",
-      "name": "docx_accept_changes",
-      "description": "接受DOCX文件中的所有修订标记",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "input_file": {
-            "type": "string",
-            "description": "输入DOCX文件路径"
-          },
-          "output_file": {
-            "type": "string",
-            "description": "输出DOCX文件路径"
-          }
-        },
-        "required": [
-          "input_file",
-          "output_file"
-        ]
-      },
-      "script_path": "scripts/accept_changes.py",
-      "is_resident": false
-    },
-    {
-      "id": "MjVrKco42nv5tP3TIQhg",
-      "skill_id": "H4ehsMA68GLUyXl56oPg",
-      "name": "docx_comment",
-      "description": "向解压后的DOCX添加注释",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "unpacked_dir": {
-            "type": "string",
-            "description": "解压后的DOCX目录"
-          },
-          "comment_id": {
-            "type": "number",
-            "description": "注释ID"
+            "enum": [
+              "text",
+              "image",
+              "table",
+              "chart",
+              "shape",
+              "media",
+              "notes"
+            ],
+            "description": "对象类型"
           },
           "text": {
             "type": "string",
-            "description": "注释文本 (需要XML转义)"
+            "description": "文本内容"
           },
-          "parent": {
-            "type": "number",
-            "description": "父注释ID (用于回复)"
+          "image": {
+            "type": "object",
+            "description": "图片配置"
           },
-          "author": {
+          "table": {
+            "type": "object",
+            "description": "表格配置"
+          },
+          "chart": {
+            "type": "object",
+            "description": "图表配置"
+          },
+          "options": {
+            "type": "object",
+            "description": "文本/对象选项"
+          },
+          "outputDir": {
             "type": "string",
-            "description": "作者名"
+            "description": "输出目录（extract时）"
           },
-          "initials": {
-            "type": "string",
-            "description": "作者缩写"
+          "properties": {
+            "type": "object",
+            "description": "文档属性"
           }
         },
         "required": [
-          "unpacked_dir",
-          "comment_id",
-          "text"
+          "action"
         ]
       },
-      "script_path": "scripts/comment.py",
+      "script_path": "index.js",
       "is_resident": false
     },
     {
-      "id": "FJkO1lIeY2ThvTHpfLxJ",
-      "skill_id": "H4ehsMA68GLUyXl56oPg",
-      "name": "docx_pack",
-      "description": "将目录打包为DOCX/PPTX/XLSX文件，支持验证和自动修复",
+      "id": "mnbe33x7cx6etzm202ae",
+      "skill_id": "BqqKfGgDw5LFZW33eBUN",
+      "name": "slide",
+      "description": "PowerPoint 幻灯片创建。创建新的演示文稿并添加幻灯片。支持单个或多个幻灯片，可配置背景、母版、文档属性。",
       "parameters": {
         "type": "object",
         "properties": {
-          "input_directory": {
+          "action": {
             "type": "string",
-            "description": "输入目录路径"
+            "enum": [
+              "add"
+            ],
+            "description": "操作类型：add=添加幻灯片"
           },
-          "output_file": {
+          "output": {
             "type": "string",
-            "description": "输出Office文件路径"
+            "description": "输出文件路径"
           },
-          "original_file": {
+          "title": {
             "type": "string",
-            "description": "原始文件路径 (用于验证)"
+            "description": "幻灯片标题"
           },
-          "validate": {
-            "type": "boolean",
-            "description": "是否验证 (默认true)"
-          }
-        },
-        "required": [
-          "input_directory",
-          "output_file"
-        ]
-      },
-      "script_path": "scripts/office/pack.py",
-      "is_resident": false
-    },
-    {
-      "id": "CO8NVgeWjzR9AsfxgCzf",
-      "skill_id": "H4ehsMA68GLUyXl56oPg",
-      "name": "docx_soffice",
-      "description": "调用LibreOffice进行格式转换 (doc转docx, docx转pdf等)",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "args": {
+          "content": {
+            "type": "string",
+            "description": "幻灯片内容"
+          },
+          "slides": {
             "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "LibreOffice命令行参数，如 [\"--headless\", \"--convert-to\", \"pdf\", \"input.docx\"]"
+            "description": "多个幻灯片数据数组"
+          },
+          "background": {
+            "type": "object",
+            "description": "背景配置"
+          },
+          "master": {
+            "type": "object",
+            "description": "母版配置"
+          },
+          "properties": {
+            "type": "object",
+            "description": "文档属性"
           }
         },
         "required": [
-          "args"
+          "action",
+          "output"
         ]
       },
-      "script_path": "scripts/office/soffice.py",
-      "is_resident": false
-    },
-    {
-      "id": "KyYdcNvvxk8MCd7a5GXV",
-      "skill_id": "H4ehsMA68GLUyXl56oPg",
-      "name": "docx_unpack",
-      "description": "解压DOCX/PPTX/XLSX文件到目录，格式化XML便于编辑",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "input_file": {
-            "type": "string",
-            "description": "Office文件路径 (.docx/.pptx/.xlsx)"
-          },
-          "output_directory": {
-            "type": "string",
-            "description": "输出目录路径"
-          },
-          "merge_runs": {
-            "type": "boolean",
-            "description": "合并相邻格式相同的runs (仅DOCX, 默认true)"
-          },
-          "simplify_redlines": {
-            "type": "boolean",
-            "description": "简化相邻修订标记 (仅DOCX, 默认true)"
-          }
-        },
-        "required": [
-          "input_file",
-          "output_directory"
-        ]
-      },
-      "script_path": "scripts/office/unpack.py",
-      "is_resident": false
-    },
-    {
-      "id": "EiGRDxbrBowgeX6fHK5F",
-      "skill_id": "H4ehsMA68GLUyXl56oPg",
-      "name": "docx_validate",
-      "description": "验证Office文档XML文件是否符合XSD规范",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "解压目录或Office文件路径"
-          },
-          "original": {
-            "type": "string",
-            "description": "原始文件路径"
-          },
-          "auto_repair": {
-            "type": "boolean",
-            "description": "自动修复常见问题"
-          },
-          "author": {
-            "type": "string",
-            "description": "修订验证的作者名"
-          },
-          "verbose": {
-            "type": "boolean",
-            "description": "详细输出"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "scripts/office/validate.py",
+      "script_path": "index.js",
       "is_resident": false
     },
     {
@@ -674,60 +600,337 @@
       "is_resident": false
     },
     {
-      "id": "mm7k4gjr8rfsrt1qmpqs",
-      "skill_id": "http-client",
-      "name": "http_get",
-      "description": "Send an HTTP GET request",
+      "id": "mnbcq1djj7f5hqvpt91q",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "convert",
+      "description": "格式转换。支持转 markdown 或 html",
       "parameters": {
         "type": "object",
         "properties": {
-          "url": {
+          "path": {
             "type": "string",
-            "description": "Request URL"
+            "description": "文档路径"
           },
-          "headers": {
-            "type": "object",
-            "description": "Custom headers"
+          "format": {
+            "type": "string",
+            "enum": [
+              "markdown",
+              "html"
+            ],
+            "description": "目标格式"
           },
-          "timeout": {
-            "type": "number",
-            "description": "Timeout in ms (default: 10000)"
+          "output": {
+            "type": "string",
+            "description": "输出文件路径（可选）"
+          },
+          "includeStyles": {
+            "type": "boolean",
+            "description": "是否包含样式（format 为 html 时）"
           }
         },
         "required": [
-          "url"
+          "path",
+          "format"
         ]
       },
       "script_path": "index.js",
       "is_resident": false
     },
     {
-      "id": "mm7k4gjwtq0oerz5hhn6",
-      "skill_id": "http-client",
-      "name": "http_post",
-      "description": "Send an HTTP POST request",
+      "id": "mnbcq1d9nrmnd6p1q3ao",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "edit",
+      "description": "编辑文档。支持 replace(替换占位符)、append(添加段落)、insert(插入段落)、delete(删除内容)",
       "parameters": {
         "type": "object",
         "properties": {
-          "url": {
+          "path": {
             "type": "string",
-            "description": "Request URL"
+            "description": "文档路径"
           },
-          "body": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "replace",
+              "append",
+              "insert",
+              "delete"
+            ],
+            "description": "编辑操作类型"
+          },
+          "replacements": {
             "type": "object",
-            "description": "Request body"
+            "description": "替换数据（action 为 replace 时）"
           },
-          "headers": {
-            "type": "object",
-            "description": "Custom headers"
+          "text": {
+            "type": "string",
+            "description": "内容文本（action 为 append/insert 时）"
           },
-          "timeout": {
-            "type": "number",
-            "description": "Timeout in ms (default: 10000)"
+          "placeholder": {
+            "type": "string",
+            "description": "占位符（action 为 insert/delete 时）"
           }
         },
         "required": [
-          "url"
+          "path",
+          "action"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbcq1dsbee2yynphhsd",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "image",
+      "description": "图片操作。支持 list(列出图片)、extract(提取图片)、insert(插入图片)",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文档路径"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "list",
+              "extract",
+              "insert"
+            ],
+            "description": "图片操作类型"
+          },
+          "imagePath": {
+            "type": "string",
+            "description": "图片路径（action 为 insert 时）"
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "占位符（action 为 insert 时）"
+          },
+          "outputDir": {
+            "type": "string",
+            "description": "输出目录（action 为 extract 时）"
+          },
+          "width": {
+            "type": "number",
+            "description": "图片宽度"
+          },
+          "height": {
+            "type": "number",
+            "description": "图片高度"
+          }
+        },
+        "required": [
+          "path",
+          "action"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbcq1dyk0agl2f3ehyi",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "link",
+      "description": "超链接操作。支持 list(列出超链接)、add(添加超链接)",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文档路径"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "list",
+              "add"
+            ],
+            "description": "超链接操作类型"
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "占位符（action 为 add 时）"
+          },
+          "text": {
+            "type": "string",
+            "description": "显示文本（action 为 add 时）"
+          },
+          "url": {
+            "type": "string",
+            "description": "链接地址（action 为 add 时）"
+          }
+        },
+        "required": [
+          "path",
+          "action"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbcq1d33y75c1tmwb35",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "patch",
+      "description": "模板填充（核心功能）。使用 Patcher API 替换文档中的占位符，保留原文档样式",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "模板文件路径"
+          },
+          "patches": {
+            "type": "object",
+            "description": "替换数据 { placeholder: value }"
+          },
+          "output": {
+            "type": "string",
+            "description": "输出文件路径（可选，默认覆盖原文件）"
+          },
+          "keepOriginalStyles": {
+            "type": "boolean",
+            "description": "保留原文档样式（默认 true）"
+          },
+          "delimiters": {
+            "type": "object",
+            "description": "占位符分隔符（默认 { start: '{{', end: '}}' }）"
+          }
+        },
+        "required": [
+          "path",
+          "patches"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbcq1cjb6cs3ehc3sys",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "read",
+      "description": "读取文档。支持 info(文档信息)、text(提取文本)、paragraphs(提取段落)、tables(提取表格)、comments(提取批注)、images(提取图片信息)、headers(提取页眉)、footers(提取页脚)",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文档路径"
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "info",
+              "text",
+              "paragraphs",
+              "tables",
+              "comments",
+              "images",
+              "headers",
+              "footers"
+            ],
+            "description": "读取范围"
+          },
+          "includeFormatting": {
+            "type": "boolean",
+            "description": "是否包含格式信息"
+          }
+        },
+        "required": [
+          "path",
+          "scope"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbcq1e5blbdv0539556",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "toc",
+      "description": "目录操作。支持 insert(插入目录)、update(更新目录提示)",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文档路径"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "insert",
+              "update"
+            ],
+            "description": "目录操作类型"
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "占位符（action 为 insert 时）"
+          }
+        },
+        "required": [
+          "path",
+          "action"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbcq1cv7mo9fac1qz0v",
+      "skill_id": "H4ehsMA68GLUyXl56oPg",
+      "name": "write",
+      "description": "写入文档。支持从 data 或 markdown 创建 Word 文档，支持页眉页脚配置、多节文档",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "输出文件路径"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "data",
+              "markdown"
+            ],
+            "description": "数据来源"
+          },
+          "content": {
+            "type": "array",
+            "description": "内容数据（source 为 data 时）"
+          },
+          "markdown": {
+            "type": "string",
+            "description": "Markdown 内容（source 为 markdown 时）"
+          },
+          "title": {
+            "type": "string",
+            "description": "文档标题"
+          },
+          "properties": {
+            "type": "object",
+            "description": "文档属性（author, subject, keywords）"
+          },
+          "header": {
+            "type": "object",
+            "description": "页眉配置 { text, alignment }"
+          },
+          "footer": {
+            "type": "object",
+            "description": "页脚配置 { text, pageNumber, pagePrefix, pageSuffix, pageAlignment }"
+          },
+          "sections": {
+            "type": "array",
+            "description": "多节配置"
+          }
+        },
+        "required": [
+          "path",
+          "source"
         ]
       },
       "script_path": "index.js",
@@ -1543,30 +1746,6 @@
       "is_resident": false
     },
     {
-      "id": "mmoasywlxbfe8237qz1s",
-      "skill_id": "mmoasyw4iar2f9qi4z96",
-      "name": "read_web_page",
-      "description": "读取网页内容并提取正文",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "url": {
-            "type": "string",
-            "description": "要读取的网页 URL"
-          },
-          "timeout": {
-            "type": "number",
-            "description": "超时时间（毫秒），默认 30000"
-          }
-        },
-        "required": [
-          "url"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
       "id": "mmoyew71tsqgw915p3ju",
       "skill_id": "mmoyew3l1qkpyq6mldhx",
       "name": "db_mark_read",
@@ -1921,304 +2100,16 @@
       "is_resident": false
     },
     {
-      "id": "mmsj2jtbspl090t5skfb",
-      "skill_id": "mmsj2jsuqvbkjqx00ldt",
-      "name": "get_message_content",
-      "description": "获取指定工具消息的完整内容。当你在上下文中看到类似 \"get_message_content(\\\"xxx\\\")\" 的提示时，可以使用此工具获取完整结果。",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "tool_call_id": {
-            "type": "string",
-            "description": "工具调用 ID，从上下文摘要中获取"
-          }
-        },
-        "required": [
-          "tool_call_id"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog43syzyxqwofcj7",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "edit_lines",
-      "description": "Edit lines in a file with insert or delete operations",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "File path"
-          },
-          "operation": {
-            "type": "string",
-            "enum": [
-              "insert",
-              "delete"
-            ],
-            "description": "Operation type: 'insert' (default) or 'delete'"
-          },
-          "line": {
-            "type": "number",
-            "description": "Line number (1-based)"
-          },
-          "end_line": {
-            "type": "number",
-            "description": "End line number for delete operation (defaults to line)"
-          },
-          "content": {
-            "type": "string",
-            "description": "Content to insert (required for insert operation)"
-          }
-        },
-        "required": [
-          "path",
-          "line"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog4dps2omtxq4bt0",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "fs_action",
-      "description": "Unified file system operations: copy, move, delete, and create directory",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "operation": {
-            "type": "string",
-            "enum": [
-              "copy",
-              "move",
-              "delete",
-              "create_dir"
-            ],
-            "description": "Operation type: 'copy' (default), 'move', 'delete', or 'create_dir'"
-          },
-          "source": {
-            "type": "string",
-            "description": "Source path (required for copy/move)"
-          },
-          "destination": {
-            "type": "string",
-            "description": "Destination path (required for copy/move)"
-          },
-          "path": {
-            "type": "string",
-            "description": "Path to delete or directory to create (required for delete/create_dir)"
-          }
-        },
-        "required": []
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog38cdkxew4qbej8",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "fs_grep",
-      "description": "Search text across files. Supports both single file and multi-file search with optional regex mode.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "pattern": {
-            "type": "string",
-            "description": "Search pattern"
-          },
-          "path": {
-            "type": "string",
-            "description": "File or directory path (default: current)"
-          },
-          "file_pattern": {
-            "type": "string",
-            "description": "File pattern filter (default: '*')"
-          },
-          "use_regex": {
-            "type": "boolean",
-            "description": "Use regex mode (default: false, use literal string match)"
-          },
-          "ignore_case": {
-            "type": "boolean",
-            "description": "Case insensitive search (default: true)"
-          }
-        },
-        "required": [
-          "pattern"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog27en36xv9j11vq",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "fs_info",
-      "description": "Get detailed metadata about a file or directory. Recommended to call before other operations.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "File or directory path"
-          },
-          "include_content_preview": {
-            "type": "boolean",
-            "description": "Include content preview for text files (default: false)"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog2wt3tpr38he9oo",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "list_files",
-      "description": "List directory contents",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "Directory path"
-          },
-          "recursive": {
-            "type": "boolean",
-            "description": "List recursively (default: false)"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog2l1t0fdnaa7jqh",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "read_file",
-      "description": "Read file content with mode parameter (lines or bytes)",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "File path"
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "lines",
-              "bytes"
-            ],
-            "description": "Read mode: 'lines' (default) or 'bytes'"
-          },
-          "from": {
-            "type": "number",
-            "description": "Start line for lines mode (default: 1)"
-          },
-          "lines": {
-            "type": "number",
-            "description": "Number of lines for lines mode (default: 100)"
-          },
-          "offset": {
-            "type": "number",
-            "description": "Start byte for bytes mode (default: 0)"
-          },
-          "bytes": {
-            "type": "number",
-            "description": "Bytes to read for bytes mode (default: 50000)"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog3tdti70159c9r2",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "replace_in_file",
-      "description": "Replace text in a file",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "File path"
-          },
-          "old": {
-            "type": "string",
-            "description": "Text to replace"
-          },
-          "new": {
-            "type": "string",
-            "description": "Replacement text"
-          }
-        },
-        "required": [
-          "path",
-          "old",
-          "new"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn0hog3iv8h29ku9iwue",
-      "skill_id": "mn0hl4n1lhv4d4sfxqom",
-      "name": "write_file",
-      "description": "Write content to a file with optional append mode",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "File path"
-          },
-          "content": {
-            "type": "string",
-            "description": "Content to write"
-          },
-          "mode": {
-            "type": "string",
-            "enum": [
-              "write",
-              "append"
-            ],
-            "description": "Write mode: 'write' (default, overwrite) or 'append'"
-          }
-        },
-        "required": [
-          "path",
-          "content"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "mn1hcsuulgyhnk8gdsku",
-      "skill_id": "mn1hcspll2vbjefyd9zo",
-      "name": "excel_calc",
+      "id": "mnbdoe3xmlrkn13qp4ag",
+      "skill_id": "mnbdoe1alv92mmh4f28y",
+      "name": "calc",
       "description": "计算工作表中的公式",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "文件路径"
+            "description": "Excel 文件路径"
           },
           "sheet": {
             "type": "string",
@@ -2233,40 +2124,32 @@
       "is_resident": false
     },
     {
-      "id": "mn1hcsu7wjgtoazevek4",
-      "skill_id": "mn1hcspll2vbjefyd9zo",
-      "name": "excel_convert",
+      "id": "mnbdoe3lnyq8a6lg0ofw",
+      "skill_id": "mnbdoe1alv92mmh4f28y",
+      "name": "convert",
       "description": "格式转换：Excel 与 JSON/CSV 互转",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "文件路径"
+            "description": "Excel 文件路径"
           },
           "format": {
             "type": "string",
-            "enum": [
-              "json",
-              "csv"
-            ],
-            "description": "目标格式"
+            "description": "目标格式: json/csv"
           },
           "direction": {
             "type": "string",
-            "enum": [
-              "to",
-              "from"
-            ],
-            "description": "转换方向"
+            "description": "转换方向: to/from"
+          },
+          "data": {
+            "type": "array",
+            "description": "数据(from方向)"
           },
           "output": {
             "type": "string",
             "description": "输出文件路径"
-          },
-          "data": {
-            "type": "array",
-            "description": "数据(from方向时)"
           }
         },
         "required": [
@@ -2279,24 +2162,20 @@
       "is_resident": false
     },
     {
-      "id": "mn1hcst7hf5s3n3scqr5",
-      "skill_id": "mn1hcspll2vbjefyd9zo",
-      "name": "excel_format",
+      "id": "mnbdoe2zdfc3svfmoez1",
+      "skill_id": "mnbdoe1alv92mmh4f28y",
+      "name": "format",
       "description": "格式化设置：列宽、单元格样式",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "文件路径"
+            "description": "Excel 文件路径"
           },
           "type": {
             "type": "string",
-            "enum": [
-              "column",
-              "cell"
-            ],
-            "description": "格式化类型"
+            "description": "格式化类型: column/cell"
           },
           "sheet": {
             "type": "string",
@@ -2324,25 +2203,24 @@
       "is_resident": false
     },
     {
-      "id": "mn1hcstsqon24g7g2vkq",
-      "skill_id": "mn1hcspll2vbjefyd9zo",
-      "name": "excel_query",
+      "id": "mnbdoe3af9belfoi08qy",
+      "skill_id": "mnbdoe1alv92mmh4f28y",
+      "name": "query",
       "description": "数据查询：筛选、排序、查找",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "文件路径"
+            "description": "Excel 文件路径"
           },
           "action": {
             "type": "string",
-            "enum": [
-              "filter",
-              "sort",
-              "find"
-            ],
-            "description": "查询类型"
+            "description": "查询类型: filter/sort/find"
+          },
+          "sheet": {
+            "type": "string",
+            "description": "工作表名称"
           },
           "column": {
             "type": "string",
@@ -2374,25 +2252,20 @@
       "is_resident": false
     },
     {
-      "id": "mn1hcsqw6cqbeo0ftzpx",
-      "skill_id": "mn1hcspll2vbjefyd9zo",
-      "name": "excel_read",
+      "id": "mnbdoe1z1wfa0e7p2ngi",
+      "skill_id": "mnbdoe1alv92mmh4f28y",
+      "name": "read",
       "description": "读取 Excel 文件，支持工作簿、工作表、单元格三种范围",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "文件路径"
+            "description": "Excel 文件路径"
           },
           "scope": {
             "type": "string",
-            "enum": [
-              "workbook",
-              "sheet",
-              "cell"
-            ],
-            "description": "读取范围"
+            "description": "读取范围: workbook/sheet/cell"
           },
           "sheet": {
             "type": "string",
@@ -2400,19 +2273,19 @@
           },
           "cell": {
             "type": "string",
-            "description": "单元格地址"
-          },
-          "includeData": {
-            "type": "boolean",
-            "description": "是否包含数据"
+            "description": "单元格地址如 A1"
           },
           "range": {
             "type": "string",
-            "description": "数据范围"
+            "description": "数据范围如 A1:C10"
           },
           "header": {
             "type": "string",
             "description": "表头模式: 1(数组) 或 json(对象)"
+          },
+          "includeData": {
+            "type": "boolean",
+            "description": "是否包含数据"
           }
         },
         "required": [
@@ -2424,30 +2297,24 @@
       "is_resident": false
     },
     {
-      "id": "mn1hcsstjs1uhtvj2awe",
-      "skill_id": "mn1hcspll2vbjefyd9zo",
-      "name": "excel_sheet",
+      "id": "mnbdoe2odp2dmr98r32i",
+      "skill_id": "mnbdoe1alv92mmh4f28y",
+      "name": "sheet",
       "description": "工作表管理：添加、删除、重命名、复制",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "文件路径"
+            "description": "Excel 文件路径"
           },
           "action": {
             "type": "string",
-            "enum": [
-              "add",
-              "delete",
-              "rename",
-              "copy"
-            ],
-            "description": "操作类型"
+            "description": "操作类型: add/delete/rename/copy"
           },
           "name": {
             "type": "string",
-            "description": "工作表名称(add时)"
+            "description": "新工作表名称(add时)"
           },
           "sheet": {
             "type": "string",
@@ -2483,25 +2350,20 @@
       "is_resident": false
     },
     {
-      "id": "mn1hcsrmotngz56sh491",
-      "skill_id": "mn1hcspll2vbjefyd9zo",
-      "name": "excel_write",
+      "id": "mnbdoe2cw09bduaidjcc",
+      "skill_id": "mnbdoe1alv92mmh4f28y",
+      "name": "write",
       "description": "写入 Excel 文件，支持工作簿、工作表、单元格三种范围",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "文件路径"
+            "description": "Excel 文件路径"
           },
           "scope": {
             "type": "string",
-            "enum": [
-              "workbook",
-              "sheet",
-              "cell"
-            ],
-            "description": "写入范围"
+            "description": "写入范围: workbook/sheet/cell"
           },
           "sheet": {
             "type": "string",
@@ -2511,34 +2373,29 @@
             "type": "string",
             "description": "单元格地址"
           },
+          "data": {
+            "type": "array",
+            "description": "数据数组"
+          },
+          "sheets": {
+            "type": "array",
+            "description": "工作表数组(workbook时)"
+          },
           "value": {
             "type": "string",
             "description": "单元格值"
           },
           "formula": {
             "type": "string",
-            "description": "公式"
-          },
-          "data": {
-            "type": "array",
-            "description": "数据"
+            "description": "单元格公式"
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "overwrite",
-              "append",
-              "insert"
-            ],
-            "description": "写入模式"
+            "description": "写入模式: overwrite/append/insert"
           },
           "startCell": {
             "type": "string",
             "description": "起始单元格"
-          },
-          "sheets": {
-            "type": "array",
-            "description": "工作表数据"
           },
           "properties": {
             "type": "object",
@@ -2554,158 +2411,633 @@
       "is_resident": false
     },
     {
-      "id": "uOYaikIKwvqxhXMRFWiT",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_ai",
-      "description": "获取AI领域相关故事（自动过滤AI关键词）",
+      "id": "mnbryh5t23866yvo0a86",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "action",
+      "description": "统一的文件系统操作。参数：operation(可选)-操作类型(copy/move/delete/create_dir), source(copy/move时必需)-源路径, destination(copy/move时必需)-目标路径, path(delete/create_dir时必需)-路径",
       "parameters": {
+        "type": "object",
         "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
+          "operation": {
+            "type": "string",
+            "description": "操作类型 - copy(默认), move, delete, create_dir",
+            "enum": [
+              "copy",
+              "move",
+              "delete",
+              "create_dir"
+            ]
           },
-          "period": {
-            "description": "时间范围：day/week/month/year",
-            "type": "string"
-          }
-        },
-        "required": [],
-        "type": "object"
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "pvoWXHh7eWN3XFOWOn3e",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_ask",
-      "description": "获取Ask HN问答",
-      "parameters": {
-        "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
-          }
-        },
-        "required": [],
-        "type": "object"
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "h0rCKAnP6BjjRIXFw0d8",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_best",
-      "description": "获取Hacker News精选故事",
-      "parameters": {
-        "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
-          }
-        },
-        "required": [],
-        "type": "object"
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "X2XFPiohjrA6071KziDZ",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_jobs",
-      "description": "获取Hacker News招聘信息",
-      "parameters": {
-        "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
-          }
-        },
-        "required": [],
-        "type": "object"
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "kAwwKwgKGHjuGG1eFjFb",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_new",
-      "description": "获取Hacker News最新故事",
-      "parameters": {
-        "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
-          }
-        },
-        "required": [],
-        "type": "object"
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "kA2lhn4aMZkeFab5sa0a",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_search",
-      "description": "搜索Hacker News故事",
-      "parameters": {
-        "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
+          "source": {
+            "type": "string",
+            "description": "源路径（copy/move操作时必需）"
           },
+          "destination": {
+            "type": "string",
+            "description": "目标路径（copy/move操作时必需）"
+          },
+          "path": {
+            "type": "string",
+            "description": "路径（delete/create_dir操作时必需）"
+          }
+        },
+        "required": []
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbryh5m0q9hnavg9dzt",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "edit_lines",
+      "description": "编辑文件行。参数：path(必需)-文件路径, operation(可选)-操作类型(insert/delete), line(必需)-行号, end_line(可选)-结束行, content(insert时必需)-插入内容",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文件路径"
+          },
+          "operation": {
+            "type": "string",
+            "description": "操作类型 - insert(默认) 或 delete",
+            "enum": [
+              "insert",
+              "delete"
+            ]
+          },
+          "line": {
+            "type": "number",
+            "description": "行号（从1开始）"
+          },
+          "end_line": {
+            "type": "number",
+            "description": "结束行（delete操作）"
+          },
+          "content": {
+            "type": "string",
+            "description": "插入内容（insert操作时必需）"
+          }
+        },
+        "required": [
+          "path",
+          "line"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbryh4xkyq1dgahn1jm",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "grep",
+      "description": "跨文件搜索文本。参数：pattern(必需)-搜索模式, path(可选)-文件或目录路径, file_pattern(可选)-文件模式过滤, use_regex(可选)-使用正则模式, ignore_case(可选)-忽略大小写",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "搜索模式"
+          },
+          "path": {
+            "type": "string",
+            "description": "文件或目录路径（默认: 当前）"
+          },
+          "file_pattern": {
+            "type": "string",
+            "description": "文件模式过滤（默认: *）"
+          },
+          "use_regex": {
+            "type": "boolean",
+            "description": "使用正则模式（默认: false）"
+          },
+          "ignore_case": {
+            "type": "boolean",
+            "description": "忽略大小写（默认: true）"
+          }
+        },
+        "required": [
+          "pattern"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbryh3zxobzvi0zim61",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "info",
+      "description": "获取文件或目录的详细元数据。建议在其他操作前先调用。参数：path(必需)-文件或目录路径, include_content_preview(可选)-包含内容预览, hash(可选)-计算文件哈希(md5/sha256/sha1)",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文件或目录路径"
+          },
+          "include_content_preview": {
+            "type": "boolean",
+            "description": "包含内容预览（默认: false）"
+          },
+          "hash": {
+            "type": "string",
+            "description": "计算文件哈希 - md5, sha256, sha1"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbryh4mp2d03td8ohn1",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "list_files",
+      "description": "列出目录内容。参数：path(必需)-目录路径, recursive(可选)-递归列出（默认: false）",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "目录路径"
+          },
+          "recursive": {
+            "type": "boolean",
+            "description": "递归列出（默认: false）"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbryh4ch6x018plems4",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "read_file",
+      "description": "读取文件内容，支持多种模式。参数：path(必需)-文件路径, mode(可选)-读取模式(lines/bytes/data_url), from(可选)-起始行, lines(可选)-行数, offset(可选)-起始字节, bytes(可选)-字节数",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文件路径"
+          },
+          "mode": {
+            "type": "string",
+            "description": "读取模式 - lines(默认), bytes, data_url",
+            "enum": [
+              "lines",
+              "bytes",
+              "data_url"
+            ]
+          },
+          "from": {
+            "type": "number",
+            "description": "起始行（lines模式，默认: 1）"
+          },
+          "lines": {
+            "type": "number",
+            "description": "行数（lines模式，默认: 100）"
+          },
+          "offset": {
+            "type": "number",
+            "description": "起始字节（bytes模式，默认: 0）"
+          },
+          "bytes": {
+            "type": "number",
+            "description": "字节数（bytes模式，默认: 50000）"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbryh5dsx8xtd75oomv",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "replace_in_file",
+      "description": "替换文件中的文本。参数：path(必需)-文件路径, old(必需)-要替换的文本, new(必需)-替换后的文本",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文件路径"
+          },
+          "old": {
+            "type": "string",
+            "description": "要替换的文本"
+          },
+          "new": {
+            "type": "string",
+            "description": "替换后的文本"
+          }
+        },
+        "required": [
+          "path",
+          "old",
+          "new"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbryh55vuvjlf45646n",
+      "skill_id": "mnbryh3fndf2lmerp216",
+      "name": "write_file",
+      "description": "写入内容到文件。参数：path(必需)-文件路径, content(必需)-写入内容, mode(可选)-写入模式(write/append)",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "文件路径"
+          },
+          "content": {
+            "type": "string",
+            "description": "写入内容"
+          },
+          "mode": {
+            "type": "string",
+            "description": "写入模式 - write(默认) 或 append",
+            "enum": [
+              "write",
+              "append"
+            ]
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbs6826wnm48mipv61b",
+      "skill_id": "mnbs681pqiej9tvgx1pd",
+      "name": "web_search",
+      "description": "Search the web using SearXNG.",
+      "parameters": {
+        "type": "object",
+        "properties": {
           "query": {
-            "description": "搜索关键词",
-            "type": "string"
+            "type": "string",
+            "description": "The search query"
           },
-          "sort": {
-            "description": "排序方式：date/popularity",
-            "type": "string"
+          "n": {
+            "type": "number",
+            "description": "Number of results (default: 10, max: 50)"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "general",
+              "images",
+              "videos",
+              "news",
+              "map",
+              "music",
+              "files",
+              "it",
+              "science"
+            ],
+            "description": "Search category"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language code like \"en\", \"zh\", \"auto\" (default: \"auto\")"
+          },
+          "time_range": {
+            "type": "string",
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "year"
+            ],
+            "description": "Time range filter"
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "json",
+              "table"
+            ],
+            "description": "Output format: \"json\" (default) or \"table\" for readable display"
           }
         },
         "required": [
           "query"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbsn9cai65tfkq6rvqh",
+      "skill_id": "mnbsn9bm15ytytah4err",
+      "name": "generate",
+      "description": "生成 ECharts 图表。支持多种图表类型和输出格式。",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "图表类型：bar/line/pie/scatter/radar/gauge/funnel/heatmap/tree/treemap/sunburst/sankey/graph/boxplot/candlestick，默认 bar",
+            "default": "bar"
+          },
+          "data": {
+            "description": "图表数据，支持数组或对象格式"
+          },
+          "options": {
+            "type": "object",
+            "description": "配置选项：title/subtitle/xAxis/yAxis/legend/series 等"
+          },
+          "output": {
+            "type": "string",
+            "description": "输出格式：svg/png/base64/file，默认 svg",
+            "default": "svg"
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "输出文件路径（output 为 file 时必填）"
+          },
+          "width": {
+            "type": "number",
+            "description": "图表宽度，默认 600",
+            "default": 600
+          },
+          "height": {
+            "type": "number",
+            "description": "图表高度，默认 400",
+            "default": 400
+          },
+          "option": {
+            "type": "object",
+            "description": "原始 ECharts 配置对象（高级用法，直接传入完整的 option）"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbsyqryik96dvuz21ri",
+      "skill_id": "mnbsyqr1kfmj4ee8io9n",
+      "name": "check",
+      "description": "Unified network check tool. Supports DNS lookup (A/AAAA/MX/TXT/CNAME/NS records), SSL certificate analysis, and HTTP headers analysis. Use when need to check domain DNS, SSL certificate info, or HTTP response headers.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "dns",
+              "ssl",
+              "http"
+            ],
+            "default": "dns",
+            "description": "Check type: dns (default), ssl, http"
+          },
+          "hostname": {
+            "type": "string",
+            "description": "Hostname to check (required for dns/ssl type)"
+          },
+          "record_type": {
+            "type": "string",
+            "enum": [
+              "A",
+              "AAAA",
+              "MX",
+              "TXT",
+              "CNAME",
+              "NS"
+            ],
+            "default": "A",
+            "description": "DNS record type (for dns type)"
+          },
+          "port": {
+            "type": "number",
+            "default": 443,
+            "description": "Port number for SSL check (default: 443)"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL to check (required for http type)"
+          },
+          "timeout": {
+            "type": "number",
+            "default": 5000,
+            "description": "Timeout in milliseconds (default: 5000)"
+          }
+        },
+        "required": []
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbsyqsjawow8e9yegvp",
+      "skill_id": "mnbsyqr1kfmj4ee8io9n",
+      "name": "connect",
+      "description": "Test TCP connection to a host and port. Returns connection status, latency, and basic info.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address"
+          },
+          "port": {
+            "type": "number",
+            "default": 80,
+            "description": "Port number (default: 80)"
+          },
+          "timeout": {
+            "type": "number",
+            "default": 5000,
+            "description": "Connection timeout in milliseconds (default: 5000)"
+          }
+        },
+        "required": [
+          "host"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbsyqtczclh1ipi194q",
+      "skill_id": "mnbsyqr1kfmj4ee8io9n",
+      "name": "http_request",
+      "description": "Make HTTP/HTTPS requests. Supports GET/POST/PUT/DELETE methods, custom headers, request body, and redirect following.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Request URL"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE",
+              "PATCH",
+              "HEAD",
+              "OPTIONS"
+            ],
+            "default": "GET",
+            "description": "HTTP method (default: GET)"
+          },
+          "headers": {
+            "type": "object",
+            "description": "Request headers as key-value pairs"
+          },
+          "body": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ],
+            "description": "Request body (string or object for JSON)"
+          },
+          "timeout": {
+            "type": "number",
+            "default": 10000,
+            "description": "Request timeout in milliseconds (default: 10000)"
+          },
+          "follow_redirects": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to follow redirects (default: true)"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mnbsyqsyo93sf9a96st2",
+      "skill_id": "mnbsyqr1kfmj4ee8io9n",
+      "name": "port_scan",
+      "description": "Scan ports on a host. Supports preset port lists (common/web/mail/db) or custom port arrays.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address"
+          },
+          "ports": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "common",
+                  "web",
+                  "mail",
+                  "db"
+                ]
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            ],
+            "default": "common",
+            "description": "Port configuration: 'common' (default), 'web', 'mail', 'db', single port number, or array of ports"
+          },
+          "timeout": {
+            "type": "number",
+            "default": 3000,
+            "description": "Scan timeout per port in milliseconds (default: 3000)"
+          }
+        },
+        "required": [
+          "host"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": false
+    },
+    {
+      "id": "mncpuylzmh8e3fmz9j6u",
+      "skill_id": "mncpuylil9ebcl4uadbq",
+      "name": "stories",
+      "description": "获取 Hacker News 故事，支持多种类型和搜索",
+      "parameters": {
+        "properties": {
+          "json": {
+            "default": false,
+            "description": "Return JSON format instead of text",
+            "type": "boolean"
+          },
+          "limit": {
+            "default": 10,
+            "description": "Number of stories to return",
+            "type": "number"
+          },
+          "period": {
+            "default": "all",
+            "description": "Time filter for AI type: day, week, month, all",
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "all"
+            ],
+            "type": "string"
+          },
+          "query": {
+            "description": "Search query (required when type is search)",
+            "type": "string"
+          },
+          "type": {
+            "description": "Story type: top, new, best, ask, show, jobs, ai, search",
+            "enum": [
+              "top",
+              "new",
+              "best",
+              "ask",
+              "show",
+              "jobs",
+              "ai",
+              "search"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
         ],
-        "type": "object"
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "72gJ2O3fhZZ02IBg6EEC",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_show",
-      "description": "获取Show HN展示",
-      "parameters": {
-        "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
-          }
-        },
-        "required": [],
-        "type": "object"
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
-      "id": "26DDrvkbuETfdsBLzGdK",
-      "skill_id": "oCIZL5Zb0Se6r5eGeQbL",
-      "name": "hn_top",
-      "description": "获取Hacker News热门故事",
-      "parameters": {
-        "properties": {
-          "limit": {
-            "description": "返回数量，默认10",
-            "type": "number"
-          }
-        },
-        "required": [],
         "type": "object"
       },
       "script_path": "index.js",
@@ -2778,49 +3110,9 @@
       "is_resident": false
     },
     {
-      "id": "mm77r8cxe0qmj4wop7ul",
-      "skill_id": "searxng",
-      "name": "web_search",
-      "description": "Search the web using SearXNG.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "query": {
-            "type": "string",
-            "description": "The search query"
-          },
-          "n": {
-            "type": "number",
-            "description": "Number of results (default: 10, max: 50)"
-          },
-          "category": {
-            "type": "string",
-            "description": "\"general\" | \"images\" | \"videos\" | \"news\" | \"map\" | \"music\" | \"files\" | \"it\" | \"science\""
-          },
-          "language": {
-            "type": "string",
-            "description": "Language code like \"en\", \"zh\", \"auto\" (default: \"auto\")"
-          },
-          "time_range": {
-            "type": "string",
-            "description": "\"day\" | \"week\" | \"month\" | \"year\""
-          },
-          "format": {
-            "type": "string",
-            "description": "\"json\" (default) or \"table\" for readable display"
-          }
-        },
-        "required": [
-          "query"
-        ]
-      },
-      "script_path": "index.js",
-      "is_resident": false
-    },
-    {
       "id": "sm_tool_delete",
       "skill_id": "skill-manager",
-      "name": "delete_skill",
+      "name": "delete",
       "description": "从数据库中删除技能（谨慎使用，会同时删除关联的工具定义）",
       "parameters": {
         "type": "object",
@@ -2840,7 +3132,7 @@
     {
       "id": "sm_tool_details",
       "skill_id": "skill-manager",
-      "name": "list_skill_details",
+      "name": "details",
       "description": "获取指定技能的完整详情，包括技能所有字段和工具定义列表。",
       "parameters": {
         "type": "object",
@@ -2860,7 +3152,7 @@
     {
       "id": "sm_tool_list",
       "skill_id": "skill-manager",
-      "name": "list_skills",
+      "name": "list",
       "description": "列出数据库中所有技能。可按启用状态过滤或按名称搜索。",
       "parameters": {
         "type": "object",
@@ -2882,7 +3174,7 @@
     {
       "id": "sm_tool_register",
       "skill_id": "skill-manager",
-      "name": "register_skill",
+      "name": "register",
       "description": "从本地目录注册或更新技能到数据库。需要先读取 SKILL.md，理解工具定义后调用此工具。同名技能会覆盖更新。",
       "parameters": {
         "type": "object",
@@ -2941,7 +3233,7 @@
     {
       "id": "sm_tool_toggle",
       "skill_id": "skill-manager",
-      "name": "toggle_skill",
+      "name": "toggle",
       "description": "启用或禁用技能（下次对话生效）",
       "parameters": {
         "type": "object",
@@ -2964,569 +3256,195 @@
       "is_resident": false
     },
     {
-      "id": "rvEYzrHJ0me1KmeMco3A",
+      "id": "mnclftkmk10dgeb81yk1",
       "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "add_watermark",
-      "description": "Add watermark to PDF.",
+      "name": "read",
+      "description": "PDF 读取操作（不修改原文件）。通过 operation 参数区分：metadata(读取元数据)、text(提取文本)、tables(提取表格)、images(提取图片)、render(渲染页面为图片)、markdown(转Markdown)、fields(检查表单字段)、field_info(获取字段信息)。",
       "parameters": {
         "type": "object",
         "properties": {
           "path": {
             "type": "string",
-            "description": "PDF file path"
+            "description": "PDF 文件路径"
           },
-          "output": {
+          "operation": {
             "type": "string",
-            "description": "Output file path"
-          },
-          "watermark": {
-            "type": "string",
-            "description": "Watermark text or PDF file path"
-          },
-          "is_text": {
-            "type": "boolean",
-            "description": "True for text watermark, False for PDF watermark (default: true)"
-          }
-        },
-        "required": [
-          "path",
-          "output",
-          "watermark"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "6ogV3LwvmeOZKDzEJCG4",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "check_bounding_boxes",
-      "description": "Validate bounding boxes for form fields.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "fields_json": {
-            "type": "string",
-            "description": "JSON file with field definitions"
-          }
-        },
-        "required": [
-          "fields_json"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "4t7DqtjEBp09ognUXT3t",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "check_fillable_fields",
-      "description": "Check if PDF has fillable form fields.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "PfIZ3jIL0t69Z0iJfRdV",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "convert_to_images",
-      "description": "Convert PDF pages to images.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "output_dir": {
-            "type": "string",
-            "description": "Output directory"
-          },
-          "dpi": {
-            "type": "number",
-            "description": "Resolution DPI (default: 150)"
-          },
-          "format": {
-            "type": "string",
-            "description": "Image format: 'png' or 'jpg' (default: 'png')"
+            "enum": [
+              "metadata",
+              "text",
+              "tables",
+              "images",
+              "render",
+              "markdown",
+              "fields",
+              "field_info"
+            ],
+            "description": "操作类型"
           },
           "from_page": {
             "type": "number",
-            "description": "Start page"
+            "description": "起始页（从1开始）"
           },
           "to_page": {
             "type": "number",
-            "description": "End page"
+            "description": "结束页（包含）"
+          },
+          "suppress_warnings": {
+            "type": "boolean",
+            "description": "抑制警告输出（默认: true）"
+          },
+          "parse_page_info": {
+            "type": "boolean",
+            "description": "解析每页详细信息（metadata操作）"
+          },
+          "image_threshold": {
+            "type": "number",
+            "description": "图片最小尺寸阈值，像素（images操作，默认: 80）"
+          },
+          "output_dir": {
+            "type": "string",
+            "description": "输出目录（render操作）"
+          },
+          "scale": {
+            "type": "number",
+            "description": "缩放比例（render操作，默认: 1.5）"
+          },
+          "desired_width": {
+            "type": "number",
+            "description": "期望宽度像素（render操作）"
+          },
+          "prefix": {
+            "type": "string",
+            "description": "输出文件名前缀（render操作，默认: page）"
+          },
+          "output": {
+            "type": "string",
+            "description": "输出文件路径（markdown/field_info操作）"
           }
         },
         "required": [
           "path",
-          "output_dir"
+          "operation"
         ]
       },
-      "script_path": "index.py",
+      "script_path": "index.js",
       "is_resident": false
     },
     {
-      "id": "hf6KYDfgaa8Xw9CtCVUA",
+      "id": "mnclftkyrkvqujo1u59a",
       "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "create_pdf",
-      "description": "Create a new PDF with text content.",
+      "name": "write",
+      "description": "PDF 写入操作（创建或修改文件）。通过 operation 参数区分：create(创建PDF)、merge(合并PDF)、split(拆分PDF)、rotate(旋转页面)、encrypt(加密)、decrypt(解密)、watermark(添加水印)、fill(填写表单)。",
       "parameters": {
         "type": "object",
         "properties": {
+          "path": {
+            "type": "string",
+            "description": "PDF 文件路径（大多数操作需要）"
+          },
           "output": {
             "type": "string",
-            "description": "Output file path"
+            "description": "输出文件路径"
           },
-          "title": {
+          "operation": {
             "type": "string",
-            "description": "PDF title"
+            "enum": [
+              "create",
+              "merge",
+              "split",
+              "rotate",
+              "encrypt",
+              "decrypt",
+              "watermark",
+              "fill"
+            ],
+            "description": "操作类型"
           },
           "content": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "Array of page content strings"
+            "description": "文本内容数组，每项为一页（create操作）"
+          },
+          "title": {
+            "type": "string",
+            "description": "PDF 标题（create操作）"
           },
           "page_size": {
             "type": "string",
-            "description": "Page size: 'a4' or 'letter' (default: 'a4')"
-          }
-        },
-        "required": [
-          "output"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "5w4vygYe6umNf3PX5FqA",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "decrypt_pdf",
-      "description": "Remove password protection from PDF.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
+            "enum": [
+              "a4",
+              "letter"
+            ],
+            "description": "页面大小（create操作，默认: a4）"
           },
-          "output": {
-            "type": "string",
-            "description": "Output file path"
-          },
-          "password": {
-            "type": "string",
-            "description": "Password to decrypt"
-          }
-        },
-        "required": [
-          "path",
-          "output",
-          "password"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "rXwiD3aS2v08AtodpE8F",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "encrypt_pdf",
-      "description": "Encrypt PDF with password.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "output": {
-            "type": "string",
-            "description": "Output file path"
-          },
-          "user_password": {
-            "type": "string",
-            "description": "User password"
-          },
-          "owner_password": {
-            "type": "string",
-            "description": "Owner password (default: same as user_password)"
-          }
-        },
-        "required": [
-          "path",
-          "output",
-          "user_password"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "tbgrP0NzapXxfxNAOm07",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "extract_form_field_info",
-      "description": "Extract form field information from PDF.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "output": {
-            "type": "string",
-            "description": "Output JSON file path"
-          }
-        },
-        "required": [
-          "path",
-          "output"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "F7CkRN4tEewR0mjM1Lhn",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "extract_form_structure",
-      "description": "Extract form structure for non-fillable PDFs.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "output": {
-            "type": "string",
-            "description": "Output JSON file path"
-          }
-        },
-        "required": [
-          "path",
-          "output"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "rrQ2RYuhkuqh4G0R4uib",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "extract_images",
-      "description": "Extract embedded images from PDF.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "output_dir": {
-            "type": "string",
-            "description": "Output directory for extracted images"
-          }
-        },
-        "required": [
-          "path",
-          "output_dir"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "GEaOf4u3VBn9kYtdspcC",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "extract_tables",
-      "description": "Extract tables from PDF using pdfplumber.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "page": {
-            "type": "number",
-            "description": "Specific page number (1-based, extracts all if not specified)"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "lip3JoZTt1mXkY9TxRr1",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "extract_text",
-      "description": "Extract text content from PDF pages.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "from_page": {
-            "type": "number",
-            "description": "Start page (1-based, default: 1)"
-          },
-          "to_page": {
-            "type": "number",
-            "description": "End page (inclusive)"
-          },
-          "preserve_layout": {
-            "type": "boolean",
-            "description": "Preserve layout (default: false)"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "25wBZTqiUENqYx3QOVrc",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "fill_fillable_fields",
-      "description": "Fill fillable form fields in PDF.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "field_values": {
-            "type": "string",
-            "description": "JSON file with field values"
-          },
-          "output": {
-            "type": "string",
-            "description": "Output PDF file path"
-          }
-        },
-        "required": [
-          "path",
-          "field_values",
-          "output"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "rhdJpnlj4k4gOPXsfnKy",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "fill_pdf_form_with_annotations",
-      "description": "Fill non-fillable PDF forms with text annotations.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "fields_json": {
-            "type": "string",
-            "description": "JSON file with field definitions and values"
-          },
-          "output": {
-            "type": "string",
-            "description": "Output PDF file path"
-          }
-        },
-        "required": [
-          "path",
-          "fields_json",
-          "output"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "DPJA8Q8wa6U0WwzMhhfS",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "merge_pdfs",
-      "description": "Merge multiple PDF files into one.",
-      "parameters": {
-        "type": "object",
-        "properties": {
           "paths": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "Array of PDF file paths (at least 2)"
+            "description": "要合并的PDF文件路径数组（merge操作）"
           },
-          "output": {
+          "output_dir": {
             "type": "string",
-            "description": "Output file path"
-          }
-        },
-        "required": [
-          "paths",
-          "output"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "TvPkd98X9ETHjwdYcJyR",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "pdf_to_markdown",
-      "description": "Convert PDF to Markdown format.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
+            "description": "输出目录（split操作）"
           },
-          "output": {
-            "type": "string",
-            "description": "Output markdown file path (optional)"
-          },
-          "from_page": {
+          "pages_per_file": {
             "type": "number",
-            "description": "Start page"
-          },
-          "to_page": {
-            "type": "number",
-            "description": "End page"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "hmePeVlaYELTc9y3dM33",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "read_pdf",
-      "description": "Read PDF metadata and basic information. Returns page count, metadata (title, author, subject, creator), and encryption status.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          }
-        },
-        "required": [
-          "path"
-        ]
-      },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "jh0wzOJFkpqySVRqXzBI",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "rotate_pages",
-      "description": "Rotate pages in PDF.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "output": {
-            "type": "string",
-            "description": "Output file path"
+            "description": "每个文件的页数（split操作，默认: 1）"
           },
           "pages": {
             "type": "array",
             "items": {
               "type": "number"
             },
-            "description": "Page numbers to rotate (1-based, all if empty)"
+            "description": "要旋转的页码（rotate操作，从1开始）"
           },
           "degrees": {
             "type": "number",
-            "description": "Rotation degrees - 90, 180, 270 (default: 90)"
+            "enum": [
+              90,
+              180,
+              270
+            ],
+            "description": "旋转角度（rotate操作，默认: 90）"
+          },
+          "user_password": {
+            "type": "string",
+            "description": "打开PDF的密码（encrypt操作）"
+          },
+          "owner_password": {
+            "type": "string",
+            "description": "编辑密码（encrypt操作）"
+          },
+          "password": {
+            "type": "string",
+            "description": "当前密码（decrypt操作）"
+          },
+          "watermark": {
+            "type": "string",
+            "description": "水印文本或水印PDF路径（watermark操作）"
+          },
+          "is_text": {
+            "type": "boolean",
+            "description": "true为文本水印，false为PDF路径（watermark操作，默认: true）"
+          },
+          "field_values": {
+            "type": "object",
+            "description": "字段名和值的键值对（fill操作）"
           }
         },
         "required": [
-          "path",
+          "operation",
           "output"
         ]
       },
-      "script_path": "index.py",
-      "is_resident": false
-    },
-    {
-      "id": "MQFe9ZGXLyqMlPFfN3Y8",
-      "skill_id": "t2RQiLTup0dtaHn8IUx0",
-      "name": "split_pdf",
-      "description": "Split PDF into multiple files.",
-      "parameters": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "PDF file path"
-          },
-          "output_dir": {
-            "type": "string",
-            "description": "Output directory"
-          },
-          "pages_per_file": {
-            "type": "number",
-            "description": "Pages per output file (default: 1)"
-          },
-          "prefix": {
-            "type": "string",
-            "description": "Output filename prefix (default: 'page')"
-          }
-        },
-        "required": [
-          "path",
-          "output_dir"
-        ]
-      },
-      "script_path": "index.py",
+      "script_path": "index.js",
       "is_resident": false
     }
   ],
   "parameters": [
-    {
-      "id": "mn0cn7jpkv3lvi5s8oytxb2n73z0v907",
-      "skill_id": "mmoasyw4iar2f9qi4z96",
-      "param_name": "UNIFUNCS_API_KEY",
-      "param_value": "sk-3NiBQQIuLjuybfEFA4Fi7JHsNmEktbFRAPOIMoYwN8OiQ08g",
-      "is_secret": true,
-      "description": null
-    },
     {
       "id": "mn0cngqm62uzwgvfxk3mj9flbb7q4cr6",
       "skill_id": "remote-llm",
@@ -3548,54 +3466,6 @@
       "skill_id": "remote-llm",
       "param_name": "prompt",
       "param_value": "请把图片中的文字转为文本给我。注意:json格式，多个字段，包括原文、图片描述等",
-      "is_secret": true,
-      "description": null
-    },
-    {
-      "id": "mm7u76shpf2hd4bb91duicmtcirqqgle",
-      "skill_id": "searxng",
-      "param_name": "SEARXNG_URL",
-      "param_value": "https://dr.x.erix.vip/searxng",
-      "is_secret": true,
-      "description": null
-    },
-    {
-      "id": "sm_param_db_host",
-      "skill_id": "skill-manager",
-      "param_name": "db_host",
-      "param_value": "${DB_HOST}",
-      "is_secret": true,
-      "description": null
-    },
-    {
-      "id": "sm_param_db_name",
-      "skill_id": "skill-manager",
-      "param_name": "db_name",
-      "param_value": "${DB_NAME}",
-      "is_secret": true,
-      "description": null
-    },
-    {
-      "id": "sm_param_db_password",
-      "skill_id": "skill-manager",
-      "param_name": "db_password",
-      "param_value": "${DB_PASSWORD}",
-      "is_secret": true,
-      "description": null
-    },
-    {
-      "id": "sm_param_db_port",
-      "skill_id": "skill-manager",
-      "param_name": "db_port",
-      "param_value": "${DB_PORT}",
-      "is_secret": true,
-      "description": null
-    },
-    {
-      "id": "sm_param_db_user",
-      "skill_id": "skill-manager",
-      "param_name": "db_user",
-      "param_value": "${DB_USER}",
       "is_secret": true,
       "description": null
     }


### PR DESCRIPTION
chore: 同步 skill-manager 技能数据到初始化脚本

## 变更内容

- 更新 `scripts/skills-data.json` 中的 `skill-manager` 技能数据
- 同步数据库中的最新技能定义（精简后的 5 工具版本）
- 更新 `skill_md` 字段，反映新的 API 调用架构

## 变更详情

### skill-manager 技能更新
- **工具数量**: 从 7 个精简到 5 个
- **移除的工具**: `assign_skill`, `unassign_skill`
- **重命名的工具**:
  - `list_skills` → `list`
  - `list_skill_details` → `details`
  - `register_skill` → `register`
  - `delete_skill` → `delete`
  - `toggle_skill` → `toggle`

### 架构变更
- 从直接数据库访问改为 API 调用模式
- 需要 `USER_ACCESS_TOKEN` 和 `API_BASE` 环境变量
- 不再需要数据库连接参数

Closes #456
