### PR TITLE
fix: 修复 skill list API 的 is_active 参数类型判断错误

### DIFF
--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -31,7 +31,8 @@ class SkillController {
 
       const where = {};
       if (is_active !== undefined) {
-        where.is_active = is_active === 'true';
+        // 支持多种格式：布尔值 true/false，字符串 'true'/'false'，'1'/'0'
+        where.is_active = is_active === true || is_active === 'true' || is_active === '1' || is_active === 1;
       }
 
       const skills = await this.Skill.findAll({


### PR DESCRIPTION
## 修复内容

修复 `skill-manager` 技能的 `list` 工具返回空列表的问题。

### 问题

当调用 `skill-manager__list({ is_active: true })` 时，API 返回空列表，即使数据库中有激活的技能。

### 根本原因

`server/controllers/skill.controller.js` 的 `list` 方法中，`is_active` 参数类型判断错误：

```javascript
// 原代码（错误）
where.is_active = is_active === 'true';
```

当传入布尔值 `true` 时，`true === 'true'` 返回 `false`，导致查询条件错误。

### 修复

```javascript
// 修复后（支持多种格式）
where.is_active = is_active === true || is_active === 'true' || is_active === '1' || is_active === 1;
```

### 变更文件

- `server/controllers/skill.controller.js`：修复 `is_active` 参数类型判断

Closes #596
