### PR TITLE
fix: 将 DATA_BASE_PATH 添加到环境变量白名单

### DIFF
--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -734,7 +734,7 @@ class SkillLoader {
     // 最小化系统环境变量白名单（仅保留必要的）
     // 注意：移除 INTERNAL_API_SECRET，技能应使用用户 Token 认证
     // 注意：API_BASE 在下面单独设置，不需要从系统环境变量继承
-    const allowedSystemVars = ['PATH', 'NODE_ENV', 'HOME', 'TMPDIR', 'LANG', 'TZ'];
+    const allowedSystemVars = ['PATH', 'NODE_ENV', 'HOME', 'TMPDIR', 'LANG', 'TZ', 'DATA_BASE_PATH'];
     const systemEnv = Object.fromEntries(
       allowedSystemVars
         .filter(key => process.env[key])


### PR DESCRIPTION
## 修复内容

将 `DATA_BASE_PATH` 环境变量添加到 `lib/skill-loader.js` 的环境变量白名单中，确保在 Docker 部署时技能子进程能正确获取数据目录路径。

## 变更

- `lib/skill-loader.js` 第 737 行：在 `allowedSystemVars` 数组中添加 `'DATA_BASE_PATH'`

## 修复前的问题

在 Docker 环境中，即使设置了 `DATA_BASE_PATH=/data` 并映射了卷，技能执行时仍然使用默认的 `/app/data` 路径，因为该环境变量被白名单过滤掉了。

## 修复后的行为

技能子进程现在能正确接收 `DATA_BASE_PATH` 环境变量，文件操作将使用正确的路径（如 `/data/work/userId/taskId`）。

## 测试建议

1. 设置 Docker 环境变量 `DATA_BASE_PATH=/data`
2. 映射卷 `-v /host/data:/data`
3. 执行文件操作技能
4. 确认文件写入到主机 `/host/data/work/` 目录

Closes #531