### PR TITLE
feat: 知识库卡片显示创建者和管理者信息

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1075,6 +1075,10 @@ thinkingFormatDeepseek: 'DeepSeek/GLM Format',
     permissionCanEdit: 'Can Edit',
     permissionCanDelete: 'Can Delete',
 
+    // User info
+    creator: 'Creator',
+    owner: 'Owner',
+
     // Transfer Owner
     transferOwner: {
       button: 'Transfer Owner',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1068,6 +1068,10 @@ thinkingFormatDeepseek: 'DeepSeek/GLM 格式',
     permissionCanEdit: '可编辑',
     permissionCanDelete: '可删除',
 
+    // 创建者和管理者
+    creator: '创建者',
+    owner: '管理者',
+
     // 转移拥有者
     transferOwner: {
       button: '转移拥有者',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -805,6 +805,9 @@ export interface KnowledgeBase {
   is_owner?: boolean
   can_edit?: boolean
   can_delete?: boolean
+  // 用户信息（API 返回时附带）
+  creator_name?: string
+  owner_name?: string
   created_at: string
   updated_at: string
 }

--- a/frontend/src/views/KnowledgeBaseView.vue
+++ b/frontend/src/views/KnowledgeBaseView.vue
@@ -73,6 +73,14 @@
               </span>
               <span v-if="kb.is_owner" class="owner-badge">{{ $t('knowledgeBase.permissionOwner') }}</span>
             </div>
+            <div class="kb-card-users">
+              <span class="user-badge" :title="$t('knowledgeBase.creator') + ': ' + kb.creator_name">
+                👤 {{ kb.creator_name }}
+              </span>
+              <span v-if="kb.owner_id !== kb.creator_id" class="user-badge" :title="$t('knowledgeBase.owner') + ': ' + kb.owner_name">
+                🔑 {{ kb.owner_name }}
+              </span>
+            </div>
             <div class="kb-card-model" v-if="kb.embedding_model_id && kb.embedding_model_id !== 'local'">
               <span class="model-badge">{{ getModelName(kb.embedding_model_id) }}</span>
             </div>
@@ -261,7 +269,7 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeBaseStore } from '@/stores/knowledgeBase'
 import { useModelStore } from '@/stores/model'
-import { useToast } from '@/components/common/Toast.vue'
+import { useToastStore } from '@/stores/toast'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import type { KnowledgeBase } from '@/types'
@@ -270,7 +278,7 @@ const { t } = useI18n()
 const router = useRouter()
 const kbStore = useKnowledgeBaseStore()
 const modelStore = useModelStore()
-const toast = useToast()
+const toast = useToastStore()
 
 // State
 const searchQuery = ref('')
@@ -389,13 +397,13 @@ const submitForm = async () => {
 
   // 检查是否有可用的 embedding 模型
   if (embeddingModels.value.length === 0) {
-    toast.error($t('knowledgeBase.noEmbeddingModelError') || '请先配置 Embedding 模型')
+    toast.error(t('knowledgeBase.noEmbeddingModelError') || '请先配置 Embedding 模型')
     return
   }
 
   // 检查是否选择了 embedding 模型
   if (!formData.value.embedding_model_id) {
-    toast.error($t('knowledgeBase.selectEmbeddingModelError') || '请选择 Embedding 模型')
+    toast.error(t('knowledgeBase.selectEmbeddingModelError') || '请选择 Embedding 模型')
     return
   }
 
@@ -967,6 +975,28 @@ onUnmounted(() => {
   padding: 2px 6px;
   border-radius: 4px;
   white-space: nowrap;
+}
+
+/* KB Card Users - Creator and Owner */
+.kb-card-users {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px dashed rgba(0, 0, 0, 0.06);
+}
+
+.user-badge {
+  font-size: 11px;
+  color: #64748b;
+  background: rgba(100, 116, 139, 0.08);
+  padding: 2px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
 }
 
 /* Dialog */

--- a/server/controllers/kb.controller.js
+++ b/server/controllers/kb.controller.js
@@ -161,8 +161,25 @@ class KbController {
         };
       }));
 
+      // 获取所有相关用户的用户名
+      const userIds = [...new Set(result.flatMap(kb => [kb.owner_id, kb.creator_id]))];
+      const User = this.db.getModel('user');
+      const users = await User.findAll({
+        where: { id: { [Op.in]: userIds } },
+        attributes: ['id', 'username'],
+        raw: true,
+      });
+      const userMap = new Map(users.map(u => [u.id, u.username]));
+
+      // 添加用户名到结果
+      const resultWithUsernames = result.map(kb => ({
+        ...kb,
+        owner_name: userMap.get(kb.owner_id) || kb.owner_id,
+        creator_name: userMap.get(kb.creator_id) || kb.creator_id,
+      }));
+
       ctx.success({
-        items: result,
+        items: resultWithUsernames,
         total: count,
         page: parseInt(page),
         limit,


### PR DESCRIPTION
## 功能描述

在知识库卡片上显示创建者和管理者信息，方便用户快速识别知识库的归属。

## 变更内容

### 后端变更
- 修改 `server/controllers/kb.controller.js` 的 `listKnowledgeBases` 方法
- 查询知识库列表时，同时查询创建者和管理者的用户名
- 返回结果中新增 `creator_name` 和 `owner_name` 字段

### 前端变更
- 修改 `frontend/src/views/KnowledgeBaseView.vue`
- 在知识库卡片底部添加创建者和管理者信息显示区域
- 使用 👤 图标表示创建者，🔑 图标表示管理者
- 当管理者与创建者不同时才显示管理者信息
- 添加悬停提示显示完整标签

### 类型定义
- 更新 `frontend/src/types/index.ts` 中的 `KnowledgeBase` 接口
- 添加 `creator_name` 和 `owner_name` 可选字段

### 国际化
- 更新 `zh-CN.ts` 和 `en-US.ts`
- 添加 `creator` 和 `owner` 翻译键

## UI 效果

知识库卡片底部显示：
- 👤 创建者用户名
- 🔑 管理者用户名（仅当管理者与创建者不同时显示）

## 测试

- [x] TypeScript 类型检查通过
- [x] 构建成功
- [x] 中文/英文国际化文本正确显示

Closes #488
