### PR TITLE
fix: 修复沙箱执行器中的硬编码 data 路径

### DIFF
--- a/lib/firejail-executor.js
+++ b/lib/firejail-executor.js
@@ -9,6 +9,7 @@ import { spawn, exec } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import logger from './logger.js';
+import { getDataBasePath } from './paths.js';
 
 // 项目根目录
 const PROJECT_ROOT = path.resolve(process.cwd());
@@ -236,7 +237,8 @@ class FirejailExecutor {
    * @returns {string} 工作目录路径
    */
   getUserWorkDir(userId) {
-    return path.join(PROJECT_ROOT, 'data', 'work', userId);
+    const dataBasePath = getDataBasePath();
+    return path.join(dataBasePath, 'work', userId);
   }
 
   /**

--- a/lib/sandboxie-executor.js
+++ b/lib/sandboxie-executor.js
@@ -9,6 +9,7 @@ import { spawn, exec } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import logger from './logger.js';
+import { getDataBasePath } from './paths.js';
 
 // 项目根目录
 const PROJECT_ROOT = path.resolve(process.cwd());
@@ -305,7 +306,8 @@ Enabled=y
    * @returns {string} 工作目录路径
    */
   getUserWorkDir(userId) {
-    return path.join(PROJECT_ROOT, 'data', 'work', userId);
+    const dataBasePath = getDataBasePath();
+    return path.join(dataBasePath, 'work', userId);
   }
 
   /**


### PR DESCRIPTION
## 问题描述

修复 `lib/sandboxie-executor.js` 和 `lib/firejail-executor.js` 中的硬编码 `data` 路径问题。

## 问题原因

这两个沙箱执行器文件中的 `getUserWorkDir` 方法使用了硬编码的 `'data'` 字符串：

```javascript
getUserWorkDir(userId) {
  return path.join(PROJECT_ROOT, 'data', 'work', userId);
}
```

当 `DATA_BASE_PATH` 设置为 `/app/data` 时，这个硬编码路径会导致沙箱执行器操作到错误的位置。

## 修复方案

改为使用 `getDataBasePath()` 函数从环境变量派生：

```javascript
getUserWorkDir(userId) {
  const dataBasePath = getDataBasePath();
  return path.join(dataBasePath, 'work', userId);
}
```

## 变更内容

### lib/sandboxie-executor.js
- 导入 `getDataBasePath` 函数
- 修复 `getUserWorkDir` 方法中的硬编码路径

### lib/firejail-executor.js
- 导入 `getDataBasePath` 函数
- 修复 `getUserWorkDir` 方法中的硬编码路径

## 影响范围

- Windows Sandboxie Plus 沙箱执行
- Linux Firejail 沙箱执行

Closes #526