### PR TITLE
fix: 添加 JSON 序列化错误处理和输出保护

### DIFF
--- a/data/skills/pypdf/index.py
+++ b/data/skills/pypdf/index.py
@@ -1073,7 +1073,16 @@ def dispatch(tool_name: str, params: Dict[str, Any]) -> Dict[str, Any]:
     
     try:
         func = tool_map[tool_name]
-        return func(params)
+        result = func(params)
+        # 确保结果可以被 JSON 序列化
+        try:
+            json.dumps(result, ensure_ascii=False)
+        except (TypeError, ValueError) as json_err:
+            return {
+                'success': False,
+                'error': f'JSON serialization error: {str(json_err)}'
+            }
+        return result
     except Exception as e:
         return {
             'success': False,
@@ -1084,15 +1093,33 @@ def dispatch(tool_name: str, params: Dict[str, Any]) -> Dict[str, Any]:
 
 # 命令行入口
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
+    try:
+        if len(sys.argv) < 2:
+            print(json.dumps({
+                'success': False,
+                'error': 'Usage: python index.py <tool_name> [params_json]'
+            }, ensure_ascii=False))
+            sys.exit(1)
+        
+        tool_name = sys.argv[1]
+        params = json.loads(sys.argv[2]) if len(sys.argv) > 2 else {}
+        
+        result = dispatch(tool_name, params)
+        # 使用 ensure_ascii=False 并捕获序列化错误
+        try:
+            output = json.dumps(result, ensure_ascii=False)
+            print(output)
+        except (TypeError, ValueError) as e:
+            print(json.dumps({
+                'success': False,
+                'error': f'JSON serialization error: {str(e)}',
+                'result_type': str(type(result))
+            }, ensure_ascii=False))
+            sys.exit(1)
+    except Exception as e:
         print(json.dumps({
             'success': False,
-            'error': 'Usage: python index.py <tool_name> [params_json]'
-        }))
+            'error': f'Fatal error: {str(e)}',
+            'traceback': traceback.format_exc()
+        }, ensure_ascii=False))
         sys.exit(1)
-    
-    tool_name = sys.argv[1]
-    params = json.loads(sys.argv[2]) if len(sys.argv) > 2 else {}
-    
-    result = dispatch(tool_name, params)
-    print(json.dumps(result, ensure_ascii=False))


### PR DESCRIPTION
fix: 添加 JSON 序列化错误处理和输出保护

## 问题
技能调用时出现错误：`Failed to parse skill output: Unterminated string in JSON at position 219264`

## 原因分析
这个错误通常由以下原因导致：

1. **输出被截断**：当返回的 JSON 数据量很大时（如提取大量图片的 base64 数据），输出可能被系统截断
2. **特殊字符未转义**：PDF 文本内容中可能包含未转义的控制字符或特殊 Unicode 字符
3. **内存问题**：处理大文件时内存不足导致输出不完整
4. **缓冲区限制**：stdout 缓冲区溢出

## 修复内容

### 1. dispatch() 函数添加 JSON 序列化预检查
```python
def dispatch(tool_name: str, params: Dict[str, Any]) -> Dict[str, Any]:
    try:
        func = tool_map[tool_name]
        result = func(params)
        # 确保结果可以被 JSON 序列化
        try:
            json.dumps(result, ensure_ascii=False)
        except (TypeError, ValueError) as json_err:
            return {
                'success': False,
                'error': f'JSON serialization error: {str(json_err)}'
            }
        return result
    except Exception as e:
        ...
```

### 2. 命令行入口添加完整错误捕获
```python
if __name__ == '__main__':
    try:
        # ... 原有逻辑
        result = dispatch(tool_name, params)
        try:
            output = json.dumps(result, ensure_ascii=False)
            print(output)
        except (TypeError, ValueError) as e:
            print(json.dumps({
                'success': False,
                'error': f'JSON serialization error: {str(e)}'
            }))
    except Exception as e:
        print(json.dumps({
            'success': False,
            'error': f'Fatal error: {str(e)}'
        }))
```

## 建议
对于大文件处理，建议：
1. 限制返回数据量（如分页返回图片）
2. 大文件保存到磁盘而非返回 base64
3. 使用 `output_dir` 参数将结果写入文件

Closes #572