### PR TITLE
fix: 修复 App Market MCP 依赖检查逻辑

### DIFF
--- a/frontend/src/components/AppMarketPanel.vue
+++ b/frontend/src/components/AppMarketPanel.vue
@@ -177,6 +177,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   getAppMarketIndex,
   getAppManifest,
@@ -191,6 +192,7 @@ import {
 } from '@/api/app-market'
 import { useToastStore } from '@/stores/toast'
 
+const { t } = useI18n()
 const toast = useToastStore()
 
 const props = defineProps<{
@@ -283,8 +285,8 @@ async function installApp(app: AppSummary) {
     // 先检查依赖
     const deps = await checkAppDependencies(app.id)
     if (!deps.satisfied) {
-      const missingMcp = deps.missing.mcp.join(', ')
-      toast.error(`${$t('appMarket.missingMcp', '缺少 MCP 服务')}: ${missingMcp}`)
+      const missingMcp = deps.missing.mcp.join(' 或 ')
+      toast.error(`${t('appMarket.missingMcp', '缺少以下任一 MCP 服务')}: ${missingMcp}`)
       return
     }
 

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1337,7 +1337,7 @@ thinkingFormatDeepseek: 'DeepSeek/GLM Format',
     license: 'License',
     dependencies: 'Dependencies',
     allDepsSatisfied: 'All dependencies satisfied',
-    missingMcp: 'Missing MCP services',
+    missingMcp: 'Missing one of the following MCP services',
     fields: 'Fields',
   },
 

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1281,7 +1281,7 @@ thinkingFormatDeepseek: 'DeepSeek/GLM 格式',
     license: '许可证',
     dependencies: '依赖检查',
     allDepsSatisfied: '所有依赖已满足',
-    missingMcp: '缺少 MCP 服务',
+    missingMcp: '缺少以下任一 MCP 服务',
     fields: '字段定义',
   },
 

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -189,9 +189,33 @@ class AppMarketService {
     // 检查 MCP 服务
     if (compatibility.requires?.mcp) {
       const configuredMcp = await this.getConfiguredMcpServices();
-      for (const mcp of compatibility.requires.mcp) {
-        if (!configuredMcp.includes(mcp)) {
-          missing.mcp.push(mcp);
+      const requiredMcp = compatibility.requires.mcp;
+      
+      // 支持两种格式：
+      // 1. 数组格式：只要有一个满足即可（容错设计）
+      // 2. 对象格式：{ all: [...], any: [...] }
+      if (Array.isArray(requiredMcp)) {
+        // 数组格式：多服务容错，至少有一个即可
+        const hasAny = requiredMcp.some(mcp => configuredMcp.includes(mcp));
+        if (!hasAny) {
+          missing.mcp = requiredMcp; // 返回所有可能的选项
+        }
+      } else if (typeof requiredMcp === 'object') {
+        // 对象格式：精确控制
+        if (requiredMcp.all) {
+          // 必须全部满足
+          for (const mcp of requiredMcp.all) {
+            if (!configuredMcp.includes(mcp)) {
+              missing.mcp.push(mcp);
+            }
+          }
+        }
+        if (requiredMcp.any) {
+          // 至少满足一个
+          const hasAny = requiredMcp.any.some(mcp => configuredMcp.includes(mcp));
+          if (!hasAny) {
+            missing.mcp = requiredMcp.any;
+          }
         }
       }
     }
@@ -213,7 +237,7 @@ class AppMarketService {
   async getConfiguredMcpServices() {
     this.ensureModels();
     const servers = await this.models.McpServer.findAll({
-      where: { is_active: true },
+      where: { is_enabled: true },
       attributes: ['name']
     });
     return servers.map(s => s.name);


### PR DESCRIPTION
- 修改依赖检查：从需要全部 MCP 改为二选一（容错设计）
- 修复 AppMarketPanel.vue 中  未定义问题
- 优化错误提示：明确告知需要任一 MCP 服务
- 更新中英文 i18n 翻译
