### PR TITLE
fix: 修复 extract_images 内存溢出问题

### DIFF
--- a/data/skills/pypdf/SKILL.md
+++ b/data/skills/pypdf/SKILL.md
@@ -26,7 +26,7 @@ dependencies:
 | `read_metadata` | 读取 PDF 元数据 | `path`, `parse_page_info` |
 | `extract_text` | 提取文本内容 | `path`, `from_page`, `to_page` |
 | `extract_tables` | 提取表格数据 | `path`, `from_page`, `to_page` |
-| `extract_images` | 提取内嵌图片 | `path`, `from_page`, `to_page`, `threshold` |
+| `extract_images` | 提取内嵌图片 | `path`, `from_page`, `to_page`, `threshold`, `output_dir` |
 | `render_pages` | 渲染页面为图片 | `path`, `from_page`, `to_page`, `output_dir`, `scale` |
 | `to_markdown` | 转换为 Markdown | `path`, `from_page`, `to_page`, `output` |
 | `read_form_fields` | 读取表单字段 | `path` |
@@ -112,12 +112,23 @@ pypdf__extract_tables({ path: "doc.pdf", from_page: 1, to_page: 3 })
 | from_page | number | ❌ | 起始页（从1开始） |
 | to_page | number | ❌ | 结束页（包含） |
 | threshold | number | ❌ | 图片最小尺寸阈值，像素（默认: 80） |
+| output_dir | string | ❌ | 输出目录（指定后图片保存到文件，不返回 base64，防止内存溢出） |
 
 **调用示例：**
 ```javascript
-// 提取所有大于100像素的图片
+// 提取所有大于100像素的图片（返回 base64，适合小文件）
 pypdf__extract_images({ path: "doc.pdf", threshold: 100 })
+
+// 提取图片到目录（推荐，防止内存溢出）
+pypdf__extract_images({ 
+  path: "doc.pdf", 
+  output_dir: "./extracted_images"
+})
 ```
+
+**注意事项：**
+- 当 PDF 包含大量高分辨率图片时，建议使用 `output_dir` 参数将图片保存到文件
+- 不指定 `output_dir` 时，所有图片以 base64 形式返回，可能导致输出被截断
 
 ---
 

--- a/data/skills/pypdf/index.py
+++ b/data/skills/pypdf/index.py
@@ -219,6 +219,7 @@ def extract_images(params: Dict[str, Any]) -> Dict[str, Any]:
     from_page = params.get('from_page')
     to_page = params.get('to_page')
     threshold = params.get('threshold', 80)
+    output_dir = params.get('output_dir')
     
     doc = fitz.open(file_path)
     
@@ -228,6 +229,10 @@ def extract_images(params: Dict[str, Any]) -> Dict[str, Any]:
         end = to_page if to_page else total_pages
         start = max(0, min(start, total_pages - 1))
         end = max(1, min(end, total_pages))
+        
+        if output_dir:
+            output_dir = resolve_path(output_dir)
+            os.makedirs(output_dir, exist_ok=True)
         
         images_info = []
         for i in range(start, end):
@@ -242,23 +247,34 @@ def extract_images(params: Dict[str, Any]) -> Dict[str, Any]:
                     if pix.n > 4:
                         pix = fitz.Pixmap(fitz.csRGB, pix)
                     
-                    img_data = pix.tobytes("png")
-                    img_b64 = base64.b64encode(img_data).decode('utf-8')
-                    
-                    images_info.append({
+                    image_info = {
                         'page': i + 1,
                         'index': img_index,
                         'width': pix.width,
-                        'height': pix.height,
-                        'data_url': f'data:image/png;base64,{img_b64}'
-                    })
+                        'height': pix.height
+                    }
+                    
+                    if output_dir:
+                        # 保存到文件，只返回路径
+                        filename = f'image_page{i+1}_idx{img_index}.png'
+                        filepath = os.path.join(output_dir, filename)
+                        pix.save(filepath)
+                        image_info['file'] = filepath
+                    else:
+                        # 返回 base64（小图片时）
+                        img_data = pix.tobytes("png")
+                        img_b64 = base64.b64encode(img_data).decode('utf-8')
+                        image_info['data_url'] = f'data:image/png;base64,{img_b64}'
+                    
+                    images_info.append(image_info)
                 
                 pix = None
         
         return {
             'success': True,
             'images': images_info,
-            'image_count': len(images_info)
+            'image_count': len(images_info),
+            'output_dir': output_dir
         }
     finally:
         doc.close()
@@ -776,6 +792,10 @@ def getTools():
                     "threshold": {
                         "type": "integer",
                         "description": "图片最小尺寸阈值，像素（默认: 80）"
+                    },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "输出目录（指定后图片保存到文件，不返回 base64，防止内存溢出）"
                     }
                 },
                 "required": ["path"]


### PR DESCRIPTION
## 修复 extract_images 内存溢出问题

### 问题
`extract_images` 工具在处理包含多张图片的 PDF 时，会将所有图片以 base64 形式返回，导致：
1. 内存占用过高
2. JSON 输出被截断（`Unterminated string in JSON`）

### 解决方案
为 `extract_images` 添加 `output_dir` 参数：
- 指定后图片保存到文件，只返回文件路径
- 不指定则保持原有行为（返回 base64）

### 变更内容
- **index.py**: 重构 `extract_images` 函数，支持 `output_dir` 参数
- **SKILL.md**: 更新工具文档，添加参数说明和使用示例

### 使用示例
```javascript
// 推荐：保存到文件，防止内存溢出
pypdf__extract_images({ 
  path: "doc.pdf", 
  output_dir: "./extracted_images"
})
```

Closes #572