### PR TITLE
fix: SkillsDirectoryTab Markdown 预览缺少图片 CSS 样式

### DIFF
--- a/frontend/src/components/panel/SkillsDirectoryTab.vue
+++ b/frontend/src/components/panel/SkillsDirectoryTab.vue
@@ -1232,4 +1232,12 @@ const handleCreateDirectory = async () => {
   border-radius: 4px;
   color: var(--code-color, #d63384);
 }
+
+/* Markdown 图片样式 */
+.preview-markdown :deep(img) {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 8px 0;
+}
 </style>


### PR DESCRIPTION
## 问题描述

`SkillsDirectoryTab.vue` 中的 Markdown 预览功能缺少图片 CSS 样式定义，导致预览 `.md` 文件时图片可能显示异常。

## 修改内容

在 `.preview-markdown` CSS 样式块中添加图片样式：

```css
/* Markdown 图片样式 */
.preview-markdown :deep(img) {
  max-width: 100%;
  height: auto;
  border-radius: 8px;
  margin: 8px 0;
}
```

## 参考实现

样式参考了 [`ChatWindow.vue`](frontend/src/components/ChatWindow.vue:1293) 和 [`TasksTab.vue`](frontend/src/components/panel/TasksTab.vue:2560) 中已有的完整 Markdown 图片样式实现。

## 测试验证

- [x] Vite HMR 热更新成功
- [ ] 手动测试：在技能目录中预览包含图片的 `.md` 文件

Closes #582