### PR TITLE
fix: 禁止 Mermaid 错误提示显示在页面底部

### DIFF
--- a/frontend/src/utils/mermaid.ts
+++ b/frontend/src/utils/mermaid.ts
@@ -19,6 +19,7 @@ const initMermaid = () => {
     theme: 'default',
     securityLevel: 'loose',
     fontFamily: 'inherit',
+    suppressErrorRendering: true, // 禁止在 DOM 中插入 "Syntax error" 图表
     flowchart: {
       useMaxWidth: true,
       htmlLabels: true,


### PR DESCRIPTION
## 修复内容

修复 Mermaid 图表语法错误时，错误提示显示在页面底部的问题。

### 变更
- 在 `frontend/src/utils/mermaid.ts` 中添加 `suppressErrorRendering: true` 配置
- 禁止 Mermaid.js 自动在 DOM 中插入 "Syntax error" 错误提示

### 效果
- 错误提示现在会显示在消息对话框内部（使用 `.mermaid-error` 样式）
- 用户可以看到友好的错误提示和原始代码，便于修正

Closes #543
