### PR TITLE
refactor: 统一 skill-loader.js 中的路径计算

### DIFF
--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
 import logger from './logger.js';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
+import { getDataBasePath } from './paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -42,11 +43,7 @@ class SkillLoader {
   constructor(db, options = {}) {
     this.db = db;
     // 默认使用 DATA_BASE_PATH/skills 目录
-    const dataBasePath = process.env.DATA_BASE_PATH
-      ? (path.isAbsolute(process.env.DATA_BASE_PATH)
-          ? process.env.DATA_BASE_PATH
-          : path.join(process.cwd(), process.env.DATA_BASE_PATH))
-      : path.join(process.cwd(), 'data');
+    const dataBasePath = getDataBasePath();
     this.skillsBasePath = options.skillsBasePath || path.join(dataBasePath, 'skills');
 
     // 技能缓存
@@ -509,11 +506,7 @@ class SkillLoader {
     );
 
     // 计算数据基础路径
-    const dataBasePath = process.env.DATA_BASE_PATH
-      ? (path.isAbsolute(process.env.DATA_BASE_PATH)
-          ? process.env.DATA_BASE_PATH
-          : path.join(process.cwd(), process.env.DATA_BASE_PATH))
-      : path.join(process.cwd(), 'data');
+    const dataBasePath = getDataBasePath();
 
     // 确定工作目录
     const workingDirectory = userContext.workingDirectory || null;
@@ -768,11 +761,7 @@ class SkillLoader {
     }
 
     // 计算数据基础路径（优先使用环境变量，否则默认为 cwd/data）
-    const dataBasePath = process.env.DATA_BASE_PATH
-      ? (path.isAbsolute(process.env.DATA_BASE_PATH)
-          ? process.env.DATA_BASE_PATH
-          : path.join(process.cwd(), process.env.DATA_BASE_PATH))
-      : path.join(process.cwd(), 'data');
+    const dataBasePath = getDataBasePath();
 
     // 确定技能路径：技能目录 = dataBasePath + source_path
     // - 绝对路径：直接使用


### PR DESCRIPTION
## 问题描述

重构 `lib/skill-loader.js`，使用 `getDataBasePath()` 函数统一路径计算逻辑。

## 问题原因

`lib/skill-loader.js` 中有3处重复的路径计算逻辑：

```javascript
const dataBasePath = process.env.DATA_BASE_PATH
  ? (path.isAbsolute(process.env.DATA_BASE_PATH)
      ? process.env.DATA_BASE_PATH
      : path.join(process.cwd(), process.env.DATA_BASE_PATH))
  : path.join(process.cwd(), 'data');
```

这种重复代码违反了 DRY 原则，应该使用统一的 `getDataBasePath()` 函数。

## 修复方案

改为使用 `getDataBasePath()` 函数：

```javascript
const dataBasePath = getDataBasePath();
```

## 变更内容

### lib/skill-loader.js
- 导入 `getDataBasePath` 函数
- 简化 `constructor` 中的路径计算
- 简化 `buildUserCodeEnvironment` 中的路径计算
- 简化 `buildSkillEnvironment` 中的路径计算

## 影响范围

- 技能加载器初始化
- 用户代码执行环境构建
- 技能执行环境构建

## 代码简化

- 删除 15 行重复代码
- 增加 4 行（导入和函数调用）
- 净减少 11 行代码

Closes #527