### PR TITLE
feat: App Market 后端实现 (Step 1-3)

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,51 @@
+# Touwaka Mate App Registry
+
+这是 Touwaka Mate 的 App Market（小程序市场）Registry，托管在 GitHub 仓库中。
+
+## 目录结构
+
+```
+apps/
+├── index.json              # Registry 索引（本目录下所有 App 的清单）
+├── README.md               # 本说明文档
+├── contract-manager/     # 合同管理 App
+│   ├── manifest.json       # App 元数据
+│   ├── handlers/           # 处理脚本
+│   └── frontend/           # 自定义组件（可选）
+└── ...其他 App
+```
+
+## 如何使用
+
+### 作为管理员
+
+在 Touwaka Mate 管理后台：
+1. 进入 Settings → 系统管理 → App 市场
+2. 浏览可用 App 列表
+3. 点击"安装"部署到您的实例
+
+### 作为开发者
+
+要创建新的 App：
+1. 复制 `_template/document-app/` 模板
+2. 修改 `manifest.json` 定义字段和状态
+3. 实现 `handlers/` 目录下的处理脚本
+4. 提交 PR 到本仓库
+
+## App 规范
+
+每个 App 必须包含：
+- `manifest.json`：元数据、字段定义、状态流转
+- `handlers/`：至少一个处理脚本（可选）
+- `frontend/`：自定义组件（可选）
+
+详见 [App Market 设计文档](../docs/design/parse3/app-market-design.md)
+
+## 仓库地址
+
+- GitHub: https://github.com/ErixWong/touwaka-ai-mate
+- Registry Raw URL: https://raw.githubusercontent.com/ErixWong/touwaka-ai-mate/main/apps/
+
+---
+
+*让我们一起愉快地构建 AI 小程序生态！* 🚀

--- a/apps/contract-manager/README.md
+++ b/apps/contract-manager/README.md
@@ -1,0 +1,40 @@
+# 销售合同管理 App
+
+**ID**: `contract-manager`
+
+## 功能描述
+
+上传合同文件，AI自动提取合同元数据，支持批量处理和确认入库。
+
+## 处理流程
+
+```
+上传文件 → [待OCR] → OCR识别 → [待提取] → LLM提取 → [待确认] → 用户确认 → [已确认]
+                ↓                      ↓
+           [OCR失败]              [提取失败]
+```
+
+## 字段定义
+
+| 字段名 | 标签 | 类型 | 必填 | AI提取 |
+|--------|------|------|------|--------|
+| contract_number | 合同编号 | text | ✅ | ✅ |
+| contract_date | 签订日期 | date | ✅ | ✅ |
+| party_a | 甲方 | text | ✅ | ✅ |
+| party_b | 乙方 | text | ✅ | ✅ |
+| contract_amount | 合同金额 | number | ✅ | ✅ |
+| start_date | 开始日期 | date | ❌ | ✅ |
+| end_date | 结束日期 | date | ❌ | ✅ |
+| payment_terms | 付款条款 | textarea | ❌ | ✅ |
+| status | 状态 | select | ❌ | ❌ |
+| contract_file | 合同文件 | file | ❌ | ❌ |
+
+## 处理脚本
+
+- **ocr-service**: 调用 markitdown/mineru 进行 OCR 识别
+- **llm-extract**: 调用 LLM 从 OCR 文本中提取结构化元数据
+
+## 依赖
+
+- MCP 服务: `markitdown`, `mineru`
+- 平台版本: >= 2.0.0

--- a/apps/contract-manager/handlers/llm-extract/index.js
+++ b/apps/contract-manager/handlers/llm-extract/index.js
@@ -1,0 +1,56 @@
+export default {
+  async process(context) {
+    const { record, app, services } = context;
+
+    const data = record.data || {};
+    const ocrText = data._ocr_text;
+    if (!ocrText) {
+      return { success: false, error: 'No OCR text found, run OCR first' };
+    }
+
+    const extractableFields = (app.fields || []).filter(f => f.ai_extractable && f.type !== 'file');
+    if (extractableFields.length === 0) {
+      return { success: false, error: 'No extractable fields defined' };
+    }
+
+    const fieldDefs = extractableFields
+      .map(f => `- ${f.name} (${f.label}): type=${f.type}${f.required ? ', required' : ''}`)
+      .join('\n');
+
+    try {
+      const response = await services.callLlm('extract_metadata', {
+        field_definitions: fieldDefs,
+        ocr_text: ocrText,
+        response_format: 'json',
+      });
+
+      let metadata;
+      const resultText = response.text || response.parsed || response;
+      if (typeof resultText === 'string') {
+        const jsonMatch = resultText.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) {
+          return { success: false, error: 'LLM did not return valid JSON' };
+        }
+        metadata = JSON.parse(jsonMatch[0]);
+      } else if (typeof resultText === 'object') {
+        metadata = resultText;
+      } else {
+        return { success: false, error: 'LLM returned unexpected format' };
+      }
+
+      const cleanMetadata = {};
+      for (const field of extractableFields) {
+        if (metadata[field.name] !== undefined) {
+          cleanMetadata[field.name] = metadata[field.name];
+        }
+      }
+
+      return {
+        success: true,
+        data: cleanMetadata,
+      };
+    } catch (e) {
+      return { success: false, error: 'LLM extraction failed: ' + e.message };
+    }
+  },
+};

