### PR TITLE
fix: 修复硬编码 data 路径问题

### DIFF
--- a/lib/resident-skill-manager.js
+++ b/lib/resident-skill-manager.js
@@ -13,6 +13,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from './logger.js';
+import { getDataBasePath } from './paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -95,7 +96,8 @@ class ResidentProcess {
 
     const skillPath = this.skill.source_path;
     const scriptPath = this.tool.script_path || 'index.js';
-    const fullPath = path.join(process.cwd(), 'data', skillPath, scriptPath);
+    const dataBasePath = getDataBasePath();
+    const fullPath = path.join(dataBasePath, skillPath, scriptPath);
 
     logger.info(`Starting resident process: ${this.tool.name} from ${fullPath}`);
 

--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -11,6 +11,7 @@ import Utils from '../../lib/utils.js';
 import { parseSkillMd, validateSkillPath } from '../../lib/skill-parser.js';
 import fsOriginal from 'fs';
 import path from 'path';
+import { getDataBasePath } from '../../lib/paths.js';
 
 class SkillController {
   constructor(db) {
@@ -933,7 +934,8 @@ class SkillController {
         skillPath = result.path;
       } else {
         // 未注册目录，直接使用 data/skills/:name
-        skillPath = path.join(PROJECT_ROOT, 'data', 'skills', id);
+        const dataBasePath = getDataBasePath();
+        skillPath = path.join(dataBasePath, 'skills', id);
       }
 
       logger.info('[listFiles] Computed skillPath:', { skillPath, exists: skillPath ? fsOriginal.existsSync(skillPath) : false });
@@ -1023,7 +1025,8 @@ class SkillController {
         skillPath = result.path;
       } else {
         // 未注册目录，直接使用 data/skills/:name
-        skillPath = path.join(PROJECT_ROOT, 'data', 'skills', id);
+        const dataBasePath = getDataBasePath();
+        skillPath = path.join(dataBasePath, 'skills', id);
       }
 
       if (!skillPath || !fsOriginal.existsSync(skillPath)) {
@@ -1080,8 +1083,8 @@ class SkillController {
    */
   async listDirectories(ctx) {
     try {
-      const PROJECT_ROOT = process.cwd();
-      const skillsDir = path.join(PROJECT_ROOT, 'data', 'skills');
+      const dataBasePath = getDataBasePath();
+      const skillsDir = path.join(dataBasePath, 'skills');
 
       // 确保 data/skills 目录存在
       if (!fsOriginal.existsSync(skillsDir)) {
@@ -1150,8 +1153,8 @@ class SkillController {
         return;
       }
 
-      const PROJECT_ROOT = process.cwd();
-      const skillsDir = path.join(PROJECT_ROOT, 'data', 'skills');
+      const dataBasePath = getDataBasePath();
+      const skillsDir = path.join(dataBasePath, 'skills');
       const newDirPath = path.join(skillsDir, name);
 
       // 检查目录是否已存在


### PR DESCRIPTION
## 问题描述

修复 `lib/resident-skill-manager.js` 和 `server/controllers/skill.controller.js` 中的硬编码 `data` 路径问题。

## 问题原因

这些文件使用了硬编码的 `'data'` 字符串来构建路径，而不是从 `DATA_BASE_PATH` 环境变量派生：

```javascript
// 错误示例
const fullPath = path.join(process.cwd(), 'data', skillPath, scriptPath);
const skillsDir = path.join(PROJECT_ROOT, 'data', 'skills');
```

当 `DATA_BASE_PATH` 设置为 `/app/data` 时，这些硬编码路径会导致文件操作到错误的位置。

## 修复方案

改为使用 `getDataBasePath()` 函数从环境变量派生：

```javascript
// 正确示例
const dataBasePath = getDataBasePath();
const fullPath = path.join(dataBasePath, skillPath, scriptPath);
const skillsDir = path.join(dataBasePath, 'skills');
```

## 变更内容

### lib/resident-skill-manager.js
- 导入 `getDataBasePath` 函数
- 修复第 98 行的硬编码路径

### server/controllers/skill.controller.js
- 导入 `getDataBasePath` 函数
- 修复 `listFiles` 方法中的硬编码路径
- 修复 `getFileContent` 方法中的硬编码路径
- 修复 `listDirectories` 方法中的硬编码路径
- 修复 `createDirectory` 方法中的硬编码路径

## 影响范围

- 驻留式技能加载
- 技能目录文件管理 API
- 技能目录创建

Closes #525