### PR TITLE
fix: 修复 fapiao 技能 - 添加 getTools() 并修正工具命名

### DIFF
--- a/data/skills/fapiao/SKILL.md
+++ b/data/skills/fapiao/SKILL.md
@@ -49,20 +49,20 @@ user-invocable: true
 
 ```javascript
 // JSON 格式输出
-invoice__extract({ 
-  path: "invoice.pdf", 
-  format: "json" 
+fapiao__extract({
+  path: "invoice.pdf",
+  format: "json"
 })
 
 // Markdown 格式输出
-invoice__extract({ 
-  path: "invoice.pdf", 
-  format: "markdown" 
+fapiao__extract({
+  path: "invoice.pdf",
+  format: "markdown"
 })
 
 // 保存到文件
-invoice__extract({ 
-  path: "invoice.pdf", 
+fapiao__extract({
+  path: "invoice.pdf",
   format: "json",
   output: "invoice_result.json"
 })
@@ -187,9 +187,9 @@ const renderResult = await pdf__read({
 
 | 任务 | 调用方式 |
 |------|----------|
-| 提取发票JSON数据 | `invoice__extract({ path: "invoice.pdf", format: "json" })` |
-| 提取发票Markdown | `invoice__extract({ path: "invoice.pdf", format: "markdown" })` |
-| 保存到文件 | `invoice__extract({ path: "invoice.pdf", output: "result.json" })` |
+| 提取发票JSON数据 | `fapiao__extract({ path: "invoice.pdf", format: "json" })` |
+| 提取发票Markdown | `fapiao__extract({ path: "invoice.pdf", format: "markdown" })` |
+| 保存到文件 | `fapiao__extract({ path: "invoice.pdf", output: "result.json" })` |
 
 ## 更新日志
 

--- a/data/skills/fapiao/index.js
+++ b/data/skills/fapiao/index.js
@@ -712,6 +712,39 @@ async function extract(params) {
 }
 
 // ============================================
+// 工具定义 - 用于技能注册
+// ============================================
+
+function getTools() {
+  return [
+    {
+      name: 'extract',
+      description: '提取发票结构化数据（支持增值税发票、普通发票、电子发票）。可提取发票号码、日期、买卖双方信息、商品明细、金额等字段。',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'PDF发票文件路径（必需）'
+          },
+          format: {
+            type: 'string',
+            enum: ['json', 'markdown'],
+            description: '输出格式，默认 json',
+            default: 'json'
+          },
+          output: {
+            type: 'string',
+            description: '输出文件路径（可选，不指定则只返回内容）'
+          }
+        },
+        required: ['path']
+      }
+    }
+  ];
+}
+
+// ============================================
 // Skill 入口
 // ============================================
 
@@ -724,4 +757,4 @@ async function execute(toolName, params, context = {}) {
   }
 }
 
-module.exports = { execute };
+module.exports = { execute, getTools };


### PR DESCRIPTION
## 修复内容

修复 `fapiao` 技能的两个问题：

### 1. 添加 `getTools()` 函数（Closes #591）

- 在 `index.js` 中添加 `getTools()` 函数，返回工具定义数组
- 更新 `module.exports` 导出 `getTools`
- 使技能注册时能自动提取工具定义

### 2. 修正 SKILL.md 中的工具命名

- 将 `invoice__extract` 改为 `fapiao__extract`
- 统一调用示例中的命名

## 变更文件

- `data/skills/fapiao/index.js` - 添加 `getTools()` 函数
- `data/skills/fapiao/SKILL.md` - 修正工具命名

## 测试

- [x] `getTools()` 返回正确的工具定义
- [x] `module.exports` 包含 `getTools`
- [x] SKILL.md 中的调用示例使用正确的 `fapiao__extract` 命名

Closes #591