### PR TITLE
chore: 移除红色调试输出

### DIFF
--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -499,13 +499,6 @@ function executeSkill(code, skillId) {
     cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
   }
   
-  // 红色输出工作目录计算规则（输出到 stderr 避免污染 stdout JSON）
-  process.stderr.write(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePath}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[skill-runner] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[skill-runner] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m\n`);
-  
   // 计算允许访问的路径列表
   // 管理员：整个 data 目录
   // 技能创作者：skills 目录 + 自己的用户工作区
@@ -626,13 +619,6 @@ async function executeUserCodeDirectly(code, source = 'inline') {
     effectiveCwd = dataBasePath;
     cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
   }
-  
-  // 红色输出工作目录计算规则（输出到 stderr 避免污染 stdout JSON）
-  process.stderr.write(`\x1b[31m[user-code] 工作目录计算规则: ${cwdRule}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[user-code] DATA_BASE_PATH = ${dataBasePath}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[user-code] WORKING_DIRECTORY = ${workingDirectory || '(空)'}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[user-code] USER_ID = ${process.env.USER_ID || '(空)'}\x1b[0m\n`);
-  process.stderr.write(`\x1b[31m[user-code] 拼接结果: effectiveCwd = ${effectiveCwd}\x1b[0m\n`);
   
   // 用户代码只能访问自己的工作目录
   const allowedPaths = [effectiveCwd];
@@ -952,13 +938,6 @@ print(json.dumps(_result))
     } else {
       cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用技能目录`;
     }
-    
-    // 红色输出工作目录计算规则（输出到 stderr 避免污染 stdout JSON）
-    process.stderr.write(`\x1b[31m[skill-runner] 工作目录计算规则: ${cwdRule}\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[skill-runner] DATA_BASE_PATH = ${dataBasePathEnv || '(空)'}\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[skill-runner] WORKING_DIRECTORY = ${workDirEnv || '(空)'}\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[skill-runner] USER_ID = ${userIdEnv || '(空)'}\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[skill-runner] 拼接结果: workingDir = ${workingDir}\x1b[0m\n`);
     
     const pythonProcess = spawn(pythonCmd, ['-c', sandboxWrapper], {
       cwd: workingDir,

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -452,13 +452,6 @@ async function executeSafeShell(command, workingDirectory, timeout = 30000) {
       }
     }
     
-    // 红色输出工作目录信息（用于调试，输出到 stderr 避免污染 stdout）
-    process.stderr.write(`\x1b[31m[executeSafeShell] 工作目录信息:\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[executeSafeShell]   DATA_BASE_PATH = ${dataBasePath}\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[executeSafeShell]   传入的 workingDirectory = ${workingDirectory || '(空)'}\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[executeSafeShell]   拼接后的完整路径 = ${cwd}\x1b[0m\n`);
-    process.stderr.write(`\x1b[31m[executeSafeShell]   执行的命令 = ${command}\x1b[0m\n`);
-
     // 设置输出限制（最大 1MB）
     const MAX_OUTPUT_SIZE = 1024 * 1024;
     let stdout = '';


### PR DESCRIPTION
## 清理：移除红色调试输出

路径问题已彻底修复，现在移除用于调试的红色 ANSI 输出。

## 修改内容

- **lib/skill-runner.js**: 移除 3 处红色调试输出（executeSkill, executeUserCodeDirectly, executePythonSkill）
- **lib/tool-manager.js**: 移除 1 处红色调试输出（executeSafeShell）

## 背景

在 #540 中添加了红色调试输出来追踪工作目录计算逻辑。现在路径拼接逻辑已验证正确：
- 使用 `DATA_BASE_PATH` 作为基础路径
- 正确拼接相对工作目录路径
- 处理绝对路径和空路径的边界情况

调试输出已完成使命，现在清理代码。

Closes #540