### PR TITLE
refactor: 合同管理专用Handler架构重构

### DIFF
--- a/apps/contract-mgr/manifest.json
+++ b/apps/contract-mgr/manifest.json
@@ -168,7 +168,7 @@
       "is_initial": false,
       "is_terminal": false,
       "is_error": false,
-      "handler": "handler-check-ocr",
+      "handler": "contract-check-ocr",
       "success_next": "pending_filter",
       "failure_next": "ocr_failed"
     },
@@ -180,7 +180,7 @@
       "is_initial": false,
       "is_terminal": false,
       "is_error": false,
-      "handler": "handler-text-filter",
+      "handler": "contract-text-filter",
       "success_next": "pending_extract",
       "failure_next": "filter_failed"
     },
@@ -192,8 +192,8 @@
       "is_initial": false,
       "is_terminal": false,
       "is_error": false,
-      "handler": "handler-extract",
-      "success_next": "pending_persist_extract",
+      "handler": "contract-llm-extract",
+      "success_next": "pending_section",
       "failure_next": "extract_failed"
     },
     {

--- a/scripts/app-handlers/contract-check-ocr/index.js
+++ b/scripts/app-handlers/contract-check-ocr/index.js
@@ -1,0 +1,118 @@
+import logger from '../../../lib/logger.js';
+
+const JUDGE_PROMPT = `判断OCR任务是否完成。
+
+MCP返回结果：
+{{MCP_RESULT}}
+
+请返回JSON格式：
+{
+  "status": "completed|pending|failed",
+  "progress": 0-100,
+  "reason": "判断原因"
+}`;
+
+function getConfig(app, stateName) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.step_resources?.[stateName] || config?.step_resources?.ocr_submitted || {};
+}
+
+function extractTextFromMcpResult(mcpResult) {
+  return mcpResult.content || mcpResult.text || mcpResult.output || mcpResult.markdown || mcpResult.result || '';
+}
+
+export const availableOutputs = [
+  { key: 'ocr_status', label: 'OCR状态', type: 'string' },
+  { key: 'ocr_progress', label: 'OCR进度', type: 'number' },
+];
+
+export default {
+  availableOutputs,
+  async process(context) {
+    const { record, services, app, stateName } = context;
+
+    logger.info(`[contract-check-ocr] Processing record ${record.id}`);
+
+    const data = record.data || {};
+    const taskId = data._ocr_task_id;
+    if (!taskId) {
+      logger.error(`[contract-check-ocr] Record ${record.id}: No OCR task_id found`);
+      return { success: false, error: 'No OCR task_id found' };
+    }
+
+    logger.info(`[contract-check-ocr] Record ${record.id}: Task ID ${taskId}`);
+
+    const resConfig = getConfig(app, stateName || 'ocr_submitted');
+    const mcp = resConfig.mcp || {};
+
+    try {
+      logger.info(`[contract-check-ocr] Record ${record.id}: Calling MCP ${mcp.server}.${mcp.tool || 'get_task'}`);
+      const mcpResult = await services.callMcp(mcp.server, mcp.tool || 'get_task', { task_id: taskId });
+      
+      logger.info(`[contract-check-ocr] Record ${record.id}: MCP result received, judging status`);
+      const judgeResult = await services.callLlm('judge_ocr_status', {
+        instruction: JUDGE_PROMPT.replace('{{MCP_RESULT}}', JSON.stringify(mcpResult, null, 2)),
+        model_id: resConfig.judge_model_id,
+        temperature: resConfig.judge_temperature || 0.1,
+        response_format: 'json',
+      });
+
+      let parsed;
+      try {
+        const jsonMatch = judgeResult.text.match(/\{[\s\S]*\}/);
+        parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : { status: 'pending', progress: 0, reason: 'Parse failed' };
+      } catch {
+        parsed = { status: 'pending', progress: 0, reason: 'JSON parse error' };
+      }
+
+      logger.info(`[contract-check-ocr] Record ${record.id}: Judge result - status=${parsed.status}, progress=${parsed.progress}`);
+
+      if (parsed.status === 'completed') {
+        const ocrText = extractTextFromMcpResult(mcpResult);
+        logger.info(`[contract-check-ocr] Record ${record.id}: OCR completed, text length=${ocrText.length}`);
+        
+        // ✅ 写入扩展表（大文本存扩展表）
+        await services.callExtension('app_contract_mgr_content', 'upsert', {
+          row_id: record.id,
+          ocr_text: ocrText,
+        });
+        
+        logger.info(`[contract-check-ocr] Record ${record.id}: OCR text saved to extension table`);
+        
+        // ✅ 只返回标记（不返回OCR文本）
+        return {
+          success: true,
+          data: {
+            _ocr_done: true,
+            _ocr_status: 'completed',
+            _ocr_progress: 100,
+          },
+        };
+      }
+
+      if (parsed.status === 'pending') {
+        logger.info(`[contract-check-ocr] Record ${record.id}: OCR pending, progress=${parsed.progress}`);
+        return {
+          success: true,
+          pending: true,
+          data: {
+            _ocr_status: 'processing',
+            _ocr_progress: parsed.progress || 0,
+          },
+        };
+      }
+
+      logger.error(`[contract-check-ocr] Record ${record.id}: OCR failed - ${parsed.reason}`);
+      return {
+        success: false,
+        error: 'OCR task failed: ' + parsed.reason,
+      };
+    } catch (e) {
+      logger.error(`[contract-check-ocr] Record ${record.id}: Check OCR status failed - ${e.message}`);
+      return { success: false, error: 'Check OCR status failed: ' + e.message };
+    }
+  },
+};

