### PR TITLE
fix: 安全修复 - 移除 copy 命令，加强 Windows 路径检查

### DIFF
--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -208,15 +208,14 @@ const WINDOWS_COMMAND_WHITELIST = [
   // 系统信息
   'date', 'time', 'ver', 'vol',
   // 文件信息
-  'attrib', 'dir',
+  'attrib',
   // 排序
   'sort',
-  // 更多命令
+  // 更多命令（分页查看）
   'more',
   // 路径
   'path',
-  // 复制（只读查看，不实际写入）
-  'copy',  // 注意：copy 在 Windows 是复制文件，需要额外限制
+  // 注意：copy 命令已移除，因为它可以覆盖文件造成安全风险
 ];
 
 /**
@@ -276,21 +275,35 @@ const DANGEROUS_ARG_PATTERNS = [
  * 禁止访问敏感系统路径
  */
 const DANGEROUS_PATH_PATTERNS = [
-  /^\//,                    // 绝对路径（以 / 开头）
-  /\.\.\//,                 // 父目录引用 ../
-  /\/etc\//,                // /etc/ 目录
-  /\/proc\//,               // /proc/ 目录
-  /\/sys\//,                // /sys/ 目录
-  /\/dev\//,                // /dev/ 目录
-  /\/root\//,               // /root/ 目录
-  /\/home\/[^/]+\/\./,      // 用户隐藏文件
-  /\.env/,                  // .env 文件
-  /\.ssh/,                  // .ssh 目录
-  /\.git/,                  // .git 目录
-  /config.*\.json/i,        // 配置文件
-  /password/i,               // 密码相关
-  /secret/i,                 // 密钥相关
-  /token/i,                  // token 相关
+  // Unix 绝对路径（以 / 开头）
+  /^\//,
+  // Windows 绝对路径（如 C:\, D:\, \\server\share）
+  /^[a-zA-Z]:\\/,
+  /^\\\\/,
+  // 父目录引用 ../ 或 ..\
+  /\.\.\//,
+  /\.\.\\/,
+  // Unix 系统目录
+  /\/etc\//,
+  /\/proc\//,
+  /\/sys\//,
+  /\/dev\//,
+  /\/root\//,
+  /\/home\/[^/]+\/\./,
+  // Windows 系统目录
+  /\\Windows\\/i,
+  /\\System32\\/i,
+  /\\Program Files\\/i,
+  /\\ProgramData\\/i,
+  /\\Users\\[^\\]+\\/i,
+  // 敏感文件和目录
+  /\.env/,
+  /\.ssh/,
+  /\.git/,
+  /config.*\.json/i,
+  /password/i,
+  /secret/i,
+  /token/i,
 ];
 
 /**


### PR DESCRIPTION
## 安全修复

第二次代码审计发现的安全问题修复。

### 修复内容

1. **移除 Windows `copy` 命令** (中危)
   - `copy` 命令可以覆盖现有文件，造成数据损坏或安全风险
   - 从白名单中移除，确保只读操作

2. **加强 Windows 路径检查** (中危)
   - 原路径检查只覆盖 Unix 绝对路径 (`/etc/passwd`)
   - 新增 Windows 绝对路径检测：
     - `C:\Windows\System32` 等盘符路径
     - `\\server\share` 等 UNC 路径
     - `..\` 等 Windows 风格父目录引用
   - 新增 Windows 系统目录保护：
     - `\Windows\`
     - `\System32\`
     - `\Program Files\`
     - `\ProgramData\`
     - `\Users\{username}\`

### 安全加固后

- ✅ 命令白名单：按平台分离，移除危险命令
- ✅ 参数过滤：管道、重定向、命令替换等
- ✅ 路径限制：Unix + Windows 绝对路径和敏感目录
- ✅ 环境变量：只传递必要变量
- ✅ 超时控制：30秒 + 5秒强制终止
- ✅ 输出限制：1MB 截断
- ✅ 权限控制：admin/creator 角色检查

Closes #508