### PR TITLE
fix: 修复 WORKING_DIRECTORY 为空字符串时技能进程 cwd 回退问题

### DIFF
--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -479,9 +479,18 @@ function executeSkill(code, skillId) {
   // 优先使用 WORKING_DIRECTORY，否则回退到 DATA_BASE_PATH
   const workingDirectory = process.env.WORKING_DIRECTORY;
   const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
-  const effectiveCwd = workingDirectory
-    ? path.join(dataBasePath, workingDirectory)
-    : dataBasePath;
+  
+  // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
+  // 优先使用 WORKING_DIRECTORY，如果为空则尝试构建默认工作目录
+  let effectiveCwd;
+  if (workingDirectory && workingDirectory.trim() !== '') {
+    effectiveCwd = path.join(dataBasePath, workingDirectory);
+  } else if (process.env.USER_ID) {
+    // 如果没有工作目录但有用户ID，使用默认用户工作目录
+    effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
+  } else {
+    effectiveCwd = dataBasePath;
+  }
   
   // 计算允许访问的路径列表
   // 管理员：整个 data 目录
@@ -585,9 +594,17 @@ async function executeUserCodeDirectly(code, source = 'inline') {
   // 确定工作目录
   const workingDirectory = process.env.WORKING_DIRECTORY;
   const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
-  const effectiveCwd = workingDirectory
-    ? path.join(dataBasePath, workingDirectory)
-    : dataBasePath;
+  
+  // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
+  let effectiveCwd;
+  if (workingDirectory && workingDirectory.trim() !== '') {
+    effectiveCwd = path.join(dataBasePath, workingDirectory);
+  } else if (process.env.USER_ID) {
+    // 如果没有工作目录但有用户ID，使用默认用户工作目录
+    effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
+  } else {
+    effectiveCwd = dataBasePath;
+  }
   
   // 用户代码只能访问自己的工作目录
   const allowedPaths = [effectiveCwd];
@@ -886,14 +903,20 @@ print(json.dumps(_result))
     
     // 确定工作目录：
     // 1. 有 WORKING_DIRECTORY 环境变量时：使用 DATA_BASE_PATH + WORKING_DIRECTORY
-    // 2. 无 WORKING_DIRECTORY 时：使用技能目录（默认行为）
+    // 2. 无 WORKING_DIRECTORY 但有 USER_ID 时：使用默认用户工作目录
+    // 3. 否则：使用技能目录（默认行为）
     let workingDir = skillPath;
     const workDirEnv = process.env.WORKING_DIRECTORY;
     const dataBasePathEnv = process.env.DATA_BASE_PATH;
+    const userIdEnv = process.env.USER_ID;
     
-    if (workDirEnv && dataBasePathEnv) {
+    if (workDirEnv && workDirEnv.trim() !== '' && dataBasePathEnv) {
       workingDir = path.join(dataBasePathEnv, workDirEnv);
       process.stderr.write(`[skill-runner] 使用工作目录: ${workingDir}\n`);
+    } else if (userIdEnv && dataBasePathEnv) {
+      // 修复：当 WORKING_DIRECTORY 为空时，使用默认用户工作目录
+      workingDir = path.join(dataBasePathEnv, 'work', userIdEnv, 'temp');
+      process.stderr.write(`[skill-runner] 使用默认用户工作目录: ${workingDir}\n`);
     } else {
       process.stderr.write(`[skill-runner] 使用技能目录作为工作目录: ${workingDir}\n`);
     }
@@ -998,9 +1021,15 @@ async function main() {
         if (script_path) {
           const workingDirectory = process.env.WORKING_DIRECTORY;
           const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
-          const userWorkDir = workingDirectory
-            ? path.join(dataBasePath, workingDirectory)
-            : path.join(dataBasePath, 'work', process.env.USER_ID || 'default');
+          const userId = process.env.USER_ID || 'default';
+          
+          // 修复：当 WORKING_DIRECTORY 为空字符串时，也使用默认用户工作目录
+          let userWorkDir;
+          if (workingDirectory && workingDirectory.trim() !== '') {
+            userWorkDir = path.join(dataBasePath, workingDirectory);
+          } else {
+            userWorkDir = path.join(dataBasePath, 'work', userId, 'temp');
+          }
           
           // 安全检查：禁止路径遍历
           const normalizedPath = path.normalize(script_path);


### PR DESCRIPTION
## 问题描述

在 Docker 部署环境中，当 `WORKING_DIRECTORY` 环境变量为空字符串时，技能进程的当前工作目录（cwd）会错误地回退到 `DATA_BASE_PATH`（即 `/app/data`），而不是预期的用户工作目录（如 `/app/data/work/{user_id}/temp`）。

这导致技能工具调用可以正确读写挂载的目录，但后端操作（如文件上传、目录显示）却操作了错误的路径。

## 根本原因

在 `lib/skill-runner.js` 中，多处使用三元运算符判断 `WORKING_DIRECTORY`：

```javascript
const effectiveCwd = workingDirectory
  ? path.join(dataBasePath, workingDirectory)
  : dataBasePath;
```

当 `WORKING_DIRECTORY` 是空字符串 `''` 时，JavaScript 将其判断为 falsy 值，导致 cwd 回退到 `DATA_BASE_PATH`。

## 修复内容

修复了 `lib/skill-runner.js` 中的 4 处工作目录判断逻辑：

1. **`executeSkill` 函数**（第 478-484 行）：Node.js 技能执行的 cwd 设置
2. **`executeUserCodeDirectly` 函数**（第 585-591 行）：用户代码直接执行的 cwd 设置
3. **`executePythonSkill` 函数**（第 887-899 行）：Python 技能执行的 cwd 设置
4. **用户代码脚本路径加载**（第 997-1003 行）：从文件加载用户代码时的路径解析

### 修复逻辑

将原来的三元运算符改为显式检查空字符串：

```javascript
// 修复前
const effectiveCwd = workingDirectory
  ? path.join(dataBasePath, workingDirectory)
  : dataBasePath;

// 修复后
let effectiveCwd;
if (workingDirectory && workingDirectory.trim() !== '') {
  effectiveCwd = path.join(dataBasePath, workingDirectory);
} else if (process.env.USER_ID) {
  // 如果没有工作目录但有用户ID，使用默认用户工作目录
  effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
} else {
  effectiveCwd = dataBasePath;
}
```

## 测试建议

1. 在 Docker 环境中部署应用
2. 设置 `DATA_BASE_PATH=/app/data`，不设置 `WORKSPACE_ROOT`
3. 挂载 `./data:/app/data`
4. 在对话模式下（无 task_id）使用文件操作技能
5. 验证文件是否正确写入 `/app/data/work/{user_id}/temp` 目录

## 相关 Issue

- 与 PR #525、#526、#527、#528 相关，进一步完善路径处理逻辑
