### PR TITLE
feat: 添加 Windows 平台支持 - 区分 Unix/Windows 命令白名单

### DIFF
--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -31,7 +31,7 @@ const BUILTIN_TOOLS = [
     type: 'function',
     function: {
       name: 'execute',
-      description: '执行 JavaScript 代码或安全的系统命令。支持两种模式：1) javascript - 在 VM 沙箱中执行 JS 代码，可访问 console、Buffer、URL 等基础 API；2) shell - 执行白名单内的安全命令（如 ls、grep、cat、head、tail、wc、sort 等），用于文件查看和文本处理。安全限制：仅允许相对路径、禁止重定向/管道/命令替换、禁止访问系统目录、30秒超时、1MB输出限制。',
+      description: `执行 JavaScript 代码或安全的系统命令。支持两种模式：1) javascript - 在 VM 沙箱中执行 JS 代码，可访问 console、Buffer、URL 等基础 API；2) shell - 执行白名单内的安全命令，用于文件查看和文本处理。当前平台: ${isWindowsPlatform() ? 'Windows' : 'Unix/Linux'}。${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, cd, date, time, ver, vol, attrib, sort, more, path' : 'Unix 支持命令: cat, head, tail, grep, wc, sort, uniq, cut, tr, diff, ls, pwd, echo, file, stat, which, date, uname, whoami, find'}。安全限制：仅允许相对路径、禁止重定向/管道/命令替换、禁止访问系统目录、30秒超时、1MB输出限制。`,
       parameters: {
         type: 'object',
         properties: {
@@ -42,7 +42,7 @@ const BUILTIN_TOOLS = [
           },
           code: {
             type: 'string',
-            description: '要执行的代码。当 type=javascript 时为 JS 代码；当 type=shell 时为系统命令（如 "ls -la"、"grep -n \"keyword\" file.txt"）。shell 命令必须使用相对路径，禁止包含 | > < $() ` 等特殊字符。',
+            description: `要执行的代码。当 type=javascript 时为 JS 代码；当 type=shell 时为系统命令。${isWindowsPlatform() ? 'Windows 示例: "dir", "type file.txt", "findstr \"keyword\" file.txt"' : 'Unix 示例: "ls -la", "cat file.txt", "grep -n \"keyword\" file.txt"'}。shell 命令必须使用相对路径，禁止包含 | > < $() \` 等特殊字符。`,
           },
           script_path: {
             type: 'string',
@@ -57,6 +57,8 @@ const BUILTIN_TOOLS = [
       toolName: 'execute',
       // 权限控制：仅 admin 和 creator 可执行脚本
       allowedRoles: ['admin', 'creator'],
+      // 平台信息
+      platform: isWindowsPlatform() ? 'windows' : 'unix',
     },
   },
   {
@@ -168,10 +170,18 @@ const BUILTIN_TOOLS = [
 ];
 
 /**
- * Shell 命令白名单
+ * 检测当前平台
+ * @returns {boolean} 是否为 Windows 平台
+ */
+function isWindowsPlatform() {
+  return process.platform === 'win32';
+}
+
+/**
+ * Unix 平台 Shell 命令白名单
  * 只允许执行这些安全的只读命令
  */
-const SHELL_COMMAND_WHITELIST = [
+const UNIX_COMMAND_WHITELIST = [
   // 文本处理类（只读）
   'cat', 'head', 'tail', 'grep', 'wc', 'sort', 'uniq', 'cut', 'tr', 'diff',
   // 信息查看类
@@ -181,6 +191,41 @@ const SHELL_COMMAND_WHITELIST = [
   // 文件查找（禁止 -exec, -delete）
   'find',
 ];
+
+/**
+ * Windows 平台 Shell 命令白名单
+ * Windows 使用 cmd.exe 内置命令和部分 Unix 工具
+ */
+const WINDOWS_COMMAND_WHITELIST = [
+  // 文件查看（对应 Unix 的 cat）
+  'type',
+  // 目录列表（对应 Unix 的 ls）
+  'dir',
+  // 查找文本（对应 Unix 的 grep）
+  'find', 'findstr',
+  // 信息查看
+  'echo', 'cd', 'pwd',
+  // 系统信息
+  'date', 'time', 'ver', 'vol',
+  // 文件信息
+  'attrib', 'dir',
+  // 排序
+  'sort',
+  // 更多命令
+  'more',
+  // 路径
+  'path',
+  // 复制（只读查看，不实际写入）
+  'copy',  // 注意：copy 在 Windows 是复制文件，需要额外限制
+];
+
+/**
+ * 获取当前平台的命令白名单
+ * @returns {string[]} 当前平台允许执行的命令列表
+ */
+function getPlatformWhitelist() {
+  return isWindowsPlatform() ? WINDOWS_COMMAND_WHITELIST : UNIX_COMMAND_WHITELIST;
+}
 
 // 移除 awk 和 sed - 它们可以执行任意代码或修改文件
 // awk 'BEGIN {system("rm -rf /")}'
@@ -268,10 +313,12 @@ function validateShellCommand(command) {
     : trimmedCommand;
   
   // 检查命令是否在白名单中
-  if (!SHELL_COMMAND_WHITELIST.includes(cmdName)) {
+  const whitelist = getPlatformWhitelist();
+  if (!whitelist.includes(cmdName)) {
+    const platform = isWindowsPlatform() ? 'Windows' : 'Unix/Linux';
     return {
       safe: false,
-      error: `Command "${cmdName}" is not in the whitelist. Allowed commands: ${SHELL_COMMAND_WHITELIST.join(', ')}`
+      error: `Command "${cmdName}" is not in the ${platform} whitelist. Allowed commands: ${whitelist.join(', ')}`
     };
   }
 

--- a/tests/test-user-code-executor.js
+++ b/tests/test-user-code-executor.js
@@ -140,27 +140,33 @@ async function main() {
     console.log('\n📦 Shell 模式测试');
     console.log('-'.repeat(40));
 
-    // 测试 5: 执行 ls 命令
-    console.log('\n📋 测试 5: 执行 ls 命令');
+    // 检测平台
+    const isWindows = process.platform === 'win32';
+    console.log(`\n🖥️  当前平台: ${isWindows ? 'Windows' : 'Unix/Linux'}`);
+
+    // 测试 5: 执行目录列表命令
+    console.log(`\n📋 测试 5: 执行 ${isWindows ? 'dir' : 'ls -la'} 命令`);
     const result5 = await runSkillTool('execute', {
       type: 'shell',
-      code: 'ls -la'
+      code: isWindows ? 'dir' : 'ls -la'
     });
     console.log('✅ 结果:', JSON.stringify(result5, null, 2));
 
-    // 测试 6: 执行 grep 命令
-    console.log('\n📋 测试 6: 执行 grep 命令');
+    // 测试 6: 执行文本查找命令
+    console.log(`\n📋 测试 6: 执行 ${isWindows ? 'findstr' : 'grep'} 命令`);
     const result6 = await runSkillTool('execute', {
       type: 'shell',
-      code: 'grep -n "test" tests/test-user-code-executor.js'
+      code: isWindows
+        ? 'findstr "test" tests\\test-user-code-executor.js'
+        : 'grep -n "test" tests/test-user-code-executor.js'
     });
     console.log('✅ 结果:', JSON.stringify(result6, null, 2));
 
-    // 测试 7: 执行 cat 命令
-    console.log('\n📋 测试 7: 执行 cat 命令');
+    // 测试 7: 执行文件查看命令
+    console.log(`\n📋 测试 7: 执行 ${isWindows ? 'type' : 'cat'} 命令`);
     const result7 = await runSkillTool('execute', {
       type: 'shell',
-      code: 'cat package.json'
+      code: isWindows ? 'type package.json' : 'cat package.json'
     });
     console.log('✅ 结果:', JSON.stringify(result7, null, 2));
 


### PR DESCRIPTION
## 变更说明

为 `execute` 工具添加 Windows 平台支持，区分 Unix/Linux 和 Windows 的命令白名单。

### 主要变更

1. **平台检测函数** `isWindowsPlatform()` - 自动检测当前运行平台

2. **分离命令白名单**:
   - `UNIX_COMMAND_WHITELIST` - Unix/Linux 平台命令（cat, ls, grep 等）
   - `WINDOWS_COMMAND_WHITELIST` - Windows 平台命令（type, dir, findstr 等）

3. **动态工具描述** - 工具描述根据当前平台自动显示支持的命令列表

4. **平台特定错误提示** - 错误消息显示当前平台和可用命令

### Windows 支持命令
- `type` - 查看文件内容（对应 Unix cat）
- `dir` - 列出目录（对应 Unix ls）
- `find` / `findstr` - 文本查找（对应 Unix grep）
- `echo`, `cd`, `date`, `time`, `ver`, `vol` - 系统信息
- `attrib`, `sort`, `more`, `path` - 其他实用命令

### Unix 支持命令
- `cat`, `head`, `tail`, `grep`, `wc`, `sort`, `uniq`, `cut`, `tr`, `diff`
- `ls`, `pwd`, `echo`, `file`, `stat`, `which`
- `date`, `uname`, `whoami`, `find`

### 测试更新
测试文件自动检测平台并执行相应的命令测试。

Closes #508