### PR TITLE
fix: 支持 Python 技能通过 getTools() 自动注册工具定义

### DIFF
--- a/data/skills/pypdf/index.py
+++ b/data/skills/pypdf/index.py
@@ -738,6 +738,151 @@ def write_watermark(params: Dict[str, Any]) -> Dict[str, Any]:
 
 # ==================== 技能入口 ====================
 
+def getTools():
+    """获取工具清单 - 用于技能注册"""
+    return [
+        {
+            "name": "read",
+            "description": "PDF 读取工具，支持 metadata、text、tables、images、render、markdown、fields 操作",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "PDF 文件路径（必需）"
+                    },
+                    "operation": {
+                        "type": "string",
+                        "enum": ["metadata", "text", "tables", "images", "render", "markdown", "fields"],
+                        "description": "操作类型（必需）"
+                    },
+                    "from_page": {
+                        "type": "integer",
+                        "description": "起始页（从1开始，可选）"
+                    },
+                    "to_page": {
+                        "type": "integer",
+                        "description": "结束页（包含，可选）"
+                    },
+                    "parse_page_info": {
+                        "type": "boolean",
+                        "description": "metadata操作：解析每页详细信息（默认false）"
+                    },
+                    "image_threshold": {
+                        "type": "integer",
+                        "description": "images操作：图片最小尺寸阈值，像素（默认80）"
+                    },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "render操作：输出目录（不指定则只返回dataUrl）"
+                    },
+                    "scale": {
+                        "type": "number",
+                        "description": "render操作：缩放比例（默认1.5，相当于150 DPI）"
+                    },
+                    "desired_width": {
+                        "type": "integer",
+                        "description": "render操作：期望宽度（像素），设置后将忽略scale"
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "render操作：输出文件名前缀（默认page）"
+                    },
+                    "output": {
+                        "type": "string",
+                        "description": "markdown操作：输出markdown文件路径"
+                    }
+                },
+                "required": ["path", "operation"]
+            }
+        },
+        {
+            "name": "write",
+            "description": "PDF 写入工具，支持 create、merge、split、rotate、encrypt、decrypt、watermark 操作",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "PDF 文件路径（split/rotate/encrypt/decrypt/watermark操作必需）"
+                    },
+                    "output": {
+                        "type": "string",
+                        "description": "输出文件路径（create/merge/rotate/encrypt/decrypt/watermark操作必需）"
+                    },
+                    "operation": {
+                        "type": "string",
+                        "enum": ["create", "merge", "split", "rotate", "encrypt", "decrypt", "watermark"],
+                        "description": "操作类型（必需）"
+                    },
+                    "content": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "create操作：文本内容数组（每项为一页，必需）"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "create操作：PDF标题（可选）"
+                    },
+                    "page_size": {
+                        "type": "string",
+                        "enum": ["a4", "letter"],
+                        "description": "create操作：页面大小（默认a4）"
+                    },
+                    "paths": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "merge操作：要合并的PDF文件路径数组（至少2个，必需）"
+                    },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "split操作：输出目录（必需）"
+                    },
+                    "pages_per_file": {
+                        "type": "integer",
+                        "description": "split操作：每个文件的页数（默认1）"
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "split操作：输出文件名前缀（默认page）"
+                    },
+                    "pages": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "description": "rotate操作：要旋转的页码（从1开始，为空则旋转所有）"
+                    },
+                    "degrees": {
+                        "type": "integer",
+                        "enum": [90, 180, 270],
+                        "description": "rotate操作：旋转角度（默认90）"
+                    },
+                    "user_password": {
+                        "type": "string",
+                        "description": "encrypt操作：打开PDF的密码（必需）"
+                    },
+                    "owner_password": {
+                        "type": "string",
+                        "description": "encrypt操作：编辑密码（默认使用user_password）"
+                    },
+                    "password": {
+                        "type": "string",
+                        "description": "decrypt操作：当前密码（必需）"
+                    },
+                    "watermark": {
+                        "type": "string",
+                        "description": "watermark操作：水印文本或水印PDF路径（必需）"
+                    },
+                    "is_text": {
+                        "type": "boolean",
+                        "description": "watermark操作：true为文本水印，false为PDF路径（默认true）"
+                    }
+                },
+                "required": ["operation"]
+            }
+        }
+    ]
+
+
 def read(params: Dict[str, Any]) -> Dict[str, Any]:
     """read 工具 - PDF 读取操作"""
     operation = params.get('operation')
