### PR TITLE
fix: App Market 安装流程完善 - handler_id 映射修复

### DIFF
--- a/scripts/init-contract-app.js
+++ b/scripts/init-contract-app.js
@@ -1,110 +1,78 @@
+/**
+ * 初始化合同管理 App（通过 App Market 流程）
+ * 
+ * 使用方式：
+ *   node scripts/init-contract-app.js
+ * 
+ * 已废弃旧的直接 SQL seed 方式，改为调用 AppMarketService.installApp()
+ * 统一使用 apps/contract-manager/manifest.json 作为唯一真相源
+ */
+
 import dotenv from 'dotenv';
 dotenv.config();
 
-import mysql from 'mysql2/promise';
+import { Sequelize } from 'sequelize';
+import dbInit from '../server/models/init-models.js';
+import AppMarketService from '../server/services/app-market.service.js';
 
-const DB_CONFIG = {
-  host: process.env.DB_HOST || 'localhost',
-  port: process.env.DB_PORT || 3306,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
-};
+const ADMIN_USER_ID = 'mn3l9nz0g3axvxwc10fp';
 
-const ADMIN_USER_ID = 'mn3l9nz0g3axvxwc12fp';
-
-async function seed() {
-  const conn = await mysql.createConnection(DB_CONFIG);
-  console.log('Connected to database:', DB_CONFIG.database);
+async function init() {
+  const sequelize = new Sequelize(
+    process.env.DB_NAME,
+    process.env.DB_USER,
+    process.env.DB_PASSWORD,
+    {
+      host: process.env.DB_HOST || 'localhost',
+      port: process.env.DB_PORT || 3306,
+      dialect: 'mysql',
+      logging: false,
+    }
+  );
 
   try {
-    const [existing] = await conn.execute(
-      `SELECT id FROM mini_apps WHERE id = 'contract-mgr'`
-    );
-    if (existing.length > 0) {
-      console.log('Contract app already exists, skipping seed.');
+    const db = dbInit(sequelize);
+    console.log('Connected to database:', process.env.DB_NAME);
+
+    // 检查是否已安装
+    const MiniApp = db.getModel('mini_app');
+    const existing = await MiniApp.findByPk('contract-manager');
+    if (existing) {
+      console.log('contract-manager already installed, skipping.');
+      await sequelize.close();
       return;
     }
 
-    await conn.execute(`
-      INSERT INTO app_row_handlers (id, name, description, handler, handler_function, concurrency, timeout, max_retries, is_active)
-      VALUES
-        ('handler-ocr', 'OCR识别', '调用markitdown/mineru进行OCR识别', 'scripts/app-handlers/ocr-service', 'process', 3, 60, 2, 1),
-        ('handler-extract', 'LLM提取', '调用LLM从OCR文本中提取结构化元数据', 'scripts/app-handlers/llm-extract', 'process', 2, 120, 2, 1)
-    `);
-    console.log('  ✓ Created handlers: handler-ocr, handler-extract');
-
-    await conn.execute(`
-      INSERT INTO mini_apps (id, name, description, icon, type, fields, views, config, visibility, owner_id, creator_id, sort_order, is_active, revision)
-      VALUES (
-        'contract-mgr',
-        '销售合同管理',
-        '上传合同文件，AI自动提取合同元数据，支持批量处理和确认入库',
-        '📄',
-        'document',
-        ?,
-        ?,
-        ?,
-        'all',
-        ?,
-        ?,
-        1,
-        1,
-        1
-      )
-    `, [
-      JSON.stringify([
-        { name: 'contract_number', label: '合同编号', type: 'text', required: true, ai_extractable: true },
-        { name: 'contract_date', label: '签订日期', type: 'date', required: true, ai_extractable: true },
-        { name: 'party_a', label: '甲方', type: 'text', required: true, ai_extractable: true },
-        { name: 'party_b', label: '乙方', type: 'text', required: true, ai_extractable: true },
-        { name: 'contract_amount', label: '合同金额', type: 'number', required: true, ai_extractable: true },
-        { name: 'start_date', label: '开始日期', type: 'date', ai_extractable: true },
-        { name: 'end_date', label: '结束日期', type: 'date', ai_extractable: true },
-        { name: 'payment_terms', label: '付款条款', type: 'textarea', ai_extractable: true },
-        { name: 'status', label: '状态', type: 'select', options: ['待审批', '执行中', '已完成', '已终止'], default: '待审批' },
-        { name: 'contract_file', label: '合同文件', type: 'file' },
-      ]),
-      JSON.stringify({
-        list: {
-          columns: ['contract_number', 'contract_date', 'party_a', 'party_b', 'contract_amount', 'status'],
-          sort: { field: 'contract_date', order: 'desc' },
-        },
-      }),
-      JSON.stringify({
-        features: ['upload', 'list', 'detail'],
-        supported_formats: ['.pdf', '.docx', '.doc', '.jpg', '.png'],
-        max_file_size: 20971520,
-        batch_enabled: true,
-        batch_limit: 50,
-      }),
-      ADMIN_USER_ID,
-      ADMIN_USER_ID,
-    ]);
-    console.log('  ✓ Created app: contract-mgr (销售合同管理)');
-
-    await conn.execute(`
-      INSERT INTO app_state (id, app_id, name, label, sort_order, is_initial, is_terminal, is_error, handler_id, success_next_state, failure_next_state)
-      VALUES
-        ('state-1', 'contract-mgr', 'pending_ocr', '待OCR', 1, 1, 0, 0, 'handler-ocr', 'pending_extract', 'ocr_failed'),
-        ('state-2', 'contract-mgr', 'pending_extract', '待提取', 2, 0, 0, 0, 'handler-extract', 'pending_review', 'extract_failed'),
-        ('state-3', 'contract-mgr', 'pending_review', '待确认', 3, 0, 0, 0, NULL, NULL, NULL),
-        ('state-4', 'contract-mgr', 'confirmed', '已确认', 4, 0, 1, 0, NULL, NULL, NULL),
-        ('state-5', 'contract-mgr', 'ocr_failed', 'OCR失败', 99, 0, 0, 1, NULL, NULL, NULL),
-        ('state-6', 'contract-mgr', 'extract_failed', '提取失败', 99, 0, 0, 1, NULL, NULL, NULL)
-    `);
-    console.log('  ✓ Created 6 states for contract-mgr');
-
-    console.log('\n✅ Seed completed successfully!');
+    // 通过 App Market 服务安装
+    const marketService = new AppMarketService(db);
+    
+    console.log('\n📦 Installing contract-manager from Registry...\n');
+    
+    const result = await marketService.installApp('contract-manager', {
+      userId: ADMIN_USER_ID,
+      visibility: 'all'
+    });
+    
+    console.log('\n✅ Installation result:', JSON.stringify(result, null, 2));
+    console.log('\n✅ Contract manager app installed successfully!');
   } catch (error) {
-    console.error('Seed error:', error.message);
+    console.error('Init error:', error.message);
+    
+    // 提示可能的解决方案
+    if (error.message.includes('not found in Registry')) {
+      console.error('\n💡 Tips:');
+      console.error('   1. Check app_market.registry_url in system_settings');
+      console.error('   2. Ensure apps/contract-manager/manifest.json exists in GitHub repo');
+      console.error('   3. Run: node scripts/upgrade-database.js');
+    }
+    
     throw error;
   } finally {
-    await conn.end();
+    await sequelize.close();
   }
 }
 
-seed().catch(err => {
+init().catch(err => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -868,6 +868,32 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== App Market 配置初始化 ====================
+
+  {
+    name: 'app_market system_settings seed',
+    check: async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT COUNT(*) as cnt FROM system_settings WHERE setting_key = 'app_market.registry_url'"
+      );
+      return rows[0].cnt > 0;
+    },
+    migrate: async (conn) => {
+      await conn.execute(`
+        INSERT INTO system_settings (setting_key, setting_value, value_type, description) VALUES
+        ('app_market.registry_url', 'https://raw.githubusercontent.com/ErixWong/touwaka-ai-mate/main/apps', 'string', 'App Market Registry URL'),
+        ('app_market.registry_branch', 'main', 'string', 'Registry 分支'),
+        ('app_market.auto_check_updates', 'true', 'boolean', '是否自动检查更新'),
+        ('app_market.check_interval_hours', '24', 'number', '自动检查间隔（小时）'),
+        ('app_market.offline_mode', 'false', 'boolean', '离线模式'),
+        ('app_market.cache_ttl_hours', '168', 'number', '缓存有效期（小时）'),
+        ('app_market.last_check_at', '', 'string', '上次检查时间')
+        ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)
+      `);
+      console.log('  ✓ Seeded app_market system_settings');
+    }
+  },
+
 ];
 
 /**

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -269,12 +269,12 @@ class AppMarketService {
       'utf-8'
     );
     
-    // 6. 安装 handlers
-    const installedHandlers = await this.installHandlers(appId, manifest);
+    // 6. 安装 handlers（返回 handlerId 映射）
+    const { installed: installedHandlers, handlerIdMap } = await this.installHandlers(appId, manifest);
     
     // 7. 插入数据库
     await this.installAppMetadata(manifest, userId, visibility);
-    await this.installStates(appId, manifest);
+    await this.installStates(appId, manifest, handlerIdMap);
     
     logger.info(`App ${appId} installed successfully`);
     
@@ -312,11 +312,20 @@ class AppMarketService {
 
   /**
    * 安装状态定义到数据库
+   * @param {string} appId
+   * @param {object} manifest
+   * @param {Map} handlerIdMap - handler名称 → app_row_handlers.id 的映射
    */
-  async installStates(appId, manifest) {
+  async installStates(appId, manifest, handlerIdMap = new Map()) {
     if (!manifest.states || manifest.states.length === 0) return;
     
     for (const state of manifest.states) {
+      // handler_id 引用 app_row_handlers 表的实际 ID
+      let handlerId = null;
+      if (state.handler && handlerIdMap.has(state.handler)) {
+        handlerId = handlerIdMap.get(state.handler);
+      }
+      
       await this.models.AppState.create({
         id: Utils.newID(20),
         app_id: appId,
@@ -326,7 +335,7 @@ class AppMarketService {
         is_initial: state.is_initial || false,
         is_terminal: state.is_terminal || false,
         is_error: state.is_error || false,
-        handler_id: state.handler || null,
+        handler_id: handlerId,
         success_next_state: state.success_next || null,
         failure_next_state: state.failure_next || null
       });
@@ -338,8 +347,9 @@ class AppMarketService {
    */
   async installHandlers(appId, manifest) {
     const installed = [];
+    const handlerIdMap = new Map(); // handlerName → app_row_handlers.id
     
-    if (!manifest.states) return installed;
+    if (!manifest.states) return { installed, handlerIdMap };
     
     // 收集需要安装的 handlers（去重）
     const handlerNames = new Set();
@@ -368,18 +378,21 @@ class AppMarketService {
         );
         
         // 插入数据库记录
+        const handlerId = `${appId}-${handlerName}`;
         await this.models.AppRowHandler.create({
-          id: `${appId}-${handlerName}`,
+          id: handlerId,
           name: handlerName,
           description: `${manifest.name} - ${handlerName}`,
           handler: `apps/${appId}/handlers/${handlerName}`,
           handler_function: 'process',
-          concurrency: 3,
-          timeout: 60,
+          concurrency: manifest.config?.handler_concurrency?.[handlerName] || 3,
+          timeout: manifest.config?.handler_timeout?.[handlerName] || 60,
           max_retries: 2,
           is_active: true
         });
         
+        // 记录映射关系：handler名称 → 数据库ID
+        handlerIdMap.set(handlerName, handlerId);
         installed.push(handlerName);
         logger.info(`Installed handler ${handlerName} for ${appId}`);
       } catch (error) {
@@ -388,7 +401,7 @@ class AppMarketService {
       }
     }
     
-    return installed;
+    return { installed, handlerIdMap };
   }
 
   // ==================== App 卸载 ====================


### PR DESCRIPTION
## 修复内容

### 1. 修复 App Market 安装时的 handler_id 映射问题

**问题**：之前 `installStates` 直接将 `state.handler`（handler 名称）作为 `handler_id` 存入数据库，导致外键关联错误。

**修复**：
- 在 `installHandlers` 中返回 `handlerIdMap`（handler名称 → app_row_handlers.id 的映射）
- `installStates` 使用正确的 handlerId 进行关联

### 2. 重写合同管理 App 初始化脚本

**变更**：
- 废弃旧的直接 SQL seed 方式
- 改为调用 `AppMarketService.installApp()` 统一流程
- 使用 `apps/contract-manager/manifest.json` 作为唯一真相源

### 3. 添加 App Market 配置数据库迁移

**新增**：`scripts/upgrade-database.js` 中添加 `app_market.*` 配置项的初始化迁移

## 测试验证

```bash
# 1. 执行数据库迁移
node scripts/upgrade-database.js

# 2. 安装合同管理 App
node scripts/init-contract-app.js

# 3. 验证状态关联
SELECT name, label, handler_id FROM app_state WHERE app_id = 'contract-manager';
```

## 文件变更

- `scripts/init-contract-app.js` - 重构为使用 App Market 服务安装
- `scripts/upgrade-database.js` - 添加 App Market 配置迁移
- `server/services/app-market.service.js` - 修复 handler_id 映射
