### PR TITLE
fix: executeSafeShell 使用 DATA_BASE_PATH 拼接工作目录

### DIFF
--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -18,6 +18,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
 import fs from 'fs';
+import { getDataBasePath } from './paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -403,7 +404,7 @@ function validateShellCommand(command) {
 /**
  * 执行安全的 shell 命令
  * @param {string} command - 要执行的命令
- * @param {string} workingDirectory - 工作目录
+ * @param {string} workingDirectory - 工作目录（相对于 DATA_BASE_PATH）
  * @param {number} timeout - 超时时间（毫秒）
  * @returns {Promise<object>} 执行结果
  */
@@ -424,22 +425,38 @@ async function executeSafeShell(command, workingDirectory, timeout = 30000) {
       return;
     }
 
+    // 获取 DATA_BASE_PATH
+    const dataBasePath = getDataBasePath();
+    
+    // 拼接完整工作目录路径
+    let cwd;
+    if (workingDirectory) {
+      // 如果 workingDirectory 已经是绝对路径，直接使用
+      if (path.isAbsolute(workingDirectory)) {
+        cwd = workingDirectory;
+      } else {
+        // 否则拼接 DATA_BASE_PATH
+        cwd = path.join(dataBasePath, workingDirectory);
+      }
+    } else {
+      cwd = dataBasePath;
+    }
+    
     // 检查工作目录是否存在
-    let cwd = workingDirectory;
     if (cwd && !fs.existsSync(cwd)) {
       try {
         fs.mkdirSync(cwd, { recursive: true });
       } catch (err) {
         logger.warn(`[ToolManager] 创建工作目录失败: ${cwd}`, err.message);
-        cwd = process.cwd();
+        cwd = dataBasePath;
       }
     }
     
     // 红色输出工作目录信息（用于调试）
     console.log(`\x1b[31m[executeSafeShell] 工作目录信息:\x1b[0m`);
+    console.log(`\x1b[31m[executeSafeShell]   DATA_BASE_PATH = ${dataBasePath}\x1b[0m`);
     console.log(`\x1b[31m[executeSafeShell]   传入的 workingDirectory = ${workingDirectory || '(空)'}\x1b[0m`);
-    console.log(`\x1b[31m[executeSafeShell]   实际使用的 cwd = ${cwd || '(空, 将使用process.cwd())'}\x1b[0m`);
-    console.log(`\x1b[31m[executeSafeShell]   process.cwd() = ${process.cwd()}\x1b[0m`);
+    console.log(`\x1b[31m[executeSafeShell]   拼接后的完整路径 = ${cwd}\x1b[0m`);
     console.log(`\x1b[31m[executeSafeShell]   执行的命令 = ${command}\x1b[0m`);
 
     // 设置输出限制（最大 1MB）


### PR DESCRIPTION
## 概述

修复 `executeSafeShell` 函数没有使用 `DATA_BASE_PATH` 拼接工作目录的问题。

## 问题

`executeSafeShell` 函数直接使用传入的 `workingDirectory` 参数（如 `work/user123/task456`），而没有使用 `DATA_BASE_PATH` 拼接完整路径，导致 shell 命令在错误的位置执行。

## 修复内容

1. 导入 `getDataBasePath` 函数
2. 使用 `path.join(dataBasePath, workingDirectory)` 拼接完整路径
3. 如果 `workingDirectory` 已经是绝对路径，则直接使用
4. 更新红色调试输出，显示 `DATA_BASE_PATH` 和拼接后的完整路径

## 修改文件

- `lib/tool-manager.js`

## 输出示例

```
[executeSafeShell] 工作目录信息:
[executeSafeShell]   DATA_BASE_PATH = d:/projects/node/touwaka-mate-v2-p0/data
[executeSafeShell]   传入的 workingDirectory = work/user123/task456
[executeSafeShell]   拼接后的完整路径 = d:/projects/node/touwaka-mate-v2-p0/data/work/user123/task456
[executeSafeShell]   执行的命令 = pwd
```

Closes #539