### PR TITLE
fix: 知识库页面 UI 问题修复

### DIFF
--- a/frontend/src/views/KnowledgeBaseView.vue
+++ b/frontend/src/views/KnowledgeBaseView.vue
@@ -15,7 +15,7 @@
         type="text"
         class="search-input"
         :placeholder="$t('knowledgeBase.searchPlaceholder')"
-        @keyup.enter="performGlobalSearch"
+        @keyup.enter="searchQuery.trim() && performGlobalSearch()"
       />
       <button
         class="btn-search"
@@ -756,6 +756,7 @@ onUnmounted(() => {
   box-sizing: border-box;
   overflow-y: auto;
   flex: 1;
+  align-content: start;
 }
 
 .kb-card {
@@ -896,6 +897,12 @@ onUnmounted(() => {
   position: absolute;
   top: 8px;
   right: 8px;
+  z-index: 1;
+}
+
+/* 当显示操作按钮时，调整模型徽章位置 */
+.kb-card:hover .kb-card-model {
+  right: 60px;
 }
 
 .model-badge {

--- a/frontend/src/views/KnowledgeDetailView.vue
+++ b/frontend/src/views/KnowledgeDetailView.vue
@@ -238,7 +238,7 @@
             type="text"
             class="search-input"
             :placeholder="$t('knowledgeBase.searchHint')"
-            @keyup.enter="performSearch"
+            @keyup.enter="searchQuery.trim() && performSearch()"
           />
 
           <div v-if="kbStore.isSearching" class="search-loading">


### PR DESCRIPTION
## 修复内容

修复知识库呈现页面的多个 UI 问题：

### 1. 卡片高度异常
- **问题**: CSS Grid 默认 `align-content: stretch` 导致卡片被拉伸填满整个页面高度
- **修复**: 在 `.kb-grid` 添加 `align-content: start`

### 2. 搜索框回车事件未做空值检查
- **问题**: 搜索输入框的 `@keyup.enter` 事件没有检查空值，按回车会触发空搜索
- **修复**: 
  - KnowledgeBaseView.vue: `@keyup.enter="searchQuery.trim() && performGlobalSearch()"`
  - KnowledgeDetailView.vue: `@keyup.enter="searchQuery.trim() && performSearch()"`

### 3. 模型徽章与操作按钮重叠
- **问题**: 当知识库使用非本地嵌入模型时，右上角的模型徽章会遮挡编辑/删除按钮
- **修复**: 
  - 添加 `z-index: 1` 确保徽章在按钮下方
  - 添加悬停时徽章右移样式: `.kb-card:hover .kb-card-model { right: 60px; }`

## 影响范围
- 前端文件：`frontend/src/views/KnowledgeBaseView.vue`、`frontend/src/views/KnowledgeDetailView.vue`
- 无后端变更
- 无数据库变更

Closes #465