@@ -799,6 +944,13 @@ def execute(tool_name: str, params: Dict[str, Any], context: Dict[str, Any] = No
 if __name__ == '__main__':
     # 从标准输入读取参数
     try:
+        # 检查是否是 getTools 调用（通过命令行参数）
+        if len(sys.argv) > 1 and sys.argv[1] == '--get-tools':
+            # 直接输出工具定义
+            tools = getTools()
+            print(json.dumps(tools))
+            sys.exit(0)
+        
         input_data = sys.stdin.read()
         data = json.loads(input_data)
         

--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -530,18 +530,49 @@ class SkillController {
         if (entryFile) {
           logger.info(`[SkillController] No tools provided, trying to load from ${entryFile}`);
           try {
-            // Windows 需要使用 file:// URL 格式
-            const { pathToFileURL } = await import('url');
             const entry_path = path.join(full_path, entryFile);
-            const entry_url = pathToFileURL(entry_path).href + '?t=' + Date.now();
-            logger.info('[SkillController] Loading from:', entry_url);
             
-            const index_module = await import(entry_url);
-            const skill_module = index_module.default || index_module;
+            if (entryFile.endsWith('.js')) {
+              // JavaScript 技能：使用 import 加载
+              const { pathToFileURL } = await import('url');
+              const entry_url = pathToFileURL(entry_path).href + '?t=' + Date.now();
+              logger.info('[SkillController] Loading JS skill from:', entry_url);
+              
+              const index_module = await import(entry_url);
+              const skill_module = index_module.default || index_module;
 
-            if (skill_module.getTools && typeof skill_module.getTools === 'function') {
-              tools_to_register = skill_module.getTools();
-              logger.info(`[SkillController] Loaded tools from ${entryFile}:`, tools_to_register?.length);
+              if (skill_module.getTools && typeof skill_module.getTools === 'function') {
+                tools_to_register = skill_module.getTools();
+                logger.info(`[SkillController] Loaded tools from ${entryFile}:`, tools_to_register?.length);
+              }
+            } else if (entryFile.endsWith('.py')) {
+              // Python 技能：使用子进程调用获取工具定义
+              logger.info('[SkillController] Loading Python skill getTools from:', entry_path);
+              const { execFile } = await import('child_process');
+              const { promisify } = await import('util');
+              const execFileAsync = promisify(execFile);
+              
+              try {
+                // 调用 Python 脚本获取工具定义
+                const { stdout } = await execFileAsync('python', [entry_path, '--get-tools'], {
+                  timeout: 10000,
+                  maxBuffer: 1024 * 1024, // 1MB
+                });
+                
+                const pythonTools = JSON.parse(stdout);
+                if (Array.isArray(pythonTools) && pythonTools.length > 0) {
+                  // 转换 Python 工具定义为系统格式
+                  tools_to_register = pythonTools.map(tool => ({
+                    name: tool.name,
+                    description: tool.description,
+                    parameters: tool.parameters,
+                    script_path: 'index.py',
+                  }));
+                  logger.info(`[SkillController] Loaded ${tools_to_register.length} tools from Python skill`);
+                }
+              } catch (pyErr) {
+                logger.warn(`[SkillController] Failed to load Python getTools:`, pyErr.message);
+              }
             }
           } catch (err) {
             logger.warn(`Could not parse tools from ${source_path}:`, err.message);


### PR DESCRIPTION
## 问题描述

Python 技能 `pypdf` 注册时无法自动获取完整的工具参数定义，导致 `split` 操作缺少必需的 `output_dir` 参数。

## 问题根源

Node.js 的 `import()` 无法直接加载 Python 文件，所以 `pypdf` 的 `getTools()` 函数没有被调用，工具参数不完整。

## 解决方案

### 1. 修改 `pypdf/index.py`
- 添加 `--get-tools` 命令行参数支持
- 通过 `python index.py --get-tools` 输出工具定义 JSON

### 2. 修改 `skill.controller.js`
- 检测 Python 技能（`.py` 文件）
- 使用子进程调用 `python index.py --get-tools` 获取工具定义
- 自动转换 Python 工具定义为系统格式

## 测试验证

```bash
cd data/skills/pypdf && python index.py --get-tools
```

输出包含完整的参数定义：
- `output_dir`: split 操作必需
- `pages_per_file`: split 操作可选
- `prefix`: split 操作可选

## 影响范围

- 修复 pypdf 技能注册问题
- 为其他 Python 技能提供自动注册支持
- 无需修改现有 JavaScript 技能

Closes #567