--- a/apps/contract-manager/handlers/ocr-service/index.js
+++ b/apps/contract-manager/handlers/ocr-service/index.js
@@ -1,0 +1,36 @@
+export default {
+  async process(context) {
+    const { record, files, services } = context;
+
+    const file = files[0];
+    if (!file || !file.attachment) {
+      return { success: false, error: 'No associated file found' };
+    }
+
+    let ocrText = '';
+    try {
+      const result = await services.callMcp('markitdown', 'convert', {
+        file_path: file.attachment.file_path,
+      });
+      ocrText = result.text;
+    } catch (e) {
+      try {
+        const result = await services.callMcp('mineru', 'parse', {
+          file_path: file.attachment.file_path,
+        });
+        ocrText = result.text;
+      } catch (e2) {
+        return { success: false, error: 'OCR failed: ' + e2.message };
+      }
+    }
+
+    return {
+      success: true,
+      data: {
+        _ocr_text: ocrText,
+        _ocr_service: 'markitdown',
+        _ocr_status: 'completed',
+      },
+    };
+  },
+};

--- a/apps/contract-manager/manifest.json
+++ b/apps/contract-manager/manifest.json
@@ -1,0 +1,60 @@
+{
+  "id": "contract-manager",
+  "name": "销售合同管理",
+  "version": "1.0.0",
+  "description": "上传合同文件，AI自动提取合同元数据，支持批量处理和确认入库",
+  "icon": "📄",
+  "type": "document",
+  "author": "Touwaka Team",
+  "license": "MIT",
+  "repository": "https://github.com/ErixWong/touwaka-ai-mate/tree/main/apps/contract-manager",
+  "keywords": ["合同", "文档", "OCR", "AI提取"],
+  
+  "compatibility": {
+    "min_platform_version": "2.0.0",
+    "requires": {
+      "mcp": ["markitdown", "mineru"],
+      "skills": []
+    }
+  },
+  
+  "fields": [
+    { "name": "contract_number", "label": "合同编号", "type": "text", "required": true, "ai_extractable": true },
+    { "name": "contract_date", "label": "签订日期", "type": "date", "required": true, "ai_extractable": true },
+    { "name": "party_a", "label": "甲方", "type": "text", "required": true, "ai_extractable": true },
+    { "name": "party_b", "label": "乙方", "type": "text", "required": true, "ai_extractable": true },
+    { "name": "contract_amount", "label": "合同金额", "type": "number", "required": true, "ai_extractable": true },
+    { "name": "start_date", "label": "开始日期", "type": "date", "ai_extractable": true },
+    { "name": "end_date", "label": "结束日期", "type": "date", "ai_extractable": true },
+    { "name": "payment_terms", "label": "付款条款", "type": "textarea", "ai_extractable": true },
+    { "name": "status", "label": "状态", "type": "select", "options": ["待审批", "执行中", "已完成", "已终止"], "default": "待审批" },
+    { "name": "contract_file", "label": "合同文件", "type": "file" }
+  ],
+  
+  "views": {
+    "list": {
+      "columns": ["contract_number", "contract_date", "party_a", "party_b", "contract_amount", "status"],
+      "sort": { "field": "contract_date", "order": "desc" }
+    }
+  },
+  
+  "config": {
+    "features": ["upload", "list", "detail"],
+    "supported_formats": [".pdf", ".docx", ".doc", ".jpg", ".png"],
+    "max_file_size": 20971520,
+    "batch_enabled": true,
+    "batch_limit": 50
+  },
+  
+  "states": [
+    { "name": "pending_ocr", "label": "待OCR", "sort_order": 1, "is_initial": true, "is_terminal": false, "is_error": false, "handler": "ocr-service", "success_next": "pending_extract", "failure_next": "ocr_failed" },
+    { "name": "pending_extract", "label": "待提取", "sort_order": 2, "is_initial": false, "is_terminal": false, "is_error": false, "handler": "llm-extract", "success_next": "pending_review", "failure_next": "extract_failed" },
+    { "name": "pending_review", "label": "待确认", "sort_order": 3, "is_initial": false, "is_terminal": false, "is_error": false, "handler": null, "success_next": null, "failure_next": null },
+    { "name": "confirmed", "label": "已确认", "sort_order": 4, "is_initial": false, "is_terminal": true, "is_error": false, "handler": null, "success_next": null, "failure_next": null },
+    { "name": "ocr_failed", "label": "OCR失败", "sort_order": 99, "is_initial": false, "is_terminal": false, "is_error": true, "handler": null, "success_next": null, "failure_next": null },
+    { "name": "extract_failed", "label": "提取失败", "sort_order": 99, "is_initial": false, "is_terminal": false, "is_error": true, "handler": null, "success_next": null, "failure_next": null }
+  ],
+  
+  "component": null,
+  "visibility": "all"
+}

