### PR TITLE
fix: 修复角色管理页面权限配置报错

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -553,10 +553,11 @@
               <div class="role-tab-footer">
                 <span class="permissions-count">
                   {{ $t('settings.selectedPermissionsCount', { count: rolePermissionIds.length }) }}
+                  <span v-if="isAdminRole" class="admin-hint">({{ $t('settings.adminRoleNoEdit') }})</span>
                 </span>
                 <button
                   class="btn-confirm"
-                  :disabled="!rolePermissionsChanged"
+                  :disabled="!rolePermissionsChanged || isAdminRole"
                   @click="saveRolePermissions"
                 >
                   {{ $t('common.save') }}
@@ -600,10 +601,11 @@
               <div class="role-tab-footer">
                 <span class="experts-count">
                   {{ $t('settings.selectedExpertsCount', { count: roleExpertIds.length }) }}
+                  <span v-if="isAdminRole" class="admin-hint">({{ $t('settings.adminRoleNoEdit') }})</span>
                 </span>
                 <button
                   class="btn-confirm"
-                  :disabled="!roleExpertsChanged"
+                  :disabled="!roleExpertsChanged || isAdminRole"
                   @click="saveRoleExperts"
                 >
                   {{ $t('common.save') }}
@@ -1893,6 +1895,7 @@ const rolePermissionsLoading = ref(false)
 const roleExpertsLoading = ref(false)
 const rolePermissionsChanged = ref(false)
 const roleExpertsChanged = ref(false)
+const isAdminRole = ref(false)  // 当前选中角色是否为管理员角色
 
 // 角色编辑对话框
 const showRoleDialog = ref(false)
@@ -2234,6 +2237,8 @@ const selectRole = async (role: Role) => {
     ])
     rolePermissionIds.value = permissionsData.permission_ids || []
     roleExpertIds.value = expertsData.expert_ids || []
+    // 判断是否为管理员角色（任一接口返回 is_admin 即为管理员）
+    isAdminRole.value = permissionsData.is_admin || expertsData.is_admin || false
     rolePermissionsChanged.value = false
     roleExpertsChanged.value = false
   } catch (err) {

--- a/server/controllers/role.controller.js
+++ b/server/controllers/role.controller.js
@@ -87,12 +87,26 @@ async function getPermissions(ctx) {
       return;
     }
 
+    // 管理员角色拥有所有权限
+    if (roleData.mark === 'admin') {
+      const permission = ctx.db.getModel('permission');
+      const allPermissions = await permission.findAll({
+        attributes: ['id', 'code', 'name', 'type', 'parent_id'],
+      });
+      ctx.success({
+        permission_ids: allPermissions.map(p => p.id),
+        is_admin: true,
+      });
+      return;
+    }
+
     const permissions = await roleData.getPermission_id_permissions({
       attributes: ['id', 'code', 'name', 'type', 'parent_id'],
     });
 
     ctx.success({
       permission_ids: permissions.map(p => p.id),
+      is_admin: false,
     });
   } catch (error) {
     console.error('[RoleController] getPermissions error:', error);
@@ -175,7 +189,7 @@ async function getExperts(ctx) {
       return;
     }
 
-    const experts = await roleData.getExpert_id_experts({
+    const experts = await roleData.getExpert_id_experts_role_experts({
       attributes: ['id', 'name'],
     });
 
@@ -227,7 +241,7 @@ async function updateExperts(ctx) {
     }
 
     // 设置角色专家
-    await roleData.setExpert_id_experts(expert_ids);
+    await roleData.setExpert_id_experts_role_experts(expert_ids);
 
     ctx.success(null, '角色专家访问权限更新成功');
   } catch (error) {


### PR DESCRIPTION
fix: 修复角色管理页面权限配置报错

## 修复内容

### 后端修复
- 修复 `getPermissions` 方法，添加管理员角色特殊处理
- 管理员角色现在返回所有权限ID + `is_admin: true`
- 普通角色返回关联表权限 + `is_admin: false`

### 前端修复
- 添加 `isAdminRole` 状态变量
- 更新 `selectRole` 方法，根据后端返回的 `is_admin` 标识判断是否为管理员角色
- 在保存按钮上添加 `isAdminRole` 禁用逻辑，管理员角色显示只读提示

## 关联 Issue

Closes #470
