### PR TITLE
fix: 技能注册后缓存未失效问题

### DIFF
--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -510,6 +510,13 @@ class SkillController {
         is_active: true,
       });
 
+      // 同步更新技能表的 updated_at，触发 SkillLoader 缓存失效
+      // 注意：upsert() 在更新已存在记录时可能不会自动更新 updated_at（取决于 Sequelize 配置）
+      await this.Skill.update(
+        { updated_at: new Date() },
+        { where: { id: skill_id } }
+      );
+
       // 删除旧的工具定义
       await this.SkillTool.destroy({ where: { skill_id } });
 


### PR DESCRIPTION
## 问题

用户反馈：重新注册技能后，技能缓存没有刷新，需要重启后端才能刷新。

## 根因分析

`SkillLoader` 的缓存机制使用 `skillId_updatedAt` 作为缓存键（见 [`lib/skill-loader.js:90`](lib/skill-loader.js:90)）：

```javascript
const cacheKey = `${skillRow.id}_${skillRow.updated_at}`;
```

当技能通过 `register()` 方法重新注册时，`Skill.upsert()` 可能不会自动更新 `updated_at` 字段（取决于 Sequelize 配置），导致缓存键不变，旧缓存仍然有效。

## 解决方案

在 `register()` 方法中，`Skill.upsert()` 之后显式更新 `updated_at` 字段：

```javascript
// 同步更新技能表的 updated_at，触发 SkillLoader 缓存失效
await this.Skill.update(
  { updated_at: new Date() },
  { where: { id: skill_id } }
);
```

这与之前在 `updateTool()` 和 `updateTools()` 中添加的修复保持一致。

## 测试验证

1. 重新注册技能（如 pypdf）
2. 验证新工具定义立即生效，无需重启后端

Closes #580