### PR TITLE
fix: migration check 函数解构错误 + registry_url 分支修正

### DIFF
--- a/apps/contract-mgr/migrations/install.js
+++ b/apps/contract-mgr/migrations/install.js
@@ -1,6 +1,6 @@
 export default {
   async check(sequelize) {
-    const [rows] = await sequelize.query(`
+    const rows = await sequelize.query(`
       SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('app_contract_mgr_rows', 'app_contract_mgr_content')
     `, { type: sequelize.QueryTypes.SELECT });

--- a/apps/contract-mgr/migrations/uninstall.js
+++ b/apps/contract-mgr/migrations/uninstall.js
@@ -1,6 +1,6 @@
 export default {
   async check(sequelize) {
-    const [rows] = await sequelize.query(`
+    const rows = await sequelize.query(`
       SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('app_contract_mgr_rows', 'app_contract_mgr_content')
     `, { type: sequelize.QueryTypes.SELECT });

--- a/apps/index.json
+++ b/apps/index.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "updated_at": "2026-04-17T17:20:00Z",
-  "registry_url": "https://raw.githubusercontent.com/ErixWong/touwaka-ai-mate/main/apps",
+  "registry_url": "https://raw.githubusercontent.com/ErixWong/touwaka-ai-mate/master/apps",
   "apps": [
     {
       "id": "contract-mgr",


### PR DESCRIPTION
## Summary

- 修复 `apps/contract-mgr/migrations/install.js` 和 `uninstall.js` 的 check 函数解构错误
- 更正 `apps/index.json` 的 registry_url 为 master 分支

## 问题描述

`check` 函数使用 `const [rows]` 解构导致 `rows` 是单个对象而非数组，调用 `.length` 时报错。

## 修复内容

```diff
- const [rows] = await sequelize.query(...)
+ const rows = await sequelize.query(...)
```