### PR TITLE
fix: 修复分页响应格式不符合规范的问题

### DIFF
--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -265,9 +265,9 @@ export const useChatStore = defineStore('chat', () => {
       // 使用符合规范的分页参数
       const response = await topicApi.getTopics({ ...params, page, size, expert_id: filterExpertId })
       topics.value = response.items || []
-      // 更新分页状态 - 优先使用规范格式
-      const pagination = response.pagination || { total: response.total, page: response.page, pages: response.pages, size: response.size }
-      topicsTotal.value = pagination.total || 0
+      // 更新分页状态
+      const pagination = response.pagination
+      topicsTotal.value = pagination?.total || 0
       topicsPage.value = pagination.page || 1
       topicsPages.value = pagination.pages || 1
       return response

--- a/frontend/src/stores/knowledgeBase.ts
+++ b/frontend/src/stores/knowledgeBase.ts
@@ -390,8 +390,8 @@ export const useKnowledgeBaseStore = defineStore('knowledgeBase', () => {
         pagination: params,
       })
       paragraphs.value = response.items || []
-      // 从 pagination 对象中读取 total，兼容两种格式
-      paragraphTotal.value = response.pagination?.total || response.total || 0
+      // 按 API 查询设计规范读取 pagination.total
+      paragraphTotal.value = response.pagination?.total || 0
       return response
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load paragraphs'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -241,24 +241,33 @@ export interface PaginationParams {
 }
 
 // 分页响应 - 符合 API 查询设计规范
+// 参考：docs/database/api-query-design.md
 export interface PaginatedResponse<T> {
+  /** 数据列表 */
   items: T[]
-  total: number
-  page: number
-  size: number  // 每页条数
-  pages: number  // 总页数
-  has_next?: boolean  // 是否有下一页
-  has_prev?: boolean  // 是否有上一页
-  // 向后兼容字段
-  limit?: number  // 别名，等于 size
-  total_pages?: number  // 别名，等于 pages
-  pagination?: {
+  /** 分页信息 */
+  pagination: {
+    /** 当前页码 */
     page: number
+    /** 每页条数 */
     size: number
+    /** 总条数 */
     total: number
+    /** 总页数 */
     pages: number
-    has_next?: boolean
-    has_prev?: boolean
+    /** 是否有下一页 */
+    has_next: boolean
+    /** 是否有上一页 */
+    has_prev: boolean
+  }
+  /** 查询摘要（可选，开发环境启用） */
+  summary?: {
+    /** 查询耗时（毫秒） */
+    took_ms: number
+    /** 应用的过滤条件数量 */
+    filters_applied?: number
+    /** 生成的 SQL（调试用） */
+    sql?: string
   }
 }
 

--- a/frontend/src/views/KnowledgeBaseView.vue
+++ b/frontend/src/views/KnowledgeBaseView.vue
@@ -532,9 +532,11 @@ const loadKbsWithPagination = async () => {
     })
     console.log('[KB] API response:', response)
     if (response) {
-      // 后端返回的是 { items, total, page, limit, pages }，不是 pagination 嵌套结构
-      totalCount.value = response.total || 0
-      totalPages.value = response.pages || 1
+      // 后端返回符合 API 查询设计规范的嵌套结构：{ items, pagination }
+      // 参考：docs/database/api-query-design.md
+      const pagination = response.pagination || {}
+      totalCount.value = pagination.total || 0
+      totalPages.value = pagination.pages || 1
 
       // 如果删除后当前页没有数据，且不是第一页，则跳转到前一页
       if (kbStore.knowledgeBases.length === 0 && currentPage.value > 1) {

--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -446,6 +446,8 @@ function buildPaginatedResponse(result, pagination, startTime, options = {}) {
   const total = result.count;
   const pages = Math.ceil(total / size);
   
+  // 返回符合 API 查询设计规范的嵌套结构
+  // 参考：docs/database/api-query-design.md
   const response = {
     items: result.rows,
     pagination: {

--- a/server/controllers/kb.controller.js
+++ b/server/controllers/kb.controller.js
@@ -182,6 +182,8 @@ class KbController {
 
       const pages = Math.ceil(count / size);
 
+      // 返回符合 API 查询设计规范的嵌套结构
+      // 参考：docs/database/api-query-design.md
       ctx.success({
         items: resultWithUsernames,
         pagination: {


### PR DESCRIPTION
## 问题描述

知识库页面前端显示无知识库，但后端 API 返回了正确的数据。原因是前端和后端的分页响应格式不一致。

## 修改内容

### 后端
- `lib/query-builder.js`: 添加注释说明分页响应格式
- `server/controllers/kb.controller.js`: 确保返回嵌套的分页结构 `{ items, pagination: {...} }`

### 前端
- `frontend/src/types/index.ts`: 更新 `PaginatedResponse` 类型定义，符合 API 查询设计规范
- `frontend/src/stores/chat.ts`: 移除兼容性代码，直接使用 `response.pagination`
- `frontend/src/stores/knowledgeBase.ts`: 移除兼容性代码
- `frontend/src/views/KnowledgeBaseView.vue`: 使用正确的分页结构

## 规范参考

所有修改遵循 [`docs/database/api-query-design.md`](docs/database/api-query-design.md) 定义的分页响应格式：

```typescript
interface PaginatedResponse<T> {
  items: T[]
  pagination: {
    page: number
    size: number
    total: number
    pages: number
    has_next: boolean
    has_prev: boolean
  }
}
```

## 测试

- [x] `npm run lint` 通过
- [x] 前端构建成功
- [x] 知识库页面正常显示数据