### PR TITLE
fix: 严格检查 DATA_BASE_PATH 环境变量

### DIFF
--- a/data/skills/remote-llm/submit.js
+++ b/data/skills/remote-llm/submit.js
@@ -23,11 +23,16 @@ const path = require('path');
 const { URL } = require('url');
 
 // 配置
+const dataBasePath = process.env.DATA_BASE_PATH;
+if (!dataBasePath) {
+  throw new Error('DATA_BASE_PATH environment variable is not set');
+}
+
 const CONFIG = {
   apiBase: process.env.API_BASE || 'http://localhost:3000',
   userAccessToken: process.env.USER_ACCESS_TOKEN || '',
   defaultTimeout: 10000,
-  dataBasePath: process.env.DATA_BASE_PATH || process.cwd(),
+  dataBasePath: dataBasePath,
 };
 
 /**

--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -478,7 +478,10 @@ function executeSkill(code, skillId) {
   // 确定工作目录（用于 process.cwd()）
   // 优先使用 WORKING_DIRECTORY，否则回退到 DATA_BASE_PATH
   const workingDirectory = process.env.WORKING_DIRECTORY;
-  const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
+  const dataBasePath = process.env.DATA_BASE_PATH;
+  if (!dataBasePath) {
+    throw new Error('DATA_BASE_PATH environment variable is not set');
+  }
   
   // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
   // 优先使用 WORKING_DIRECTORY，如果为空则尝试构建默认工作目录
@@ -593,7 +596,10 @@ async function executeUserCodeDirectly(code, source = 'inline') {
   
   // 确定工作目录
   const workingDirectory = process.env.WORKING_DIRECTORY;
-  const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
+  const dataBasePath = process.env.DATA_BASE_PATH;
+  if (!dataBasePath) {
+    throw new Error('DATA_BASE_PATH environment variable is not set');
+  }
   
   // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
   let effectiveCwd;
@@ -743,7 +749,10 @@ async function executePythonSkill(skillPath, scriptPath, toolName, params, conte
     const isAdmin = process.env.IS_ADMIN === 'true';
     const isSkillCreator = process.env.IS_SKILL_CREATOR === 'true';
     const userId = process.env.USER_ID || 'default';
-    const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
+    const dataBasePath = process.env.DATA_BASE_PATH;
+    if (!dataBasePath) {
+      throw new Error('DATA_BASE_PATH environment variable is not set');
+    }
     
     // 计算允许访问的路径列表（与 Node.js 沙箱保持一致）
     let allowedPaths;
@@ -1020,7 +1029,10 @@ async function main() {
         // 如果提供了脚本路径，从文件加载代码
         if (script_path) {
           const workingDirectory = process.env.WORKING_DIRECTORY;
-          const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
+          const dataBasePath = process.env.DATA_BASE_PATH;
+          if (!dataBasePath) {
+            throw new Error('DATA_BASE_PATH environment variable is not set');
+          }
           const userId = process.env.USER_ID || 'default';
           
           // 修复：当 WORKING_DIRECTORY 为空字符串时，也使用默认用户工作目录


### PR DESCRIPTION
## 修复内容

严格检查 `DATA_BASE_PATH` 环境变量，未设置时直接报错，避免静默使用错误路径。

### 修改的文件

1. **lib/skill-runner.js** (4处)
   - `executeSkill` 函数
   - `executeUserCodeDirectly` 函数  
   - `executePythonSkill` 函数
   - `main` 函数（用户代码模式）

2. **data/skills/remote-llm/submit.js** (1处)
   - CONFIG 初始化

### 变更说明

**修改前：**
```javascript
const dataBasePath = process.env.DATA_BASE_PATH || process.cwd();
```

**修改后：**
```javascript
const dataBasePath = process.env.DATA_BASE_PATH;
if (!dataBasePath) {
  throw new Error('DATA_BASE_PATH environment variable is not set');
}
```

### 影响

- Docker 部署必须设置 `DATA_BASE_PATH` 环境变量
- 本地开发必须设置 `DATA_BASE_PATH` 环境变量
- 未设置时会明确报错，避免路径错误问题
