### PR TITLE
feat: App Market 前端界面 (Step 4)

### DIFF
--- a/frontend/src/api/app-market.ts
+++ b/frontend/src/api/app-market.ts
@@ -1,0 +1,185 @@
+import apiClient, { apiRequest } from './client'
+
+export interface AppMarketIndex {
+  version: string
+  updated_at: string
+  apps: AppSummary[]
+  categories: Category[]
+}
+
+export interface AppSummary {
+  id: string
+  name: string
+  version: string
+  icon: string
+  type: string
+  description: string
+  author: string
+  tags: string[]
+  path: string
+}
+
+export interface Category {
+  id: string
+  name: string
+  icon: string
+  description?: string
+}
+
+export interface AppManifest {
+  id: string
+  name: string
+  version: string
+  description: string
+  icon: string
+  type: 'document' | 'workflow' | 'data' | 'utility'
+  author: string
+  license: string
+  repository?: string
+  keywords: string[]
+  compatibility: {
+    min_platform_version: string
+    requires: {
+      mcp?: string[]
+      skills?: string[]
+    }
+  }
+  fields: FieldDefinition[]
+  views: {
+    list: {
+      columns: string[]
+      sort: { field: string; order: 'asc' | 'desc' }
+    }
+  }
+  config: {
+    features: string[]
+    supported_formats: string[]
+    max_file_size: number
+  }
+  states: AppStateDefinition[]
+  component: string | null
+  visibility: 'owner' | 'department' | 'all' | 'role'
+}
+
+export interface FieldDefinition {
+  name: string
+  label: string
+  type: string
+  required?: boolean
+  ai_extractable?: boolean
+  options?: string[]
+  default?: any
+}
+
+export interface AppStateDefinition {
+  name: string
+  label: string
+  sort_order: number
+  is_initial: boolean
+  is_terminal: boolean
+  is_error: boolean
+  handler: string | null
+  success_next: string | null
+  failure_next: string | null
+}
+
+export interface DependencyCheckResult {
+  satisfied: boolean
+  missing: {
+    mcp: string[]
+    skills: string[]
+    platform_version: boolean
+  }
+}
+
+export interface InstallResult {
+  success: boolean
+  app_id: string
+  name: string
+  version: string
+  installed_handlers: string[]
+}
+
+export interface UpdateCheckResult {
+  has_update: boolean
+  local_version: string
+  registry_version: string
+  changelog: string
+}
+
+export interface RegistryConfig {
+  registry_url: string
+  registry_branch: string
+  auto_check_updates: boolean
+  check_interval_hours: number
+  offline_mode: boolean
+  cache_ttl_hours: number
+  last_check_at: string | null
+}
+
+// 获取 Registry 索引（可用 App 列表）
+export async function getAppMarketIndex(): Promise<AppMarketIndex> {
+  return apiRequest(apiClient.get('/app-market/index'))
+}
+
+// 获取 App 详情（从 Registry 拉取 manifest）
+export async function getAppManifest(appId: string): Promise<AppManifest> {
+  return apiRequest(apiClient.get(`/app-market/apps/${appId}`))
+}
+
+// 检查依赖
+export async function checkAppDependencies(appId: string): Promise<DependencyCheckResult> {
+  return apiRequest(apiClient.post('/app-market/check-dependencies', { app_id: appId }))
+}
+
+// 安装 App
+export async function installAppFromMarket(
+  appId: string,
+  visibility?: string
+): Promise<InstallResult> {
+  return apiRequest(
+    apiClient.post('/app-market/install', { app_id: appId, visibility })
+  )
+}
+
+// 卸载 App
+export async function uninstallAppFromMarket(
+  appId: string,
+  keepData?: boolean
+): Promise<{ success: boolean; app_id: string; keepData: boolean }> {
+  return apiRequest(
+    apiClient.delete(`/app-market/apps/${appId}`, { data: { keep_data: keepData } })
+  )
+}
+
+// 检查更新
+export async function checkAppUpdate(appId: string): Promise<UpdateCheckResult> {
+  return apiRequest(apiClient.get(`/app-market/apps/${appId}/check-update`))
+}
+
+// 更新 App
+export async function updateAppFromMarket(appId: string): Promise<InstallResult> {
+  return apiRequest(apiClient.put(`/app-market/apps/${appId}/update`))
+}
+
+// 获取 Registry 配置
+export async function getRegistryConfig(): Promise<RegistryConfig> {
+  return apiRequest(apiClient.get('/app-market/settings'))
+}
+
+// 更新 Registry 配置
+export async function updateRegistryConfig(
+  config: Partial<RegistryConfig>
+): Promise<{ message: string }> {
+  return apiRequest(apiClient.put('/app-market/settings', config))
+}
+
+// 获取组件代码（用于动态加载）
+export async function getAppComponent(appId: string): Promise<{
+  name: string
+  code: string
+  css: string | null
+  version: string
+}> {
+  return apiRequest(apiClient.get(`/app-market/component/${appId}`))
+}

