### PR TITLE
fix: 修复 App Market 代码审计问题

### DIFF
--- a/server/controllers/app-market.controller.js
+++ b/server/controllers/app-market.controller.js
@@ -148,13 +148,17 @@ class AppMarketController {
       const { appId } = ctx.params;
       const userId = ctx.state.session.id;
       
+      // 保留旧 App 的 visibility
+      const oldApp = await this.db.getModels().MiniApp.findByPk(appId);
+      const oldVisibility = oldApp ? oldApp.visibility : 'all';
+      
       // 先卸载旧版本（保留数据）
       await this.appMarketService.uninstallApp(appId, { keepData: true });
       
       // 安装新版本
       const result = await this.appMarketService.installApp(appId, {
         userId,
-        visibility: 'all'
+        visibility: oldVisibility
       });
       
       ctx.success(result, 'App updated successfully');

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -1,8 +1,8 @@
 import logger from '../../lib/logger.js';
+import Utils from '../../lib/utils.js';
 import { Op } from 'sequelize';
 import fs from 'fs/promises';
 import path from 'path';
-import { generateId } from '../../lib/utils.js';
 
 /**
  * App Market 服务
@@ -101,7 +101,7 @@ class AppMarketService {
     try {
       const response = await fetch(url, { 
         headers: { 'Accept': 'application/json' },
-        timeout: 10000 
+        signal: AbortSignal.timeout(10000)
       });
       
       if (!response.ok) {
@@ -135,7 +135,7 @@ class AppMarketService {
     try {
       const response = await fetch(url, { 
         headers: { 'Accept': 'application/json' },
-        timeout: 10000 
+        signal: AbortSignal.timeout(10000)
       });
       
       if (!response.ok) {
@@ -162,7 +162,7 @@ class AppMarketService {
     logger.info(`Fetching handler ${handlerName} for ${appId}`);
     
     try {
-      const response = await fetch(url, { timeout: 10000 });
+      const response = await fetch(url, { signal: AbortSignal.timeout(10000) });
       
       if (!response.ok) {
         throw new Error(`Failed to fetch handler: HTTP ${response.status}`);
@@ -318,7 +318,7 @@ class AppMarketService {
     
     for (const state of manifest.states) {
       await this.models.AppState.create({
-        id: generateId(),
+        id: Utils.newID(20),
         app_id: appId,
         name: state.name,
         label: state.label,


### PR DESCRIPTION
## 审计发现并修复的问题

### 1. 🔴 严重：import 导入错误
\generateId\ 在 \lib/utils.js\ 中不存在
- 修复：改为 \Utils.newID(20)\

### 2. 🟡 中等：fetch timeout 参数不支持
Node.js 内置 \etch\ 不支持 \	imeout\ 选项
- 修复：改用 \AbortSignal.timeout(10000)\

### 3. 🟡 中等：visibility 硬编码
\updateApp\ 中 \isibility\ 硬编码为 \'all'\
- 修复：读取旧 App 的 visibility 并保留

### 审计清单检查结果

- [x] ES 模块导入验证（已修复）
- [x] API 响应格式：使用 \ctx.success()\
- [x] 权限校验：所有路由有 \equireAdmin()\
- [x] 错误处理：所有方法有 try-catch
- [x] 数据库方法：使用 ORM（Sequelize）
- [x] 无数据库迁移变更