### PR TITLE
fix: 修复用户管理界面用户列表垂直滚动条问题

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -3681,6 +3681,7 @@ onMounted(() => {
   flex: 1;
   padding: 16px;
   overflow-y: auto;
+  max-height: calc(100vh - 320px);
 }
 
 .user-item {


### PR DESCRIPTION
## 修复内容

修复用户管理界面用户列表缺少垂直滚动条的问题。

### 问题描述
用户管理界面的 `.user-list` 样式缺少 `max-height` 限制，导致容器会无限扩展，无法触发垂直滚动条显示。

### 解决方案
为 `.user-list` 添加 `max-height: calc(100vh - 320px)` 限制，确保列表区域在超出视口高度时显示垂直滚动条。

### 修改文件
- `frontend/src/views/SettingsView.vue`: 第3680行添加 `max-height` 属性

Closes #495