### PR TITLE
feat: MCP Stateless HTTP 传输支持

### DIFF
--- a/data/skills/mcp-client/index.js
+++ b/data/skills/mcp-client/index.js
@@ -18,6 +18,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import StatelessHTTPTransport from '../../../lib/mcp-stateless-http.js';
 
 // ============== 全局状态 ==============
 
@@ -173,12 +174,15 @@ function parseHeaders(headersStr) {
 function buildAuthHeaders(headersStr, credentials) {
   const headers = parseHeaders(headersStr);
   
-  if (credentials?.api_key) {
-    headers['Authorization'] = `Bearer ${credentials.api_key}`;
-  } else if (credentials?.token) {
-    headers['Authorization'] = `Bearer ${credentials.token}`;
-  } else if (credentials?.API_KEY) {
-    headers['X-API-Key'] = credentials.API_KEY;
+  // 凭证可能存储在 credentials.env_overrides 中
+  const envOverrides = credentials?.env_overrides || credentials || {};
+  
+  if (envOverrides.api_key) {
+    headers['Authorization'] = `Bearer ${envOverrides.api_key}`;
+  } else if (envOverrides.token) {
+    headers['Authorization'] = `Bearer ${envOverrides.token}`;
+  } else if (envOverrides.API_KEY) {
+    headers['X-API-Key'] = envOverrides.API_KEY;
   }
   
   return headers;
@@ -194,15 +198,27 @@ function sanitizeHeaders(headers) {
 async function createTransport(serverConfig, credentials = null) {
   const transportType = serverConfig.transport_type || 'stdio';
   
-  if (transportType === 'http' || transportType === 'streamableHttp' || transportType === 'sse') {
+  if (transportType === 'http' || transportType === 'streamableHttp' || transportType === 'sse' || transportType === 'statelessHttp') {
     if (!serverConfig.url) {
       throw new Error(`MCP Server '${serverConfig.name}' missing URL`);
     }
     
     const headers = buildAuthHeaders(serverConfig.headers, credentials);
+    
+    // 判断是否使用 StatelessHTTPTransport
+    // 1. 明确指定 statelessHttp
+    // 2. 或者 server 不支持 session（headers 中没有 mcp-session-id 提示）
+    const isStateless = transportType === 'statelessHttp' || serverConfig.stateless === true;
+    
+    if (isStateless) {
+      log(`Creating StatelessHTTP transport for ${serverConfig.name}: ${serverConfig.url}`);
+      log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
+      return new StatelessHTTPTransport(new URL(serverConfig.url), { requestInit: { headers } });
+    }
+    
     const useSSE = transportType === 'sse' || serverConfig.url.endsWith('/sse') || serverConfig.use_sse;
     
-    log(`Creating ${useSSE ? 'SSE' : 'HTTP'} transport for ${serverConfig.name}: ${serverConfig.url}`);
+    log(`Creating ${useSSE ? 'SSE' : 'StreamableHTTP'} transport for ${serverConfig.name}: ${serverConfig.url}`);
     log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
     
     const TransportClass = useSSE ? SSEClientTransport : StreamableHTTPClientTransport;

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -27,6 +27,7 @@ declare module 'vue' {
     DateField: typeof import('./src/components/apps/fields/DateField.vue')['default']
     DebugTab: typeof import('./src/components/panel/DebugTab.vue')['default']
     DepartmentTreeNode: typeof import('./src/components/settings/DepartmentTreeNode.vue')['default']
+    ElAlert: typeof import('element-plus/es')['ElAlert']
     ElButton: typeof import('element-plus/es')['ElButton']
     ElCheckbox: typeof import('element-plus/es')['ElCheckbox']
     ElCheckboxGroup: typeof import('element-plus/es')['ElCheckboxGroup']

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -981,12 +981,11 @@ export interface McpUserCredential {
 // MCP 工具缓存类型
 export interface McpToolCache {
   id: string
-  server_id: string
+  mcp_server_id: string
   tool_name: string
-  tool_description: string
-  tool_input_schema: string
-  created_at: string
-  updated_at: string
+  description: string
+  input_schema: string
+  cached_at: string
 }
 
 // MCP API

--- a/frontend/src/components/settings/McpTab.vue
+++ b/frontend/src/components/settings/McpTab.vue
@@ -81,8 +81,8 @@
               class="tool-item"
             >
               <div class="tool-info">
-                <span class="tool-name">{{ (tool as any).tool_name || tool.tool_name }}</span>
-                <span v-if="(tool as any).tool_description || tool.tool_description" class="tool-description">{{ (tool as any).tool_description || tool.tool_description }}</span>
+                <span class="tool-name">{{ (tool as any).tool_name }}</span>
+                <span v-if="(tool as any).description" class="tool-description">{{ (tool as any).description }}</span>
               </div>
               <el-button size="small" @click="openTestToolDialog(tool)" :disabled="testToolLoading">▶</el-button>
             </div>
@@ -93,7 +93,7 @@
         <div v-if="showTestToolDialog" class="dialog-overlay" @click.self="showTestToolDialog = false">
           <div class="dialog test-tool-dialog">
             <div class="dialog-header">
-              <h3>▶ {{ (testingTool as any)?.tool_name || testingTool?.tool_name }}</h3>
+              <h3>▶ {{ (testingTool as any)?.tool_name }}</h3>
               <button class="btn-close" @click="showTestToolDialog = false">&times;</button>
             </div>
             <div class="dialog-body">
@@ -202,6 +202,7 @@
               <el-radio value="stdio">{{ $t('settings.mcp.transportTypes.stdio') }}</el-radio>
               <el-radio value="http">{{ $t('settings.mcp.transportTypes.http') }}</el-radio>
               <el-radio value="sse">{{ $t('settings.mcp.transportTypes.sse') }}</el-radio>
+              <el-radio value="statelessHttp">{{ $t('settings.mcp.transportTypes.statelessHttp') }}</el-radio>
             </el-radio-group>
             <p class="form-hint">{{ $t('settings.mcp.transportTypeHint') }}</p>
           </div>
@@ -326,7 +327,7 @@ const isServerFormValid = computed(() => {
 })
 
 const isStdioMode = computed(() => serverForm.transport_type === 'stdio')
-const isHttpMode = computed(() => serverForm.transport_type === 'http' || serverForm.transport_type === 'sse')
+const isHttpMode = computed(() => serverForm.transport_type === 'http' || serverForm.transport_type === 'sse' || serverForm.transport_type === 'statelessHttp')
 
 // Server 删除对话框
 const showDeleteServerDialog = ref(false)
@@ -498,7 +499,7 @@ const executeTestTool = async () => {
     } else {
       args = JSON.parse(testToolArgs.value || '{}')
     }
-    const result = await mcpApi.callTool(selectedServer.value.id, (testingTool.value as any).tool_name || testingTool.value.tool_name, args)
+    const result = await mcpApi.callTool(selectedServer.value.id, (testingTool.value as any).tool_name, args)
     testToolResult.value = formatToolResult(result.result)
   } catch (error: any) {
     testToolResult.value = `Error: ${error.message}`

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -756,11 +756,12 @@ thinkingFormatDeepseek: 'DeepSeek/GLM Format',
       envHint: 'Environment variable configuration, one KEY=value per line',
       // Transport Type and HTTP Configuration
       transportType: 'Transport Type',
-      transportTypeHint: 'Select MCP server communication method: STDIO for local processes, HTTP Stream for remote services',
+      transportTypeHint: 'Select MCP server communication method: STDIO for local processes, HTTP Stream for remote services, Stateless HTTP for stateless remote services (no SSE)',
       transportTypes: {
         stdio: 'STDIO (Local Process)',
         http: 'HTTP Stream (Remote Service)',
         sse: 'SSE (Server-Sent Events)',
+        statelessHttp: 'Stateless HTTP (Stateless Remote)',
       },
       url: 'Server URL',
       urlPlaceholder: 'https://api.example.com/mcp',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -592,11 +592,12 @@ thinkingFormatDeepseek: 'DeepSeek/GLM 格式',
       envHint: '环境变量配置，每行一个 KEY=value',
       // 传输类型和 HTTP 配置
       transportType: '传输类型',
-      transportTypeHint: '选择 MCP 服务器的通信方式：STDIO 用于本地进程，HTTP Stream 用于远程服务',
+      transportTypeHint: '选择 MCP 服务器的通信方式：STDIO 用于本地进程，HTTP Stream 用于远程服务，Stateless HTTP 用于无状态的远程服务（无 SSE）',
       transportTypes: {
         stdio: 'STDIO (本地进程)',
         http: 'HTTP Stream (远程服务)',
         sse: 'SSE (Server-Sent Events)',
+        statelessHttp: 'Stateless HTTP (无状态远程)',
       },
       url: '服务器地址',
       urlPlaceholder: 'https://api.example.com/mcp',

--- a/lib/mcp-stateless-http.js
+++ b/lib/mcp-stateless-http.js
@@ -1,0 +1,133 @@
+/**
+ * StatelessHTTPTransport - 用于无状态的 HTTP MCP Server
+ * 
+ * 某些 MCP Server（如 markitdown）是无状态的（无 session-id），不需要 GET SSE stream。
+ * SDK 的 StreamableHTTPClientTransport 会在 start() 后尝试 GET SSE，导致超时。
+ * 
+ * 这个 Transport 跳过 GET SSE 步骤，只通过 POST 发送请求。
+ */
+
+export class StatelessHTTPTransport {
+  constructor(url, options = {}) {
+    this._url = url;
+    this._requestInit = options.requestInit || {};
+    this._started = false;
+    
+    this.onclose = null;
+    this.onerror = null;
+    this.onmessage = null;
+  }
+  
+  async start() {
+    if (this._started) {
+      throw new Error('Transport already started');
+    }
+    this._started = true;
+  }
+  
+  async close() {
+    this._started = false;
+    if (this.onclose) this.onclose();
+  }
+  
+  async send(message) {
+    if (!this._started) {
+      throw new Error('Transport not started');
+    }
+    
+    const messages = Array.isArray(message) ? message : [message];
+    
+    for (const msg of messages) {
+      await this._sendSingle(msg);
+    }
+  }
+  
+  async _sendSingle(message) {
+    const headers = {
+      ...(this._requestInit.headers || {}),
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+    };
+    
+    const body = JSON.stringify(message);
+    
+    try {
+      const response = await fetch(this._url, {
+        method: 'POST',
+        headers,
+        body,
+      });
+      
+      if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        throw new Error(`HTTP ${response.status}: ${text.substring(0, 100)}`);
+      }
+      
+      const contentType = response.headers.get('content-type') || '';
+      
+      // 202 Accepted - notification 无响应体
+      if (response.status === 202) {
+        return;
+      }
+      
+      if (contentType.includes('application/json')) {
+        const text = await response.text();
+        if (!text || text.trim() === '') {
+          return;
+        }
+        const data = JSON.parse(text);
+        if (this.onmessage) {
+          this.onmessage(data);
+        }
+      } else if (contentType.includes('text/event-stream')) {
+        await this._handleSSE(response);
+      }
+      
+    } catch (error) {
+      if (this.onerror) {
+        this.onerror(error);
+      }
+      throw error;
+    }
+  }
+  
+  async _handleSSE(response) {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        
+        buffer += decoder.decode(value, { stream: true });
+        
+        const events = buffer.split('\n\n');
+        buffer = events.pop() || '';
+        
+        for (const event of events) {
+          const lines = event.split('\n');
+          for (const line of lines) {
+            if (line.startsWith('data:')) {
+              const data = line.substring(5).trim();
+              if (data && this.onmessage) {
+                try {
+                  this.onmessage(JSON.parse(data));
+                } catch (e) {
+                  // Ignore parse errors
+                }
+              }
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (this.onerror) {
+        this.onerror(error);
+      }
+    }
+  }
+}
+
+export default StatelessHTTPTransport;

--- a/models/mcp_server.js
+++ b/models/mcp_server.js
@@ -89,10 +89,10 @@ export default class mcp_server extends Model {
       defaultValue: Sequelize.Sequelize.fn('current_timestamp')
     },
     transport_type: {
-      type: DataTypes.ENUM('stdio','http','sse'),
+      type: DataTypes.ENUM('stdio','http','sse','statelessHttp'),
       allowNull: true,
       defaultValue: "stdio",
-      comment: "MCP 传输类型：stdio=标准输入输出, http=HTTP Stream, sse=Server-Sent Events"
+      comment: "MCP 传输类型：stdio=标准输入输出, http=HTTP Stream, sse=Server-Sent Events, statelessHttp=无状态HTTP"
     },
     url: {
       type: DataTypes.STRING(512),

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -894,7 +894,6 @@ const MIGRATIONS = [
     }
   },
 
-<<<<<<< HEAD
   // ==================== MCP HTTP 传输支持 ====================
   {
     name: 'mcp_servers.add_transport_type_and_http_fields',
@@ -952,6 +951,27 @@ const MIGRATIONS = [
         VALUES ('mcp-client-invoke', 'mcp-client', 'invoke', 'MCP Client 驻留进程入口工具', '{"type":"object","properties":{"action":{"type":"string","description":"操作类型"}}}', 'index.js', 1, NOW(), NOW())
       `);
       console.log('  ✓ Registered mcp-client invoke tool (is_resident=1)');
+    }
+  },
+
+  // ==================== MCP Stateless HTTP 传输支持 ====================
+  {
+    name: 'mcp_servers.add_stateless_http_transport',
+    check: async (conn) => {
+      const [rows] = await conn.execute(`
+        SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'mcp_servers' AND COLUMN_NAME = 'transport_type'
+      `);
+      const enumStr = rows[0]?.COLUMN_TYPE || '';
+      return enumStr.includes('statelessHttp');
+    },
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE mcp_servers 
+        MODIFY COLUMN transport_type ENUM('stdio', 'http', 'sse', 'statelessHttp') DEFAULT 'stdio' 
+        COMMENT 'MCP 传输类型：stdio=标准输入输出, http=HTTP Stream, sse=Server-Sent Events, statelessHttp=无状态HTTP'
+      `);
+      console.log('  ✓ Added statelessHttp to transport_type ENUM');
     }
   },
 

--- a/server/routes/mcp.routes.js
+++ b/server/routes/mcp.routes.js
@@ -158,15 +158,7 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         raw: true,
       });
 
-      ctx.success({
-        tools: tools.map(t => ({
-          id: t.id,
-          name: t.tool_name,
-          description: t.description,
-          input_schema: t.input_schema,
-          cached_at: t.cached_at,
-        }))
-      });
+      ctx.success({ tools });
 
     } catch (error) {
       logger.error('Get MCP server tools error:', error);
@@ -239,13 +231,7 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
       });
 
       ctx.success({
-        tools: tools.map(t => ({
-          id: t.id,
-          name: t.tool_name,
-          description: t.description,
-          input_schema: t.input_schema,
-          cached_at: t.cached_at,
-        })),
+        tools,
         message: refreshedTools.length > 0
           ? `已刷新 ${refreshedTools.length} 个工具`
           : '驻留进程未就绪，工具列表已清空。请启动 mcp-client 驻留进程后重试。',

--- a/tests/test-markitdown.js
+++ b/tests/test-markitdown.js
@@ -1,0 +1,225 @@
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const MCP_URL = 'https://ocr1.g.erik.top/mcp';
+const MCP_TOKEN = 'Bearer sk-a9Fbq0tS65VQhG0AA296F9E2F9Ab4975A41f5aEdF97d571a';
+const PDF_PATH = resolve('D:\\tmp\\奇瑞质量协议签章版.pdf');
+
+console.log('=== markitdown MCP 诊断测试 ===\n');
+
+async function postMCP(message) {
+  const res = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': MCP_TOKEN,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+    },
+    body: JSON.stringify(message),
+  });
+
+  console.log(`  HTTP ${res.status} ${res.statusText}`);
+  console.log(`  Content-Type: ${res.headers.get('content-type')}`);
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    console.log(`  响应体 (前500字): ${text.substring(0, 500)}`);
+    return null;
+  }
+
+  if (!text || text.trim() === '') {
+    console.log('  (空响应体)');
+    return null;
+  }
+
+  return text;
+}
+
+function parseSSE(text) {
+  const results = [];
+  for (const block of text.split('\n\n')) {
+    for (const line of block.split('\n')) {
+      if (line.startsWith('data:')) {
+        const data = line.substring(5).trim();
+        if (data) {
+          try { results.push(JSON.parse(data)); } catch {}
+        }
+      }
+    }
+  }
+  return results;
+}
+
+async function run() {
+  // Step 0: 检查 PDF 文件
+  console.log('0. 检查测试文件...');
+  if (!existsSync(PDF_PATH)) {
+    console.error(`  ❌ 文件不存在: ${PDF_PATH}`);
+    process.exit(1);
+  }
+  const pdfBuf = readFileSync(PDF_PATH);
+  const pdfBase64 = pdfBuf.toString('base64');
+  console.log(`  ✅ PDF 文件: ${pdfBuf.length} bytes (${(pdfBuf.length / 1024).toFixed(1)} KB)\n`);
+
+  // Step 1: 基础连通性 - GET 请求
+  console.log('1. GET 连通性测试...');
+  try {
+    const getRes = await fetch(MCP_URL, {
+      method: 'GET',
+      headers: { 'Authorization': MCP_TOKEN },
+    });
+    console.log(`  HTTP ${getRes.status} ${getRes.statusText}`);
+    const getBody = await getRes.text();
+    console.log(`  响应 (前200字): ${getBody.substring(0, 200)}\n`);
+  } catch (e) {
+    console.log(`  ❌ GET 失败: ${e.message}\n`);
+  }
+
+  // Step 2: initialize
+  console.log('2. MCP initialize...');
+  const initMsg = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-script', version: '1.0.0' },
+    },
+  };
+
+  const initResult = await postMCP(initMsg);
+  if (!initResult) {
+    console.log('  ❌ initialize 失败，终止测试\n');
+    process.exit(1);
+  }
+
+  let initData;
+  const ct = 'application/json';
+  try {
+    initData = JSON.parse(initResult);
+  } catch {
+    const parsed = parseSSE(initResult);
+    initData = parsed[0];
+  }
+  console.log(`  服务端信息: ${JSON.stringify(initData?.result?.serverInfo || initData)}\n`);
+
+  // Step 3: initialized notification
+  console.log('3. 发送 initialized notification...');
+  await postMCP({
+    jsonrpc: '2.0',
+    method: 'notifications/initialized',
+  });
+  console.log();
+
+  // Step 4: list tools
+  console.log('4. 列出工具...');
+  const toolsResult = await postMCP({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/list',
+  });
+
+  if (!toolsResult) {
+    console.log('  ❌ 获取工具列表失败\n');
+    process.exit(1);
+  }
+
+  let toolsData;
+  try { toolsData = JSON.parse(toolsResult); } catch { toolsData = parseSSE(toolsResult)[0]; }
+  const tools = toolsData?.result?.tools || [];
+  console.log(`  工具数量: ${tools.length}`);
+  for (const t of tools) {
+    console.log(`  - ${t.name}: ${t.description || '(无描述)'}`);
+    if (t.inputSchema?.properties) {
+      console.log(`    参数: ${Object.keys(t.inputSchema.properties).join(', ')}`);
+    }
+  }
+  console.log();
+
+  // Step 5: 调用工具 - 用 PDF
+  console.log('5. 调用工具 (PDF 第6-8页)...');
+
+  // 找到合适的工具和参数
+  const convertTool = tools.find(t => t.name.includes('convert') || t.name.includes('markit') || t.name.includes('read') || t.name.includes('parse'));
+  if (!convertTool) {
+    console.log('  ❌ 没找到可用的转换工具');
+    console.log('  可用工具:', tools.map(t => t.name));
+    process.exit(1);
+  }
+
+  console.log(`  使用工具: ${convertTool.name}`);
+  const inputProps = convertTool.inputSchema?.properties || {};
+  console.log(`  工具参数: ${JSON.stringify(Object.keys(inputProps))}`);
+
+  // 构建参数
+  const toolArgs = {};
+
+  // 尝试不同的参数名
+  if (inputProps.uri) {
+    toolArgs.uri = `data:application/pdf;base64,${pdfBase64}`;
+  }
+  if (inputProps.file) {
+    toolArgs.file = { content: pdfBase64, mime_type: 'application/pdf' };
+  }
+  if (inputProps.content) {
+    toolArgs.content = pdfBase64;
+  }
+  if (inputProps.data) {
+    toolArgs.data = pdfBase64;
+  }
+  if (inputProps.pages) {
+    toolArgs.pages = '6-8';
+  }
+  if (inputProps.page_range) {
+    toolArgs.page_range = '6-8';
+  }
+  if (inputProps.pageRange) {
+    toolArgs.pageRange = '6-8';
+  }
+  if (inputProps.url) {
+    toolArgs.url = `data:application/pdf;base64,${pdfBase64}`;
+  }
+  if (inputProps.path) {
+    toolArgs.path = PDF_PATH;
+  }
+
+  console.log(`  调用参数: ${Object.keys(toolArgs).join(', ')}`);
+
+  const callResult = await postMCP({
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/call',
+    params: {
+      name: convertTool.name,
+      arguments: toolArgs,
+    },
+  });
+
+  if (callResult) {
+    let callData;
+    try { callData = JSON.parse(callResult); } catch { callData = parseSSE(callResult)[0]; }
+    const content = callData?.result?.content;
+    if (content) {
+      for (const c of content) {
+        if (c.type === 'text') {
+          console.log(`\n  === 转换结果 (前1500字) ===`);
+          console.log(c.text.substring(0, 1500));
+          console.log(`  ... (总长: ${c.text.length} 字符)`);
+        } else {
+          console.log(`  content type: ${c.type}`, JSON.stringify(c).substring(0, 200));
+        }
+      }
+    } else {
+      console.log('  原始响应:', JSON.stringify(callData).substring(0, 500));
+    }
+  }
+
+  console.log('\n=== 测试完成 ===');
+}
+
+run().catch(err => {
+  console.error('测试异常:', err.message);
+  process.exit(1);
+});

--- a/tests/test-mcp-http-direct.js
+++ b/tests/test-mcp-http-direct.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * 测试 MCP HTTP 直连
+ * 
+ * 使用场景：验证 MCP Server 是否可正常连接
+ */
+
+import https from 'https';
+
+const MCP_URL = 'https://markitdown.g.erik.top/mcp/';
+const MCP_TOKEN = 'Bearer sk-a9Fbq0tS65VQhG0AA296F9E2F9Ab4975A41f5aEdF97d571a';
+
+async function testMcpConnection() {
+  console.log('=== MCP HTTP Direct Connection Test ===\n');
+  console.log('URL:', MCP_URL);
+  
+  // 测试 1: initialize
+  console.log('\n--- Test 1: initialize ---');
+  const initResult = await sendRequest({
+    jsonrpc: '2.0',
+    method: 'initialize',
+    id: 1,
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '1.0.0' }
+    }
+  });
+  console.log('Result:', JSON.stringify(initResult, null, 2));
+  
+  // 测试 2: tools/list
+  console.log('\n--- Test 2: tools/list ---');
+  const toolsResult = await sendRequest({
+    jsonrpc: '2.0',
+    method: 'tools/list',
+    id: 2
+  });
+  console.log('Result:', JSON.stringify(toolsResult, null, 2));
+  
+  // 测试 3: 尝试调用工具
+  if (toolsResult?.result?.tools?.length > 0) {
+    const firstTool = toolsResult.result.tools[0];
+    console.log('\n--- Test 3: call tool:', firstTool.name, '---');
+    
+    // 构造参数 - 假设有一个 URI 参数
+    const toolArgs = { uri: 'https://example.com/test.txt' };
+    
+    const callResult = await sendRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      id: 3,
+      params: {
+        name: firstTool.name,
+        arguments: toolArgs
+      }
+    });
+    console.log('Result:', JSON.stringify(callResult, null, 2).substring(0, 500));
+  }
+}
+
+function sendRequest(body) {
+  return new Promise((resolve, reject) => {
+    const postData = JSON.stringify(body);
+    
+    const options = {
+      hostname: 'markitdown.g.erik.top',
+      port: 443,
+      path: '/mcp/',
+      method: 'POST',
+      headers: {
+        'Authorization': MCP_TOKEN,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'Content-Length': Buffer.byteLength(postData)
+      },
+      timeout: 10000
+    };
+    
+    const req = https.request(options, (res) => {
+      console.log('Status:', res.statusCode);
+      console.log('Content-Type:', res.headers['content-type']);
+      console.log('mcp-session-id:', res.headers['mcp-session-id'] || 'none');
+      
+      let data = '';
+      let isSSE = res.headers['content-type']?.includes('text/event-stream');
+      
+      res.on('data', (chunk) => {
+        data += chunk;
+        if (isSSE) {
+          // SSE 流式数据，读取到完整事件后停止
+          if (data.includes('\n\n') && data.includes('data:')) {
+            // 解析 SSE 格式
+            const lines = data.split('\n');
+            for (const line of lines) {
+              if (line.startsWith('data:')) {
+                try {
+                  const jsonStr = line.substring(5).trim();
+                  if (jsonStr) {
+                    resolve(JSON.parse(jsonStr));
+                    req.destroy();
+                    return;
+                  }
+                } catch (e) {}
+              }
+            }
+          }
+        }
+      });
+      
+      res.on('end', () => {
+        if (!isSSE) {
+          try {
+            resolve(JSON.parse(data));
+          } catch (e) {
+            resolve({ raw: data, error: 'parse failed' });
+          }
+        }
+      });
+      
+      res.on('error', (e) => {
+        reject(e);
+      });
+    });
+    
+    req.on('error', (e) => {
+      reject(e);
+    });
+    
+    req.on('timeout', () => {
+      console.log('Request timeout after 10s');
+      req.destroy();
+      reject(new Error('Timeout'));
+    });
+    
+    req.write(postData);
+    req.end();
+  });
+}
+
+testMcpConnection()
+  .then(() => {
+    console.log('\n=== Test Complete ===');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('\n=== Test Failed ===');
+    console.error('Error:', err.message);
+    process.exit(1);
+  });

