### PR TITLE
feat: 合同管理v2 全栈实现

### DIFF
--- a/apps/contract-mgr-v2/README.md
+++ b/apps/contract-mgr-v2/README.md
@@ -1,0 +1,39 @@
+# 销售合同管理 v2
+
+> App ID: `contract-mgr-v2`
+> 版本: 2.0.0
+> 关联 Issue: #661
+
+## 功能特性
+
+- **组织层级管理**：三层树状结构（集团 → 甲方 → 项目）
+- **多版本管理**：同一合同支持多个版本上传和对比
+- **4层持久化**：OCR → 过滤 → 提取 → 章节，每层数据独立持久化
+- **Dashboard**：统计概览
+
+## Handler 流程
+
+```
+pending_ocr → ocr_submitted → pending_filter → pending_extract
+→ pending_section → pending_review → confirmed
+```
+
+| Handler | 读 | 写 |
+|---------|----|----|
+| handler-submit-ocr | record.data | MCP |
+| contract-v2-check-ocr | MCP结果 | app_contract_v2_content.ocr_text |
+| contract-v2-text-filter | app_contract_v2_content.ocr_text | app_contract_v2_content.filtered_text |
+| contract-v2-llm-extract | app_contract_v2_content.filtered_text | app_contract_v2_rows + app_contract_v2_content |
+| contract-v2-text-section | app_contract_v2_content.filtered_text | app_contract_v2_content.sections |
+
+> **设计原则**：业务数据直接读写扩展表，不经过 `record.data`（`mini_app_rows.data`）中转。
+
+## 数据库表
+
+| 表名 | 类型 | 说明 |
+|------|------|------|
+| contract_v2_org_nodes | 独立表 | 组织树 |
+| contract_v2_main_records | 独立表 | 合同主记录 |
+| contract_v2_versions | 独立表 | 合同版本 |
+| app_contract_v2_content | 扩展表 | 内容数据 |
+| app_contract_v2_rows | 扩展表 | 元数据 |

--- a/apps/contract-mgr-v2/handlers/contract-v2-check-ocr/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-check-ocr/index.js
@@ -1,0 +1,112 @@
+import logger from '../../../lib/logger.js';
+
+const JUDGE_PROMPT = `判断OCR任务是否完成。
+
+任务返回信息（截取前1000字符）：
+{{TASK_INFO}}
+
+请返回JSON格式：
+{
+  "status": "completed|pending|failed",
+  "progress": 0-100,
+  "reason": "判断原因"
+}`;
+
+function getConfig(app, stateName) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.step_resources?.[stateName] || config?.step_resources?.ocr_submitted || {};
+}
+
+function extractTextFromMcpResult(mcpResult) {
+  return mcpResult.content || mcpResult.text || mcpResult.output || mcpResult.markdown || mcpResult.result || '';
+}
+
+function truncateTaskInfo(mcpResult, maxLen = 1000) {
+  const jsonStr = JSON.stringify(mcpResult, null, 2);
+  if (jsonStr.length <= maxLen) return jsonStr;
+  return jsonStr.substring(0, maxLen) + '\n... (截取前' + maxLen + '字符)';
+}
+
+export const availableOutputs = [
+  { key: 'ocr_status', label: 'OCR状态', type: 'string' },
+  { key: 'ocr_progress', label: 'OCR进度', type: 'number' },
+];
+
+export default {
+  availableOutputs,
+  async process(context) {
+    const { record, services, app, stateName } = context;
+
+    logger.info(`[contract-v2-check-ocr] Processing record ${record.id}`);
+
+    const data = record.data || {};
+    const taskId = data._ocr_task_id;
+    if (!taskId) {
+      logger.error(`[contract-v2-check-ocr] Record ${record.id}: No OCR task_id found`);
+      return { success: false, error: 'No OCR task_id found' };
+    }
+
+    const resConfig = getConfig(app, stateName || 'ocr_submitted');
+    const mcp = resConfig.mcp || {};
+
+    try {
+      const mcpResult = await services.callMcp(mcp.server, mcp.tool || 'get_task', { task_id: taskId });
+      const taskInfo = truncateTaskInfo(mcpResult, 1000);
+
+      const judgeResult = await services.callLlm('judge_ocr_status', {
+        instruction: JUDGE_PROMPT.replace('{{TASK_INFO}}', taskInfo),
+        model_id: resConfig.judge_model_id,
+        temperature: resConfig.judge_temperature || 0.1,
+        response_format: 'json',
+      });
+
+      let parsed;
+      try {
+        const jsonMatch = judgeResult.text.match(/\{[\s\S]*\}/);
+        parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : { status: 'pending', progress: 0, reason: 'Parse failed' };
+      } catch {
+        parsed = { status: 'pending', progress: 0, reason: 'JSON parse error' };
+      }
+
+      if (parsed.status === 'completed') {
+        const ocrText = extractTextFromMcpResult(mcpResult);
+        logger.info(`[contract-v2-check-ocr] Record ${record.id}: OCR completed, text length=${ocrText.length}`);
+
+        await services.callExtension('app_contract_v2_content', 'upsert', {
+          row_id: record.id,
+          ocr_text: ocrText,
+          ocr_service: mcp.server || 'markitdown',
+          ocr_at: new Date(),
+        });
+
+        return {
+          success: true,
+          data: {
+            _ocr_done: true,
+            _ocr_status: 'completed',
+            _ocr_progress: 100,
+          },
+        };
+      }
+
+      if (parsed.status === 'pending') {
+        return {
+          success: true,
+          pending: true,
+          data: {
+            _ocr_status: 'processing',
+            _ocr_progress: parsed.progress || 0,
+          },
+        };
+      }
+
+      return { success: false, error: 'OCR task failed: ' + parsed.reason };
+    } catch (e) {
+      logger.error(`[contract-v2-check-ocr] Record ${record.id}: ${e.message}`);
+      return { success: false, error: 'Check OCR status failed: ' + e.message };
+    }
+  },
+};

--- a/apps/contract-mgr-v2/handlers/contract-v2-llm-extract/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-llm-extract/index.js
@@ -1,0 +1,141 @@
+import logger from '../../../lib/logger.js';
+
+const DEFAULT_EXTRACT_CONFIG = {
+  type: 'internal_llm',
+  model_id: null,
+  temperature: 0.3,
+};
+
+const CONTENT_TABLE = 'app_contract_v2_content';
+const ROWS_TABLE = 'app_contract_v2_rows';
+
+const CONTRACT_FIELDS = [
+  { name: 'contract_number', label: '合同编号', guide: '查找合同编号，通常在合同首页顶部，格式如 HT-XXX 或 合同编号：XXX' },
+  { name: 'party_a', label: '甲方', guide: '查找甲方名称，通常在合同开头，甲方：XXX' },
+  { name: 'party_b', label: '乙方', guide: '查找乙方名称，通常在合同开头，乙方：XXX' },
+  { name: 'parent_company', label: '上级公司', guide: '如果甲方是子公司，推断其上级公司名称' },
+  { name: 'contract_amount', label: '合同金额', guide: '查找合同总金额，注意区分币种' },
+  { name: 'contract_date', label: '签订日期', guide: '查找签订日期，格式 YYYY-MM-DD' },
+];
+
+function getExtractConfig(app, stateName) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.step_resources?.[stateName] || config?.step_resources?.pending_extract || DEFAULT_EXTRACT_CONFIG;
+}
+
+function getExtractPrompt(app) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.prompts?.extract || null;
+}
+
+export const availableOutputs = [
+  { key: 'extract_status', label: '提取状态', type: 'string' },
+];
+
+export default {
+  availableOutputs,
+  async process(context) {
+    const { record, services, app } = context;
+
+    logger.info(`[contract-v2-llm-extract] Processing record ${record.id}`);
+
+    const content = await services.callExtension(CONTENT_TABLE, 'read', {
+      row_id: record.id,
+      fields: ['filtered_text'],
+    });
+
+    if (!content || !content.filtered_text) {
+      return { success: false, error: 'No filtered text found in extension table' };
+    }
+
+    const text = content.filtered_text;
+    logger.info(`[contract-v2-llm-extract] Record ${record.id}: Filtered text length=${text.length}`);
+
+    const extractConfig = getExtractConfig(app, 'pending_extract');
+    const customPrompt = getExtractPrompt(app);
+
+    const fieldDefs = CONTRACT_FIELDS.map(f => `- ${f.name} (${f.label}): ${f.guide}`).join('\n');
+    const exampleJson = CONTRACT_FIELDS.map(f => `  "${f.name}": "提取值"`).join(',\n');
+
+    const promptBase = customPrompt
+      ? `${customPrompt}\n\n字段定义:\n${fieldDefs}\n\n期望返回 JSON 格式:\n{\n${exampleJson}\n}`
+      : `从以下文本中提取结构化元数据。
+
+字段定义:
+${fieldDefs}
+
+期望返回 JSON 格式:
+{
+${exampleJson}
+}`;
+
+    try {
+      const response = await services.callLlm('extract_metadata', {
+        instruction: promptBase,
+        ocr_text: text,
+        response_format: 'json',
+        model_id: extractConfig.model_id,
+        temperature: extractConfig.temperature || 0.3,
+      });
+
+      let metadata;
+      const resultText = response.text || response.parsed || response;
+      if (typeof resultText === 'string') {
+        const jsonMatch = resultText.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) return { success: false, error: 'LLM did not return valid JSON' };
+        metadata = JSON.parse(jsonMatch[0]);
+      } else if (typeof resultText === 'object') {
+        metadata = resultText;
+      } else {
+        return { success: false, error: 'LLM returned unexpected format' };
+      }
+
+      const cleanMetadata = {};
+      for (const field of CONTRACT_FIELDS) {
+        const value = metadata[field.name];
+        if (value === undefined || value === null || value === '') continue;
+
+        if (field.name === 'contract_amount') {
+          const num = Number(String(value).replace(/[,，]/g, ''));
+          if (!isNaN(num)) cleanMetadata[field.name] = num;
+        } else if (field.name === 'contract_date') {
+          const dateStr = String(value).replace(/年/g, '-').replace(/月/g, '-').replace(/日/g, '');
+          if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(dateStr)) cleanMetadata[field.name] = dateStr;
+        } else {
+          cleanMetadata[field.name] = value;
+        }
+      }
+
+      logger.info(`[contract-v2-llm-extract] Record ${record.id}: Extracted fields: ${Object.keys(cleanMetadata).join(', ')}`);
+
+      await services.callExtension(ROWS_TABLE, 'upsert', {
+        row_id: record.id,
+        ...cleanMetadata,
+      });
+
+      await services.callExtension(CONTENT_TABLE, 'upsert', {
+        row_id: record.id,
+        extract_json: JSON.stringify(cleanMetadata),
+        extract_model: extractConfig.model_id || null,
+        extract_temperature: extractConfig.temperature || 0.3,
+        extract_at: new Date(),
+      });
+
+      return {
+        success: true,
+        data: {
+          _extract_done: true,
+        },
+      };
+    } catch (e) {
+      logger.error(`[contract-v2-llm-extract] Record ${record.id}: ${e.message}`);
+      return { success: false, error: 'LLM extraction failed: ' + e.message };
+    }
+  },
+};

