### PR TITLE
fix: lib/paths.js 严格检查 DATA_BASE_PATH 环境变量

### DIFF
--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -29,7 +29,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:?DB_PASSWORD is required}
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET is required}
       - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET:?JWT_REFRESH_SECRET is required}
-      - DATA_BASE_PATH=/app/data
+      - DATA_BASE_PATH=${DATA_BASE_PATH:-/app/data}
       # WORKSPACE_ROOT 默认值为 ${DATA_BASE_PATH}/work，自动派生
       # 只有当工作目录需要与数据目录分离时才需要手动设置
       # - WORKSPACE_ROOT=/app/data/work

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD:-touwaka_secret}
       - JWT_SECRET=${JWT_SECRET:-change-this-secret-in-production}
       - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET:-change-this-refresh-secret-in-production}
-      - DATA_BASE_PATH=/app/data
+      - DATA_BASE_PATH=${DATA_BASE_PATH:-/app/data}
       # WORKSPACE_ROOT 默认值为 ${DATA_BASE_PATH}/work，自动派生
       # 只有当工作目录需要与数据目录分离时才需要手动设置
       # - WORKSPACE_ROOT=/app/data/work

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -8,12 +8,12 @@ import path from 'path';
 
 /**
  * 获取数据基础路径
- * 优先从环境变量读取，否则使用默认值
+ * 严格从环境变量读取，未设置时报错
  */
 export function getDataBasePath() {
   const envPath = process.env.DATA_BASE_PATH;
   if (!envPath) {
-    return path.join(process.cwd(), 'data');
+    throw new Error('DATA_BASE_PATH environment variable is not set');
   }
   return path.isAbsolute(envPath) ? envPath : path.join(process.cwd(), envPath);
 }


### PR DESCRIPTION
## 修复内容

严格检查 `DATA_BASE_PATH` 环境变量，未设置时直接报错。

### 修改的文件

1. **lib/paths.js**
   - `getDataBasePath()` 函数：移除 fallback 到 `process.cwd() + '/data'` 的逻辑
   - 未设置 `DATA_BASE_PATH` 时抛出明确错误

2. **docker-compose.yml** 和 **docker-compose.standalone.yml**
   - 将 `DATA_BASE_PATH=/app/data` 改为 `DATA_BASE_PATH=${DATA_BASE_PATH:-/app/data}`
   - 支持通过环境变量自定义数据目录路径

### 变更说明

**修改前：**
```javascript
export function getDataBasePath() {
  const envPath = process.env.DATA_BASE_PATH;
  if (!envPath) {
    return path.join(process.cwd(), 'data');  // 静默使用错误路径
  }
  return path.isAbsolute(envPath) ? envPath : path.join(process.cwd(), envPath);
}
```

**修改后：**
```javascript
export function getDataBasePath() {
  const envPath = process.env.DATA_BASE_PATH;
  if (!envPath) {
    throw new Error('DATA_BASE_PATH environment variable is not set');  // 明确报错
  }
  return path.isAbsolute(envPath) ? envPath : path.join(process.cwd(), envPath);
}
```

### 影响

- Docker 部署必须设置 `DATA_BASE_PATH` 环境变量
- 本地开发必须设置 `DATA_BASE_PATH` 环境变量
- 未设置时会明确报错，避免路径错误问题