--- a/tests/test-mcp-stateless.js
+++ b/tests/test-mcp-stateless.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * 测试 StatelessHTTP MCP Server 连接
+ * 
+ * 验证：
+ * 1. StatelessHTTPTransport 能正常连接
+ * 2. 能获取工具列表
+ * 3. 能调用工具
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import StatelessHTTPTransport from '../lib/mcp-stateless-http.js';
+
+const MCP_URL = 'https://markitdown.g.erik.top/mcp/';
+const MCP_TOKEN = 'Bearer sk-a9Fbq0tS65VQhG0AA296F9E2F9Ab4975A41f5aEdF97d571a';
+
+console.log('=== StatelessHTTP MCP Connection Test ===\n');
+console.log('URL:', MCP_URL);
+
+async function testConnection() {
+  // 创建 Transport
+  const headers = {
+    'Authorization': MCP_TOKEN,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json, text/event-stream',
+  };
+  
+  const transport = new StatelessHTTPTransport(new URL(MCP_URL), {
+    requestInit: { headers }
+  });
+  
+  console.log('\n1. Creating Client...');
+  const client = new Client(
+    { name: 'test-client', version: '1.0.0' },
+    { capabilities: {} }
+  );
+  
+  console.log('\n2. Connecting...');
+  const connectPromise = client.connect(transport);
+  
+  // 设置超时
+  const timeout = setTimeout(() => {
+    console.log('TIMEOUT after 10s!');
+    process.exit(1);
+  }, 10000);
+  
+await connectPromise;
+  clearTimeout(timeout);
+  console.log('✅ Connected!');
+  
+  console.log('\n3. Listing tools...');
+  const toolsResult = await client.listTools();
+  console.log('Tools:', toolsResult.tools.map(t => t.name));
+  
+  if (toolsResult.tools.length > 0) {
+    const firstTool = toolsResult.tools[0];
+    console.log('\n4. Calling tool:', firstTool.name);
+    
+    try {
+      const callResult = await client.callTool({
+        name: firstTool.name,
+        arguments: { uri: 'https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/master/README.md' }
+      });
+      
+      console.log('Result type:', callResult.content?.[0]?.type);
+      const preview = callResult.content?.[0]?.text?.substring(0, 300) || '(empty)';
+      console.log('Content preview:', preview);
+    } catch (e) {
+      console.log('Call error:', e.message);
+    }
+  }
+  
+  console.log('\n=== Test Complete ===');
+  process.exit(0);
+}
+
+testConnection().catch((err) => {
+  console.error('Test failed:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

实现 MCP Stateless HTTP 传输支持，允许通过 HTTP 方式调用 MCP Server，无需常驻进程。

- 新增 `lib/mcp-stateless-http.js`：Stateless HTTP 传输层实现
- MCP Client 技能支持 HTTP 传输类型
- 修复 MCP 工具列表显示问题，统一数据库/后端/前端字段命名
- 新增测试脚本验证 Stateless HTTP 调用

## Test plan

1. 配置一个 HTTP 传输类型的 MCP Server
2. 测试 Stateless HTTP 调用是否正常工作
3. 验证工具列表正确显示工具名称

Closes #N/A (新功能)