### PR TITLE
fix: 添加 user_skill_parameters 表到数据库迁移脚本

### DIFF
--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -361,6 +361,32 @@ const MIGRATIONS = [
       console.log('  ✓ Added allow_user_override column to skill_parameters table');
     }
   },
+
+  // ==================== user_skill_parameters 表创建 ====================
+  // 用户技能参数表（只存储用户覆盖的参数）
+  {
+    name: 'user_skill_parameters table create',
+    check: async (conn) => await hasTable(conn, 'user_skill_parameters'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        CREATE TABLE IF NOT EXISTS user_skill_parameters (
+          id VARCHAR(32) PRIMARY KEY,
+          user_id VARCHAR(32) NOT NULL COMMENT '用户ID',
+          skill_id VARCHAR(64) NOT NULL COMMENT '技能ID',
+          param_name VARCHAR(100) NOT NULL COMMENT '参数名',
+          param_value TEXT COMMENT '参数值',
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY uk_user_skill_param (user_id, skill_id, param_name),
+          INDEX idx_user_id (user_id),
+          INDEX idx_skill_id (skill_id),
+          FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+          FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='用户技能参数表（只存储用户覆盖的参数）'
+      `);
+      console.log('  ✓ Created user_skill_parameters table');
+    }
+  },
 ];
 
 /**


### PR DESCRIPTION
## 修复内容

将 `user_skill_parameters` 表添加到数据库迁移脚本 `scripts/upgrade-database.js` 中，确保在其他实例部署时能够自动创建该表。

## 变更详情

在 `MIGRATIONS` 数组末尾添加新的迁移项：
- **迁移名称**: `user_skill_parameters table create`
- **检查函数**: 使用 `hasTable()` 检查表是否已存在（幂等性）
- **迁移函数**: 创建完整的 `user_skill_parameters` 表结构

## 表结构

| 字段 | 类型 | 说明 |
|------|------|------|
| id | VARCHAR(32) | 主键 |
| user_id | VARCHAR(32) | 用户ID，外键关联 users 表 |
| skill_id | VARCHAR(64) | 技能ID，外键关联 skills 表 |
| param_name | VARCHAR(100) | 参数名 |
| param_value | TEXT | 参数值 |
| created_at | DATETIME | 创建时间 |
| updated_at | DATETIME | 更新时间 |

## 约束
- 唯一索引: `(user_id, skill_id, param_name)`
- 外键: `user_id` → `users.id` (ON DELETE CASCADE)
- 外键: `skill_id` → `skills.id` (ON DELETE CASCADE)

## 测试
- [x] 迁移脚本遵循幂等性原则
- [x] 包含完整的外键约束
- [x] 包含必要的索引

Closes #479