--- a/apps/index.json
+++ b/apps/index.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0.0",
+  "updated_at": "2026-04-17T17:20:00Z",
+  "registry_url": "https://raw.githubusercontent.com/ErixWong/touwaka-ai-mate/main/apps",
+  "apps": [
+    {
+      "id": "contract-manager",
+      "name": "销售合同管理",
+      "version": "1.0.0",
+      "icon": "📄",
+      "type": "document",
+      "description": "上传合同文件，AI自动提取合同元数据，支持批量处理和确认入库",
+      "author": "Touwaka Team",
+      "license": "MIT",
+      "tags": ["合同", "文档", "OCR", "AI提取"],
+      "path": "apps/contract-manager",
+      "manifest_url": "apps/contract-manager/manifest.json"
+    }
+  ],
+  "categories": [
+    { "id": "document", "name": "文档管理", "icon": "📄", "description": "文档上传、OCR识别、数据提取" },
+    { "id": "workflow", "name": "流程审批", "icon": "🔄", "description": "审批流程、状态流转" },
+    { "id": "data", "name": "数据管理", "icon": "📊", "description": "结构化数据管理" },
+    { "id": "utility", "name": "实用工具", "icon": "🔧", "description": "各类实用小工具" }
+  ],
+  "metadata": {
+    "total_apps": 1,
+    "min_platform_version": "2.0.0",
+    "last_updated_by": "Touwaka Team"
+  }
+}

