### PR TITLE
fix: 为 execute 工具的 shell 命令执行添加工作目录调试输出

### DIFF
--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -434,6 +434,13 @@ async function executeSafeShell(command, workingDirectory, timeout = 30000) {
         cwd = process.cwd();
       }
     }
+    
+    // 红色输出工作目录信息（用于调试）
+    console.log(`\x1b[31m[executeSafeShell] 工作目录信息:\x1b[0m`);
+    console.log(`\x1b[31m[executeSafeShell]   传入的 workingDirectory = ${workingDirectory || '(空)'}\x1b[0m`);
+    console.log(`\x1b[31m[executeSafeShell]   实际使用的 cwd = ${cwd || '(空, 将使用process.cwd())'}\x1b[0m`);
+    console.log(`\x1b[31m[executeSafeShell]   process.cwd() = ${process.cwd()}\x1b[0m`);
+    console.log(`\x1b[31m[executeSafeShell]   执行的命令 = ${command}\x1b[0m`);
 
     // 设置输出限制（最大 1MB）
     const MAX_OUTPUT_SIZE = 1024 * 1024;


### PR DESCRIPTION
## 概述

为 `execute` 工具的 shell 命令执行添加工作目录调试输出。

## 问题背景

PR #536 在 `skill-runner.js` 中添加了工作目录的红色调试输出，但 `execute` 工具执行 shell 命令（如 `pwd`）时**不经过** `skill-runner.js`，而是直接通过 `tool-manager.js` 中的 `executeSafeShell` 函数执行。

## 修改内容

在 `lib/tool-manager.js` 的 `executeSafeShell` 函数中添加红色调试输出，显示：
- 传入的 workingDirectory 参数
- 实际使用的 cwd（处理后的工作目录）
- process.cwd() 的值
- 执行的命令

## 输出示例

```
[executeSafeShell] 工作目录信息:
[executeSafeShell]   传入的 workingDirectory = work/user123/task456
[executeSafeShell]   实际使用的 cwd = d:/projects/node/touwaka-mate-v2-p0/data/work/user123/task456
[executeSafeShell]   process.cwd() = d:/projects/node/touwaka-mate-v2-p0
[executeSafeShell]   执行的命令 = pwd
```

使用 ANSI 转义码 `\x1b[31m` 输出红色日志。

Closes #537