### PR TITLE
feat: 实现重提取API - 支持状态重置触发重新提取

### DIFF
--- a/server/controllers/mini-app.controller.js
+++ b/server/controllers/mini-app.controller.js
@@ -148,8 +148,19 @@ class MiniAppController {
     try {
       const { appId, recordId } = ctx.params;
       const userId = ctx.state.session.id;
-      const { data } = ctx.request.body;
-      const record = await this.miniAppService.updateRecord(appId, recordId, userId, data || {});
+      const { data, status } = ctx.request.body;
+      
+      const options = {};
+      if (status) {
+        const isAdmin = await this.miniAppService.isAdmin(userId);
+        if (!isAdmin) {
+          ctx.error('Only admin can change status', 403);
+          return;
+        }
+        options.status = status;
+      }
+      
+      const record = await this.miniAppService.updateRecord(appId, recordId, userId, data || {}, options);
       ctx.success(record, 'Updated');
     } catch (error) {
       logger.error('Update record error:', error);
@@ -178,6 +189,25 @@ class MiniAppController {
       ctx.success(record, 'Confirmed');
     } catch (error) {
       logger.error('Confirm record error:', error);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async reExtractRecord(ctx) {
+    try {
+      const { appId, recordId } = ctx.params;
+      const userId = ctx.state.session.id;
+      
+      const isAdmin = await this.miniAppService.isAdmin(userId);
+      if (!isAdmin) {
+        ctx.error('Only admin can re-extract', 403);
+        return;
+      }
+      
+      const record = await this.miniAppService.updateRecord(appId, recordId, userId, {}, { status: 'pending_extract' });
+      ctx.success(record, 'Re-extract triggered');
+    } catch (error) {
+      logger.error('Re-extract error:', error);
       ctx.error(error.message, 400);
     }
   }

--- a/server/routes/mini-app.routes.js
+++ b/server/routes/mini-app.routes.js
@@ -30,6 +30,7 @@ export default (controller) => {
 
   router.post('/api/mini-apps/:appId/data/batch', authenticate(), (ctx) => controller.batchUpload(ctx));
   router.put('/api/mini-apps/:appId/data/:recordId/confirm', authenticate(), (ctx) => controller.confirmRecord(ctx));
+  router.post('/api/mini-apps/:appId/data/:recordId/re-extract', authenticate(), requireAdmin(), (ctx) => controller.reExtractRecord(ctx));
   router.get('/api/mini-apps/:appId/status-summary', authenticate(), (ctx) => controller.getStatusSummary(ctx));
 
   // ==================== State CRUD ====================

--- a/server/services/mini-app.service.js
+++ b/server/services/mini-app.service.js
@@ -475,7 +475,7 @@ class MiniAppService {
     }
   }
 
-  async updateRecord(appId, recordId, userId, data) {
+  async updateRecord(appId, recordId, userId, data, options = {}) {
     this.ensureModels();
     const record = await this.models.MiniAppRow.findOne({
       where: { id: recordId, app_id: appId },
@@ -498,11 +498,17 @@ class MiniAppService {
     const transaction = await this.db.sequelize.transaction();
     
     try {
-      await record.update({
+      const updateFields = {
         data: mergedData,
         title,
         revision: record.revision + 1,
-      }, { transaction });
+      };
+      
+      if (options.status) {
+        updateFields.status = options.status;
+      }
+      
+      await record.update(updateFields, { transaction });
 
       const extConfigs = await this.extensionService.getExtensionConfigs(appId);
       if (extConfigs && extConfigs.length > 0) {


### PR DESCRIPTION
## 实现说明

用户建议：重提取API的核心就是状态重置，App Clock会自动处理后续流程。

### 实现方案

**方案1：扩展updateRecord方法**

修改 `mini-app.service.js:478` 的 `updateRecord` 方法：
- 添加 `options.status` 参数支持修改status字段
- Controller层限制：仅管理员可以修改status

**方案2：新增专用端点**

添加 `POST /api/mini-apps/:appId/data/:recordId/re-extract` 端点：
- 直接将status重置为 `pending_extract`
- 触发App Clock自动处理提取流程
- 权限控制：仅管理员可调用

### API调用示例

**方式1：通用update API**
```bash
PUT /api/mini-apps/contract-mgr/data/:recordId
{
  "data": { ... },      // 可选，修改业务数据
  "status": "pending_extract"  // 仅管理员可修改
}
```

**方式2：专用重提取API**
```bash
POST /api/mini-apps/contract-mgr/data/:recordId/re-extract
# 自动将status设置为 pending_extract
# App Clock检测后触发handler重新提取
```

### 流程说明

1. 用户调用重提取API
2. 系统将status从 `pending_review` 改为 `pending_extract`
3. App Clock检测状态变化（5秒轮询）
4. 触发 `handler-extract` → `handler-text-section` 流程
5. 完成后status回到 `pending_review`

### 测试建议

- 调用API后观察status变化
- 确认App Clock触发handler执行
- 验证提取结果更新

### 权限控制

- 仅管理员可以修改status或调用re-extract
- 普通用户只能修改data字段

Closes #649