--- a/frontend/src/components/AppMarketPanel.vue
+++ b/frontend/src/components/AppMarketPanel.vue
@@ -1,0 +1,743 @@
+<template>
+  <div class="app-market-panel">
+    <!-- 顶部工具栏 -->
+    <div class="toolbar">
+      <div class="category-filter">
+        <button
+          :class="['filter-btn', { active: selectedCategory === 'all' }]"
+          @click="selectedCategory = 'all'"
+        >
+          {{ $t('appMarket.all', '全部') }}
+        </button>
+        <button
+          v-for="cat in categories"
+          :key="cat.id"
+          :class="['filter-btn', { active: selectedCategory === cat.id }]"
+          @click="selectedCategory = cat.id"
+        >
+          {{ cat.icon }} {{ cat.name }}
+        </button>
+      </div>
+
+      <div class="search-box">
+        <input
+          v-model="searchQuery"
+          type="text"
+          :placeholder="$t('appMarket.searchPlaceholder', '搜索应用...')"
+          @input="handleSearch"
+        />
+        <button class="btn-refresh" @click="refreshIndex" :disabled="isLoading">
+          {{ $t('common.refresh', '刷新') }}
+        </button>
+      </div>
+    </div>
+
+    <!-- 加载状态 -->
+    <div v-if="isLoading" class="loading-state">
+      <div class="spinner"></div>
+      <span>{{ $t('common.loading', '加载中...') }}</span>
+    </div>
+
+    <!-- 错误状态 -->
+    <div v-else-if="error" class="error-state">
+      <p>{{ error }}</p>
+      <button class="btn-retry" @click="refreshIndex">
+        {{ $t('common.retry', '重试') }}
+      </button>
+    </div>
+
+    <!-- App 列表 -->
+    <div v-else class="market-grid">
+      <div
+        v-for="app in filteredApps"
+        :key="app.id"
+        :class="['market-app-card', { installed: isInstalled(app.id) }]"
+      >
+        <div class="app-header">
+          <div class="app-icon">{{ app.icon }}</div>
+          <div class="app-version">v{{ app.version }}</div>
+        </div>
+
+        <h3 class="app-name">{{ app.name }}</h3>
+        <p class="app-desc">{{ app.description }}</p>
+
+        <div class="app-tags">
+          <span v-for="tag in app.tags.slice(0, 3)" :key="tag" class="tag">
+            {{ tag }}
+          </span>
+        </div>
+
+        <div class="app-meta">
+          <span class="app-author">{{ app.author }}</span>
+          <span v-if="app.hasUpdate" class="update-badge">{{ $t('appMarket.updateAvailable', '有更新') }}</span>
+        </div>
+
+        <div class="app-actions">
+          <button
+            v-if="isInstalled(app.id)"
+            class="btn-installed"
+            disabled
+          >
+            <span class="icon">✓</span>
+            {{ $t('appMarket.installed', '已安装') }}
+          </button>
+          <button
+            v-else-if="isInstalling === app.id"
+            class="btn-installing"
+            disabled
+          >
+            <span class="spinner-small"></span>
+            {{ $t('appMarket.installing', '安装中...') }}
+          </button>
+          <button
+            v-else
+            class="btn-install"
+            @click="installApp(app)"
+          >
+            {{ $t('appMarket.install', '安装') }}
+          </button>
+
+          <button
+            v-if="isInstalled(app.id)"
+            class="btn-uninstall"
+            @click="uninstallApp(app)"
+          >
+            {{ $t('appMarket.uninstall', '卸载') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 详情弹窗 -->
+    <div v-if="showDetail" class="dialog-overlay" @click.self="closeDetail">
+      <div class="dialog">
+        <div class="dialog-header">
+          <h3>{{ selectedApp?.name }}</h3>
+          <button class="btn-close" @click="closeDetail">×</button>
+        </div>
+
+        <div class="dialog-body">
+          <div class="app-info">
+            <div class="app-icon-large">{{ selectedApp?.icon }}</div>
+            <div class="app-meta-detail">
+              <p class="version">v{{ selectedAppManifest?.version }}</p>
+              <p class="author">{{ $t('appMarket.author', '作者') }}: {{ selectedApp?.author }}</p>
+              <p class="license">{{ $t('appMarket.license', '许可证') }}: {{ selectedAppManifest?.license }}</p>
+            </div>
+          </div>
+
+          <p class="description">{{ selectedApp?.description }}</p>
+
+          <!-- 依赖检查 -->
+          <div v-if="dependencyCheck" class="deps-section">
+            <h4>{{ $t('appMarket.dependencies', '依赖检查') }}</h4>
+            <div v-if="dependencyCheck.satisfied" class="deps-satisfied">
+              <span class="icon">✓</span> {{ $t('appMarket.allDepsSatisfied', '所有依赖已满足') }}
+            </div>
+            <div v-else class="deps-missing">
+              <p v-if="dependencyCheck.missing.mcp.length > 0">
+                <strong>{{ $t('appMarket.missingMcp', '缺少 MCP 服务') }}:</strong>
+                {{ dependencyCheck.missing.mcp.join(', ') }}
+              </p>
+            </div>
+          </div>
+
+          <!-- 字段列表 -->
+          <div v-if="selectedAppManifest?.fields" class="fields-section">
+            <h4>{{ $t('appMarket.fields', '字段定义') }} ({{ selectedAppManifest.fields.length }})</h4>
+            <ul class="field-list">
+              <li
+                v-for="field in selectedAppManifest.fields.slice(0, 10)"
+                :key="field.name"
+              >
+                {{ field.label }} ({{ field.type }})
+                <span v-if="field.required" class="required">*</span>
+                <span v-if="field.ai_extractable" class="ai-badge">AI</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="dialog-footer">
+          <button class="btn-cancel" @click="closeDetail">
+            {{ $t('common.close', '关闭') }}
+          </button>
+          <button
+            v-if="!isInstalled(selectedApp?.id) && dependencyCheck?.satisfied"
+            class="btn-primary"
+            @click="installFromDetail"
+          >
+            {{ $t('appMarket.install', '安装') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import {
+  getAppMarketIndex,
+  getAppManifest,
+  checkAppDependencies,
+  installAppFromMarket,
+  uninstallAppFromMarket,
+  checkAppUpdate,
+  type AppSummary,
+  type Category,
+  type AppManifest,
+  type DependencyCheckResult
+} from '@/api/app-market'
+
+const props = defineProps<{
+  installedApps: string[]
+}>()
+
+const emit = defineEmits<{
+  installed: [appId: string]
+  uninstalled: [appId: string]
+}>()
+
+// 状态
+const isLoading = ref(false)
+const error = ref<string | null>(null)
+const index = ref<{ apps: AppSummary[]; categories: Category[] } | null>(null)
+const selectedCategory = ref<string>('all')
+const searchQuery = ref('')
+const isInstalling = ref<string | null>(null)
+
+// 详情弹窗
+const showDetail = ref(false)
+const selectedApp = ref<AppSummary | null>(null)
+const selectedAppManifest = ref<AppManifest | null>(null)
+const dependencyCheck = ref<DependencyCheckResult | null>(null)
+
+// 计算属性
+const categories = computed(() => index.value?.categories || [])
+
+const filteredApps = computed(() => {
+  let apps = index.value?.apps || []
+
+  // 分类筛选
+  if (selectedCategory.value !== 'all') {
+    apps = apps.filter(a => a.type === selectedCategory.value)
+  }
+
+  // 搜索筛选
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    apps = apps.filter(a =>
+      a.name.toLowerCase().includes(q) ||
+      a.description.toLowerCase().includes(q) ||
+      a.tags.some(t => t.toLowerCase().includes(q))
+    )
+  }
+
+  // 标记已安装和有更新的
+  return apps.map(app => ({
+    ...app,
+    hasUpdate: props.installedApps.includes(app.id) && appHasUpdate(app.id)
+  }))
+})
+
+// 检查应用是否有更新（简化版，实际需要调用 API）
+function appHasUpdate(appId: string): boolean {
+  // 这里可以实现本地缓存的版本对比
+  return false
+}
+
+function isInstalled(appId: string): boolean {
+  return props.installedApps.includes(appId)
+}
+
+// 加载 Registry 索引
+async function refreshIndex() {
+  isLoading.value = true
+  error.value = null
+  try {
+    index.value = await getAppMarketIndex()
+  } catch (err: any) {
+    error.value = err.message || 'Failed to load app market'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// 搜索防抖
+let searchTimeout: ReturnType<typeof setTimeout>
+function handleSearch() {
+  clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    // 搜索逻辑已在 computed 中处理
+  }, 300)
+}
+
+// 安装应用
+async function installApp(app: AppSummary) {
+  isInstalling.value = app.id
+  try {
+    // 先检查依赖
+    const deps = await checkAppDependencies(app.id)
+    if (!deps.satisfied) {
+      const missingMcp = deps.missing.mcp.join(', ')
+      alert(`Missing dependencies: ${missingMcp}`)
+      return
+    }
+
+    // 安装
+    await installAppFromMarket(app.id, 'all')
+    emit('installed', app.id)
+    alert(`App ${app.name} installed successfully`)
+  } catch (err: any) {
+    alert(`Installation failed: ${err.message}`)
+  } finally {
+    isInstalling.value = null
+  }
+}
+
+// 卸载应用
+async function uninstallApp(app: AppSummary) {
+  const confirm = window.confirm(
+    `Are you sure you want to uninstall ${app.name}?\n\nData will be kept by default.`
+  )
+  if (!confirm) return
+
+  try {
+    await uninstallAppFromMarket(app.id, true)
+    emit('uninstalled', app.id)
+    alert(`App ${app.name} uninstalled successfully`)
+  } catch (err: any) {
+    alert(`Uninstallation failed: ${err.message}`)
+  }
+}
+
+// 查看详情
+async function showAppDetail(app: AppSummary) {
+  selectedApp.value = app
+  showDetail.value = true
+  try {
+    selectedAppManifest.value = await getAppManifest(app.id)
+    dependencyCheck.value = await checkAppDependencies(app.id)
+  } catch (err: any) {
+    console.error('Failed to load app detail:', err)
+  }
+}
+
+function closeDetail() {
+  showDetail.value = false
+  selectedApp.value = null
+  selectedAppManifest.value = null
+  dependencyCheck.value = null
+}
+
+function installFromDetail() {
+  if (selectedApp.value) {
+    installApp(selectedApp.value)
+    closeDetail()
+  }
+}
+
+onMounted(() => {
+  refreshIndex()
+})
+</script>
+
+<style scoped>
+.app-market-panel {
+  padding: 0;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.category-filter {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  padding: 8px 16px;
+  border: 1px solid var(--color-border, #e0e0e0);
+  background: var(--color-bg-primary, #fff);
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.2s;
+}
+
+.filter-btn:hover {
+  border-color: var(--color-primary, #4a90d9);
+}
+
+.filter-btn.active {
+  background: var(--color-primary, #4a90d9);
+  color: white;
+  border-color: var(--color-primary, #4a90d9);
+}
+
+.search-box {
+  display: flex;
+  gap: 8px;
+}
+
+.search-box input {
+  padding: 8px 12px;
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: 6px;
+  width: 200px;
+  font-size: 13px;
+}
+
+.btn-refresh {
+  padding: 8px 16px;
+  background: var(--color-bg-secondary, #f5f5f5);
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.btn-refresh:hover:not(:disabled) {
+  background: var(--color-bg-tertiary, #eee);
+}
+
+.loading-state,
+.error-state {
+  text-align: center;
+  padding: 80px 20px;
+  color: var(--color-text-secondary, #666);
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid #e0e0e0;
+  border-top-color: var(--color-primary, #4a90d9);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 16px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.btn-retry {
+  margin-top: 16px;
+  padding: 8px 16px;
+  background: var(--color-primary, #4a90d9);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.market-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.market-app-card {
+  background: var(--color-bg-primary, #fff);
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: 12px;
+  padding: 20px;
+  transition: all 0.2s;
+}
+
+.market-app-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.market-app-card.installed {
+  border-color: #52c41a;
+  background: #f6ffed;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.app-icon {
+  font-size: 36px;
+}
+
+.app-version {
+  font-size: 12px;
+  color: var(--color-text-tertiary, #999);
+}
+
+.app-name {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.app-desc {
+  font-size: 13px;
+  color: var(--color-text-secondary, #666);
+  margin-bottom: 12px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.app-tags {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-size: 11px;
+  padding: 2px 8px;
+  background: var(--color-bg-secondary, #f5f5f5);
+  color: var(--color-text-secondary, #666);
+  border-radius: 4px;
+}
+
+.app-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.app-author {
+  font-size: 12px;
+  color: var(--color-text-tertiary, #999);
+}
+
+.update-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  background: #fff2f0;
+  color: #ff4d4f;
+  border-radius: 4px;
+}
+
+.app-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.app-actions button {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  border: none;
+  transition: all 0.2s;
+}
+
+.btn-install {
+  background: var(--color-primary, #4a90d9);
+  color: white;
+}
+
+.btn-install:hover {
+  background: var(--color-primary-dark, #3a7bc8);
+}
+
+.btn-installing {
+  background: #f5f5f5;
+  color: #999;
+  cursor: not-allowed;
+}
+
+.spinner-small {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #e0e0e0;
+  border-top-color: var(--color-primary, #4a90d9);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-right: 6px;
+}
+
+.btn-installed {
+  background: #f6ffed;
+  color: #52c41a;
+  border: 1px solid #52c41a;
+  cursor: default;
+}
+
+.btn-uninstall {
+  background: #fff2f0;
+  color: #ff4d4f;
+  border: 1px solid #ffccc7;
+}
+
+.btn-uninstall:hover {
+  background: #ff4d4f;
+  color: white;
+}
+
+/* 弹窗样式 */
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.dialog {
+  background: white;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 560px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--color-border, #e0e0e0);
+}
+
+.dialog-header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: var(--color-text-secondary, #666);
+}
+
+.dialog-body {
+  padding: 24px;
+}
+
+.app-info {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.app-icon-large {
+  font-size: 56px;
+}
+
+.app-meta-detail p {
+  margin: 4px 0;
+  font-size: 13px;
+  color: var(--color-text-secondary, #666);
+}
+
+.description {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--color-text-primary, #333);
+  margin-bottom: 20px;
+}
+
+.deps-section,
+.fields-section {
+  margin-bottom: 20px;
+}
+
+.deps-section h4,
+.fields-section h4 {
+  font-size: 14px;
+  margin: 0 0 12px;
+  color: var(--color-text-primary, #333);
+}
+
+.deps-satisfied {
+  color: #52c41a;
+  font-size: 13px;
+}
+
+.deps-missing {
+  color: #ff4d4f;
+  font-size: 13px;
+}
+
+.field-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 13px;
+}
+
+.field-list li {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--color-border-light, #f0f0f0);
+}
+
+.required {
+  color: #ff4d4f;
+  margin-left: 4px;
+}
+
+.ai-badge {
+  font-size: 10px;
+  padding: 1px 4px;
+  background: var(--color-primary, #4a90d9);
+  color: white;
+  border-radius: 3px;
+  margin-left: 4px;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--color-border, #e0e0e0);
+}
+
+.btn-cancel {
+  padding: 10px 20px;
+  background: var(--color-bg-secondary, #f5f5f5);
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.btn-primary {
+  padding: 10px 20px;
+  background: var(--color-primary, #4a90d9);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.btn-primary:hover {
+  background: var(--color-primary-dark, #3a7bc8);
+}
+</style>

--- a/frontend/src/views/AppsView.vue
+++ b/frontend/src/views/AppsView.vue
@@ -1,56 +1,150 @@
 <template>
   <div class="apps-view">
     <div class="view-header">
-      <h1 class="view-title">{{ $t('apps.title', 'App 小程序') }}</h1>
-    </div>
-
-    <div v-if="isLoading" class="loading-state">
-      {{ $t('common.loading', '加载中...') }}
-    </div>
-
-    <div v-else-if="apps.length === 0" class="empty-state">
-      <div class="empty-icon">📱</div>
-      <p>{{ $t('apps.noApps', '暂无可用的小程序') }}</p>
-    </div>
-
-    <div v-else class="apps-grid">
-      <div
-        v-for="app in apps"
-        :key="app.id"
-        class="app-card"
-        @click="openApp(app)"
-      >
-        <div class="app-card-icon">{{ app.icon || '📱' }}</div>
-        <div class="app-card-name">{{ app.name }}</div>
-        <div class="app-card-desc" v-if="app.description">{{ app.description }}</div>
-        <div class="app-card-type">{{ app.type }}</div>
+      <h1 class="view-title">{{ $t('apps.title', '应用中心') }}</h1>
+      
+      <!-- Tab 切换 -->
+      <div v-if="userStore.isAdmin" class="tab-switcher">
+        <button
+          :class="['tab-btn', { active: currentTab === 'my-apps' }]"
+          @click="currentTab = 'my-apps'"
+        >
+          {{ $t('apps.myApps', '我的应用') }}
+        </button>
+        <button
+          :class="['tab-btn', { active: currentTab === 'market' }]"
+          @click="currentTab = 'market'"
+        >
+          {{ $t('apps.appMarket', '应用市场') }}
+          <span v-if="hasUpdates" class="update-badge">{{ updateCount }}</span>
+        </button>
       </div>
+    </div>
+
+    <!-- Tab 1: 我的应用 -->
+    <div v-show="currentTab === 'my-apps'" class="tab-content">
+      <div v-if="isLoadingMyApps" class="loading-state">
+        {{ $t('common.loading', '加载中...') }}
+      </div>
+
+      <div v-else-if="myApps.length === 0" class="empty-state">
+        <div class="empty-icon">📱</div>
+        <p>{{ $t('apps.noApps', '暂无可用的小程序') }}</p>
+        <button
+          v-if="userStore.isAdmin"
+          class="btn-primary"
+          @click="currentTab = 'market'"
+        >
+          {{ $t('apps.goToMarket', '去应用市场安装') }}
+        </button>
+      </div>
+
+      <div v-else class="apps-grid">
+        <div
+          v-for="app in myApps"
+          :key="app.id"
+          class="app-card"
+          @click="openApp(app)"
+        >
+          <div class="app-card-icon">{{ app.icon || '📱' }}</div>
+          <div class="app-card-name">{{ app.name }}</div>
+          <div class="app-card-desc" v-if="app.description">{{ app.description }}</div>
+          <div class="app-card-meta">
+            <span class="app-type">{{ app.type }}</span>
+            <span v-if="app.updateAvailable" class="update-tag">{{ $t('apps.hasUpdate', '有更新') }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Tab 2: 应用市场（仅管理员可见） -->
+    <div v-show="currentTab === 'market'" class="tab-content">
+      <AppMarketPanel
+        :installed-apps="myApps.map(a => a.id)"
+        @installed="handleAppInstalled"
+        @uninstalled="handleAppUninstalled"
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { useUserStore } from '@/stores/user'
 import { getApps, type MiniApp } from '@/api/mini-apps'
+import { checkAppUpdate } from '@/api/app-market'
+import AppMarketPanel from '@/components/AppMarketPanel.vue'
 
 const router = useRouter()
-const apps = ref<MiniApp[]>([])
-const isLoading = ref(true)
+const userStore = useUserStore()
 
-onMounted(async () => {
+// Tab 切换
+const currentTab = ref<'my-apps' | 'market'>('my-apps')
+
+// 我的应用
+const myApps = ref<MiniApp[]>([])
+const isLoadingMyApps = ref(true)
+const hasUpdates = ref(false)
+const updateCount = ref(0)
+
+// 加载我的应用
+async function loadMyApps() {
+  isLoadingMyApps.value = true
   try {
-    apps.value = await getApps()
+    const apps = await getApps()
+    
+    // 检查更新（仅管理员）
+    if (userStore.isAdmin) {
+      const appsWithUpdate = await Promise.all(
+        apps.map(async (app) => {
+          try {
+            const updateInfo = await checkAppUpdate(app.id)
+            return { ...app, updateAvailable: updateInfo.has_update }
+          } catch {
+            return { ...app, updateAvailable: false }
+          }
+        })
+      )
+      myApps.value = appsWithUpdate
+      updateCount.value = appsWithUpdate.filter(a => a.updateAvailable).length
+      hasUpdates.value = updateCount.value > 0
+    } else {
+      myApps.value = apps
+    }
   } catch (error) {
     console.error('Failed to load apps:', error)
   } finally {
-    isLoading.value = false
+    isLoadingMyApps.value = false
   }
-})
+}
 
+// 打开 App
 function openApp(app: MiniApp) {
   router.push(`/apps/${app.id}`)
 }
+
+// 处理应用安装完成
+function handleAppInstalled(appId: string) {
+  loadMyApps()
+  currentTab.value = 'my-apps'
+}
+
+// 处理应用卸载完成
+function handleAppUninstalled(appId: string) {
+  loadMyApps()
+}
+
+onMounted(() => {
+  loadMyApps()
+})
+
+// 切换回我的应用时刷新
+watch(currentTab, (tab) => {
+  if (tab === 'my-apps') {
+    loadMyApps()
+  }
+})
 </script>
 
 <style scoped>
@@ -61,7 +155,12 @@ function openApp(app: MiniApp) {
 }
 
 .view-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 24px;
+  flex-wrap: wrap;
+  gap: 16px;
 }
 
 .view-title {
@@ -70,10 +169,60 @@ function openApp(app: MiniApp) {
   margin: 0;
 }
 
+.tab-switcher {
+  display: flex;
+  gap: 8px;
+  background: var(--color-bg-secondary, #f5f5f5);
+  padding: 4px;
+  border-radius: 8px;
+}
+
+.tab-btn {
+  padding: 8px 16px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--color-text-secondary, #666);
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tab-btn:hover {
+  color: var(--color-text-primary, #333);
+}
+
+.tab-btn.active {
+  background: var(--color-bg-primary, #fff);
+  color: var(--color-primary, #4a90d9);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.update-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  background: #ff4d4f;
+  color: white;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 9px;
+}
+
+.tab-content {
+  min-height: 400px;
+}
+
 .loading-state,
 .empty-state {
   text-align: center;
-  padding: 60px 20px;
+  padding: 80px 20px;
   color: var(--color-text-secondary, #666);
 }
 
@@ -82,9 +231,24 @@ function openApp(app: MiniApp) {
   margin-bottom: 16px;
 }
 
+.empty-state .btn-primary {
+  margin-top: 16px;
+  padding: 10px 20px;
+  background: var(--color-primary, #4a90d9);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.empty-state .btn-primary:hover {
+  background: var(--color-primary-dark, #3a7bc8);
+}
+
 .apps-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 20px;
 }
 
@@ -125,9 +289,24 @@ function openApp(app: MiniApp) {
   overflow: hidden;
 }
 
-.app-card-type {
+.app-card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.app-type {
   font-size: 12px;
   color: var(--color-text-tertiary, #999);
   text-transform: uppercase;
+}
+
+.update-tag {
+  font-size: 11px;
+  padding: 2px 8px;
+  background: #fff2f0;
+  color: #ff4d4f;
+  border-radius: 4px;
+  border: 1px solid #ffccc7;
 }
 </style>


### PR DESCRIPTION
## App Market 前端界面 (Step 4)

### 设计改进

将 App Market 从 Settings 移出，集成到现有的 Apps 页面：

```
App 页面 (AppsView.vue)
├── Tab 1: 我的应用 (普通用户可见)
│   └── 显示已安装的本地 App 列表
│   └── 有更新时显示 badge
│
└── Tab 2: 应用市场 (仅管理员可见)
    └── AppMarketPanel 组件
        ├── 分类筛选（文档/流程/数据/工具）
        ├── 搜索框
        ├── 刷新按钮
        ├── 应用卡片网格
        │   ├── 图标/名称/描述
        │   ├── 标签
        │   ├── 安装/卸载按钮
        │   └── 已安装标识
        └── 详情弹窗
            ├── 依赖检查
            ├── 字段定义列表
            └── 安装按钮
```

### 新增文件

1. **frontend/src/api/app-market.ts**
   - 所有 App Market API 封装
   - TypeScript 类型定义（AppManifest, Category, DependencyCheckResult 等）

2. **frontend/src/components/AppMarketPanel.vue**
   - 应用市场核心组件
   - 分类筛选、搜索
   - 应用卡片列表
   - 详情弹窗

3. **frontend/src/views/AppsView.vue** (重构)
   - 添加 Tab 切换
   - 我的应用列表
   - 管理员权限检查
   - 更新检测 badge

### 权限控制

- `userStore.isAdmin` 控制 Tab 2 的显示
- 所有 App Market API 路由需要管理员权限

### 下一步

- 添加国际化翻译键
- 前端代码审计检查
- Step 5: 依赖检查逻辑细化