### PR TITLE
fix: 将调试输出重定向到 stderr 避免污染 JSON

### DIFF
--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -499,12 +499,12 @@ function executeSkill(code, skillId) {
     cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
   }
   
-  // 红色输出工作目录计算规则
-  console.log(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m`);
-  console.log(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePath}\x1b[0m`);
-  console.log(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m`);
-  console.log(`\x1b[31m[skill-runner] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m`);
-  console.log(`\x1b[31m[skill-runner] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m`);
+  // 红色输出工作目录计算规则（输出到 stderr 避免污染 stdout JSON）
+  process.stderr.write(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePath}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[skill-runner] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[skill-runner] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m\n`);
   
   // 计算允许访问的路径列表
   // 管理员：整个 data 目录
@@ -627,12 +627,12 @@ async function executeUserCodeDirectly(code, source = 'inline') {
     cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
   }
   
-  // 红色输出工作目录计算规则
-  console.log(`\x1b[31m[user-code] 工作目录计算规则: ${cwdRule}\x1b[0m`);
-  console.log(`\x1b[31m[user-code] DATA_BASE_PATH = ${dataBasePath}\x1b[0m`);
-  console.log(`\x1b[31m[user-code] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m`);
-  console.log(`\x1b[31m[user-code] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m`);
-  console.log(`\x1b[31m[user-code] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m`);
+  // 红色输出工作目录计算规则（输出到 stderr 避免污染 stdout JSON）
+  process.stderr.write(`\x1b[31m[user-code] 工作目录计算规则: ${cwdRule}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[user-code] DATA_BASE_PATH = ${dataBasePath}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[user-code] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[user-code] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m\n`);
+  process.stderr.write(`\x1b[31m[user-code] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m\n`);
   
   // 用户代码只能访问自己的工作目录
   const allowedPaths = [effectiveCwd];
@@ -953,12 +953,12 @@ print(json.dumps(_result))
       cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用技能目录`;
     }
     
-    // 红色输出工作目录计算规则
-    console.log(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m`);
-    console.log(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePathEnv || '(空)'}\x1b[0m`);
-    console.log(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workDirEnv || '(空)'}\x1b[0m`);
-    console.log(`\x1b[31m[skill-runner] USER_ID = ${userIdEnv || '(空)'}\x1b[0m`);
-    console.log(`\x1b[31m[skill-runner] 拼接结果: workingDir = ${workingDir}\x1b[0m`);
+    // 红色输出工作目录计算规则（输出到 stderr 避免污染 stdout JSON）
+    process.stderr.write(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePathEnv || '(空)'}\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workDirEnv || '(空)'}\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[skill-runner] USER_ID = ${userIdEnv || '(空)'}\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[skill-runner] 拼接结果: workingDir = ${workingDir}\x1b[0m\n`);
     
     const pythonProcess = spawn(pythonCmd, ['-c', sandboxWrapper], {
       cwd: workingDir,

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -452,12 +452,12 @@ async function executeSafeShell(command, workingDirectory, timeout = 30000) {
       }
     }
     
-    // 红色输出工作目录信息（用于调试）
-    console.log(`\x1b[31m[executeSafeShell] 工作目录信息:\x1b[0m`);
-    console.log(`\x1b[31m[executeSafeShell]   DATA_BASE_PATH = ${dataBasePath}\x1b[0m`);
-    console.log(`\x1b[31m[executeSafeShell]   传入的 workingDirectory = ${workingDirectory || '(空)'}\x1b[0m`);
-    console.log(`\x1b[31m[executeSafeShell]   拼接后的完整路径 = ${cwd}\x1b[0m`);
-    console.log(`\x1b[31m[executeSafeShell]   执行的命令 = ${command}\x1b[0m`);
+    // 红色输出工作目录信息（用于调试，输出到 stderr 避免污染 stdout）
+    process.stderr.write(`\x1b[31m[executeSafeShell] 工作目录信息:\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[executeSafeShell]   DATA_BASE_PATH = ${dataBasePath}\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[executeSafeShell]   传入的 workingDirectory = ${workingDirectory || '(空)'}\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[executeSafeShell]   拼接后的完整路径 = ${cwd}\x1b[0m\n`);
+    process.stderr.write(`\x1b[31m[executeSafeShell]   执行的命令 = ${command}\x1b[0m\n`);
 
     // 设置输出限制（最大 1MB）
     const MAX_OUTPUT_SIZE = 1024 * 1024;


### PR DESCRIPTION
## 问题描述

修复红色调试输出污染 JSON 输出的问题。

在 #540 的修改中，为了调试工作目录的计算逻辑，添加了红色 ANSI 颜色的 `console.log` 输出。但是：
- `skill-runner.js` 使用 `stdout` 返回 JSON 格式的执行结果给父进程
- `console.log` 默认输出到 `stdout`，导致 ANSI 转义序列污染了 JSON 输出
- 父进程解析 JSON 时失败，报错：`Unexpected token '', "[31m[skil"... is not valid JSON`

## 解决方案

将所有红色调试输出从 `console.log` (stdout) 改为 `process.stderr.write` (stderr)，这样：
1. 调试信息仍然可见（输出到 stderr）
2. JSON 结果保持纯净（stdout 只包含结果）
3. 父进程可以正常解析 JSON

## 修改文件

- `lib/skill-runner.js`: 3 处 `console.log` → `process.stderr.write`
- `lib/tool-manager.js`: 1 处 `console.log` → `process.stderr.write`

## 测试

- [x] 技能执行时不再污染 JSON 输出
- [x] 调试信息仍然输出到 stderr
- [x] 父进程可以正常解析技能执行结果

Closes #540