### PR TITLE
fix: remote-llm submit 工具使用环境变量获取 skill_id

### DIFF
--- a/data/skills/remote-llm/submit.js
+++ b/data/skills/remote-llm/submit.js
@@ -309,8 +309,17 @@ async function execute(toolName, params, context = {}) {
     const resolvedModelId = defaults.model_id;
 
     // 调用驻留进程
+    // 使用环境变量中的 SKILL_ID（技能 UUID），必须存在，否则报错
+    const skillId = process.env.SKILL_ID;
+    if (!skillId) {
+      return {
+        success: false,
+        error: '缺少技能ID：SKILL_ID 环境变量未设置',
+      };
+    }
+    
     const result = await invokeResidentTool({
-      skill_id: 'remote-llm',
+      skill_id: skillId,
       tool_name: 'executor',
       params: {
         user_id,


### PR DESCRIPTION
## 修复内容

修复 `remote-llm` 技能的 `submit` 工具无法调用驻留进程 `executor` 的问题。

## 问题原因

`submit.js` 中硬编码了 `skill_id: 'remote-llm'`（mark），但数据库中 `skill_tools.skill_id` 字段是 UUID 外键，导致 `ResidentSkillManager.invokeByName()` 查询失败。

## 解决方案

使用环境变量 `SKILL_ID` 获取真实的技能 UUID，并添加严格的错误检查（无 fallback）：

```javascript
const skillId = process.env.SKILL_ID;
if (!skillId) {
  return {
    success: false,
    error: '缺少技能ID：SKILL_ID 环境变量未设置',
  };
}
```

## 变更文件

- `data/skills/remote-llm/submit.js`

Closes #589