### PR TITLE
fix: 移除 script_path 默认值，强制要求提供入口文件路径

### DIFF
--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -590,7 +590,7 @@ class SkillController {
           const tool_name = tool.function?.name || tool.name;
           const tool_desc = tool.function?.description || tool.description;
           const tool_params = tool.function?.parameters || tool.parameters;
-          const tool_script_path = tool.script_path || 'index.js';
+          const tool_script_path = tool.script_path;
 
           logger.info('[SkillController] Processing tool:', {
             tool_name,
@@ -601,6 +601,12 @@ class SkillController {
           if (!tool_name) {
             logger.warn(`Skipping tool without name:`, tool);
             continue;
+          }
+
+          // 检查 script_path 是否提供
+          if (!tool_script_path) {
+            ctx.error(`工具 "${tool_name}" 缺少 script_path 字段，请提供入口文件路径（如 index.js 或 index.py）`, 400);
+            return;
           }
 
           await this.SkillTool.create({


### PR DESCRIPTION
fix: 移除 script_path 默认值，强制要求提供入口文件路径

## 变更内容
- 删除 `tool.script_path || 'index.js'` 的默认逻辑
- 当工具定义缺少 `script_path` 字段时，返回 400 错误并提示用户提供入口文件路径

## 原因
之前的默认值 `index.js` 导致 Python 技能（如 pypdf）被错误注册为使用 `index.js` 作为入口文件，造成运行时错误。现在强制要求明确指定入口文件，避免此类问题。

## 影响
- skill-manager 注册技能时必须提供 `script_path` 字段
- 如果缺少该字段，API 会返回明确的错误信息