### PR TITLE
feat: 添加工作目录计算规则的红色调试输出

### DIFF
--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -486,14 +486,25 @@ function executeSkill(code, skillId) {
   // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
   // 优先使用 WORKING_DIRECTORY，如果为空则尝试构建默认工作目录
   let effectiveCwd;
+  let cwdRule;
   if (workingDirectory && workingDirectory.trim() !== '') {
     effectiveCwd = path.join(dataBasePath, workingDirectory);
+    cwdRule = `规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)`;
   } else if (process.env.USER_ID) {
     // 如果没有工作目录但有用户ID，使用默认用户工作目录
     effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
+    cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID -> path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')`;
   } else {
     effectiveCwd = dataBasePath;
+    cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
   }
+  
+  // 红色输出工作目录计算规则
+  console.log(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m`);
+  console.log(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePath}\x1b[0m`);
+  console.log(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m`);
+  console.log(`\x1b[31m[skill-runner] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m`);
+  console.log(`\x1b[31m[skill-runner] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m`);
   
   // 计算允许访问的路径列表
   // 管理员：整个 data 目录
@@ -603,14 +614,25 @@ async function executeUserCodeDirectly(code, source = 'inline') {
   
   // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
   let effectiveCwd;
+  let cwdRule;
   if (workingDirectory && workingDirectory.trim() !== '') {
     effectiveCwd = path.join(dataBasePath, workingDirectory);
+    cwdRule = `规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)`;
   } else if (process.env.USER_ID) {
     // 如果没有工作目录但有用户ID，使用默认用户工作目录
     effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
+    cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID -> path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')`;
   } else {
     effectiveCwd = dataBasePath;
+    cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
   }
+  
+  // 红色输出工作目录计算规则
+  console.log(`\x1b[31m[user-code] 工作目录计算规则: ${cwdRule}\x1b[0m`);
+  console.log(`\x1b[31m[user-code] DATA_BASE_PATH = ${dataBasePath}\x1b[0m`);
+  console.log(`\x1b[31m[user-code] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m`);
+  console.log(`\x1b[31m[user-code] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m`);
+  console.log(`\x1b[31m[user-code] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m`);
   
   // 用户代码只能访问自己的工作目录
   const allowedPaths = [effectiveCwd];
@@ -918,17 +940,25 @@ print(json.dumps(_result))
     const workDirEnv = process.env.WORKING_DIRECTORY;
     const dataBasePathEnv = process.env.DATA_BASE_PATH;
     const userIdEnv = process.env.USER_ID;
+    let cwdRule;
     
     if (workDirEnv && workDirEnv.trim() !== '' && dataBasePathEnv) {
       workingDir = path.join(dataBasePathEnv, workDirEnv);
-      process.stderr.write(`[skill-runner] 使用工作目录: ${workingDir}\n`);
+      cwdRule = `规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)`;
     } else if (userIdEnv && dataBasePathEnv) {
       // 修复：当 WORKING_DIRECTORY 为空时，使用默认用户工作目录
       workingDir = path.join(dataBasePathEnv, 'work', userIdEnv, 'temp');
-      process.stderr.write(`[skill-runner] 使用默认用户工作目录: ${workingDir}\n`);
+      cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID -> path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')`;
     } else {
-      process.stderr.write(`[skill-runner] 使用技能目录作为工作目录: ${workingDir}\n`);
+      cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用技能目录`;
     }
+    
+    // 红色输出工作目录计算规则
+    console.log(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m`);
+    console.log(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePathEnv || '(空)'}\x1b[0m`);
+    console.log(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workDirEnv || '(空)'}\x1b[0m`);
+    console.log(`\x1b[31m[skill-runner] USER_ID = ${userIdEnv || '(空)'}\x1b[0m`);
+    console.log(`\x1b[31m[skill-runner] 拼接结果: workingDir = ${workingDir}\x1b[0m`);
     
     const pythonProcess = spawn(pythonCmd, ['-c', sandboxWrapper], {
       cwd: workingDir,


### PR DESCRIPTION
## 概述

在 `lib/skill-runner.js` 的三个关键位置添加红色调试输出，用于显示工作目录 (cwd) 的计算规则和拼接结果。

## 修改内容

### 1. `executeSkill` 函数 (Node.js 技能执行)
- 添加红色输出显示使用的计算规则
- 显示 `DATA_BASE_PATH`、`WORKING_DIRECTORY`、`USER_ID` 的值
- 显示最终的 `effectiveCwd` 拼接结果

### 2. `executeUserCodeDirectly` 函数 (用户代码直接执行)
- 同上，使用 `[user-code]` 前缀区分

### 3. `executePythonSkill` 函数 (Python 技能执行)
- 同上，用于 Python 子进程的工作目录计算

## 工作目录计算规则

| 规则 | 条件 | 结果 |
|------|------|------|
| 规则1 | WORKING_DIRECTORY 存在且非空 | `path.join(DATA_BASE_PATH, WORKING_DIRECTORY)` |
| 规则2 | WORKING_DIRECTORY 为空但有 USER_ID | `path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')` |
| 规则3 | 无 WORKING_DIRECTORY 和 USER_ID | 使用 `DATA_BASE_PATH` 或技能目录 |

## 测试

执行任意技能时，控制台将显示红色输出：
```
[skill-runner] 工作目录计算规则: 规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)
[skill-runner] DATA_BASE_PATH = d:/projects/node/touwaka-mate-v2-p0/data
[skill-runner] WORKING_DIRECTORY = work/user123/task456
[skill-runner] USER_ID = user123
[skill-runner] 拼接结果: effectiveCwd = d:/projects/node/touwaka-mate-v2-p0/data/work/user123/task456
```

Closes #535