--- a/scripts/app-handlers/contract-check-ocr/index.js
+++ b/scripts/app-handlers/contract-check-ocr/index.js
@@ -2,8 +2,8 @@ import logger from '../../../lib/logger.js';
 
 const JUDGE_PROMPT = `判断OCR任务是否完成。
 
-MCP返回结果：
-{{MCP_RESULT}}
+任务返回信息（截取前1000字符）：
+{{TASK_INFO}}
 
 请返回JSON格式：
 {
@@ -22,6 +22,14 @@ function getConfig(app, stateName) {
 
 function extractTextFromMcpResult(mcpResult) {
   return mcpResult.content || mcpResult.text || mcpResult.output || mcpResult.markdown || mcpResult.result || '';
+}
+
+function truncateTaskInfo(mcpResult, maxLen = 1000) {
+  const jsonStr = JSON.stringify(mcpResult, null, 2);
+  if (jsonStr.length <= maxLen) {
+    return jsonStr;
+  }
+  return jsonStr.substring(0, maxLen) + '\n... (截取前' + maxLen + '字符)';
 }
 
 export const availableOutputs = [
@@ -53,8 +61,13 @@ export default {
       const mcpResult = await services.callMcp(mcp.server, mcp.tool || 'get_task', { task_id: taskId });
       
       logger.info(`[contract-check-ocr] Record ${record.id}: MCP result received, judging status`);
+      
+      // ✅ 截取前1000字符避免token超限
+      const taskInfo = truncateTaskInfo(mcpResult, 1000);
+      logger.info(`[contract-check-ocr] Record ${record.id}: Task info length=${taskInfo.length}`);
+      
       const judgeResult = await services.callLlm('judge_ocr_status', {
-        instruction: JUDGE_PROMPT.replace('{{MCP_RESULT}}', JSON.stringify(mcpResult, null, 2)),
+        instruction: JUDGE_PROMPT.replace('{{TASK_INFO}}', taskInfo),
         model_id: resConfig.judge_model_id,
         temperature: resConfig.judge_temperature || 0.1,
         response_format: 'json',
@@ -74,7 +87,6 @@ export default {
         const ocrText = extractTextFromMcpResult(mcpResult);
         logger.info(`[contract-check-ocr] Record ${record.id}: OCR completed, text length=${ocrText.length}`);
         
-        // ✅ 写入扩展表（大文本存扩展表）
         await services.callExtension('app_contract_mgr_content', 'upsert', {
           row_id: record.id,
           ocr_text: ocrText,
@@ -82,7 +94,6 @@ export default {
         
         logger.info(`[contract-check-ocr] Record ${record.id}: OCR text saved to extension table`);
         
-        // ✅ 只返回标记（不返回OCR文本）
         return {
           success: true,
           data: {

--- a/scripts/app-handlers/contract-llm-extract/index.js
+++ b/scripts/app-handlers/contract-llm-extract/index.js
@@ -1,0 +1,158 @@
+import logger from '../../../lib/logger.js';
+
+const DEFAULT_EXTRACT_CONFIG = {
+  type: 'internal_llm',
+  model_id: null,
+  temperature: 0.3,
+};
+
+const CONTRACT_FIELDS = [
+  { name: 'contract_number', label: '合同编号', guide: '查找合同编号，通常在合同首页顶部，格式如 HT-XXX 或 合同编号：XXX' },
+  { name: 'party_a', label: '甲方', guide: '查找甲方名称，通常在合同开头，甲方：XXX' },
+  { name: 'party_b', label: '乙方', guide: '查找乙方名称，通常在合同开头，乙方：XXX' },
+  { name: 'parent_company', label: '上级公司', guide: '如果甲方是子公司，推断其上级公司名称' },
+  { name: 'contract_amount', label: '合同金额', guide: '查找合同总金额，注意区分币种' },
+  { name: 'contract_date', label: '签订日期', guide: '查找签订日期，格式 YYYY-MM-DD' },
+];
+
+function getExtractConfig(app, stateName) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.step_resources?.[stateName] || config?.step_resources?.pending_extract || DEFAULT_EXTRACT_CONFIG;
+}
+
+function getExtractPrompt(app) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.prompts?.extract || null;
+}
+
+export const availableOutputs = [
+  { key: 'extract_status', label: '提取状态', type: 'string' },
+];
+
+export default {
+  availableOutputs,
+  async process(context) {
+    const { record, services, app } = context;
+
+    logger.info(`[contract-llm-extract] Processing record ${record.id}`);
+
+    // ✅ 从扩展表读取清洗文本（不依赖mini_app_rows.data）
+    const content = await services.callExtension('app_contract_mgr_content', 'read', {
+      row_id: record.id,
+      fields: ['filtered_text'],
+    });
+
+    if (!content || !content.filtered_text) {
+      logger.error(`[contract-llm-extract] Record ${record.id}: No filtered text found in extension table`);
+      return { success: false, error: 'No filtered text found in extension table' };
+    }
+
+    const text = content.filtered_text;
+    logger.info(`[contract-llm-extract] Record ${record.id}: Filtered text length=${text.length}`);
+
+    const extractConfig = getExtractConfig(app, 'pending_extract');
+    const customPrompt = getExtractPrompt(app);
+
+    const fieldDefs = CONTRACT_FIELDS.map(f => `- ${f.name} (${f.label}): ${f.guide}`).join('\n');
+    const exampleJson = CONTRACT_FIELDS.map(f => `  "${f.name}": "提取值"`).join(',\n');
+
+    const promptBase = customPrompt
+      ? `${customPrompt}\n\n字段定义:\n${fieldDefs}\n\n期望返回 JSON 格式:\n{\n${exampleJson}\n}`
+      : `从以下文本中提取结构化元数据。
+
+字段定义:
+${fieldDefs}
+
+期望返回 JSON 格式:
+{
+${exampleJson}
+}`;
+
+    try {
+      logger.info(`[contract-llm-extract] Record ${record.id}: Calling LLM for extraction`);
+      const response = await services.callLlm('extract_metadata', {
+        instruction: promptBase,
+        ocr_text: text,
+        response_format: 'json',
+        model_id: extractConfig.model_id,
+        temperature: extractConfig.temperature || 0.3,
+      });
+
+      logger.info(`[contract-llm-extract] Record ${record.id}: LLM response received`);
+
+      let metadata;
+      const resultText = response.text || response.parsed || response;
+      if (typeof resultText === 'string') {
+        const jsonMatch = resultText.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) {
+          logger.error(`[contract-llm-extract] Record ${record.id}: LLM did not return valid JSON`);
+          return { success: false, error: 'LLM did not return valid JSON' };
+        }
+        metadata = JSON.parse(jsonMatch[0]);
+      } else if (typeof resultText === 'object') {
+        metadata = resultText;
+      } else {
+        logger.error(`[contract-llm-extract] Record ${record.id}: LLM returned unexpected format`);
+        return { success: false, error: 'LLM returned unexpected format' };
+      }
+
+      // 清理元数据
+      const cleanMetadata = {};
+      for (const field of CONTRACT_FIELDS) {
+        const value = metadata[field.name];
+        if (value === undefined || value === null || value === '') continue;
+        
+        // 类型转换
+        if (field.name === 'contract_amount') {
+          const num = Number(String(value).replace(/[,，]/g, ''));
+          if (!isNaN(num)) {
+            cleanMetadata[field.name] = num;
+          }
+        } else if (field.name === 'contract_date') {
+          const dateStr = String(value).replace(/年/g, '-').replace(/月/g, '-').replace(/日/g, '');
+          if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(dateStr)) {
+            cleanMetadata[field.name] = dateStr;
+          }
+        } else {
+          cleanMetadata[field.name] = value;
+        }
+      }
+
+      logger.info(`[contract-llm-extract] Record ${record.id}: Extracted fields: ${Object.keys(cleanMetadata).join(', ')}`);
+
+      // ✅ 写入rows扩展表（元数据）
+      await services.callExtension('app_contract_mgr_rows', 'upsert', {
+        row_id: record.id,
+        ...cleanMetadata,
+      });
+
+      logger.info(`[contract-llm-extract] Record ${record.id}: Metadata saved to app_contract_mgr_rows`);
+
+      // ✅ 写入content扩展表（提取记录）
+      await services.callExtension('app_contract_mgr_content', 'upsert', {
+        row_id: record.id,
+        extract_json: JSON.stringify(cleanMetadata),
+        extract_at: new Date(),
+      });
+
+      logger.info(`[contract-llm-extract] Record ${record.id}: Extract info saved to app_contract_mgr_content`);
+
+      // ✅ 只返回标记（不返回元数据）
+      return {
+        success: true,
+        data: {
+          _extract_done: true,
+        },
+      };
+    } catch (e) {
+      logger.error(`[contract-llm-extract] Record ${record.id}: Extraction failed - ${e.message}`);
+      return { success: false, error: 'LLM extraction failed: ' + e.message };
+    }
+  },
+};

--- a/scripts/app-handlers/contract-text-filter/index.js
+++ b/scripts/app-handlers/contract-text-filter/index.js
@@ -1,0 +1,247 @@
+import logger from '../../../lib/logger.js';
+
+const DEFAULT_FILTER_CONFIG = {
+  type: 'internal_llm',
+  model_id: null,
+  temperature: 0.3,
+};
+
+const CHUNK_MAX_LENGTH = parseInt(process.env.TEXT_FILTER_MAX_LENGTH) || 120000;
+const CONTEXT_SUMMARY_MAX_LENGTH = 2000;
+
+function getFilterConfig(app, stateName) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.step_resources?.[stateName] || config?.step_resources?.pending_filter || DEFAULT_FILTER_CONFIG;
+}
+
+function getFilterPrompt(app) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.prompts?.filter || '去除页码、水印、乱码、多余的空白字符，保留正文内容';
+}
+
+function splitIntoChunks(text, maxLen) {
+  const paragraphs = text.split('\n\n');
+  const chunks = [];
+  let current = '';
+
+  for (const para of paragraphs) {
+    if (current.length + para.length + 2 <= maxLen) {
+      current += (current ? '\n\n' : '') + para;
+    } else {
+      if (current) chunks.push(current);
+      if (para.length > maxLen) {
+        let remaining = para;
+        while (remaining.length > 0) {
+          chunks.push(remaining.slice(0, maxLen));
+          remaining = remaining.slice(maxLen);
+        }
+        current = '';
+      } else {
+        current = para;
+      }
+    }
+  }
+  if (current) chunks.push(current);
+
+  return chunks.length > 0 ? chunks : [text];
+}
+
+const CHUNK_SYSTEM_SUFFIX = `
+
+你必须返回严格的JSON格式：
+{
+  "processed_part": "本轮清洗后的文本片段",
+  "carried_over": "未完成的尾部内容（空字符串表示无剩余）",
+  "context_summary": {
+    "key_terms": {},
+    "points": []
+  }
+}
+
+规则：
+- processed_part: 本轮已完整清洗的文本
+- carried_over: 如果末尾文本不完整（如句子被截断），放到这里，会拼接到下轮输入开头
+- context_summary.key_terms: 已出现的专业术语及其标准译名/写法（对象格式，键为原文术语，值为标准写法）
+- context_summary.points: 已处理文本的摘要要点列表（字符串数组），总长度不超过${CONTEXT_SUMMARY_MAX_LENGTH}字符
+- context_summary 会在后续轮次中提供给你，确保术语和关键信息跨块一致`;
+
+async function filterSingleChunk(services, filterPrompt, filterConfig, chunkInput, contextSummary) {
+  const promptBase = filterPrompt + CHUNK_SYSTEM_SUFFIX;
+
+  let contextNote = '';
+  if (contextSummary && (Object.keys(contextSummary.key_terms || {}).length > 0 || (contextSummary.points || []).length > 0)) {
+    contextNote = `\n\n[前文上下文摘要]\n${JSON.stringify(contextSummary, null, 2)}\n请参考以上上下文保持术语和风格一致。`;
+  }
+
+  const response = await services.callLlm('filter_text_chunked', {
+    instruction: promptBase,
+    ocr_text: chunkInput + contextNote,
+    response_format: 'json',
+    model_id: filterConfig.model_id,
+    temperature: filterConfig.temperature || 0.3,
+  });
+
+  let parsed;
+  if (response.parsed && typeof response.parsed === 'object') {
+    parsed = response.parsed;
+  } else {
+    try {
+      const jsonMatch = response.text.match(/\{[\s\S]*\}/);
+      parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : null;
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (!parsed || typeof parsed.processed_part !== 'string') {
+    throw new Error('LLM返回的JSON格式无效');
+  }
+
+  return {
+    processed_part: parsed.processed_part || '',
+    carried_over: parsed.carried_over || '',
+    context_summary: parsed.context_summary || { key_terms: {}, points: [] },
+  };
+}
+
+function trimContextSummary(summary) {
+  if (!summary) return { key_terms: {}, points: [] };
+
+  const points = summary.points || [];
+  const keyTerms = summary.key_terms || {};
+  const trimmedPoints = [];
+  let result = { key_terms: keyTerms, points: trimmedPoints };
+
+  for (const point of points) {
+    const candidate = { key_terms: keyTerms, points: [...trimmedPoints, point] };
+    if (JSON.stringify(candidate).length <= CONTEXT_SUMMARY_MAX_LENGTH) {
+      trimmedPoints.push(point);
+    }
+  }
+
+  return { key_terms: keyTerms, points: trimmedPoints };
+}
+
+async function filterWithSlidingWindow(services, filterPrompt, filterConfig, ocrText) {
+  const chunks = splitIntoChunks(ocrText, CHUNK_MAX_LENGTH);
+  logger.info(`[contract-text-filter] Sliding window: split into ${chunks.length} chunks`);
+
+  const allProcessed = [];
+  let carriedOver = '';
+  let contextSummary = { key_terms: {}, points: [] };
+
+  for (let i = 0; i < chunks.length; i++) {
+    let nextChunk = chunks[i];
+    if (carriedOver.length + nextChunk.length > CHUNK_MAX_LENGTH * 1.5) {
+      const allowLen = Math.floor(CHUNK_MAX_LENGTH * 1.5) - carriedOver.length;
+      logger.warn(`[contract-text-filter] Chunk ${i + 1}: carried_over (${carriedOver.length}) + chunk (${nextChunk.length}) exceeds 1.5x limit, truncating chunk to ${allowLen}`);
+      allProcessed.push(nextChunk.slice(0, Math.max(0, CHUNK_MAX_LENGTH - carriedOver.length)));
+      nextChunk = nextChunk.slice(Math.max(0, CHUNK_MAX_LENGTH - carriedOver.length));
+    }
+    const chunkInput = carriedOver + (carriedOver ? '\n\n' : '') + nextChunk;
+    logger.info(`[contract-text-filter] Processing chunk ${i + 1}/${chunks.length}, input length=${chunkInput.length}`);
+
+    try {
+      const result = await filterSingleChunk(services, filterPrompt, filterConfig, chunkInput, contextSummary);
+
+      allProcessed.push(result.processed_part);
+      carriedOver = result.carried_over || '';
+      contextSummary = trimContextSummary(result.context_summary);
+
+      logger.info(`[contract-text-filter] Chunk ${i + 1} done, processed=${result.processed_part.length}, carried_over=${carriedOver.length}`);
+    } catch (chunkErr) {
+      logger.error(`[contract-text-filter] Chunk ${i + 1} failed: ${chunkErr.message}, appending original text`);
+      allProcessed.push(chunkInput);
+      carriedOver = '';
+      contextSummary = { key_terms: {}, points: [] };
+    }
+  }
+
+  if (carriedOver) {
+    allProcessed.push(carriedOver);
+  }
+
+  return allProcessed.join('\n\n');
+}
+
+export const availableOutputs = [
+  { key: 'filter_status', label: '过滤状态', type: 'string' },
+];
+
+export default {
+  availableOutputs,
+  async process(context) {
+    const { record, services, app } = context;
+
+    logger.info(`[contract-text-filter] Processing record ${record.id}`);
+
+    // ✅ 从扩展表读取OCR文本（不依赖mini_app_rows.data）
+    const content = await services.callExtension('app_contract_mgr_content', 'read', {
+      row_id: record.id,
+      fields: ['ocr_text'],
+    });
+
+    if (!content || !content.ocr_text) {
+      logger.error(`[contract-text-filter] Record ${record.id}: No OCR text found in extension table`);
+      return { success: false, error: 'No OCR text found in extension table' };
+    }
+
+    const ocrText = content.ocr_text;
+    logger.info(`[contract-text-filter] Record ${record.id}: OCR text length=${ocrText.length}`);
+
+    const filterConfig = getFilterConfig(app, 'pending_filter');
+    const filterPrompt = getFilterPrompt(app);
+
+    let filteredText;
+    
+    if (ocrText.length <= CHUNK_MAX_LENGTH) {
+      try {
+        logger.info(`[contract-text-filter] Record ${record.id}: Calling LLM for single-pass filtering`);
+        const response = await services.callLlm('filter_text', {
+          instruction: filterPrompt,
+          ocr_text: ocrText,
+          response_format: 'text',
+          model_id: filterConfig.model_id,
+          temperature: filterConfig.temperature || 0.3,
+        });
+
+        filteredText = response.text || ocrText;
+        logger.info(`[contract-text-filter] Record ${record.id}: Filter complete, result length=${filteredText.length}`);
+      } catch (e) {
+        logger.error(`[contract-text-filter] Record ${record.id}: LLM filter failed - ${e.message}, keeping original`);
+        filteredText = ocrText;
+      }
+    } else {
+      try {
+        logger.info(`[contract-text-filter] Record ${record.id}: Text too long (${ocrText.length}), using sliding window`);
+        filteredText = await filterWithSlidingWindow(services, filterPrompt, filterConfig, ocrText);
+        logger.info(`[contract-text-filter] Record ${record.id}: Sliding window complete, result length=${filteredText.length}`);
+      } catch (e) {
+        logger.error(`[contract-text-filter] Record ${record.id}: Sliding window filter failed - ${e.message}, keeping original`);
+        filteredText = ocrText;
+      }
+    }
+
+    // ✅ 写入扩展表（大文本存扩展表）
+    await services.callExtension('app_contract_mgr_content', 'upsert', {
+      row_id: record.id,
+      filtered_text: filteredText,
+    });
+
+    logger.info(`[contract-text-filter] Record ${record.id}: Filtered text saved to extension table`);
+
+    // ✅ 只返回标记（不返回清洗文本）
+    return {
+      success: true,
+      data: {
+        _filter_done: true,
+      },
+    };
+  },
+};


### PR DESCRIPTION
# 专用Handler架构重构

## 核心改进

解决通用handler在`result.data`返回大文本导致的性能问题：
- **mini_app_rows.data存储冗余**：几十KB的大文本存储在data字段
- **前端更新性能问题**：每次更新元数据传递几十KB，触发"request entity too large"
- **数据一致性风险**：扩展表和mini_app_rows.data双写

---

## 专用Handler架构

### Handler职责划分

| Handler | 读取来源 | 写入目标 | 返回内容 |
|---------|---------|---------|---------|
| contract-check-ocr | MCP服务 | `app_contract_mgr_content.ocr_text` | `_ocr_done: true` |
| contract-text-filter | `app_contract_mgr_content.ocr_text` | `app_contract_mgr_content.filtered_text` | `_filter_done: true` |
| contract-llm-extract | `app_contract_mgr_content.filtered_text` | `app_contract_mgr_rows`（元数据） | `_extract_done: true` |

### mini_app_rows.data职责

**只存流程标记**（几十字节）：
```json
{
  "_ocr_task_id": "task123",
  "_ocr_done": true,
  "_filter_done": true,
  "_extract_done": true,
  "_ocr_status": "completed"
}
```

**不存大文本**：
- ❌ `_ocr_text`（几十KB）
- ❌ `_filtered_text`（几十KB）
- ❌ `_sections`（几百KB）

---

## 实施内容

### 1. 创建专用Handler

**contract-check-ocr**：
- 从MCP读取OCR状态
- 写入扩展表（大文本存扩展表）
- 只返回标记（不返回OCR文本）

**contract-text-filter**：
- 从扩展表读取OCR文本（不依赖mini_app_rows.data）
- 清洗后写入扩展表
- 只返回标记（不返回清洗文本）

**contract-llm-extract**：
- 从扩展表读取清洗文本
- 提取元数据直接写入扩展表
- 只返回标记（不返回元数据）

### 2. 修改manifest.json

- `ocr_submitted`: `handler-check-ocr` → `contract-check-ocr`
- `pending_filter`: `handler-text-filter` → `contract-text-filter`
- `pending_extract`: `handler-extract` → `contract-llm-extract`
- 删除`pending_persist_extract` state（不再需要）

---

## 预期效果

| 项目 | 旧架构 | 新架构 | 优化效果 |
|------|--------|--------|---------|
| mini_app_rows.data大小 | 几十KB | 几十字节 | ↓99% |
| 前端更新请求体 | 几十KB | 几百字节 | ↓99% |
| 数据存储源 | 双写（冗余） | 扩展表唯一 | ✅ |
| 流程传递方式 | 通过data | 通过扩展表 | ✅ |

---

## 数据流转对比

### 旧流程（错误）

```
check-ocr → mini_app_rows.data += { _ocr_text: "几十KB" } ❌
text-filter → 从data读取 → mini_app_rows.data += { _filtered_text: "几十KB" } ❌
llm-extract → 从data读取 → mini_app_rows.data += { metadata } ✅
```

### 新流程（正确）

```
contract-check-ocr → app_contract_mgr_content.ocr_text ✅ + mini_app_rows.data._ocr_done ✅
contract-text-filter → 从content表读取 ✅ → content.filtered_text ✅ + data._filter_done ✅
contract-llm-extract → 从content表读取 ✅ → rows.metadata ✅ + data._extract_done ✅
```

---

## 验证清单

- [x] 专用handler正确读写扩展表
- [x] mini_app_rows.data只存标记（不存大文本）
- [ ] 前端列表显示正常（扩展表字段）
- [ ] 前端更新元数据成功（不传大文本）
- [ ] 流程状态正确流转
- [ ] 数据大小优化验证

---

## 关联Issue

Closes #668