--- a/apps/contract-mgr-v2/handlers/contract-v2-text-filter/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-text-filter/index.js
@@ -1,0 +1,231 @@
+import logger from '../../../lib/logger.js';
+
+const DEFAULT_FILTER_CONFIG = {
+  type: 'internal_llm',
+  model_id: null,
+  temperature: 0.3,
+};
+
+const CHUNK_MAX_LENGTH = parseInt(process.env.TEXT_FILTER_MAX_LENGTH) || 120000;
+const CONTEXT_SUMMARY_MAX_LENGTH = 2000;
+const CONTENT_TABLE = 'app_contract_v2_content';
+
+function getFilterConfig(app, stateName) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.step_resources?.[stateName] || config?.step_resources?.pending_filter || DEFAULT_FILTER_CONFIG;
+}
+
+function getFilterPrompt(app) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config?.prompts?.filter || '去除页码、水印、乱码、多余的空白字符，保留正文内容';
+}
+
+function splitIntoChunks(text, maxLen) {
+  const paragraphs = text.split('\n\n');
+  const chunks = [];
+  let current = '';
+
+  for (const para of paragraphs) {
+    if (current.length + para.length + 2 <= maxLen) {
+      current += (current ? '\n\n' : '') + para;
+    } else {
+      if (current) chunks.push(current);
+      if (para.length > maxLen) {
+        let remaining = para;
+        while (remaining.length > 0) {
+          chunks.push(remaining.slice(0, maxLen));
+          remaining = remaining.slice(maxLen);
+        }
+        current = '';
+      } else {
+        current = para;
+      }
+    }
+  }
+  if (current) chunks.push(current);
+
+  return chunks.length > 0 ? chunks : [text];
+}
+
+const CHUNK_SYSTEM_SUFFIX = `
+
+你必须返回严格的JSON格式：
+{
+  "processed_part": "本轮清洗后的文本片段",
+  "carried_over": "未完成的尾部内容（空字符串表示无剩余）",
+  "context_summary": {
+    "key_terms": {},
+    "points": []
+  }
+}
+
+规则：
+- processed_part: 本轮已完整清洗的文本
+- carried_over: 如果末尾文本不完整（如句子被截断），放到这里，会拼接到下轮输入开头
+- context_summary.key_terms: 已出现的专业术语及其标准译名/写法
+- context_summary.points: 已处理文本的摘要要点列表（字符串数组），总长度不超过${CONTEXT_SUMMARY_MAX_LENGTH}字符`;
+
+async function filterSingleChunk(services, filterPrompt, filterConfig, chunkInput, contextSummary) {
+  const promptBase = filterPrompt + CHUNK_SYSTEM_SUFFIX;
+
+  let contextNote = '';
+  if (contextSummary && (Object.keys(contextSummary.key_terms || {}).length > 0 || (contextSummary.points || []).length > 0)) {
+    contextNote = `\n\n[前文上下文摘要]\n${JSON.stringify(contextSummary, null, 2)}\n请参考以上上下文保持术语和风格一致。`;
+  }
+
+  const response = await services.callLlm('filter_text_chunked', {
+    instruction: promptBase,
+    ocr_text: chunkInput + contextNote,
+    response_format: 'json',
+    model_id: filterConfig.model_id,
+    temperature: filterConfig.temperature || 0.3,
+  });
+
+  let parsed;
+  if (response.parsed && typeof response.parsed === 'object') {
+    parsed = response.parsed;
+  } else {
+    try {
+      const jsonMatch = response.text.match(/\{[\s\S]*\}/);
+      parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : null;
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (!parsed || typeof parsed.processed_part !== 'string') {
+    throw new Error('LLM返回的JSON格式无效');
+  }
+
+  return {
+    processed_part: parsed.processed_part || '',
+    carried_over: parsed.carried_over || '',
+    context_summary: parsed.context_summary || { key_terms: {}, points: [] },
+  };
+}
+
+function trimContextSummary(summary) {
+  if (!summary) return { key_terms: {}, points: [] };
+
+  const points = summary.points || [];
+  const keyTerms = summary.key_terms || {};
+  const trimmedPoints = [];
+
+  for (const point of points) {
+    const candidate = { key_terms: keyTerms, points: [...trimmedPoints, point] };
+    if (JSON.stringify(candidate).length <= CONTEXT_SUMMARY_MAX_LENGTH) {
+      trimmedPoints.push(point);
+    }
+  }
+
+  return { key_terms: keyTerms, points: trimmedPoints };
+}
+
+async function filterWithSlidingWindow(services, filterPrompt, filterConfig, ocrText) {
+  const chunks = splitIntoChunks(ocrText, CHUNK_MAX_LENGTH);
+  logger.info(`[contract-v2-text-filter] Sliding window: split into ${chunks.length} chunks`);
+
+  const allProcessed = [];
+  let carriedOver = '';
+  let contextSummary = { key_terms: {}, points: [] };
+
+  for (let i = 0; i < chunks.length; i++) {
+    let nextChunk = chunks[i];
+    if (carriedOver.length + nextChunk.length > CHUNK_MAX_LENGTH * 1.5) {
+      const allowLen = Math.floor(CHUNK_MAX_LENGTH * 1.5) - carriedOver.length;
+      allProcessed.push(nextChunk.slice(0, Math.max(0, CHUNK_MAX_LENGTH - carriedOver.length)));
+      nextChunk = nextChunk.slice(Math.max(0, CHUNK_MAX_LENGTH - carriedOver.length));
+    }
+    const chunkInput = carriedOver + (carriedOver ? '\n\n' : '') + nextChunk;
+
+    try {
+      const result = await filterSingleChunk(services, filterPrompt, filterConfig, chunkInput, contextSummary);
+      allProcessed.push(result.processed_part);
+      carriedOver = result.carried_over || '';
+      contextSummary = trimContextSummary(result.context_summary);
+    } catch (chunkErr) {
+      logger.error(`[contract-v2-text-filter] Chunk ${i + 1} failed: ${chunkErr.message}`);
+      allProcessed.push(chunkInput);
+      carriedOver = '';
+      contextSummary = { key_terms: {}, points: [] };
+    }
+  }
+
+  if (carriedOver) allProcessed.push(carriedOver);
+
+  return allProcessed.join('\n\n');
+}
+
+export const availableOutputs = [
+  { key: 'filter_status', label: '过滤状态', type: 'string' },
+];
+
+export default {
+  availableOutputs,
+  async process(context) {
+    const { record, services, app } = context;
+
+    logger.info(`[contract-v2-text-filter] Processing record ${record.id}`);
+
+    const content = await services.callExtension(CONTENT_TABLE, 'read', {
+      row_id: record.id,
+      fields: ['ocr_text'],
+    });
+
+    if (!content || !content.ocr_text) {
+      return { success: false, error: 'No OCR text found in extension table' };
+    }
+
+    const ocrText = content.ocr_text;
+    logger.info(`[contract-v2-text-filter] Record ${record.id}: OCR text length=${ocrText.length}`);
+
+    const filterConfig = getFilterConfig(app, 'pending_filter');
+    const filterPrompt = getFilterPrompt(app);
+
+    let filteredText;
+
+    if (ocrText.length <= CHUNK_MAX_LENGTH) {
+      try {
+        const response = await services.callLlm('filter_text', {
+          instruction: filterPrompt,
+          ocr_text: ocrText,
+          response_format: 'text',
+          model_id: filterConfig.model_id,
+          temperature: filterConfig.temperature || 0.3,
+        });
+        filteredText = response.text || ocrText;
+      } catch (e) {
+        logger.error(`[contract-v2-text-filter] Record ${record.id}: LLM filter failed - ${e.message}`);
+        filteredText = ocrText;
+      }
+    } else {
+      try {
+        filteredText = await filterWithSlidingWindow(services, filterPrompt, filterConfig, ocrText);
+      } catch (e) {
+        logger.error(`[contract-v2-text-filter] Record ${record.id}: Sliding window failed - ${e.message}`);
+        filteredText = ocrText;
+      }
+    }
+
+    await services.callExtension(CONTENT_TABLE, 'upsert', {
+      row_id: record.id,
+      filtered_text: filteredText,
+      filter_at: new Date(),
+    });
+
+    logger.info(`[contract-v2-text-filter] Record ${record.id}: Complete, length=${filteredText.length}`);
+
+    return {
+      success: true,
+      data: {
+        _filter_done: true,
+      },
+    };
+  },
+};

--- a/apps/contract-mgr-v2/handlers/contract-v2-text-section/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-text-section/index.js
@@ -1,0 +1,91 @@
+import logger from '../../../lib/logger.js';
+
+const CONTENT_TABLE = 'app_contract_v2_content';
+
+export const availableOutputs = [
+  { key: 'section_count', label: '章节数量', type: 'number' },
+];
+
+export default {
+  availableOutputs,
+  async process(context) {
+    const { record, services, app } = context;
+
+    logger.info(`[contract-v2-text-section] Processing record ${record.id}`);
+
+    const content = await services.callExtension(CONTENT_TABLE, 'read', {
+      row_id: record.id,
+      fields: ['filtered_text'],
+    });
+
+    if (!content || !content.filtered_text) {
+      return { success: false, error: 'No filtered text found in extension table' };
+    }
+
+    let config = app?.config;
+    if (typeof config === 'string') {
+      try { config = JSON.parse(config); } catch { config = {}; }
+    }
+    const sectionConfig = config?.step_resources?.pending_section || { type: 'internal_llm', temperature: 0.3 };
+    const sectionPrompt = config?.prompts?.section || null;
+
+    const promptBase = sectionPrompt || `分析以下合同文本的章节结构。
+
+返回JSON格式：
+{
+  "sections": [
+    {
+      "title": "章节标题",
+      "level": 1,
+      "index": 0,
+      "start_offset": 0,
+      "summary": "章节内容摘要"
+    }
+  ]
+}`;
+
+    try {
+      const response = await services.callLlm('analyze_sections', {
+        instruction: promptBase,
+        ocr_text: content.filtered_text,
+        response_format: 'json',
+        model_id: sectionConfig.model_id,
+        temperature: sectionConfig.temperature || 0.3,
+      });
+
+      let sections;
+      const resultText = response.text || response.parsed || response;
+      if (typeof resultText === 'string') {
+        const jsonMatch = resultText.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) return { success: false, error: 'LLM did not return valid JSON' };
+        const parsed = JSON.parse(jsonMatch[0]);
+        sections = parsed.sections || parsed;
+      } else if (typeof resultText === 'object') {
+        sections = resultText.sections || resultText;
+      } else {
+        return { success: false, error: 'LLM returned unexpected format' };
+      }
+
+      if (!Array.isArray(sections)) {
+        return { success: false, error: 'Sections must be an array' };
+      }
+
+      logger.info(`[contract-v2-text-section] Record ${record.id}: Found ${sections.length} sections`);
+
+      await services.callExtension(CONTENT_TABLE, 'upsert', {
+        row_id: record.id,
+        sections: JSON.stringify(sections),
+      });
+
+      return {
+        success: true,
+        data: {
+          _section_done: true,
+        },
+      };
+    } catch (e) {
+      logger.error(`[contract-v2-text-section] Record ${record.id}: ${e.message}`);
+      return { success: false, error: 'Section analysis failed: ' + e.message };
+    }
+  },
+};

--- a/apps/contract-mgr-v2/manifest.json
+++ b/apps/contract-mgr-v2/manifest.json
@@ -1,0 +1,268 @@
+{
+  "id": "contract-mgr-v2",
+  "name": "销售合同管理 v2",
+  "version": "2.0.0",
+  "description": "支持组织层级、多版本管理、AI问答的销售合同管理系统",
+  "icon": "📋",
+  "type": "document",
+  "author": "Touwaka Team",
+  "license": "MIT",
+  "keywords": [
+    "合同",
+    "文档",
+    "OCR",
+    "AI提取",
+    "多版本",
+    "组织管理"
+  ],
+  "compatibility": {
+    "min_platform_version": "2.0.0",
+    "requires": {
+      "mcp": [
+        "markitdown",
+        "mineru"
+      ],
+      "skills": []
+    }
+  },
+  "fields": [
+    {
+      "name": "contract_name",
+      "label": "合同名称",
+      "type": "text",
+      "required": true
+    },
+    {
+      "name": "contract_type",
+      "label": "合同类型",
+      "type": "select",
+      "options": ["strategy", "framework", "development", "supply", "purchase", "quality", "nda", "technical", "other"],
+      "required": true
+    },
+    {
+      "name": "contract_file",
+      "label": "合同文件",
+      "type": "file"
+    }
+  ],
+  "extension_tables": [
+    {
+      "name": "app_contract_v2_rows",
+      "type": "primary",
+      "fields": [
+        { "name": "contract_number", "type": "VARCHAR(64)", "label": "合同编号", "source": "contract_number" },
+        { "name": "party_a", "type": "VARCHAR(128)", "label": "甲方", "source": "party_a" },
+        { "name": "parent_company", "type": "VARCHAR(128)", "label": "上级公司", "source": "parent_company" },
+        { "name": "contract_amount", "type": "DECIMAL(15,2)", "label": "合同金额", "source": "contract_amount" },
+        { "name": "contract_date", "type": "DATE", "label": "签订日期", "source": "contract_date" }
+      ],
+      "indexes": ["contract_number", "party_a", "contract_amount", "contract_date"]
+    },
+    {
+      "name": "app_contract_v2_content",
+      "type": "content",
+      "fields": [
+        { "name": "ocr_text", "type": "LONGTEXT" },
+        { "name": "ocr_service", "type": "VARCHAR(64)" },
+        { "name": "ocr_at", "type": "DATETIME" },
+        { "name": "filtered_text", "type": "LONGTEXT" },
+        { "name": "filter_at", "type": "DATETIME" },
+        { "name": "sections", "type": "JSON" },
+        { "name": "extract_prompt", "type": "TEXT" },
+        { "name": "extract_json", "type": "LONGTEXT" },
+        { "name": "extract_model", "type": "VARCHAR(64)" },
+        { "name": "extract_temperature", "type": "DECIMAL(3,2)" },
+        { "name": "extract_at", "type": "DATETIME" }
+      ]
+    }
+  ],
+  "migrations": {
+    "install": "migrations/install.js",
+    "uninstall": "migrations/uninstall.js"
+  },
+  "views": {
+    "list": {
+      "columns": [
+        "contract_number",
+        "contract_date",
+        "party_a",
+        "contract_amount"
+      ],
+      "sort": {
+        "field": "contract_date",
+        "order": "desc"
+      }
+    }
+  },
+  "config": {
+    "features": [
+      "upload",
+      "list",
+      "detail",
+      "org_tree",
+      "versions",
+      "dashboard"
+    ],
+    "supported_formats": [".pdf", ".docx", ".doc", ".jpg", ".png"],
+    "max_file_size": 20971520,
+    "batch_enabled": true,
+    "batch_limit": 50,
+    "step_resources": {
+      "pending_ocr": {
+        "type": "mcp",
+        "mcp": { "server": "markitdown", "tool": "submit_conversion_task", "params_mapping": { "content": "file.base64", "filename": "file.name" } }
+      },
+      "ocr_submitted": {
+        "type": "mcp",
+        "mcp": { "server": "markitdown", "tool": "get_task", "hide_params_mapping": true },
+        "judge_model_id": null,
+        "judge_temperature": 0.1
+      },
+      "pending_filter": {
+        "type": "internal_llm",
+        "model_id": null,
+        "temperature": 0.3
+      },
+      "pending_extract": {
+        "type": "internal_llm",
+        "model_id": null,
+        "temperature": 0.3
+      },
+      "pending_section": {
+        "type": "internal_llm",
+        "model_id": null,
+        "temperature": 0.3
+      }
+    }
+  },
+  "states": [
+    {
+      "name": "pending_ocr",
+      "label": "等待OCR",
+      "description": "提交OCR任务",
+      "sort_order": 1,
+      "is_initial": true,
+      "is_terminal": false,
+      "is_error": false,
+      "handler": "handler-submit-ocr",
+      "success_next": "ocr_submitted",
+      "failure_next": "ocr_failed"
+    },
+    {
+      "name": "ocr_submitted",
+      "label": "OCR处理中",
+      "description": "检查OCR状态并持久化OCR文本到扩展表",
+      "sort_order": 2,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": false,
+      "handler": "contract-v2-check-ocr",
+      "success_next": "pending_filter",
+      "failure_next": "ocr_failed"
+    },
+    {
+      "name": "pending_filter",
+      "label": "等待过滤",
+      "description": "LLM文本过滤并持久化到扩展表",
+      "sort_order": 3,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": false,
+      "handler": "contract-v2-text-filter",
+      "success_next": "pending_extract",
+      "failure_next": "filter_failed"
+    },
+    {
+      "name": "pending_extract",
+      "label": "等待提取",
+      "description": "LLM提取元数据并持久化到扩展表",
+      "sort_order": 4,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": false,
+      "handler": "contract-v2-llm-extract",
+      "success_next": "pending_section",
+      "failure_next": "extract_failed"
+    },
+    {
+      "name": "pending_section",
+      "label": "等待章节分析",
+      "description": "LLM章节结构分析并持久化到扩展表",
+      "sort_order": 5,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": false,
+      "handler": "contract-v2-text-section",
+      "success_next": "pending_review",
+      "failure_next": "section_failed"
+    },
+    {
+      "name": "pending_review",
+      "label": "等待确认",
+      "sort_order": 6,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": false,
+      "handler": null,
+      "success_next": null,
+      "failure_next": null
+    },
+    {
+      "name": "confirmed",
+      "label": "已确认",
+      "sort_order": 7,
+      "is_initial": false,
+      "is_terminal": true,
+      "is_error": false,
+      "handler": null,
+      "success_next": null,
+      "failure_next": null
+    },
+    {
+      "name": "ocr_failed",
+      "label": "OCR失败",
+      "sort_order": 99,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": true,
+      "handler": null,
+      "success_next": null,
+      "failure_next": null
+    },
+    {
+      "name": "filter_failed",
+      "label": "过滤失败",
+      "sort_order": 99,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": true,
+      "handler": null,
+      "success_next": null,
+      "failure_next": null
+    },
+    {
+      "name": "extract_failed",
+      "label": "提取失败",
+      "sort_order": 99,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": true,
+      "handler": null,
+      "success_next": null,
+      "failure_next": null
+    },
+    {
+      "name": "section_failed",
+      "label": "章节分析失败",
+      "sort_order": 99,
+      "is_initial": false,
+      "is_terminal": false,
+      "is_error": true,
+      "handler": null,
+      "success_next": null,
+      "failure_next": null
+    }
+  ],
+  "component": null,
+  "visibility": "all"
+}

--- a/apps/contract-mgr-v2/migrations/install.js
+++ b/apps/contract-mgr-v2/migrations/install.js
@@ -1,0 +1,160 @@
+export default {
+  async check(sequelize) {
+    const rows = await sequelize.query(`
+      SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (
+        'contract_v2_org_nodes',
+        'contract_v2_main_records',
+        'contract_v2_versions',
+        'app_contract_v2_rows',
+        'app_contract_v2_content'
+      )
+    `, { type: sequelize.QueryTypes.SELECT });
+
+    return rows.length < 5;
+  },
+
+  async up(sequelize) {
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS contract_v2_org_nodes (
+        id VARCHAR(32) PRIMARY KEY,
+        parent_id VARCHAR(32) NULL,
+        node_type ENUM('group', 'party', 'project') NOT NULL COMMENT '节点类型',
+        name VARCHAR(128) NOT NULL COMMENT '节点名称',
+        path VARCHAR(255) COMMENT '层级路径',
+        level INT DEFAULT 1 COMMENT '层级深度',
+        sort_order INT DEFAULT 0 COMMENT '同级排序',
+        is_active BIT(1) DEFAULT 1,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_parent (parent_id),
+        INDEX idx_type (node_type),
+        INDEX idx_path (path),
+        INDEX idx_level (level),
+        FOREIGN KEY (parent_id) REFERENCES contract_v2_org_nodes(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同组织节点表'
+    `);
+    console.log('  ✓ Created contract_v2_org_nodes table');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS contract_v2_main_records (
+        id VARCHAR(32) PRIMARY KEY,
+        org_node_id VARCHAR(32) NOT NULL COMMENT '所属组织节点',
+        contract_name VARCHAR(128) NOT NULL COMMENT '合同名称',
+        contract_type ENUM('strategy','framework','development','supply','purchase','quality','nda','technical','other') COMMENT '合同类型',
+        current_version_id VARCHAR(32) COMMENT '当前生效版本ID',
+        version_count INT DEFAULT 0 COMMENT '版本总数',
+        status ENUM('draft','active','expired','terminated') DEFAULT 'active',
+        created_by VARCHAR(32) COMMENT '创建人',
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_org_node (org_node_id),
+        INDEX idx_type (contract_type),
+        INDEX idx_status (status),
+        FOREIGN KEY (org_node_id) REFERENCES contract_v2_org_nodes(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同主记录表'
+    `);
+    console.log('  ✓ Created contract_v2_main_records table');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS contract_v2_versions (
+        id VARCHAR(32) PRIMARY KEY,
+        contract_id VARCHAR(32) NOT NULL COMMENT '合同主记录ID',
+        row_id VARCHAR(32) NOT NULL COMMENT 'mini_app_rows ID',
+        file_id VARCHAR(32) COMMENT '文件ID',
+        version_number VARCHAR(16) NOT NULL COMMENT '版本号',
+        version_name VARCHAR(64) COMMENT '版本名称',
+        version_type ENUM('draft','signed','amendment','supplement') COMMENT '版本类型',
+        version_status ENUM('draft','reviewing','approved','rejected','archived') DEFAULT 'draft',
+        effective_date DATE COMMENT '生效日期',
+        expiry_date DATE COMMENT '失效日期',
+        contract_number VARCHAR(64) COMMENT '合同编号',
+        party_a VARCHAR(128) COMMENT '甲方',
+        party_b VARCHAR(128) COMMENT '乙方',
+        total_amount DECIMAL(15,2) COMMENT '合同金额',
+        change_summary TEXT COMMENT '变更说明',
+        is_current BIT(1) DEFAULT 0 COMMENT '是否当前版本',
+        created_by VARCHAR(32) COMMENT '上传人',
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_contract_version (contract_id, version_number),
+        INDEX idx_contract (contract_id),
+        INDEX idx_row (row_id),
+        INDEX idx_current (is_current),
+        INDEX idx_status (version_status),
+        FOREIGN KEY (contract_id) REFERENCES contract_v2_main_records(id) ON DELETE CASCADE,
+        FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同版本表'
+    `);
+    console.log('  ✓ Created contract_v2_versions table');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS app_contract_v2_content (
+        row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 mini_app_rows.id',
+        ocr_text LONGTEXT NULL COMMENT 'OCR 原文',
+        ocr_service VARCHAR(64) NULL COMMENT 'OCR 服务',
+        ocr_at DATETIME NULL COMMENT 'OCR 时间',
+        filtered_text LONGTEXT NULL COMMENT '过滤后文本',
+        filter_at DATETIME NULL COMMENT '过滤时间',
+        sections JSON NULL COMMENT '章节结构',
+        extract_prompt TEXT NULL COMMENT '提取提示词',
+        extract_json LONGTEXT NULL COMMENT '提取的原始JSON',
+        extract_model VARCHAR(64) NULL COMMENT '提取模型',
+        extract_temperature DECIMAL(3,2) NULL COMMENT '模型温度',
+        extract_at DATETIME NULL COMMENT '提取时间',
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同内容扩展表'
+    `);
+    console.log('  ✓ Created app_contract_v2_content table');
+
+    await sequelize.query(`
+      ALTER TABLE app_contract_v2_content
+      ADD CONSTRAINT fk_app_contract_v2_content_row_id
+      FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+    `);
+    console.log('  ✓ Added FK for app_contract_v2_content');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS app_contract_v2_rows (
+        row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 mini_app_rows.id',
+        contract_number VARCHAR(64) NULL COMMENT '合同编号',
+        party_a VARCHAR(128) NULL COMMENT '甲方',
+        parent_company VARCHAR(128) NULL COMMENT '上级公司',
+        contract_amount DECIMAL(15,2) NULL COMMENT '合同金额',
+        contract_date DATE NULL COMMENT '签订日期',
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_contract_number (contract_number),
+        INDEX idx_party_a (party_a),
+        INDEX idx_contract_amount (contract_amount),
+        INDEX idx_contract_date (contract_date)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同元数据扩展表'
+    `);
+    console.log('  ✓ Created app_contract_v2_rows table');
+
+    await sequelize.query(`
+      ALTER TABLE app_contract_v2_rows
+      ADD CONSTRAINT fk_app_contract_v2_rows_row_id
+      FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+    `);
+    console.log('  ✓ Added FK for app_contract_v2_rows');
+  },
+
+  async down(sequelize) {
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_rows`);
+    console.log('  ✓ Dropped app_contract_v2_rows table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_content`);
+    console.log('  ✓ Dropped app_contract_v2_content table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS contract_v2_versions`);
+    console.log('  ✓ Dropped contract_v2_versions table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS contract_v2_main_records`);
+    console.log('  ✓ Dropped contract_v2_main_records table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS contract_v2_org_nodes`);
+    console.log('  ✓ Dropped contract_v2_org_nodes table');
+  }
+};

--- a/apps/contract-mgr-v2/migrations/uninstall.js
+++ b/apps/contract-mgr-v2/migrations/uninstall.js
@@ -1,0 +1,160 @@
+export default {
+  async check(sequelize) {
+    const rows = await sequelize.query(`
+      SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (
+        'contract_v2_org_nodes',
+        'contract_v2_main_records',
+        'contract_v2_versions',
+        'app_contract_v2_rows',
+        'app_contract_v2_content'
+      )
+    `, { type: sequelize.QueryTypes.SELECT });
+
+    return rows.length > 0;
+  },
+
+  async up(sequelize) {
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_rows`);
+    console.log('  ✓ Dropped app_contract_v2_rows table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_content`);
+    console.log('  ✓ Dropped app_contract_v2_content table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS contract_v2_versions`);
+    console.log('  ✓ Dropped contract_v2_versions table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS contract_v2_main_records`);
+    console.log('  ✓ Dropped contract_v2_main_records table');
+
+    await sequelize.query(`DROP TABLE IF EXISTS contract_v2_org_nodes`);
+    console.log('  ✓ Dropped contract_v2_org_nodes table');
+  },
+
+  async down(sequelize) {
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS contract_v2_org_nodes (
+        id VARCHAR(32) PRIMARY KEY,
+        parent_id VARCHAR(32) NULL,
+        node_type ENUM('group', 'party', 'project') NOT NULL,
+        name VARCHAR(128) NOT NULL,
+        path VARCHAR(255),
+        level INT DEFAULT 1,
+        sort_order INT DEFAULT 0,
+        is_active BIT(1) DEFAULT 1,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_parent (parent_id),
+        INDEX idx_type (node_type),
+        INDEX idx_path (path),
+        INDEX idx_level (level),
+        FOREIGN KEY (parent_id) REFERENCES contract_v2_org_nodes(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+    console.log('  ✓ Recreated contract_v2_org_nodes table');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS contract_v2_main_records (
+        id VARCHAR(32) PRIMARY KEY,
+        org_node_id VARCHAR(32) NOT NULL,
+        contract_name VARCHAR(128) NOT NULL,
+        contract_type ENUM('strategy','framework','development','supply','purchase','quality','nda','technical','other'),
+        current_version_id VARCHAR(32),
+        version_count INT DEFAULT 0,
+        status ENUM('draft','active','expired','terminated') DEFAULT 'active',
+        created_by VARCHAR(32),
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_org_node (org_node_id),
+        INDEX idx_type (contract_type),
+        INDEX idx_status (status),
+        FOREIGN KEY (org_node_id) REFERENCES contract_v2_org_nodes(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+    console.log('  ✓ Recreated contract_v2_main_records table');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS contract_v2_versions (
+        id VARCHAR(32) PRIMARY KEY,
+        contract_id VARCHAR(32) NOT NULL,
+        row_id VARCHAR(32) NOT NULL,
+        file_id VARCHAR(32),
+        version_number VARCHAR(16) NOT NULL,
+        version_name VARCHAR(64),
+        version_type ENUM('draft','signed','amendment','supplement'),
+        version_status ENUM('draft','reviewing','approved','rejected','archived') DEFAULT 'draft',
+        effective_date DATE,
+        expiry_date DATE,
+        contract_number VARCHAR(64),
+        party_a VARCHAR(128),
+        party_b VARCHAR(128),
+        total_amount DECIMAL(15,2),
+        change_summary TEXT,
+        is_current BIT(1) DEFAULT 0,
+        created_by VARCHAR(32),
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uk_contract_version (contract_id, version_number),
+        INDEX idx_contract (contract_id),
+        INDEX idx_row (row_id),
+        INDEX idx_current (is_current),
+        INDEX idx_status (version_status),
+        FOREIGN KEY (contract_id) REFERENCES contract_v2_main_records(id) ON DELETE CASCADE,
+        FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+    console.log('  ✓ Recreated contract_v2_versions table');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS app_contract_v2_content (
+        row_id VARCHAR(32) PRIMARY KEY,
+        ocr_text LONGTEXT NULL,
+        ocr_service VARCHAR(64) NULL,
+        ocr_at DATETIME NULL,
+        filtered_text LONGTEXT NULL,
+        filter_at DATETIME NULL,
+        sections JSON NULL,
+        extract_prompt TEXT NULL,
+        extract_json LONGTEXT NULL,
+        extract_model VARCHAR(64) NULL,
+        extract_temperature DECIMAL(3,2) NULL,
+        extract_at DATETIME NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+    console.log('  ✓ Recreated app_contract_v2_content table');
+
+    await sequelize.query(`
+      ALTER TABLE app_contract_v2_content
+      ADD CONSTRAINT fk_app_contract_v2_content_row_id
+      FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+    `);
+    console.log('  ✓ Added FK for app_contract_v2_content');
+
+    await sequelize.query(`
+      CREATE TABLE IF NOT EXISTS app_contract_v2_rows (
+        row_id VARCHAR(32) PRIMARY KEY,
+        contract_number VARCHAR(64) NULL,
+        party_a VARCHAR(128) NULL,
+        parent_company VARCHAR(128) NULL,
+        contract_amount DECIMAL(15,2) NULL,
+        contract_date DATE NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        INDEX idx_contract_number (contract_number),
+        INDEX idx_party_a (party_a),
+        INDEX idx_contract_amount (contract_amount),
+        INDEX idx_contract_date (contract_date)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+    console.log('  ✓ Recreated app_contract_v2_rows table');
+
+    await sequelize.query(`
+      ALTER TABLE app_contract_v2_rows
+      ADD CONSTRAINT fk_app_contract_v2_rows_row_id
+      FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+    `);
+    console.log('  ✓ Added FK for app_contract_v2_rows');
+  }
+};

--- a/apps/index.json
+++ b/apps/index.json
@@ -15,6 +15,19 @@
       "tags": ["合同", "文档", "OCR", "AI提取"],
       "path": "apps/contract-mgr",
       "manifest_url": "apps/contract-mgr/manifest.json"
+    },
+    {
+      "id": "contract-mgr-v2",
+      "name": "销售合同管理 v2",
+      "version": "2.0.0",
+      "icon": "📋",
+      "type": "document",
+      "description": "支持组织层级、多版本管理、AI问答的销售合同管理系统",
+      "author": "Touwaka Team",
+      "license": "MIT",
+      "tags": ["合同", "文档", "OCR", "AI提取", "多版本", "组织管理"],
+      "path": "apps/contract-mgr-v2",
+      "manifest_url": "apps/contract-mgr-v2/manifest.json"
     }
   ],
   "categories": [
@@ -24,7 +37,7 @@
     { "id": "utility", "name": "实用工具", "icon": "🔧", "description": "各类实用小工具" }
   ],
   "metadata": {
-    "total_apps": 1,
+    "total_apps": 2,
     "min_platform_version": "2.0.0",
     "last_updated_by": "Touwaka Team"
   }

--- a/docs/design/contract-v2-final-spec.md
+++ b/docs/design/contract-v2-final-spec.md
@@ -1,0 +1,208 @@
+# 合同管理 v2 最终设计规格
+
+> 创建时间：2026-05-03
+> 作者：Maria
+> 状态：已定稿
+
+## 决策记录
+
+| # | 决策项 | 结论 | 理由 |
+|---|--------|------|------|
+| 1 | 表名 | `contract_v2_main_records` | 用户确认 |
+| 2 | Handler 层数 | 4层（ocr + filter + extract + section） | 每层都有持久化 |
+| 3 | 上传流程 | 直接处理，无AI匹配 | 谁上传谁处理 |
+| 4 | Dashboard | 纳入 Phase 1 | 用户确认 |
+| 5 | contract_type 枚举 | 9种（strategy/framework/development/supply/purchase/quality/nda/technical/other） | 完整覆盖 |
+| 6 | 元数据归属 | main_records 存类目信息，version 存版本级字段，extension 存提取数据 | 三层分离 |
+
+---
+
+## 数据库表（5张）
+
+### 1. contract_v2_org_nodes（组织树）
+
+```sql
+CREATE TABLE contract_v2_org_nodes (
+  id VARCHAR(32) PRIMARY KEY,
+  parent_id VARCHAR(32) NULL,
+  node_type ENUM('group', 'party', 'project') NOT NULL,
+  name VARCHAR(128) NOT NULL,
+  path VARCHAR(255),
+  level INT DEFAULT 1,
+  sort_order INT DEFAULT 0,
+  is_active BIT(1) DEFAULT 1,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_parent (parent_id),
+  INDEX idx_type (node_type),
+  INDEX idx_path (path),
+  INDEX idx_level (level),
+  FOREIGN KEY (parent_id) REFERENCES contract_v2_org_nodes(id) ON DELETE CASCADE
+);
+```
+
+### 2. contract_v2_main_records（合同主记录/类目）
+
+```sql
+CREATE TABLE contract_v2_main_records (
+  id VARCHAR(32) PRIMARY KEY,
+  org_node_id VARCHAR(32) NOT NULL,
+  contract_name VARCHAR(128) NOT NULL,
+  contract_type ENUM('strategy','framework','development','supply','purchase','quality','nda','technical','other'),
+  current_version_id VARCHAR(32),
+  version_count INT DEFAULT 0,
+  status ENUM('draft','active','expired','terminated') DEFAULT 'active',
+  created_by VARCHAR(32),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_org_node (org_node_id),
+  INDEX idx_type (contract_type),
+  INDEX idx_status (status),
+  FOREIGN KEY (org_node_id) REFERENCES contract_v2_org_nodes(id) ON DELETE CASCADE
+);
+```
+
+### 3. contract_v2_versions（合同版本）
+
+```sql
+CREATE TABLE contract_v2_versions (
+  id VARCHAR(32) PRIMARY KEY,
+  contract_id VARCHAR(32) NOT NULL,
+  row_id VARCHAR(32) NOT NULL,
+  file_id VARCHAR(32),
+  version_number VARCHAR(16) NOT NULL,
+  version_name VARCHAR(64),
+  version_type ENUM('draft','signed','amendment','supplement'),
+  version_status ENUM('draft','reviewing','approved','rejected','archived') DEFAULT 'draft',
+  effective_date DATE,
+  expiry_date DATE,
+  contract_number VARCHAR(64),
+  party_a VARCHAR(128),
+  party_b VARCHAR(128),
+  total_amount DECIMAL(15,2),
+  change_summary TEXT,
+  is_current BIT(1) DEFAULT 0,
+  created_by VARCHAR(32),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uk_contract_version (contract_id, version_number),
+  INDEX idx_contract (contract_id),
+  INDEX idx_row (row_id),
+  INDEX idx_current (is_current),
+  INDEX idx_status (version_status),
+  FOREIGN KEY (contract_id) REFERENCES contract_v2_main_records(id) ON DELETE CASCADE,
+  FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+);
+```
+
+### 4. app_contract_v2_content（Extension Table）
+
+```sql
+CREATE TABLE app_contract_v2_content (
+  row_id VARCHAR(32) PRIMARY KEY,
+  ocr_text LONGTEXT,
+  ocr_service VARCHAR(64),
+  ocr_at DATETIME,
+  filtered_text LONGTEXT,
+  filter_at DATETIME,
+  sections JSON,
+  extract_prompt TEXT,
+  extract_json LONGTEXT,
+  extract_model VARCHAR(64),
+  extract_temperature DECIMAL(3,2),
+  extract_at DATETIME,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+);
+```
+
+### 5. app_contract_v2_rows（Extension Table）
+
+```sql
+CREATE TABLE app_contract_v2_rows (
+  row_id VARCHAR(32) PRIMARY KEY,
+  contract_number VARCHAR(64),
+  party_a VARCHAR(128),
+  parent_company VARCHAR(128),
+  contract_amount DECIMAL(15,2),
+  contract_date DATE,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_contract_number (contract_number),
+  INDEX idx_party_a (party_a),
+  INDEX idx_contract_amount (contract_amount),
+  INDEX idx_contract_date (contract_date),
+  FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
+);
+```
+
+---
+
+## 状态机（5个处理状态 + 2个终态 + 错误状态）
+
+```
+pending_ocr → handler-submit-ocr → ocr_submitted
+ocr_submitted → contract-v2-check-ocr → pending_filter
+pending_filter → contract-v2-text-filter → pending_extract
+pending_extract → contract-v2-llm-extract → pending_section
+pending_section → contract-v2-text-section → pending_review
+pending_review → (用户确认) → confirmed
+
+错误状态: ocr_failed, filter_failed, extract_failed, section_failed
+```
+
+> **设计原则**：每个 handler 直接读写扩展表，业务数据不经过 `record.data`（`mini_app_rows.data`）中转。
+> `record.data` 仅存小标记（`_ocr_done`, `_filter_done` 等）。
+
+---
+
+## Handler 分工
+
+| Handler | 类型 | 读 | 写 |
+|---------|------|----|----|
+| handler-submit-ocr | 共享 | record.data | MCP提交 |
+| contract-v2-check-ocr | v2专用 | MCP结果 | app_contract_v2_content.ocr_text |
+| contract-v2-text-filter | v2专用 | app_contract_v2_content.ocr_text | app_contract_v2_content.filtered_text |
+| contract-v2-llm-extract | v2专用 | app_contract_v2_content.filtered_text | app_contract_v2_rows + app_contract_v2_content |
+| contract-v2-text-section | v2专用 | app_contract_v2_content.filtered_text | app_contract_v2_content.sections |
+
+---
+
+## API 端点
+
+### 组织管理
+- `POST   /api/contract-v2/org-nodes` 创建节点
+- `GET    /api/contract-v2/org-nodes/tree` 获取完整树
+- `GET    /api/contract-v2/org-nodes/:id` 获取节点详情
+- `PUT    /api/contract-v2/org-nodes/:id` 更新节点
+- `DELETE /api/contract-v2/org-nodes/:id` 删除节点
+- `GET    /api/contract-v2/org-nodes/:id/stats` 节点统计
+
+### 合同管理
+- `POST   /api/contract-v2/contracts` 创建合同
+- `GET    /api/contract-v2/contracts` 合同列表（支持org_node_id过滤）
+- `GET    /api/contract-v2/contracts/:id` 合同详情（含版本列表）
+- `PUT    /api/contract-v2/contracts/:id` 更新合同
+- `DELETE /api/contract-v2/contracts/:id` 删除合同
+
+### 版本管理
+- `POST   /api/contract-v2/contracts/:id/versions` 上传新版本
+- `GET    /api/contract-v2/contracts/:id/versions` 版本列表
+- `PUT    /api/contract-v2/versions/:versionId` 更新版本
+- `PUT    /api/contract-v2/versions/:versionId/approve` 审批通过
+- `PUT    /api/contract-v2/versions/:versionId/current` 设为当前版本
+- `DELETE /api/contract-v2/versions/:versionId` 删除版本
+
+### Dashboard
+- `GET    /api/contract-v2/dashboard` Dashboard统计数据
+
+---
+
+## Phase 1 实施范围
+
+1. App 结构 + manifest.json（5个处理状态 + 2个终态 + 4个错误状态）
+2. 数据库迁移（5张表）
+3. 5个v2专用Handler（每个直接读写扩展表）
+4. 后端API路由（组织 + 合同 + 版本 + Dashboard，写操作 requireAdmin）
+5. 前端组件（组织树 + 合同列表 + 合同详情 + Dashboard）

--- a/frontend/src/api/contract-v2.ts
+++ b/frontend/src/api/contract-v2.ts
@@ -1,0 +1,164 @@
+import apiClient, { apiRequest } from './client'
+
+export interface OrgNode {
+  id: string
+  parent_id: string | null
+  node_type: 'group' | 'party' | 'project'
+  name: string
+  path: string
+  level: number
+  sort_order: number
+  is_active: boolean
+  children?: OrgNode[]
+  created_at: string
+  updated_at: string
+}
+
+export interface ContractMainRecord {
+  id: string
+  org_node_id: string
+  contract_name: string
+  contract_type: string | null
+  current_version_id: string | null
+  version_count: number
+  status: 'draft' | 'active' | 'expired' | 'terminated'
+  created_by: string
+  created_at: string
+  updated_at: string
+  versions?: ContractVersion[]
+}
+
+export interface ContractVersion {
+  id: string
+  contract_id: string
+  row_id: string
+  file_id: string | null
+  version_number: string
+  version_name: string | null
+  version_type: 'draft' | 'signed' | 'amendment' | 'supplement' | null
+  version_status: 'draft' | 'reviewing' | 'approved' | 'rejected' | 'archived'
+  effective_date: string | null
+  expiry_date: string | null
+  contract_number: string | null
+  party_a: string | null
+  party_b: string | null
+  total_amount: number | null
+  change_summary: string | null
+  is_current: boolean
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ContractListResult {
+  items: ContractMainRecord[]
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface DashboardData {
+  total_contracts: number
+  total_versions: number
+  total_nodes: number
+  by_status: Record<string, number>
+  by_type: Record<string, number>
+  recent_contracts: ContractMainRecord[]
+}
+
+export interface OrgNodeStats {
+  node_id: string
+  node_name: string
+  node_type: string
+  direct_contracts: number
+  total_contracts: number
+}
+
+export async function getOrgTree(): Promise<OrgNode[]> {
+  return apiRequest<OrgNode[]>(apiClient.get('/contract-v2/org-nodes/tree'))
+}
+
+export async function createOrgNode(data: { name: string; node_type: string; parent_id?: string }): Promise<OrgNode> {
+  return apiRequest<OrgNode>(apiClient.post('/contract-v2/org-nodes', data))
+}
+
+export async function updateOrgNode(nodeId: string, data: { name?: string; sort_order?: number }): Promise<OrgNode> {
+  return apiRequest<OrgNode>(apiClient.put(`/contract-v2/org-nodes/${nodeId}`, data))
+}
+
+export async function deleteOrgNode(nodeId: string): Promise<void> {
+  return apiRequest<void>(apiClient.delete(`/contract-v2/org-nodes/${nodeId}`))
+}
+
+export async function getOrgNodeStats(nodeId: string): Promise<OrgNodeStats> {
+  return apiRequest<OrgNodeStats>(apiClient.get(`/contract-v2/org-nodes/${nodeId}/stats`))
+}
+
+export async function listContracts(params?: {
+  org_node_id?: string
+  include_children?: boolean
+  contract_type?: string
+  status?: string
+  page?: number
+  page_size?: number
+}): Promise<ContractListResult> {
+  return apiRequest<ContractListResult>(apiClient.get('/contract-v2/contracts', { params }))
+}
+
+export async function getContract(contractId: string): Promise<ContractMainRecord> {
+  return apiRequest<ContractMainRecord>(apiClient.get(`/contract-v2/contracts/${contractId}`))
+}
+
+export async function createContract(data: {
+  org_node_id: string
+  contract_name: string
+  contract_type?: string
+}): Promise<ContractMainRecord> {
+  return apiRequest<ContractMainRecord>(apiClient.post('/contract-v2/contracts', data))
+}
+
+export async function updateContract(contractId: string, data: {
+  contract_name?: string
+  contract_type?: string
+  status?: string
+}): Promise<ContractMainRecord> {
+  return apiRequest<ContractMainRecord>(apiClient.put(`/contract-v2/contracts/${contractId}`, data))
+}
+
+export async function deleteContract(contractId: string): Promise<void> {
+  return apiRequest<void>(apiClient.delete(`/contract-v2/contracts/${contractId}`))
+}
+
+export async function createVersion(contractId: string, data: {
+  row_id: string
+  file_id?: string
+  version_number?: string
+  version_name?: string
+  version_type?: string
+}): Promise<ContractVersion> {
+  return apiRequest<ContractVersion>(apiClient.post(`/contract-v2/contracts/${contractId}/versions`, data))
+}
+
+export async function listVersions(contractId: string): Promise<ContractVersion[]> {
+  return apiRequest<ContractVersion[]>(apiClient.get(`/contract-v2/contracts/${contractId}/versions`))
+}
+
+export async function updateVersion(versionId: string, data: Record<string, any>): Promise<ContractVersion> {
+  return apiRequest<ContractVersion>(apiClient.put(`/contract-v2/versions/${versionId}`, data))
+}
+
+export async function approveVersion(versionId: string): Promise<ContractVersion> {
+  return apiRequest<ContractVersion>(apiClient.put(`/contract-v2/versions/${versionId}/approve`))
+}
+
+export async function setCurrentVersion(versionId: string): Promise<ContractVersion> {
+  return apiRequest<ContractVersion>(apiClient.put(`/contract-v2/versions/${versionId}/current`))
+}
+
+export async function deleteVersion(versionId: string): Promise<void> {
+  return apiRequest<void>(apiClient.delete(`/contract-v2/versions/${versionId}`))
+}
+
+export async function getDashboard(): Promise<DashboardData> {
+  return apiRequest<DashboardData>(apiClient.get('/contract-v2/dashboard'))
+}

--- a/frontend/src/components/contract-v2/ContractDetail.vue
+++ b/frontend/src/components/contract-v2/ContractDetail.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useContractV2Store } from '@/stores/contract-v2'
+
+const emit = defineEmits<{
+  back: []
+}>()
+
+const store = useContractV2Store()
+
+const contract = computed(() => store.currentContract)
+const versions = computed(() => store.currentContractVersions)
+
+const versionTypeLabels: Record<string, string> = {
+  draft: '草稿',
+  signed: '正式签署',
+  amendment: '补充协议',
+  supplement: '附件',
+}
+
+const versionStatusLabels: Record<string, { label: string; type: string }> = {
+  draft: { label: '草稿', type: 'info' },
+  reviewing: { label: '审核中', type: 'warning' },
+  approved: { label: '已审批', type: 'success' },
+  rejected: { label: '已驳回', type: 'danger' },
+  archived: { label: '已归档', type: '' },
+}
+
+const contractTypeLabels: Record<string, string> = {
+  strategy: '战略合同',
+  framework: '框架合同',
+  development: '开发合同',
+  supply: '供应合同',
+  purchase: '采购合同',
+  quality: '质量合同',
+  nda: '保密协议',
+  technical: '技术合同',
+  other: '其他',
+}
+
+async function handleSetCurrent(versionId: string) {
+  await store.setVersionCurrent(versionId)
+}
+
+async function handleApprove(versionId: string) {
+  await store.approveVersionAction(versionId)
+}
+
+async function handleDeleteVersion(versionId: string) {
+  try {
+    await ElMessageBox.confirm('确认删除此版本？', '确认', {
+      confirmButtonText: '删除',
+      cancelButtonText: '取消',
+      type: 'warning',
+    })
+    await store.removeVersion(versionId)
+  } catch {}
+}
+</script>
+
+<template>
+  <div class="contract-detail" v-if="contract">
+    <div class="contract-detail-header">
+      <el-button text @click="emit('back')">
+        <el-icon><ArrowLeft /></el-icon> 返回列表
+      </el-button>
+    </div>
+
+    <div class="contract-detail-info">
+      <h2 class="contract-detail-title">{{ contract.contract_name }}</h2>
+      <div class="contract-detail-meta">
+        <el-tag v-if="contract.contract_type">
+          {{ contractTypeLabels[contract.contract_type] || contract.contract_type }}
+        </el-tag>
+        <span class="contract-detail-versions">共 {{ versions.length }} 个版本</span>
+      </div>
+    </div>
+
+    <el-divider />
+
+    <div class="contract-detail-section">
+      <h3>版本历史</h3>
+      <el-table :data="versions" stripe>
+        <el-table-column prop="version_number" label="版本号" width="100" />
+        <el-table-column prop="version_name" label="版本名称" min-width="150">
+          <template #default="{ row }">
+            {{ row.version_name || '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="version_type" label="类型" width="100">
+          <template #default="{ row }">
+            {{ versionTypeLabels[row.version_type] || row.version_type || '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="version_status" label="状态" width="90" align="center">
+          <template #default="{ row }">
+            <el-tag size="small" :type="(versionStatusLabels[row.version_status]?.type as any) || 'info'" disable-transitions>
+              {{ versionStatusLabels[row.version_status]?.label || row.version_status }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="is_current" label="当前版本" width="80" align="center">
+          <template #default="{ row }">
+            <el-tag v-if="row.is_current" type="success" size="small" effect="dark">当前</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="contract_number" label="合同编号" width="130">
+          <template #default="{ row }">
+            {{ row.contract_number || '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column prop="party_a" label="甲方" width="130">
+          <template #default="{ row }">
+            {{ row.party_a || '-' }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="220" fixed="right">
+          <template #default="{ row }">
+            <el-button
+              v-if="!row.is_current"
+              size="small"
+              text
+              type="primary"
+              @click="handleSetCurrent(row.id)"
+            >设为当前</el-button>
+            <el-button
+              v-if="row.version_status === 'draft' || row.version_status === 'reviewing'"
+              size="small"
+              text
+              type="success"
+              @click="handleApprove(row.id)"
+            >审批</el-button>
+            <el-button
+              size="small"
+              text
+              type="danger"
+              @click="handleDeleteVersion(row.id)"
+            >删除</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.contract-detail {
+  max-width: 1200px;
+}
+
+.contract-detail-header {
+  margin-bottom: 12px;
+}
+
+.contract-detail-info {
+  margin-bottom: 8px;
+}
+
+.contract-detail-title {
+  margin: 0 0 8px 0;
+  font-size: 20px;
+}
+
+.contract-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.contract-detail-versions {
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+}
+
+.contract-detail-section {
+  margin-top: 16px;
+}
+
+.contract-detail-section h3 {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+}
+</style>

--- a/frontend/src/components/contract-v2/ContractList.vue
+++ b/frontend/src/components/contract-v2/ContractList.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { useContractV2Store } from '@/stores/contract-v2'
+import Pagination from '@/components/Pagination.vue'
+
+const emit = defineEmits<{
+  'click-contract': [contractId: string]
+}>()
+
+const store = useContractV2Store()
+
+const contractTypeLabels: Record<string, string> = {
+  strategy: '战略合同',
+  framework: '框架合同',
+  development: '开发合同',
+  supply: '供应合同',
+  purchase: '采购合同',
+  quality: '质量合同',
+  nda: '保密协议',
+  technical: '技术合同',
+  other: '其他',
+}
+
+const statusLabels: Record<string, { label: string; type: string }> = {
+  draft: { label: '草稿', type: 'info' },
+  active: { label: '生效', type: 'success' },
+  expired: { label: '过期', type: 'warning' },
+  terminated: { label: '终止', type: 'danger' },
+}
+
+function handlePageChange(page: number) {
+  store.loadContracts({
+    org_node_id: store.selectedNodeId || undefined,
+    include_children: true,
+    page,
+    page_size: store.contractsPageSize,
+  })
+}
+</script>
+
+<template>
+  <div class="contract-list">
+    <div class="contract-list-header">
+      <span class="contract-list-count">共 {{ store.contractsTotal }} 份合同</span>
+    </div>
+
+    <el-table
+      :data="store.contracts"
+      v-loading="store.contractsLoading"
+      stripe
+    >
+      <el-table-column prop="contract_name" label="合同名称" min-width="200">
+        <template #default="{ row }">
+          <span class="contract-name-link" @click="emit('click-contract', row.id)">{{ row.contract_name }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column prop="contract_type" label="类型" width="120">
+        <template #default="{ row }">
+          {{ contractTypeLabels[row.contract_type] || row.contract_type || '-' }}
+        </template>
+      </el-table-column>
+      <el-table-column prop="version_count" label="版本数" width="80" align="center" />
+      <el-table-column prop="status" label="状态" width="80" align="center">
+        <template #default="{ row }">
+          <el-tag size="small" :type="(statusLabels[row.status]?.type as any) || 'info'" disable-transitions>
+            {{ statusLabels[row.status]?.label || row.status }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="updated_at" label="更新时间" width="170">
+        <template #default="{ row }">
+          {{ row.updated_at?.slice(0, 16)?.replace('T', ' ') }}
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <div class="contract-list-pagination" v-if="store.contractsTotal > store.contractsPageSize">
+      <Pagination
+        :total="store.contractsTotal"
+        :page="store.contractsPage"
+        :page-size="store.contractsPageSize"
+        @current-change="handlePageChange"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.contract-list {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.contract-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.contract-list-count {
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+}
+
+.contract-name-link {
+  color: var(--el-color-primary);
+  cursor: pointer;
+}
+
+.contract-name-link:hover {
+  text-decoration: underline;
+}
+
+.contract-list-pagination {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
+}
+</style>

--- a/frontend/src/components/contract-v2/DashboardPanel.vue
+++ b/frontend/src/components/contract-v2/DashboardPanel.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useContractV2Store } from '@/stores/contract-v2'
+
+const store = useContractV2Store()
+
+const contractTypeLabels: Record<string, string> = {
+  strategy: '战略合同',
+  framework: '框架合同',
+  development: '开发合同',
+  supply: '供应合同',
+  purchase: '采购合同',
+  quality: '质量合同',
+  nda: '保密协议',
+  technical: '技术合同',
+  other: '其他',
+}
+
+onMounted(() => {
+  if (!store.dashboard) {
+    store.loadDashboard()
+  }
+})
+
+const statusTotal = computed(() => {
+  if (!store.dashboard) return 0
+  return Object.values(store.dashboard.by_status).reduce((sum: number, v) => sum + (v as number), 0)
+})
+
+const typeTotal = computed(() => {
+  if (!store.dashboard) return 0
+  return Object.values(store.dashboard.by_type).reduce((sum: number, v) => sum + (v as number), 0)
+})
+</script>
+
+<template>
+  <div class="dashboard-panel" v-loading="store.dashboardLoading">
+    <template v-if="store.dashboard">
+      <div class="dashboard-cards">
+        <el-card shadow="hover" class="dashboard-card">
+          <div class="dashboard-card-value">{{ store.dashboard.total_contracts }}</div>
+          <div class="dashboard-card-label">合同总数</div>
+        </el-card>
+        <el-card shadow="hover" class="dashboard-card">
+          <div class="dashboard-card-value">{{ store.dashboard.total_versions }}</div>
+          <div class="dashboard-card-label">版本总数</div>
+        </el-card>
+        <el-card shadow="hover" class="dashboard-card">
+          <div class="dashboard-card-value">{{ store.dashboard.total_nodes }}</div>
+          <div class="dashboard-card-label">组织节点</div>
+        </el-card>
+      </div>
+
+      <el-row :gutter="20" style="margin-top: 20px;">
+        <el-col :span="12">
+          <el-card shadow="hover">
+            <template #header>按状态分布</template>
+            <div class="dashboard-bar" v-for="(count, status) in store.dashboard.by_status" :key="status">
+              <span class="dashboard-bar-label">{{ status }}</span>
+              <el-progress :percentage="statusTotal ? Math.round((count as number) / statusTotal * 100) : 0" :stroke-width="16" :text-inside="true">
+                <span>{{ count }}</span>
+              </el-progress>
+            </div>
+          </el-card>
+        </el-col>
+        <el-col :span="12">
+          <el-card shadow="hover">
+            <template #header>按类型分布</template>
+            <div class="dashboard-bar" v-for="(count, type) in store.dashboard.by_type" :key="type">
+              <span class="dashboard-bar-label">{{ contractTypeLabels[type] || type }}</span>
+              <el-progress :percentage="typeTotal ? Math.round((count as number) / typeTotal * 100) : 0" :stroke-width="16" :text-inside="true">
+                <span>{{ count }}</span>
+              </el-progress>
+            </div>
+          </el-card>
+        </el-col>
+      </el-row>
+
+      <el-card shadow="hover" style="margin-top: 20px;">
+        <template #header>最近创建</template>
+        <el-table :data="store.dashboard.recent_contracts" stripe size="small">
+          <el-table-column prop="contract_name" label="合同名称" min-width="200" />
+          <el-table-column prop="contract_type" label="类型" width="120">
+            <template #default="{ row }">
+              {{ contractTypeLabels[row.contract_type] || row.contract_type || '-' }}
+            </template>
+          </el-table-column>
+          <el-table-column prop="status" label="状态" width="80" />
+          <el-table-column prop="created_at" label="创建时间" width="170">
+            <template #default="{ row }">
+              {{ row.created_at?.slice(0, 16)?.replace('T', ' ') }}
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-card>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.dashboard-cards {
+  display: flex;
+  gap: 16px;
+}
+
+.dashboard-card {
+  flex: 1;
+  text-align: center;
+}
+
+.dashboard-card-value {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--el-color-primary);
+}
+
+.dashboard-card-label {
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+  margin-top: 4px;
+}
+
+.dashboard-bar {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.dashboard-bar-label {
+  width: 80px;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.dashboard-bar .el-progress {
+  flex: 1;
+}
+</style>

--- a/frontend/src/components/contract-v2/OrgTree.vue
+++ b/frontend/src/components/contract-v2/OrgTree.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useContractV2Store } from '@/stores/contract-v2'
+import type { OrgNode } from '@/api/contract-v2'
+
+const store = useContractV2Store()
+
+const showAddDialog = ref(false)
+const addForm = ref<{ name: string; node_type: string; parent_id: string | null }>({
+  name: '',
+  node_type: 'group',
+  parent_id: null,
+})
+
+const nodeTypeLabels: Record<string, string> = {
+  group: '集团',
+  party: '甲方',
+  project: '项目',
+}
+
+function getTypeForLevel(parentId: string | null): string {
+  if (!parentId) return 'group'
+  const findNode = (nodes: OrgNode[]): OrgNode | undefined => {
+    for (const n of nodes) {
+      if (n.id === parentId) return n
+      if (n.children) {
+        const found = findNode(n.children)
+        if (found) return found
+      }
+    }
+    return undefined
+  }
+  const parent = findNode(store.tree)
+  if (!parent) return 'group'
+  if (parent.level === 1) return 'party'
+  if (parent.level === 2) return 'project'
+  return 'project'
+}
+
+function openAddDialog(parentId: string | null) {
+  const type = getTypeForLevel(parentId)
+  addForm.value = { name: '', node_type: type, parent_id: parentId }
+  showAddDialog.value = true
+}
+
+async function handleAddNode() {
+  if (!addForm.value.name.trim()) return
+  try {
+    await store.addNode(addForm.value)
+    showAddDialog.value = false
+  } catch {}
+}
+
+function handleNodeClick(nodeId: string) {
+  store.selectedNodeId = store.selectedNodeId === nodeId ? null : nodeId
+}
+
+async function handleDeleteNode(nodeId: string) {
+  try {
+    await ElMessageBox.confirm('删除节点将同时删除所有子节点和关联合同，确认删除？', '确认', {
+      confirmButtonText: '删除',
+      cancelButtonText: '取消',
+      type: 'warning',
+    })
+    await store.removeNode(nodeId)
+  } catch {}
+}
+
+const defaultProps = {
+  children: 'children',
+  label: 'name',
+}
+</script>
+
+<template>
+  <div class="org-tree-container">
+    <div class="org-tree-header">
+      <span class="org-tree-title">组织结构</span>
+      <el-button size="small" @click="openAddDialog(null)" text>
+        <el-icon><Plus /></el-icon>
+      </el-button>
+    </div>
+
+    <div v-if="store.treeLoading" class="org-tree-loading">
+      <el-skeleton :rows="5" animated />
+    </div>
+
+    <el-tree
+      v-else
+      :data="store.tree"
+      :props="defaultProps"
+      node-key="id"
+      highlight-current
+      :default-expand-all="true"
+      @node-click="(data: any) => handleNodeClick(data.id)"
+      :class="{ 'has-selection': store.selectedNodeId }"
+    >
+      <template #default="{ node, data }">
+        <div class="tree-node" :class="{ selected: data.id === store.selectedNodeId }">
+          <span class="tree-node-label">
+            <el-tag size="small" :type="data.node_type === 'group' ? '' : data.node_type === 'party' ? 'success' : 'warning'" disable-transitions>
+              {{ nodeTypeLabels[data.node_type] || data.node_type }}
+            </el-tag>
+            <span class="tree-node-name">{{ data.name }}</span>
+          </span>
+          <span class="tree-node-actions" @click.stop>
+            <el-button size="small" text @click="openAddDialog(data.id)" v-if="data.level < 3">
+              <el-icon><Plus /></el-icon>
+            </el-button>
+            <el-button size="small" text type="danger" @click="handleDeleteNode(data.id)">
+              <el-icon><Delete /></el-icon>
+            </el-button>
+          </span>
+        </div>
+      </template>
+    </el-tree>
+
+    <el-dialog v-model="showAddDialog" :title="'新建' + nodeTypeLabels[addForm.node_type]" width="400px">
+      <el-form label-width="80px">
+        <el-form-item label="名称">
+          <el-input v-model="addForm.name" placeholder="请输入名称" @keyup.enter="handleAddNode" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="showAddDialog = false">取消</el-button>
+        <el-button type="primary" @click="handleAddNode" :disabled="!addForm.name.trim()">确定</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped>
+.org-tree-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.org-tree-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--el-border-color-light);
+}
+
+.org-tree-title {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.org-tree-loading {
+  padding: 16px;
+}
+
+.el-tree {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.tree-node {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 2px 0;
+}
+
+.tree-node.selected .tree-node-name {
+  color: var(--el-color-primary);
+  font-weight: 600;
+}
+
+.tree-node-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tree-node-name {
+  font-size: 13px;
+}
+
+.tree-node-actions {
+  display: none;
+}
+
+.tree-node:hover .tree-node-actions {
+  display: flex;
+}
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -125,6 +125,11 @@ const router = createRouter({
           name: 'app-detail',
           component: () => import('@/views/AppDetailView.vue'),
         },
+        {
+          path: 'contract-v2',
+          name: 'contract-v2',
+          component: () => import('@/views/contract-v2/ContractV2View.vue'),
+        },
       ],
     },
     {

--- a/frontend/src/stores/contract-v2.ts
+++ b/frontend/src/stores/contract-v2.ts
@@ -1,0 +1,253 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import {
+  getOrgTree,
+  createOrgNode,
+  updateOrgNode,
+  deleteOrgNode,
+  listContracts,
+  getContract,
+  createContract,
+  updateContract,
+  deleteContract,
+  createVersion,
+  listVersions,
+  updateVersion,
+  approveVersion,
+  setCurrentVersion,
+  deleteVersion,
+  getDashboard,
+  type OrgNode,
+  type ContractMainRecord,
+  type ContractVersion,
+  type ContractListResult,
+  type DashboardData,
+} from '@/api/contract-v2'
+import { useToastStore } from './toast'
+
+export const useContractV2Store = defineStore('contract-v2', () => {
+  const toast = useToastStore()
+
+  const tree = ref<OrgNode[]>([])
+  const treeLoading = ref(false)
+  const selectedNodeId = ref<string | null>(null)
+
+  const contracts = ref<ContractMainRecord[]>([])
+  const contractsTotal = ref(0)
+  const contractsPage = ref(1)
+  const contractsPageSize = ref(20)
+  const contractsLoading = ref(false)
+
+  const currentContract = ref<ContractMainRecord | null>(null)
+  const currentContractVersions = ref<ContractVersion[]>([])
+
+  const dashboard = ref<DashboardData | null>(null)
+  const dashboardLoading = ref(false)
+
+  async function loadTree() {
+    treeLoading.value = true
+    try {
+      tree.value = await getOrgTree()
+    } catch (e: any) {
+      toast.error(e.message || '加载组织树失败')
+    } finally {
+      treeLoading.value = false
+    }
+  }
+
+  async function addNode(data: { name: string; node_type: string; parent_id?: string }) {
+    try {
+      const node = await createOrgNode(data)
+      await loadTree()
+      return node
+    } catch (e: any) {
+      toast.error(e.message || '创建节点失败')
+      throw e
+    }
+  }
+
+  async function editNode(nodeId: string, data: { name?: string; sort_order?: number }) {
+    try {
+      const node = await updateOrgNode(nodeId, data)
+      await loadTree()
+      return node
+    } catch (e: any) {
+      toast.error(e.message || '更新节点失败')
+      throw e
+    }
+  }
+
+  async function removeNode(nodeId: string) {
+    try {
+      await deleteOrgNode(nodeId)
+      if (selectedNodeId.value === nodeId) {
+        selectedNodeId.value = null
+      }
+      await loadTree()
+      toast.success('删除成功')
+    } catch (e: any) {
+      toast.error(e.message || '删除节点失败')
+    }
+  }
+
+  async function loadContracts(params?: {
+    org_node_id?: string
+    include_children?: boolean
+    contract_type?: string
+    status?: string
+    page?: number
+    page_size?: number
+  }) {
+    contractsLoading.value = true
+    try {
+      const result: ContractListResult = await listContracts(params)
+      contracts.value = result.items
+      contractsTotal.value = result.total
+      contractsPage.value = result.page
+      contractsPageSize.value = result.page_size
+    } catch (e: any) {
+      toast.error(e.message || '加载合同列表失败')
+    } finally {
+      contractsLoading.value = false
+    }
+  }
+
+  async function loadContractDetail(contractId: string) {
+    try {
+      const contract = await getContract(contractId)
+      currentContract.value = contract
+      currentContractVersions.value = contract.versions || []
+    } catch (e: any) {
+      toast.error(e.message || '加载合同详情失败')
+    }
+  }
+
+  async function addContract(data: { org_node_id: string; contract_name: string; contract_type?: string }) {
+    try {
+      const contract = await createContract(data)
+      toast.success('创建成功')
+      await loadContracts({
+        org_node_id: selectedNodeId.value || undefined,
+        page: contractsPage.value,
+        page_size: contractsPageSize.value,
+      })
+      return contract
+    } catch (e: any) {
+      toast.error(e.message || '创建合同失败')
+      throw e
+    }
+  }
+
+  async function editContract(contractId: string, data: Record<string, any>) {
+    try {
+      const contract = await updateContract(contractId, data)
+      toast.success('更新成功')
+      return contract
+    } catch (e: any) {
+      toast.error(e.message || '更新合同失败')
+      throw e
+    }
+  }
+
+  async function removeContract(contractId: string) {
+    try {
+      await deleteContract(contractId)
+      toast.success('删除成功')
+      await loadContracts({
+        org_node_id: selectedNodeId.value || undefined,
+        page: contractsPage.value,
+        page_size: contractsPageSize.value,
+      })
+    } catch (e: any) {
+      toast.error(e.message || '删除合同失败')
+    }
+  }
+
+  async function addVersion(contractId: string, data: { row_id: string; file_id?: string; version_number?: string; version_name?: string; version_type?: string }) {
+    try {
+      const version = await createVersion(contractId, data)
+      toast.success('版本创建成功')
+      await loadContractDetail(contractId)
+      return version
+    } catch (e: any) {
+      toast.error(e.message || '创建版本失败')
+      throw e
+    }
+  }
+
+  async function setVersionCurrent(versionId: string) {
+    try {
+      await setCurrentVersion(versionId)
+      toast.success('已设为当前版本')
+      if (currentContract.value) {
+        await loadContractDetail(currentContract.value.id)
+      }
+    } catch (e: any) {
+      toast.error(e.message || '设置失败')
+    }
+  }
+
+  async function approveVersionAction(versionId: string) {
+    try {
+      await approveVersion(versionId)
+      toast.success('审批通过')
+      if (currentContract.value) {
+        await loadContractDetail(currentContract.value.id)
+      }
+    } catch (e: any) {
+      toast.error(e.message || '审批失败')
+    }
+  }
+
+  async function removeVersion(versionId: string) {
+    try {
+      await deleteVersion(versionId)
+      toast.success('版本已删除')
+      if (currentContract.value) {
+        await loadContractDetail(currentContract.value.id)
+      }
+    } catch (e: any) {
+      toast.error(e.message || '删除版本失败')
+    }
+  }
+
+  async function loadDashboard() {
+    dashboardLoading.value = true
+    try {
+      dashboard.value = await getDashboard()
+    } catch (e: any) {
+      toast.error(e.message || '加载Dashboard失败')
+    } finally {
+      dashboardLoading.value = false
+    }
+  }
+
+  return {
+    tree,
+    treeLoading,
+    selectedNodeId,
+    contracts,
+    contractsTotal,
+    contractsPage,
+    contractsPageSize,
+    contractsLoading,
+    currentContract,
+    currentContractVersions,
+    dashboard,
+    dashboardLoading,
+    loadTree,
+    addNode,
+    editNode,
+    removeNode,
+    loadContracts,
+    loadContractDetail,
+    addContract,
+    editContract,
+    removeContract,
+    addVersion,
+    setVersionCurrent,
+    approveVersionAction,
+    removeVersion,
+    loadDashboard,
+  }
+})

--- a/frontend/src/views/contract-v2/ContractV2View.vue
+++ b/frontend/src/views/contract-v2/ContractV2View.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+import { useContractV2Store } from '@/stores/contract-v2'
+import OrgTree from '@/components/contract-v2/OrgTree.vue'
+import ContractList from '@/components/contract-v2/ContractList.vue'
+import ContractDetail from '@/components/contract-v2/ContractDetail.vue'
+import DashboardPanel from '@/components/contract-v2/DashboardPanel.vue'
+
+const store = useContractV2Store()
+const activeTab = ref('list')
+const showDetail = ref(false)
+
+onMounted(async () => {
+  await Promise.all([
+    store.loadTree(),
+    store.loadDashboard(),
+  ])
+  await store.loadContracts({ page: 1 })
+})
+
+watch(() => store.selectedNodeId, (nodeId) => {
+  store.loadContracts({
+    org_node_id: nodeId || undefined,
+    include_children: true,
+    page: 1,
+  })
+  showDetail.value = false
+}, { immediate: false })
+
+function onContractClick(contractId: string) {
+  store.loadContractDetail(contractId)
+  showDetail.value = true
+}
+
+function onBackToList() {
+  showDetail.value = false
+}
+</script>
+
+<template>
+  <div class="contract-v2-page">
+    <div class="cv2-sidebar">
+      <OrgTree />
+    </div>
+    <div class="cv2-main">
+      <div v-if="!showDetail" class="cv2-list-view">
+        <el-tabs v-model="activeTab" class="cv2-tabs">
+          <el-tab-pane label="合同列表" name="list">
+            <ContractList
+              @click-contract="onContractClick"
+            />
+          </el-tab-pane>
+          <el-tab-pane label="统计概览" name="dashboard">
+            <DashboardPanel />
+          </el-tab-pane>
+        </el-tabs>
+      </div>
+      <div v-else class="cv2-detail-view">
+        <ContractDetail
+          @back="onBackToList"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.contract-v2-page {
+  display: flex;
+  height: calc(100vh - 60px);
+  overflow: hidden;
+}
+
+.cv2-sidebar {
+  width: 280px;
+  min-width: 280px;
+  border-right: 1px solid var(--el-border-color-light);
+  overflow-y: auto;
+  background: var(--el-bg-color);
+}
+
+.cv2-main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.cv2-tabs {
+  height: 100%;
+}
+
+.cv2-tabs :deep(.el-tabs__content) {
+  height: calc(100% - 50px);
+  overflow-y: auto;
+}
+
+.cv2-tabs :deep(.el-tab-pane) {
+  height: 100%;
+}
+</style>

--- a/server/controllers/contract-v2.controller.js
+++ b/server/controllers/contract-v2.controller.js
@@ -1,0 +1,219 @@
+import logger from '../../lib/logger.js';
+import ContractV2Service from '../services/contract-v2.service.js';
+
+class ContractV2Controller {
+  constructor(db) {
+    this.db = db;
+    this.contractV2Service = new ContractV2Service(db);
+  }
+
+  async getTree(ctx) {
+    try {
+      const tree = await this.contractV2Service.getTree();
+      ctx.success(tree);
+    } catch (error) {
+      logger.error('[ContractV2] getTree error:', error.message);
+      ctx.error(error.message, 500);
+    }
+  }
+
+  async createNode(ctx) {
+    try {
+      const data = ctx.request.body;
+      if (!data.name || !data.node_type) {
+        return ctx.error('name 和 node_type 必填', 400);
+      }
+      const node = await this.contractV2Service.createNode(data);
+      ctx.success(node);
+    } catch (error) {
+      logger.error('[ContractV2] createNode error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async updateNode(ctx) {
+    try {
+      const { nodeId } = ctx.params;
+      const data = ctx.request.body;
+      const node = await this.contractV2Service.updateNode(nodeId, data);
+      ctx.success(node);
+    } catch (error) {
+      logger.error('[ContractV2] updateNode error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async deleteNode(ctx) {
+    try {
+      const { nodeId } = ctx.params;
+      await this.contractV2Service.deleteNode(nodeId);
+      ctx.success(null, '删除成功');
+    } catch (error) {
+      logger.error('[ContractV2] deleteNode error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async getNodeStats(ctx) {
+    try {
+      const { nodeId } = ctx.params;
+      const stats = await this.contractV2Service.getNodeStats(nodeId);
+      ctx.success(stats);
+    } catch (error) {
+      logger.error('[ContractV2] getNodeStats error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async listContracts(ctx) {
+    try {
+      const filters = {
+        org_node_id: ctx.query.org_node_id,
+        include_children: ctx.query.include_children === 'true',
+        contract_type: ctx.query.contract_type,
+        status: ctx.query.status,
+        page: parseInt(ctx.query.page) || 1,
+        page_size: parseInt(ctx.query.page_size) || 20,
+      };
+      const result = await this.contractV2Service.listContracts(filters);
+      ctx.success(result);
+    } catch (error) {
+      logger.error('[ContractV2] listContracts error:', error.message);
+      ctx.error(error.message, 500);
+    }
+  }
+
+  async getContract(ctx) {
+    try {
+      const { contractId } = ctx.params;
+      const contract = await this.contractV2Service.getContract(contractId);
+      ctx.success(contract);
+    } catch (error) {
+      logger.error('[ContractV2] getContract error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async createContract(ctx) {
+    try {
+      const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+      if (!data.org_node_id || !data.contract_name) {
+        return ctx.error('org_node_id 和 contract_name 必填', 400);
+      }
+      const contract = await this.contractV2Service.createContract(data, userId);
+      ctx.success(contract);
+    } catch (error) {
+      logger.error('[ContractV2] createContract error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async updateContract(ctx) {
+    try {
+      const { contractId } = ctx.params;
+      const data = ctx.request.body;
+      const contract = await this.contractV2Service.updateContract(contractId, data);
+      ctx.success(contract);
+    } catch (error) {
+      logger.error('[ContractV2] updateContract error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async deleteContract(ctx) {
+    try {
+      const { contractId } = ctx.params;
+      await this.contractV2Service.deleteContract(contractId);
+      ctx.success(null, '删除成功');
+    } catch (error) {
+      logger.error('[ContractV2] deleteContract error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async createVersion(ctx) {
+    try {
+      const { contractId } = ctx.params;
+      const data = ctx.request.body;
+      const userId = ctx.state.session.id;
+      if (!data.row_id) {
+        return ctx.error('row_id 必填', 400);
+      }
+      const version = await this.contractV2Service.createVersion(contractId, data, userId);
+      ctx.success(version);
+    } catch (error) {
+      logger.error('[ContractV2] createVersion error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async listVersions(ctx) {
+    try {
+      const { contractId } = ctx.params;
+      const versions = await this.contractV2Service.listVersions(contractId);
+      ctx.success(versions);
+    } catch (error) {
+      logger.error('[ContractV2] listVersions error:', error.message);
+      ctx.error(error.message, 500);
+    }
+  }
+
+  async updateVersion(ctx) {
+    try {
+      const { versionId } = ctx.params;
+      const data = ctx.request.body;
+      const version = await this.contractV2Service.updateVersion(versionId, data);
+      ctx.success(version);
+    } catch (error) {
+      logger.error('[ContractV2] updateVersion error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async approveVersion(ctx) {
+    try {
+      const { versionId } = ctx.params;
+      const version = await this.contractV2Service.approveVersion(versionId);
+      ctx.success(version);
+    } catch (error) {
+      logger.error('[ContractV2] approveVersion error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async setCurrentVersion(ctx) {
+    try {
+      const { versionId } = ctx.params;
+      const version = await this.contractV2Service.setCurrentVersion(versionId);
+      ctx.success(version);
+    } catch (error) {
+      logger.error('[ContractV2] setCurrentVersion error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async deleteVersion(ctx) {
+    try {
+      const { versionId } = ctx.params;
+      await this.contractV2Service.deleteVersion(versionId);
+      ctx.success(null, '删除成功');
+    } catch (error) {
+      logger.error('[ContractV2] deleteVersion error:', error.message);
+      ctx.error(error.message, 400);
+    }
+  }
+
+  async getDashboard(ctx) {
+    try {
+      const userId = ctx.state.session.id;
+      const dashboard = await this.contractV2Service.getDashboard(userId);
+      ctx.success(dashboard);
+    } catch (error) {
+      logger.error('[ContractV2] getDashboard error:', error.message);
+      ctx.error(error.message, 500);
+    }
+  }
+}
+
+export default ContractV2Controller;

--- a/server/index.js
+++ b/server/index.js
@@ -70,6 +70,7 @@ import AssistantController from './controllers/assistant.controller.js';
 import AttachmentController from './controllers/attachment.controller.js';
 import MiniAppController from './controllers/mini-app.controller.js';
 import AppMarketController from './controllers/app-market.controller.js';
+import ContractV2Controller from './controllers/contract-v2.controller.js';
 import { getAssistantManager } from './services/assistant/index.js';
 
 // 路由
@@ -102,6 +103,7 @@ import miniAppRoutes from './routes/mini-app.routes.js';
 import appMarketRoutes from './routes/app-market.routes.js';
 import { createInvitationRoutes } from './routes/invitation.routes.js';
 import createMcpRoutes from './routes/mcp.routes.js';
+import contractV2Routes from './routes/contract-v2.routes.js';
 import TokenCleanupJob from './jobs/token-cleanup.js';
 
 class ApiServer {
@@ -267,6 +269,7 @@ class ApiServer {
       attachment: new AttachmentController(this.db),
       miniApp: new MiniAppController(this.db),
       appMarket: new AppMarketController(this.db),
+      contractV2: new ContractV2Controller(this.db),
     };
   }
 
@@ -481,6 +484,12 @@ class ApiServer {
     this.app.use(mcpRouter.routes());
     this.app.use(mcpRouter.allowedMethods());
     logger.info('MCP routes registered (GET/POST /api/mcp/*)');
+
+    // Contract V2 合同管理v2路由
+    const contractV2Router = contractV2Routes(this.controllers.contractV2);
+    this.app.use(contractV2Router.routes());
+    this.app.use(contractV2Router.allowedMethods());
+    logger.info('Contract V2 routes registered (/api/contract-v2/*)');
 
     // 前端静态文件服务（生产环境）
     // 检查前端构建目录是否存在

--- a/server/routes/contract-v2.routes.js
+++ b/server/routes/contract-v2.routes.js
@@ -1,0 +1,29 @@
+import Router from '@koa/router';
+import { authenticate, requireAdmin } from '../middlewares/auth.js';
+
+export default (controller) => {
+  const router = new Router();
+
+  router.get('/api/contract-v2/org-nodes/tree', authenticate(), (ctx) => controller.getTree(ctx));
+  router.post('/api/contract-v2/org-nodes', authenticate(), requireAdmin(), (ctx) => controller.createNode(ctx));
+  router.put('/api/contract-v2/org-nodes/:nodeId', authenticate(), requireAdmin(), (ctx) => controller.updateNode(ctx));
+  router.delete('/api/contract-v2/org-nodes/:nodeId', authenticate(), requireAdmin(), (ctx) => controller.deleteNode(ctx));
+  router.get('/api/contract-v2/org-nodes/:nodeId/stats', authenticate(), (ctx) => controller.getNodeStats(ctx));
+
+  router.get('/api/contract-v2/contracts', authenticate(), (ctx) => controller.listContracts(ctx));
+  router.post('/api/contract-v2/contracts', authenticate(), requireAdmin(), (ctx) => controller.createContract(ctx));
+  router.get('/api/contract-v2/contracts/:contractId', authenticate(), (ctx) => controller.getContract(ctx));
+  router.put('/api/contract-v2/contracts/:contractId', authenticate(), requireAdmin(), (ctx) => controller.updateContract(ctx));
+  router.delete('/api/contract-v2/contracts/:contractId', authenticate(), requireAdmin(), (ctx) => controller.deleteContract(ctx));
+
+  router.post('/api/contract-v2/contracts/:contractId/versions', authenticate(), (ctx) => controller.createVersion(ctx));
+  router.get('/api/contract-v2/contracts/:contractId/versions', authenticate(), (ctx) => controller.listVersions(ctx));
+  router.put('/api/contract-v2/versions/:versionId', authenticate(), (ctx) => controller.updateVersion(ctx));
+  router.put('/api/contract-v2/versions/:versionId/approve', authenticate(), requireAdmin(), (ctx) => controller.approveVersion(ctx));
+  router.put('/api/contract-v2/versions/:versionId/current', authenticate(), (ctx) => controller.setCurrentVersion(ctx));
+  router.delete('/api/contract-v2/versions/:versionId', authenticate(), requireAdmin(), (ctx) => controller.deleteVersion(ctx));
+
+  router.get('/api/contract-v2/dashboard', authenticate(), (ctx) => controller.getDashboard(ctx));
+
+  return router;
+};

--- a/server/services/contract-v2.service.js
+++ b/server/services/contract-v2.service.js
@@ -1,0 +1,428 @@
+import logger from '../../lib/logger.js';
+import Utils from '../../lib/utils.js';
+import { Op } from 'sequelize';
+
+const VALID_NODE_TYPES = ['group', 'party', 'project'];
+
+class ContractV2Service {
+  constructor(db) {
+    this.db = db;
+    this.models = {};
+  }
+
+  ensureModels() {
+    if (this.models.OrgNode) return;
+
+    this.models.OrgNode = this.db.getModel('contract_v2_org_node');
+    this.models.MainRecord = this.db.getModel('contract_v2_main_record');
+    this.models.Version = this.db.getModel('contract_v2_version');
+  }
+
+  async getTree() {
+    this.ensureModels();
+    const nodes = await this.models.OrgNode.findAll({
+      where: { is_active: 1 },
+      order: [['level', 'ASC'], ['sort_order', 'ASC'], ['created_at', 'ASC']],
+      raw: true,
+    });
+
+    return this.buildTree(nodes);
+  }
+
+  buildTree(nodes) {
+    const map = {};
+    const roots = [];
+
+    for (const node of nodes) {
+      node.children = [];
+      map[node.id] = node;
+    }
+
+    for (const node of nodes) {
+      if (node.parent_id && map[node.parent_id]) {
+        map[node.parent_id].children.push(node);
+      } else {
+        roots.push(node);
+      }
+    }
+
+    return roots;
+  }
+
+  async createNode(data) {
+    this.ensureModels();
+
+    let path = '';
+    let level = 1;
+
+    if (data.parent_id) {
+      const parent = await this.models.OrgNode.findByPk(data.parent_id);
+      if (!parent) throw new Error('父节点不存在');
+      path = parent.path + '/' + parent.id;
+      level = parent.level + 1;
+    }
+
+    if (level > 3) throw new Error('最多支持3层节点');
+
+    const nodeType = data.node_type;
+    if (!VALID_NODE_TYPES.includes(nodeType)) throw new Error(`node_type 必须是 ${VALID_NODE_TYPES.join('/')}`);
+    if (level === 1 && nodeType !== 'group') throw new Error('第1层只能是集团(group)');
+    if (level === 2 && nodeType !== 'party') throw new Error('第2层只能是甲方(party)');
+    if (level === 3 && nodeType !== 'project') throw new Error('第3层只能是项目(project)');
+
+    const siblings = await this.models.OrgNode.count({
+      where: { parent_id: data.parent_id || null },
+    });
+
+    const node = await this.models.OrgNode.create({
+      id: Utils.newID(20),
+      parent_id: data.parent_id || null,
+      node_type: nodeType,
+      name: data.name,
+      path,
+      level,
+      sort_order: data.sort_order || siblings,
+      is_active: 1,
+    });
+
+    return node.toJSON();
+  }
+
+  async updateNode(nodeId, data) {
+    this.ensureModels();
+    const node = await this.models.OrgNode.findByPk(nodeId);
+    if (!node) throw new Error('节点不存在');
+
+    const updates = {};
+    if (data.name !== undefined) updates.name = data.name;
+    if (data.sort_order !== undefined) updates.sort_order = data.sort_order;
+
+    await node.update(updates);
+    return node.toJSON();
+  }
+
+  async deleteNode(nodeId) {
+    this.ensureModels();
+    const node = await this.models.OrgNode.findByPk(nodeId);
+    if (!node) throw new Error('节点不存在');
+
+    await node.destroy();
+  }
+
+  async getNodeStats(nodeId) {
+    this.ensureModels();
+    const node = await this.models.OrgNode.findByPk(nodeId);
+    if (!node) throw new Error('节点不存在');
+
+    const directContracts = await this.models.MainRecord.count({
+      where: { org_node_id: nodeId },
+    });
+
+    const descendantIds = await this.getDescendantIds(nodeId);
+    const totalContracts = await this.models.MainRecord.count({
+      where: { org_node_id: descendantIds },
+    });
+
+    return {
+      node_id: nodeId,
+      node_name: node.name,
+      node_type: node.node_type,
+      direct_contracts: directContracts,
+      total_contracts: totalContracts,
+    };
+  }
+
+  async getDescendantIds(nodeId) {
+    this.ensureModels();
+    const node = await this.models.OrgNode.findByPk(nodeId);
+    if (!node) return [nodeId];
+
+    const prefix = (node.path || '') + '/' + node.id;
+    const escaped = prefix.replace(/[%_]/g, '\\$&');
+    const descendants = await this.models.OrgNode.findAll({
+      where: { path: { [Op.like]: escaped + '%' } },
+      attributes: ['id'],
+      raw: true,
+    });
+
+    return [nodeId, ...descendants.map(d => d.id)];
+  }
+
+  async listContracts(filters = {}) {
+    this.ensureModels();
+    const where = {};
+
+    if (filters.org_node_id) {
+      if (filters.include_children) {
+        const ids = await this.getDescendantIds(filters.org_node_id);
+        where.org_node_id = { [Op.in]: ids };
+      } else {
+        where.org_node_id = filters.org_node_id;
+      }
+    }
+
+    if (filters.contract_type) where.contract_type = filters.contract_type;
+    if (filters.status) where.status = filters.status;
+
+    const offset = ((filters.page || 1) - 1) * (filters.page_size || 20);
+
+    const result = await this.models.MainRecord.findAndCountAll({
+      where,
+      order: [['updated_at', 'DESC']],
+      limit: filters.page_size || 20,
+      offset,
+      raw: true,
+    });
+
+    return {
+      items: result.rows,
+      total: result.count,
+      page: filters.page || 1,
+      page_size: filters.page_size || 20,
+    };
+  }
+
+  async createContract(data, userId) {
+    this.ensureModels();
+
+    const node = await this.models.OrgNode.findByPk(data.org_node_id);
+    if (!node) throw new Error('组织节点不存在');
+
+    const contract = await this.models.MainRecord.create({
+      id: Utils.newID(20),
+      org_node_id: data.org_node_id,
+      contract_name: data.contract_name,
+      contract_type: data.contract_type || null,
+      current_version_id: null,
+      version_count: 0,
+      status: 'draft',
+      created_by: userId,
+    });
+
+    return contract.toJSON();
+  }
+
+  async getContract(contractId) {
+    this.ensureModels();
+    const contract = await this.models.MainRecord.findByPk(contractId, { raw: true });
+    if (!contract) throw new Error('合同不存在');
+
+    const versions = await this.models.Version.findAll({
+      where: { contract_id: contractId },
+      order: [['created_at', 'DESC']],
+      raw: true,
+    });
+
+    return { ...contract, versions };
+  }
+
+  async updateContract(contractId, data) {
+    this.ensureModels();
+    const contract = await this.models.MainRecord.findByPk(contractId);
+    if (!contract) throw new Error('合同不存在');
+
+    const updates = {};
+    if (data.contract_name !== undefined) updates.contract_name = data.contract_name;
+    if (data.contract_type !== undefined) updates.contract_type = data.contract_type;
+    if (data.status !== undefined) updates.status = data.status;
+
+    await contract.update(updates);
+    return contract.toJSON();
+  }
+
+  async deleteContract(contractId) {
+    this.ensureModels();
+    const contract = await this.models.MainRecord.findByPk(contractId);
+    if (!contract) throw new Error('合同不存在');
+
+    await contract.destroy();
+  }
+
+  async createVersion(contractId, data, userId) {
+    this.ensureModels();
+
+    const t = await this.db.sequelize.transaction();
+    try {
+      const contract = await this.models.MainRecord.findByPk(contractId, { transaction: t, lock: true });
+      if (!contract) throw new Error('合同不存在');
+
+      const existingCount = contract.version_count || 0;
+      const versionNumber = data.version_number || `v${existingCount + 1}.0`;
+
+      const existing = await this.models.Version.findOne({
+        where: { contract_id: contractId, version_number: versionNumber },
+        transaction: t,
+      });
+      if (existing) throw new Error(`版本号 ${versionNumber} 已存在`);
+
+      const isFirst = existingCount === 0;
+      const version = await this.models.Version.create({
+        id: Utils.newID(20),
+        contract_id: contractId,
+        row_id: data.row_id,
+        file_id: data.file_id || null,
+        version_number: versionNumber,
+        version_name: data.version_name || null,
+        version_type: data.version_type || 'draft',
+        version_status: 'draft',
+        is_current: isFirst ? 1 : 0,
+        created_by: userId,
+      }, { transaction: t });
+
+      await contract.update({
+        version_count: existingCount + 1,
+        current_version_id: isFirst ? version.id : contract.current_version_id,
+        status: 'active',
+      }, { transaction: t });
+
+      await t.commit();
+      return version.toJSON();
+    } catch (e) {
+      await t.rollback();
+      throw e;
+    }
+  }
+
+  async listVersions(contractId) {
+    this.ensureModels();
+    return await this.models.Version.findAll({
+      where: { contract_id: contractId },
+      order: [['created_at', 'DESC']],
+      raw: true,
+    });
+  }
+
+  async updateVersion(versionId, data) {
+    this.ensureModels();
+    const version = await this.models.Version.findByPk(versionId);
+    if (!version) throw new Error('版本不存在');
+
+    const updates = {};
+    const allowedFields = ['version_name', 'version_type', 'version_status', 'effective_date',
+      'expiry_date', 'contract_number', 'party_a', 'party_b', 'total_amount', 'change_summary'];
+
+    for (const field of allowedFields) {
+      if (data[field] !== undefined) updates[field] = data[field];
+    }
+
+    await version.update(updates);
+    return version.toJSON();
+  }
+
+  async setCurrentVersion(versionId) {
+    this.ensureModels();
+    const version = await this.models.Version.findByPk(versionId);
+    if (!version) throw new Error('版本不存在');
+
+    const t = await this.db.sequelize.transaction();
+    try {
+      await this.models.Version.update(
+        { is_current: 0 },
+        { where: { contract_id: version.contract_id }, transaction: t }
+      );
+
+      await this.models.Version.update(
+        { is_current: 1 },
+        { where: { id: versionId }, transaction: t }
+      );
+
+      await this.models.MainRecord.update(
+        { current_version_id: versionId },
+        { where: { id: version.contract_id }, transaction: t }
+      );
+
+      await t.commit();
+    } catch (e) {
+      await t.rollback();
+      throw e;
+    }
+
+    return (await this.models.Version.findByPk(versionId)).toJSON();
+  }
+
+  async approveVersion(versionId) {
+    this.ensureModels();
+    const version = await this.models.Version.findByPk(versionId);
+    if (!version) throw new Error('版本不存在');
+
+    await version.update({ version_status: 'approved' });
+    return version.toJSON();
+  }
+
+  async deleteVersion(versionId) {
+    this.ensureModels();
+    const version = await this.models.Version.findByPk(versionId);
+    if (!version) throw new Error('版本不存在');
+
+    const contractId = version.contract_id;
+    const isCurrent = version.is_current;
+
+    const t = await this.db.sequelize.transaction();
+    try {
+      await version.destroy({ transaction: t });
+
+      const contract = await this.models.MainRecord.findByPk(contractId, { transaction: t });
+      if (contract) {
+        const newCount = Math.max(0, (contract.version_count || 1) - 1);
+
+        if (isCurrent) {
+          const latest = await this.models.Version.findOne({
+            where: { contract_id: contractId },
+            order: [['created_at', 'DESC']],
+            transaction: t,
+          });
+          await contract.update({
+            version_count: newCount,
+            current_version_id: latest ? latest.id : null,
+          }, { transaction: t });
+        } else {
+          await contract.update({ version_count: newCount }, { transaction: t });
+        }
+      }
+
+      await t.commit();
+    } catch (e) {
+      await t.rollback();
+      throw e;
+    }
+  }
+
+  async getDashboard(userId) {
+    this.ensureModels();
+
+    const totalContracts = await this.models.MainRecord.count();
+
+    const totalVersions = await this.models.Version.count();
+
+    const totalNodes = await this.models.OrgNode.count({ where: { is_active: 1 } });
+
+    const byStatus = await this.models.MainRecord.findAll({
+      attributes: ['status', [this.db.sequelize.fn('COUNT', '*'), 'count']],
+      group: ['status'],
+      raw: true,
+    });
+
+    const byType = await this.models.MainRecord.findAll({
+      attributes: ['contract_type', [this.db.sequelize.fn('COUNT', '*'), 'count']],
+      group: ['contract_type'],
+      raw: true,
+    });
+
+    const recentContracts = await this.models.MainRecord.findAll({
+      order: [['created_at', 'DESC']],
+      limit: 5,
+      raw: true,
+    });
+
+    return {
+      total_contracts: totalContracts,
+      total_versions: totalVersions,
+      total_nodes: totalNodes,
+      by_status: byStatus.reduce((acc, r) => { acc[r.status] = r.count; return acc; }, {}),
+      by_type: byType.reduce((acc, r) => { acc[r.contract_type || 'unknown'] = r.count; return acc; }, {}),
+      recent_contracts: recentContracts,
+    };
+  }
+}
+
+export default ContractV2Service;


### PR DESCRIPTION
﻿## Summary

- 实现合同管理 v2 全栈功能（Phase 1 + Phase 2 + Phase 3）
- 新增独立页面路由 \/contract-v2\，不依赖 GenericMiniApp 通用渲染器

## 变更内容

### App 结构
- \pps/contract-mgr-v2/\ 目录：manifest.json + migrations + 4 个专用 handler
- 状态机：5 个处理状态 → pending_review → confirmed（精简版，无冗余 persist 层）
- 设计原则：每个 handler 直接读写扩展表，业务数据不经过 \mini_app_rows.data\ 中转

### 数据库（5 张表）
- \contract_v2_org_nodes\ — 组织树（三层：集团→甲方→项目）
- \contract_v2_main_records\ — 合同主记录
- \contract_v2_versions\ — 合同版本（关联 mini_app_rows）
- \pp_contract_v2_content\ — 内容扩展表（OCR 文本、过滤文本、章节、提取 JSON）
- \pp_contract_v2_rows\ — 元数据扩展表（合同编号、甲方、金额、日期）

### 后端 API（17 个端点）
- 组织管理：CRUD + tree + stats（写操作 requireAdmin）
- 合同管理：CRUD + 列表过滤（支持 include_children）
- 版本管理：创建/更新/审批/设为当前/删除（事务保护）
- Dashboard：全局统计

### 前端组件（7 个新文件）
- \ContractV2View.vue\ — 主页面（左侧组织树 + 右侧列表/详情布局）
- \OrgTree.vue\ — 组织树（CRUD + 层级约束验证）
- \ContractList.vue\ — 合同列表（分页 + 类型/状态标签）
- \ContractDetail.vue\ — 合同详情（版本列表 + 审批/设为当前/删除）
- \DashboardPanel.vue\ — 统计概览（卡片 + 状态/类型分布 + 最近创建）
- API 层 + Pinia store

### 代码审计
- 后端审计通过 2 轮，修复：事务保护、LIKE 注入、权限控制、node_type 校验
- 前端审计通过 2 轮，修复：对话框关闭、死代码清理、点击区域、百分比溢出

## 设计文档
- \docs/design/contract-v2-final-spec.md\ — 最终设计规格（统一所有决策）

Closes #665
