### PR TITLE
feat: 实现助理通知重发功能

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -888,4 +888,10 @@ export const assistantApi = {
     apiRequest<{ request_id: string; original_request_id: string; message: string }>(
       apiClient.post(`/assistants/requests/${requestId}/retry`)
     ),
+
+  // 重发通知给专家
+  resendNotification: (requestId: string) =>
+    apiRequest<{ success: boolean; message: string; request_id: string }>(
+      apiClient.post(`/assistants/requests/${requestId}/resend-notification`)
+    ),
 }

--- a/frontend/src/components/panel/AssistantTab.vue
+++ b/frontend/src/components/panel/AssistantTab.vue
@@ -87,8 +87,15 @@
                 {{ $t('assistant.archived') || '已归档' }}
               </span>
             </div>
-            <!-- 操作按钮 -->
             <div class="request-actions" @click.stop>
+              <button
+                v-if="canResendNotification(request)"
+                class="action-btn resend"
+                @click="handleResendNotification(request)"
+                :title="$t('assistant.resendNotification') || '重发通知'"
+              >
+                📢
+              </button>
               <button
                 v-if="canRetry(request)"
                 class="action-btn retry"
@@ -324,6 +331,29 @@ function canRetry(request: AssistantRequest): boolean {
   if (request.is_archived) return false
   // 只允许失败的执行重试
   return ['failed', 'timeout'].includes(request.status)
+}
+
+// 判断是否可以重发通知（始终显示重发按钮给已完成的委托）
+function canResendNotification(request: AssistantRequest): boolean {
+  // 只有已完成的委托才显示重发按钮
+  if (request.status !== 'completed') return false
+  // 已归档的委托不允许重发
+  if (request.is_archived) return false
+  return true
+}
+
+// 处理重发通知
+async function handleResendNotification(request: AssistantRequest) {
+  console.log(`[重发通知] 开始重发: request_id=${request.request_id}`)
+  try {
+    const result = await assistantStore.resendNotification(request.request_id)
+    console.log(`[重发通知] 成功:`, result)
+    toast.success(t('assistant.resendNotificationSuccess') || '通知已重发，请在控制台查看详情')
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : t('assistant.resendNotificationFailed')
+    console.error(`[重发通知] 失败:`, errorMsg)
+    toast.error(errorMsg)
+  }
 }
 
 // 处理删除