--- a/server/controllers/app-market.controller.js
+++ b/server/controllers/app-market.controller.js
@@ -1,0 +1,241 @@
+import logger from '../../lib/logger.js';
+import AppMarketService from '../services/app-market.service.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * App Market 控制器
+ */
+class AppMarketController {
+  constructor(db) {
+    this.db = db;
+    this.appMarketService = new AppMarketService(db);
+  }
+
+  // ==================== Registry 配置 ====================
+
+  /**
+   * 获取 Registry 配置
+   */
+  async getSettings(ctx) {
+    try {
+      const config = await this.appMarketService.getRegistryConfig();
+      ctx.success(config);
+    } catch (error) {
+      logger.error('Get registry settings error:', error);
+      ctx.error(error.message, 500);
+    }
+  }
+
+  /**
+   * 更新 Registry 配置
+   */
+  async updateSettings(ctx) {
+    try {
+      const updates = ctx.request.body;
+      await this.appMarketService.updateRegistryConfig(updates);
+      ctx.success({ message: 'Settings updated' });
+    } catch (error) {
+      logger.error('Update registry settings error:', error);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  // ==================== Registry 浏览 ====================
+
+  /**
+   * 获取 Registry 索引（可用 App 列表）
+   */
+  async getIndex(ctx) {
+    try {
+      const index = await this.appMarketService.fetchIndex();
+      ctx.success(index);
+    } catch (error) {
+      logger.error('Fetch registry index error:', error);
+      ctx.error(error.message, 500);
+    }
+  }
+
+  /**
+   * 获取 App manifest（从 Registry 拉取）
+   */
+  async getManifest(ctx) {
+    try {
+      const { appId } = ctx.params;
+      const manifest = await this.appMarketService.fetchManifest(appId);
+      ctx.success(manifest);
+    } catch (error) {
+      logger.error(`Fetch manifest for ${ctx.params.appId} error:`, error);
+      ctx.error(error.message, 404);
+    }
+  }
+
+  // ==================== App 安装/卸载 ====================
+
+  /**
+   * 检查依赖
+   */
+  async checkDependencies(ctx) {
+    try {
+      const { app_id } = ctx.request.body;
+      const manifest = await this.appMarketService.fetchManifest(app_id);
+      const result = await this.appMarketService.checkDependencies(manifest);
+      ctx.success(result);
+    } catch (error) {
+      logger.error('Check dependencies error:', error);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  /**
+   * 安装 App
+   */
+  async installApp(ctx) {
+    try {
+      const { app_id, visibility = 'all' } = ctx.request.body;
+      const userId = ctx.state.session.id;
+      
+      const result = await this.appMarketService.installApp(app_id, {
+        userId,
+        visibility
+      });
+      
+      ctx.success(result, 'App installed successfully');
+    } catch (error) {
+      logger.error('Install app error:', error);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  /**
+   * 卸载 App
+   */
+  async uninstallApp(ctx) {
+    try {
+      const { appId } = ctx.params;
+      const { keep_data = false } = ctx.request.body || {};
+      
+      const result = await this.appMarketService.uninstallApp(appId, {
+        keepData: keep_data
+      });
+      
+      ctx.success(result, 'App uninstalled successfully');
+    } catch (error) {
+      logger.error('Uninstall app error:', error);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  /**
+   * 检查更新
+   */
+  async checkUpdate(ctx) {
+    try {
+      const { appId } = ctx.params;
+      const result = await this.appMarketService.checkUpdate(appId);
+      ctx.success(result);
+    } catch (error) {
+      logger.error('Check update error:', error);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  /**
+   * 更新 App（重新安装最新版本）
+   */
+  async updateApp(ctx) {
+    try {
+      const { appId } = ctx.params;
+      const userId = ctx.state.session.id;
+      
+      // 先卸载旧版本（保留数据）
+      await this.appMarketService.uninstallApp(appId, { keepData: true });
+      
+      // 安装新版本
+      const result = await this.appMarketService.installApp(appId, {
+        userId,
+        visibility: 'all'
+      });
+      
+      ctx.success(result, 'App updated successfully');
+    } catch (error) {
+      logger.error('Update app error:', error);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  // ==================== 自定义组件 ====================
+
+  /**
+   * 获取 App 自定义组件代码
+   */
+  async getComponent(ctx) {
+    try {
+      const { appId } = ctx.params;
+      const { MiniApp } = this.db.getModels();
+      
+      // 获取 App 信息
+      const app = await MiniApp.findByPk(appId);
+      if (!app || !app.is_active) {
+        ctx.error('App not found or inactive', 404);
+        return;
+      }
+      
+      // 无自定义组件
+      if (!app.component) {
+        ctx.status = 204;
+        return;
+      }
+      
+      // 从文件系统读取组件代码
+      const componentPath = path.join(
+        process.cwd(),
+        'apps',
+        appId,
+        'frontend',
+        `${app.component}.umd.js`
+      );
+      
+      try {
+        const code = await fs.readFile(componentPath, 'utf-8');
+        
+        // 读取 CSS（可选）
+        const cssPath = componentPath.replace('.umd.js', '.css');
+        let css = null;
+        try {
+          css = await fs.readFile(cssPath, 'utf-8');
+        } catch {
+          // CSS 不存在，忽略
+        }
+        
+        // 获取文件修改时间作为版本
+        const stat = await fs.stat(componentPath);
+        const version = stat.mtime.toISOString();
+        
+        // ETag 缓存
+        const etag = `"${version}"`;
+        if (ctx.headers['if-none-match'] === etag) {
+          ctx.status = 304;
+          return;
+        }
+        
+        ctx.set('ETag', etag);
+        ctx.set('Cache-Control', 'public, max-age=3600');
+        ctx.success({
+          name: app.component,
+          code,
+          css,
+          version
+        });
+      } catch (error) {
+        logger.error(`Failed to load component for ${appId}:`, error);
+        ctx.error(`Component ${app.component} not found`, 404);
+      }
+    } catch (error) {
+      logger.error('Get component error:', error);
+      ctx.error(error.message, 500);
+    }
+  }
+}
+
+export default AppMarketController;

--- a/server/index.js
+++ b/server/index.js
@@ -67,6 +67,7 @@ import InternalController from './controllers/internal.controller.js';
 import AssistantController from './controllers/assistant.controller.js';
 import AttachmentController from './controllers/attachment.controller.js';
 import MiniAppController from './controllers/mini-app.controller.js';
+import AppMarketController from './controllers/app-market.controller.js';
 import { getAssistantManager } from './services/assistant/index.js';
 
 // 路由
@@ -95,6 +96,7 @@ import taskStaticRoutes from './routes/task-static.routes.js';
 import attachmentRoutes from './routes/attachment.routes.js';
 import attachmentStaticRoutes from './routes/attachment-static.routes.js';
 import miniAppRoutes from './routes/mini-app.routes.js';
+import appMarketRoutes from './routes/app-market.routes.js';
 import { createInvitationRoutes } from './routes/invitation.routes.js';
 import createMcpRoutes from './routes/mcp.routes.js';
 import TokenCleanupJob from './jobs/token-cleanup.js';
@@ -255,6 +257,7 @@ class ApiServer {
       assistant: new AssistantController(this.db),
       attachment: new AttachmentController(this.db),
       miniApp: new MiniAppController(this.db),
+      appMarket: new AppMarketController(this.db),
     };
   }
 
@@ -439,6 +442,12 @@ class ApiServer {
     this.app.use(miniAppRouter.routes());
     this.app.use(miniAppRouter.allowedMethods());
     logger.info('Mini App routes registered (/api/mini-apps/*, /api/handlers/*)');
+
+    // App Market 路由
+    const appMarketRouter = appMarketRoutes(this.controllers.appMarket);
+    this.app.use(appMarketRouter.routes());
+    this.app.use(appMarketRouter.allowedMethods());
+    logger.info('App Market routes registered (/api/app-market/*)');
 
     // Invitation 邀请码路由（Issue #222）
     const invitationRouter = createInvitationRoutes(this.db);

--- a/server/routes/app-market.routes.js
+++ b/server/routes/app-market.routes.js
@@ -1,0 +1,68 @@
+import Router from '@koa/router';
+import { authenticate, requireAdmin } from '../middlewares/auth.js';
+
+/**
+ * App Market 路由
+ * 管理员接口：浏览、安装、卸载 App
+ */
+export default (controller) => {
+  const router = new Router();
+
+  // ==================== Registry 接口 ====================
+
+  // 获取 Registry 配置
+  router.get('/api/app-market/settings', authenticate(), requireAdmin(), (ctx) => 
+    controller.getSettings(ctx)
+  );
+
+  // 更新 Registry 配置
+  router.put('/api/app-market/settings', authenticate(), requireAdmin(), (ctx) => 
+    controller.updateSettings(ctx)
+  );
+
+  // 获取 Registry 索引（可用 App 列表）
+  router.get('/api/app-market/index', authenticate(), requireAdmin(), (ctx) => 
+    controller.getIndex(ctx)
+  );
+
+  // 获取 App manifest（从 Registry 拉取）
+  router.get('/api/app-market/apps/:appId', authenticate(), requireAdmin(), (ctx) => 
+    controller.getManifest(ctx)
+  );
+
+  // ==================== App 安装/卸载 ====================
+
+  // 检查依赖
+  router.post('/api/app-market/check-dependencies', authenticate(), requireAdmin(), (ctx) => 
+    controller.checkDependencies(ctx)
+  );
+
+  // 安装 App
+  router.post('/api/app-market/install', authenticate(), requireAdmin(), (ctx) => 
+    controller.installApp(ctx)
+  );
+
+  // 卸载 App
+  router.delete('/api/app-market/apps/:appId', authenticate(), requireAdmin(), (ctx) => 
+    controller.uninstallApp(ctx)
+  );
+
+  // 检查更新
+  router.get('/api/app-market/apps/:appId/check-update', authenticate(), requireAdmin(), (ctx) => 
+    controller.checkUpdate(ctx)
+  );
+
+  // 更新 App
+  router.put('/api/app-market/apps/:appId/update', authenticate(), requireAdmin(), (ctx) => 
+    controller.updateApp(ctx)
+  );
+
+  // ==================== 自定义组件 ====================
+
+  // 获取 App 自定义组件代码
+  router.get('/api/app-market/component/:appId', authenticate(), (ctx) => 
+    controller.getComponent(ctx)
+  );
+
+  return router;
+};

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -1,0 +1,461 @@
+import logger from '../../lib/logger.js';
+import { Op } from 'sequelize';
+import fs from 'fs/promises';
+import path from 'path';
+import { generateId } from '../../lib/utils.js';
+
+/**
+ * App Market 服务
+ * 负责从 GitHub Registry 拉取、安装、卸载 App
+ */
+class AppMarketService {
+  constructor(db) {
+    this.db = db;
+    this.models = {};
+    this.appsDir = path.join(process.cwd(), 'apps');
+  }
+
+  ensureModels() {
+    if (!this.models.MiniApp) {
+      this.models.MiniApp = this.db.getModel('mini_app');
+      this.models.AppState = this.db.getModel('app_state');
+      this.models.AppRowHandler = this.db.getModel('app_row_handler');
+      this.models.SystemSetting = this.db.getModel('system_setting');
+      this.models.McpServer = this.db.getModel('mcp_server');
+    }
+  }
+
+  // ==================== Registry 配置 ====================
+
+  /**
+   * 获取 Registry 配置
+   */
+  async getRegistryConfig() {
+    this.ensureModels();
+    
+    const settings = await this.models.SystemSetting.findAll({
+      where: { setting_key: { [Op.like]: 'app_market.%' } }
+    });
+    
+    const config = {};
+    for (const s of settings) {
+      const key = s.setting_key.replace('app_market.', '');
+      config[key] = this.parseValue(s.setting_value, s.value_type);
+    }
+    
+    return {
+      registry_url: config.registry_url || 'https://raw.githubusercontent.com/ErixWong/touwaka-ai-mate/main/apps',
+      registry_branch: config.registry_branch || 'main',
+      auto_check_updates: config.auto_check_updates !== 'false',
+      check_interval_hours: parseInt(config.check_interval_hours) || 24,
+      offline_mode: config.offline_mode === 'true',
+      cache_ttl_hours: parseInt(config.cache_ttl_hours) || 168,
+      last_check_at: config.last_check_at || null
+    };
+  }
+
+  parseValue(value, type) {
+    switch (type) {
+      case 'boolean': return value === 'true';
+      case 'number': return parseFloat(value);
+      default: return value;
+    }
+  }
+
+  /**
+   * 更新 Registry 配置
+   */
+  async updateRegistryConfig(updates) {
+    this.ensureModels();
+    
+    for (const [key, value] of Object.entries(updates)) {
+      const settingKey = `app_market.${key}`;
+      const stringValue = String(value);
+      
+      // 推断 value_type
+      let valueType = 'string';
+      if (typeof value === 'boolean') valueType = 'boolean';
+      else if (typeof value === 'number') valueType = 'number';
+      
+      await this.models.SystemSetting.upsert({
+        setting_key: settingKey,
+        setting_value: stringValue,
+        value_type: valueType
+      });
+    }
+    
+    logger.info('Registry config updated:', updates);
+  }
+
+  // ==================== Registry 拉取 ====================
+
+  /**
+   * 从 GitHub Registry 拉取索引
+   */
+  async fetchIndex() {
+    const config = await this.getRegistryConfig();
+    const url = `${config.registry_url}/index.json`;
+    
+    logger.info(`Fetching Registry index from: ${url}`);
+    
+    try {
+      const response = await fetch(url, { 
+        headers: { 'Accept': 'application/json' },
+        timeout: 10000 
+      });
+      
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      
+      const index = await response.json();
+      
+      // 更新最后检查时间
+      await this.models.SystemSetting.update(
+        { setting_value: new Date().toISOString() },
+        { where: { setting_key: 'app_market.last_check_at' } }
+      );
+      
+      return index;
+    } catch (error) {
+      logger.error('Failed to fetch Registry index:', error);
+      throw new Error(`无法连接到 App Market Registry: ${error.message}`);
+    }
+  }
+
+  /**
+   * 从 GitHub Registry 拉取 App manifest
+   */
+  async fetchManifest(appId) {
+    const config = await this.getRegistryConfig();
+    const url = `${config.registry_url}/${appId}/manifest.json`;
+    
+    logger.info(`Fetching manifest for ${appId} from: ${url}`);
+    
+    try {
+      const response = await fetch(url, { 
+        headers: { 'Accept': 'application/json' },
+        timeout: 10000 
+      });
+      
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error(`App ${appId} not found in Registry`);
+        }
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      
+      return await response.json();
+    } catch (error) {
+      logger.error(`Failed to fetch manifest for ${appId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * 拉取处理脚本内容
+   */
+  async fetchHandler(appId, handlerName) {
+    const config = await this.getRegistryConfig();
+    const url = `${config.registry_url}/${appId}/handlers/${handlerName}/index.js`;
+    
+    logger.info(`Fetching handler ${handlerName} for ${appId}`);
+    
+    try {
+      const response = await fetch(url, { timeout: 10000 });
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch handler: HTTP ${response.status}`);
+      }
+      
+      return await response.text();
+    } catch (error) {
+      logger.error(`Failed to fetch handler ${handlerName}:`, error);
+      throw error;
+    }
+  }
+
+  // ==================== 依赖检查 ====================
+
+  /**
+   * 检查 App 依赖是否满足
+   */
+  async checkDependencies(manifest) {
+    this.ensureModels();
+    
+    const missing = { mcp: [], skills: [], platform_version: false };
+    const compatibility = manifest.compatibility || {};
+    
+    // 检查 MCP 服务
+    if (compatibility.requires?.mcp) {
+      const configuredMcp = await this.getConfiguredMcpServices();
+      for (const mcp of compatibility.requires.mcp) {
+        if (!configuredMcp.includes(mcp)) {
+          missing.mcp.push(mcp);
+        }
+      }
+    }
+    
+    // 检查平台版本（简化处理，实际应比较版本号）
+    if (compatibility.min_platform_version) {
+      const currentVersion = process.env.PLATFORM_VERSION || '2.0.0';
+      if (this.compareVersion(currentVersion, compatibility.min_platform_version) < 0) {
+        missing.platform_version = true;
+      }
+    }
+    
+    return {
+      satisfied: missing.mcp.length === 0 && missing.skills.length === 0 && !missing.platform_version,
+      missing
+    };
+  }
+
+  async getConfiguredMcpServices() {
+    this.ensureModels();
+    const servers = await this.models.McpServer.findAll({
+      where: { is_active: true },
+      attributes: ['name']
+    });
+    return servers.map(s => s.name);
+  }
+
+  compareVersion(v1, v2) {
+    const parts1 = v1.split('.').map(Number);
+    const parts2 = v2.split('.').map(Number);
+    
+    for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+      const p1 = parts1[i] || 0;
+      const p2 = parts2[i] || 0;
+      if (p1 < p2) return -1;
+      if (p1 > p2) return 1;
+    }
+    return 0;
+  }
+
+  // ==================== App 安装 ====================
+
+  /**
+   * 安装 App
+   */
+  async installApp(appId, options = {}) {
+    this.ensureModels();
+    
+    const { userId, visibility = 'all' } = options;
+    
+    // 1. 检查 App 是否已存在
+    const existing = await this.models.MiniApp.findByPk(appId);
+    if (existing) {
+      throw new Error(`App ${appId} 已安装`);
+    }
+    
+    // 2. 拉取 manifest
+    const manifest = await this.fetchManifest(appId);
+    
+    // 3. 检查依赖
+    const deps = await this.checkDependencies(manifest);
+    if (!deps.satisfied) {
+      const missingMcp = deps.missing.mcp.join(', ');
+      throw new Error(`缺少依赖的 MCP 服务: ${missingMcp}`);
+    }
+    
+    // 4. 创建 App 目录
+    const appDir = path.join(this.appsDir, appId);
+    await fs.mkdir(appDir, { recursive: true });
+    
+    // 5. 保存 manifest 到本地
+    await fs.writeFile(
+      path.join(appDir, 'manifest.json'),
+      JSON.stringify(manifest, null, 2),
+      'utf-8'
+    );
+    
+    // 6. 安装 handlers
+    const installedHandlers = await this.installHandlers(appId, manifest);
+    
+    // 7. 插入数据库
+    await this.installAppMetadata(manifest, userId, visibility);
+    await this.installStates(appId, manifest);
+    
+    logger.info(`App ${appId} installed successfully`);
+    
+    return {
+      success: true,
+      app_id: appId,
+      name: manifest.name,
+      version: manifest.version,
+      installed_handlers: installedHandlers
+    };
+  }
+
+  /**
+   * 安装 App 元数据到数据库
+   */
+  async installAppMetadata(manifest, userId, visibility) {
+    await this.models.MiniApp.create({
+      id: manifest.id,
+      name: manifest.name,
+      description: manifest.description,
+      icon: manifest.icon || '📱',
+      type: manifest.type,
+      component: manifest.component || null,
+      fields: JSON.stringify(manifest.fields || []),
+      views: JSON.stringify(manifest.views || {}),
+      config: JSON.stringify(manifest.config || {}),
+      visibility,
+      owner_id: userId,
+      creator_id: userId,
+      sort_order: 0,
+      is_active: true,
+      revision: 1
+    });
+  }
+
+  /**
+   * 安装状态定义到数据库
+   */
+  async installStates(appId, manifest) {
+    if (!manifest.states || manifest.states.length === 0) return;
+    
+    for (const state of manifest.states) {
+      await this.models.AppState.create({
+        id: generateId(),
+        app_id: appId,
+        name: state.name,
+        label: state.label,
+        sort_order: state.sort_order || 0,
+        is_initial: state.is_initial || false,
+        is_terminal: state.is_terminal || false,
+        is_error: state.is_error || false,
+        handler_id: state.handler || null,
+        success_next_state: state.success_next || null,
+        failure_next_state: state.failure_next || null
+      });
+    }
+  }
+
+  /**
+   * 安装处理脚本
+   */
+  async installHandlers(appId, manifest) {
+    const installed = [];
+    
+    if (!manifest.states) return installed;
+    
+    // 收集需要安装的 handlers（去重）
+    const handlerNames = new Set();
+    for (const state of manifest.states) {
+      if (state.handler) {
+        handlerNames.add(state.handler);
+      }
+    }
+    
+    // App 专属 handlers 目录
+    const appHandlersDir = path.join(this.appsDir, appId, 'handlers');
+    await fs.mkdir(appHandlersDir, { recursive: true });
+    
+    for (const handlerName of handlerNames) {
+      try {
+        // 从 Registry 拉取脚本
+        const scriptContent = await this.fetchHandler(appId, handlerName);
+        
+        // 保存到本地
+        const handlerDir = path.join(appHandlersDir, handlerName);
+        await fs.mkdir(handlerDir, { recursive: true });
+        await fs.writeFile(
+          path.join(handlerDir, 'index.js'),
+          scriptContent,
+          'utf-8'
+        );
+        
+        // 插入数据库记录
+        await this.models.AppRowHandler.create({
+          id: `${appId}-${handlerName}`,
+          name: handlerName,
+          description: `${manifest.name} - ${handlerName}`,
+          handler: `apps/${appId}/handlers/${handlerName}`,
+          handler_function: 'process',
+          concurrency: 3,
+          timeout: 60,
+          max_retries: 2,
+          is_active: true
+        });
+        
+        installed.push(handlerName);
+        logger.info(`Installed handler ${handlerName} for ${appId}`);
+      } catch (error) {
+        logger.error(`Failed to install handler ${handlerName}:`, error);
+        // 继续安装其他 handlers
+      }
+    }
+    
+    return installed;
+  }
+
+  // ==================== App 卸载 ====================
+
+  /**
+   * 卸载 App
+   */
+  async uninstallApp(appId, options = {}) {
+    this.ensureModels();
+    
+    const { keepData = false } = options;
+    
+    // 1. 检查 App 是否存在
+    const app = await this.models.MiniApp.findByPk(appId);
+    if (!app) {
+      throw new Error(`App ${appId} 不存在`);
+    }
+    
+    // 2. 删除数据库记录
+    await this.models.MiniApp.destroy({ where: { id: appId } });
+    await this.models.AppState.destroy({ where: { app_id: appId } });
+    await this.models.AppRowHandler.destroy({ 
+      where: { handler: { [Op.like]: `apps/${appId}/handlers/%` } }
+    });
+    
+    // 3. 根据选项决定是否删除数据行
+    if (!keepData) {
+      const { MiniAppRow } = this.db.getModels();
+      await MiniAppRow.destroy({ where: { app_id: appId } });
+    }
+    
+    // 4. 删除本地文件
+    const appDir = path.join(this.appsDir, appId);
+    try {
+      await fs.rm(appDir, { recursive: true, force: true });
+    } catch (error) {
+      logger.warn(`Failed to remove app directory ${appDir}:`, error);
+    }
+    
+    logger.info(`App ${appId} uninstalled successfully`);
+    
+    return { success: true, app_id: appId, keepData };
+  }
+
+  // ==================== App 更新 ====================
+
+  /**
+   * 检查更新
+   */
+  async checkUpdate(appId) {
+    this.ensureModels();
+    
+    const app = await this.models.MiniApp.findByPk(appId);
+    if (!app) {
+      throw new Error(`App ${appId} 不存在`);
+    }
+    
+    const manifest = await this.fetchManifest(appId);
+    const localVersion = app.getDataValue ? app.getDataValue('revision') : 1;
+    
+    return {
+      has_update: this.compareVersion(manifest.version, localVersion.toString()) > 0,
+      local_version: localVersion.toString(),
+      registry_version: manifest.version,
+      changelog: manifest.changelog || ''
+    };
+  }
+}
+
+export default AppMarketService;


### PR DESCRIPTION
## App Market 后端实现 (Step 1-3)

本次提交实现了 App Market 的后端基础功能：

### 新增文件

1. **apps/** - Registry 目录结构
   - `index.json` - Registry 索引
   - `README.md` - Registry 说明
   - `contract-manager/` - 示例 App

2. **server/services/app-market.service.js** - 核心服务
   - Registry 配置管理（复用 system_settings）
   - 从 GitHub 拉取索引和 manifest
   - App 安装/卸载逻辑
   - 依赖检查（MCP 服务）

3. **server/routes/app-market.routes.js** - 路由定义

4. **server/controllers/app-market.controller.js** - 控制器

### API 端点

- `GET /api/app-market/settings` - 获取 Registry 配置
- `PUT /api/app-market/settings` - 更新配置
- `GET /api/app-market/index` - 获取可用 App 列表
- `GET /api/app-market/apps/:appId` - 获取 App 详情
- `POST /api/app-market/check-dependencies` - 检查依赖
- `POST /api/app-market/install` - 安装 App
- `DELETE /api/app-market/apps/:appId` - 卸载 App
- `GET /api/app-market/apps/:appId/check-update` - 检查更新
- `PUT /api/app-market/apps/:appId/update` - 更新 App
- `GET /api/app-market/component/:appId` - 获取组件代码

### 关键设计决策

- **零新增数据库表**：复用现有表
- **App 专属目录**：handlers 存储在 `apps/{appId}/handlers/`
- **配置存储**：`system_settings.app_market.*`

### 测试方式

```bash
# 1. 初始化 Registry 配置
node scripts/db-query.js "INSERT INTO system_settings (setting_key, setting_value, value_type, description) VALUES ('app_market.registry_url', 'https://raw.githubusercontent.com/ErixWong/touwaka-ai-mate/main/apps', 'string', 'App Market Registry URL');"

# 2. 获取 Registry 索引
curl -H "Authorization: Bearer <token>" http://localhost:3000/api/app-market/index

# 3. 安装 contract-manager
curl -X POST -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{"app_id": "contract-manager"}' http://localhost:3000/api/app-market/install
```

---

下一步：前端 AppMarketTab.vue 界面开发