### PR TITLE
fix: 修复 upgrade-database.js 中 WORKSPACE_ROOT 路径派生问题

### DIFF
--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -28,8 +28,13 @@ const DB_CONFIG = {
 
 // 知识库图片存储目录
 const KB_IMAGES_ROOT = process.env.KB_IMAGES_ROOT || './data/kb-images';
-// 工作空间根目录
-const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT || './data/work';
+// 工作空间根目录 - 从 DATA_BASE_PATH 派生
+const DATA_BASE_PATH = process.env.DATA_BASE_PATH
+  ? (path.isAbsolute(process.env.DATA_BASE_PATH)
+      ? process.env.DATA_BASE_PATH
+      : path.join(process.cwd(), process.env.DATA_BASE_PATH))
+  : path.join(process.cwd(), 'data');
+const WORKSPACE_ROOT = path.join(DATA_BASE_PATH, 'work');
 
 /**
  * 检查表是否存在


### PR DESCRIPTION
## 问题描述

修复 `scripts/upgrade-database.js` 中 `WORKSPACE_ROOT` 未从 `DATA_BASE_PATH` 派生的问题。

## 问题原因

`scripts/upgrade-database.js` 第 32 行还在使用旧的逻辑：

```javascript
const WORKSPACE_ROOT = process.env.WORKSPACE_ROOT || './data/work';
```

这会导致当 `DATA_BASE_PATH=/app/data` 时，如果没有设置 `WORKSPACE_ROOT`，它会使用默认的 `./data/work`（相对于当前工作目录 `/app`），即 `/app/data/work`，而不是从 `DATA_BASE_PATH` 派生。

## 修复方案

改为从 `DATA_BASE_PATH` 派生：

```javascript
const DATA_BASE_PATH = process.env.DATA_BASE_PATH
  ? (path.isAbsolute(process.env.DATA_BASE_PATH)
      ? process.env.DATA_BASE_PATH
      : path.join(process.cwd(), process.env.DATA_BASE_PATH))
  : path.join(process.cwd(), 'data');
const WORKSPACE_ROOT = path.join(DATA_BASE_PATH, 'work');
```

## 变更内容

- 修复 `scripts/upgrade-database.js` 中的路径派生逻辑
- 确保 `WORKSPACE_ROOT` 始终从 `DATA_BASE_PATH` 派生

Closes #524