@@ -672,12 +702,35 @@ onUnmounted(() => {
   background: var(--primary-light, #e3f2fd);
 }
 
+.action-btn.resend:hover {
+  background: var(--info-bg, #e1f5fe);
+}
+
 .action-btn.archive:hover {
   background: var(--warning-bg, #fff8e1);
 }
 
 .action-btn.unarchive:hover {
   background: var(--success-bg, #e8f5e9);
+}
+
+/* 重发按钮 */
+.resend-btn {
+  margin-top: 8px;
+  padding: 4px 12px;
+  font-size: 12px;
+  border: 1px solid var(--primary-color, #2196f3);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--primary-color, #2196f3);
+  cursor: pointer;
+  opacity: 0.8;
+  transition: all 0.2s;
+}
+
+.resend-btn:hover {
+  opacity: 1;
+  background: var(--primary-light, #e3f2fd);
 }
 
 .empty-hint {

--- a/frontend/src/stores/assistant.ts
+++ b/frontend/src/stores/assistant.ts
@@ -270,6 +270,32 @@ export const useAssistantStore = defineStore('assistant', () => {
     }
   }
 
+  // 重发通知给专家
+  async function resendNotification(requestId: string) {
+    try {
+      isLoading.value = true
+      const response = await assistantApi.resendNotification(requestId)
+      // 刷新当前委托状态
+      const updated = await assistantApi.getRequest(requestId)
+      // 更新列表中的委托
+      const index = requests.value.findIndex(r => r.request_id === requestId)
+      if (index !== -1) {
+        requests.value[index] = updated
+      }
+      // 如果是当前选中的委托，也更新 activeRequest
+      if (activeRequest.value?.request_id === requestId) {
+        activeRequest.value = updated
+      }
+      return response
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to resend notification'
+      console.error('Failed to resend notification:', e)
+      throw e
+    } finally {
+      isLoading.value = false
+    }
+  }
+
   return {
     // State
     assistants,
@@ -301,5 +327,6 @@ export const useAssistantStore = defineStore('assistant', () => {
     unarchiveRequest,
     deleteRequest,
     retryRequest,
+    resendNotification,
   }
 })

--- a/models/assistant_request.js
+++ b/models/assistant_request.js
@@ -97,6 +97,22 @@ export default class assistant_request extends Model {
       allowNull: true,
       defaultValue: false,
       comment: "是否已归档"
+    },
+    notification_status: {
+      type: DataTypes.ENUM('pending','sent','failed','skipped'),
+      allowNull: true,
+      defaultValue: "pending",
+      comment: "通知专家状态: pending=待发送, sent=已发送, failed=发送失败, skipped=跳过(无SSE连接)"
+    },
+    notification_error: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      comment: "通知失败时的错误信息"
+    },
+    notification_sent_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      comment: "通知发送时间"
     }
   }, {
     sequelize,
@@ -138,6 +154,13 @@ export default class assistant_request extends Model {
         using: "BTREE",
         fields: [
           { name: "created_at" },
+        ]
+      },
+      {
+        name: "idx_notification_status",
+        using: "BTREE",
+        fields: [
+          { name: "notification_status" },
         ]
       },
     ]

--- a/models/init-models.js
+++ b/models/init-models.js
@@ -123,6 +123,8 @@ export default function initModels(sequelize) {
   permission.hasMany(permission, { as: "permissions", foreignKey: "parent_id"});
   role_permission.belongsTo(permission, { as: "permission", foreignKey: "permission_id"});
   permission.hasMany(role_permission, { as: "role_permissions", foreignKey: "permission_id"});
+  user.belongsTo(position, { as: "position", foreignKey: "position_id"});
+  position.hasMany(user, { as: "users", foreignKey: "position_id"});
   ai_model.belongsTo(provider, { as: "provider", foreignKey: "provider_id"});
   provider.hasMany(ai_model, { as: "ai_models", foreignKey: "provider_id"});
   role_expert.belongsTo(role, { as: "role", foreignKey: "role_id"});

--- a/models/skill.js
+++ b/models/skill.js
@@ -14,6 +14,12 @@ export default class skill extends Model {
       allowNull: false,
       unique: "name"
     },
+    mark: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      comment: "技能标识（不可编辑，唯一），用于生成 tool_name",
+      unique: "idx_mark"
+    },
     description: {
       type: DataTypes.TEXT,
       allowNull: true
@@ -100,12 +106,6 @@ export default class skill extends Model {
       type: DataTypes.DATE,
       allowNull: true,
       defaultValue: Sequelize.Sequelize.fn('current_timestamp')
-    },
-    mark: {
-      type: DataTypes.STRING(50),
-      allowNull: true,
-      comment: "技能标识（不可编辑，唯一），用于生成 tool_name",
-      unique: "idx_mark"
     }
   }, {
     sequelize,

--- a/models/user.js
+++ b/models/user.js
@@ -65,7 +65,11 @@ export default class user extends Model {
     position_id: {
       type: DataTypes.STRING(20),
       allowNull: true,
-      comment: "职位ID"
+      comment: "职位ID",
+      references: {
+        model: 'positions',
+        key: 'id'
+      }
     },
     invitation_quota: {
       type: DataTypes.INTEGER,

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -429,6 +429,7 @@ const MIGRATIONS = [
       console.log('  ✓ Added fk_user_position foreign key to users table');
     }
   },
+
 ];
 
 /**

--- a/server/controllers/assistant.controller.js
+++ b/server/controllers/assistant.controller.js
@@ -400,6 +400,33 @@ class AssistantController {
   }
 
   /**
+   * 重发通知给专家
+   * POST /api/assistants/requests/:request_id/resend-notification
+   */
+  async resendNotification(ctx) {
+    try {
+      const { request_id } = ctx.params;
+
+      if (!request_id) {
+        ctx.error('缺少 request_id 参数', 400);
+        return;
+      }
+
+      const result = await this.assistantManager.resendNotification(request_id);
+      ctx.success(result, '通知已重发');
+    } catch (error) {
+      logger.error('Resend notification error:', error);
+      if (error.message.includes('不存在')) {
+        ctx.error(error.message, 404);
+      } else if (error.message.includes('状态不允许')) {
+        ctx.error(error.message, 400);
+      } else {
+        ctx.app.emit('error', error, ctx);
+      }
+    }
+  }
+
+  /**
    * 重新执行委托
    * POST /api/assistants/requests/:request_id/retry
    */

--- a/server/routes/assistant.routes.js
+++ b/server/routes/assistant.routes.js
@@ -33,6 +33,9 @@ export default function createAssistantRoutes(controller) {
   // DELETE /api/assistants/requests/:request_id - 删除委托
   router.delete('/requests/:request_id', authenticate(), controller.delete.bind(controller));
 
+  // POST /api/assistants/requests/:request_id/resend-notification - 重发通知给专家
+  router.post('/requests/:request_id/resend-notification', authenticate(), controller.resendNotification.bind(controller));
+
   // POST /api/assistants/requests/:request_id/retry - 重新执行委托
   router.post('/requests/:request_id/retry', authenticate(), controller.retry.bind(controller));
 

--- a/server/services/assistant/expert-notifier.js
+++ b/server/services/assistant/expert-notifier.js
@@ -71,6 +71,147 @@ export function pushSSENotification(expertConnections, expertId, userId, notific
 }
 
 /**
+ * 内存中的通知状态记录（用于重发功能）
+ * key: requestId, value: { status, error, sentAt, retryCount }
+ */
+const notificationStatusMap = new Map();
+
+/**
+ * 更新通知状态到内存
+ * @param {string} requestId - 请求ID
+ * @param {string} status - 通知状态: pending, sent, failed, skipped
+ * @param {string} error - 错误信息（可选）
+ * @returns {object} 当前状态记录
+ */
+function updateNotificationStatus(requestId, status, error = null) {
+  const record = {
+    status,
+    error: error || null,
+    sentAt: status === 'sent' ? new Date() : null,
+    retryCount: (notificationStatusMap.get(requestId)?.retryCount || 0) + (status === 'sent' ? 0 : 1),
+  };
+  notificationStatusMap.set(requestId, record);
+  
+  // 控制台输出通知状态
+  console.log(`\n[通知状态] request_id: ${requestId}`);
+  console.log(`  状态: ${status}`);
+  if (error) {
+    console.log(`  失败原因: ${error}`);
+  }
+  if (record.sentAt) {
+    console.log(`  发送时间: ${record.sentAt.toISOString()}`);
+  }
+  console.log(`  重试次数: ${record.retryCount}`);
+  console.log('');
+  
+  logger.info(`[ExpertNotifier] 通知状态更新: request=${requestId}, status=${status}`);
+  return record;
+}
+
+/**
+ * 获取通知状态
+ * @param {string} requestId - 请求ID
+ * @returns {object|null} 状态记录
+ */
+export function getNotificationStatus(requestId) {
+  return notificationStatusMap.get(requestId) || null;
+}
+
+/**
+ * 清除通知状态（用于重发）
+ * @param {string} requestId - 请求ID
+ */
+function clearNotificationStatus(requestId) {
+  notificationStatusMap.delete(requestId);
+  logger.info(`[ExpertNotifier] 清除通知状态: request=${requestId}`);
+}
+
+/**
+ * 重发通知给专家
+ * @param {Database} db - 数据库实例
+ * @param {string} requestId - 请求ID
+ * @param {object} services - 服务引用
+ * @returns {Promise<object>} 重发结果
+ */
+export async function resendNotification(db, requestId, services) {
+  const { expertConnections, chatService } = services;
+  
+  logger.info(`[ExpertNotifier] 开始重发通知: request=${requestId}`);
+  
+  console.log(`\n========================================`);
+  console.log(`[重发通知] request_id: ${requestId}`);
+  console.log(`========================================\n`);
+  
+  try {
+    // 从数据库获取请求
+    const AssistantRequest = db.getModel('assistant_request');
+    const request = await AssistantRequest.findOne({
+      where: { request_id: requestId },
+      raw: true,
+    });
+    
+    if (!request) {
+      const error = `请求不存在: ${requestId}`;
+      console.log(`[重发失败] ${error}`);
+      throw new Error(error);
+    }
+    
+    // 检查请求状态
+    if (request.status !== 'completed' && request.status !== 'failed') {
+      const error = `请求状态不允许重发: ${request.status}`;
+      console.log(`[重发失败] ${error}`);
+      throw new Error(error);
+    }
+    
+    // 解析 input
+    let input = request.input;
+    if (typeof input === 'string') {
+      try {
+        input = JSON.parse(input);
+      } catch (e) {
+        input = {};
+      }
+    }
+    
+    // 构建完整的请求对象
+    const fullRequest = {
+      ...request,
+      input,
+      result: request.result,
+      status: request.status,
+      error_message: request.error_message,
+      latency_ms: request.latency_ms,
+    };
+    
+    // 清除内存中的通知标记，允许重新通知
+    const notifyKey = `${requestId}_${request.status}`;
+    notifiedRequests.delete(notifyKey);
+    
+    // 清除通知状态记录
+    clearNotificationStatus(requestId);
+    
+    console.log(`[重发] 清除历史通知标记，准备重新发送...\n`);
+    
+    // 重新发送通知
+    await notifyExpertResult(db, fullRequest, services);
+    
+    const result = {
+      success: true,
+      message: '通知已重发',
+      request_id: requestId,
+    };
+    
+    console.log(`[重发成功] request_id: ${requestId}\n`);
+    
+    return result;
+  } catch (error) {
+    console.log(`[重发失败] ${error.message}\n`);
+    logger.error(`[ExpertNotifier] 重发通知失败: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
  * 通过 Internal API 通知 Expert 会话结果
  * @param {Database} db - 数据库实例
  * @param {object} request - 请求对象
@@ -84,6 +225,8 @@ export async function notifyExpertResult(db, request, services) {
 
   // 检查是否已经通知过
   if (!shouldNotify(request_id, status)) {
+    // 更新状态为已跳过（重复通知）
+    updateNotificationStatus(request_id, 'skipped', '重复通知请求被跳过');
     return;
   }
 
@@ -149,11 +292,14 @@ export async function notifyExpertResult(db, request, services) {
   // P0-A 修复：不再因 topic_id 为 null 而跳过通知
   // 只有当 user_id 或 expert_id 缺失时才跳过（这是真正的必填信息）
   if (!finalUserId || !finalExpertId) {
+    const errorMsg = `缺少必填信息: user_id=${finalUserId}, expert_id=${finalExpertId}`;
     logger.error(`[ExpertNotifier] 跳过通知：request=${request_id}, 缺少必填信息:`, {
       user_id: finalUserId || 'MISSING',
       expert_id: finalExpertId || 'MISSING',
       topic_id: finalTopicId || '(已处理)',
     });
+    // 更新通知状态为失败
+    updateNotificationStatus(request_id, 'failed', errorMsg);
     return;
   }
 
@@ -347,9 +493,13 @@ export async function notifyExpertResult(db, request, services) {
       logger.warn(`[ExpertNotifier] 无 chatService，无法触发专家响应`);
     }
 
+    // 更新通知状态为已发送
+    updateNotificationStatus(request_id, 'sent');
     logger.info(`[ExpertNotifier] 通知成功: request_id=${request_id}, topic_id=${finalTopicId}`);
   } catch (err) {
     logger.error(`[ExpertNotifier] 通知失败: ${err.message}`);
+    // 更新通知状态为失败
+    updateNotificationStatus(request_id, 'failed', err.message);
     throw err;
   }
 }
@@ -508,4 +658,5 @@ export default {
   pushSSENotification,
   notifyExpertResult,
   triggerExpertResponse,
+  resendNotification,
 };

--- a/server/services/assistant/index.js
+++ b/server/services/assistant/index.js
@@ -18,7 +18,7 @@ export { refreshAssistantsCache, getAssistant, createAssistant, updateAssistant,
 export { executeAssistant, executeDirect, executeLLM, executeLLMWithTools } from './executor.js';
 export { getAssistantTools, getInheritedToolDefinitions, executeInheritedTool } from './tool-integration.js';
 export { extractImageInput, executeVisionWithInput, readImageFile } from './vision-processor.js';
-export { pushSSENotification, notifyExpertResult, triggerExpertResponse } from './expert-notifier.js';
+export { pushSSENotification, notifyExpertResult, triggerExpertResponse, resendNotification } from './expert-notifier.js';
 
 // 默认导出
 export { default } from './manager.js';

--- a/server/services/assistant/manager.js
+++ b/server/services/assistant/manager.js
@@ -19,7 +19,7 @@ import { getAssistantTools, getInheritedToolDefinitions, executeInheritedTool } 
 import { extractImageInput, executeVisionWithInput, readImageFile } from './vision-processor.js';
 import { refreshAssistantsCache, getAssistant, createAssistant, updateAssistant, deleteAssistant, getAssistantDetail } from './config-repository.js';
 import { executeAssistant } from './executor.js';
-import { pushSSENotification, notifyExpertResult, triggerExpertResponse } from './expert-notifier.js';
+import { pushSSENotification, notifyExpertResult, triggerExpertResponse, resendNotification } from './expert-notifier.js';
 
 class AssistantManager {
   /**
@@ -350,6 +350,10 @@ class AssistantManager {
       created_at: request.created_at,
       started_at: request.started_at,
       completed_at: request.completed_at,
+      // 通知状态字段
+      notification_status: request.notification_status,
+      notification_error: request.notification_error,
+      notification_sent_at: request.notification_sent_at,
     };
   }
 
@@ -745,6 +749,18 @@ class AssistantManager {
       default:
         throw new Error(`Unknown tool: ${toolName}`);
     }
+  }
+
+  /**
+   * 重发通知给专家
+   * @param {string} requestId - 请求ID
+   * @returns {Promise<object>} 重发结果
+   */
+  async resendNotification(requestId) {
+    return await resendNotification(this.db, requestId, {
+      expertConnections: this.expertConnections,
+      chatService: this.chatService,
+    });
   }
 
   // ==================== 视觉处理 ====================


### PR DESCRIPTION
## 功能描述

实现助理通知重发功能，解决助理调用结果成功但未能通知到专家的问题。

## 主要变更

### 后端
- **内存存储通知状态**：使用 `notificationStatusMap` 存储通知状态，避免数据库变更
- **通知状态跟踪**：在 `expert-notifier.js` 中记录通知状态、失败原因、时间、重试次数
- **重发 API**：新增 `POST /api/assistants/requests/:request_id/resend-notification` 接口
- **重发逻辑**：清除内存状态后重新通知，避免重复检测拦截

### 前端
- **重发按钮**：在委托卡片上添加 📢 重发通知按钮（仅对已完成的委托显示）
- **API 调用**：新增 `resendNotification()` 方法
- **状态刷新**：重发成功后刷新委托列表

## 技术细节

### 通知状态结构
```javascript
{
  status: 'pending' | 'sent' | 'failed',
  failedReason?: string,
  notifiedAt?: Date,
  retryCount: number
}
```

### 控制台输出
通知状态会输出到控制台，包含：
- 状态（pending/sent/failed）
- 失败原因（如果有）
- 通知时间
- 重试次数

## 测试步骤

1. 创建一个助理委托并等待完成
2. 在右侧 Assistant Tab 的委托卡片上点击 📢 按钮
3. 查看控制台输出通知状态
4. 验证专家是否收到通知

## 关联 Issue

Closes #493
