### PR TITLE
fix: extension table 命名前缀修正

### DIFF
--- a/apps/contract-mgr-v2/README.md
+++ b/apps/contract-mgr-v2/README.md
@@ -21,10 +21,10 @@ pending_ocr → ocr_submitted → pending_filter → pending_extract
 | Handler | 读 | 写 |
 |---------|----|----|
 | handler-submit-ocr | record.data | MCP |
-| contract-v2-check-ocr | MCP结果 | app_contract_v2_content.ocr_text |
-| contract-v2-text-filter | app_contract_v2_content.ocr_text | app_contract_v2_content.filtered_text |
-| contract-v2-llm-extract | app_contract_v2_content.filtered_text | app_contract_v2_rows + app_contract_v2_content |
-| contract-v2-text-section | app_contract_v2_content.filtered_text | app_contract_v2_content.sections |
+| contract-v2-check-ocr | MCP结果 | app_contract_mgr_v2_content.ocr_text |
+| contract-v2-text-filter | app_contract_mgr_v2_content.ocr_text | app_contract_mgr_v2_content.filtered_text |
+| contract-v2-llm-extract | app_contract_mgr_v2_content.filtered_text | app_contract_mgr_v2_rows + app_contract_mgr_v2_content |
+| contract-v2-text-section | app_contract_mgr_v2_content.filtered_text | app_contract_mgr_v2_content.sections |
 
 > **设计原则**：业务数据直接读写扩展表，不经过 `record.data`（`mini_app_rows.data`）中转。
 
@@ -35,5 +35,5 @@ pending_ocr → ocr_submitted → pending_filter → pending_extract
 | contract_v2_org_nodes | 独立表 | 组织树 |
 | contract_v2_main_records | 独立表 | 合同主记录 |
 | contract_v2_versions | 独立表 | 合同版本 |
-| app_contract_v2_content | 扩展表 | 内容数据 |
-| app_contract_v2_rows | 扩展表 | 元数据 |
+| app_contract_mgr_v2_content | 扩展表 | 内容数据 |
+| app_contract_mgr_v2_rows | 扩展表 | 元数据 |

--- a/apps/contract-mgr-v2/handlers/contract-v2-check-ocr/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-check-ocr/index.js
@@ -75,7 +75,7 @@ export default {
         const ocrText = extractTextFromMcpResult(mcpResult);
         logger.info(`[contract-v2-check-ocr] Record ${record.id}: OCR completed, text length=${ocrText.length}`);
 
-        await services.callExtension('app_contract_v2_content', 'upsert', {
+        await services.callExtension('app_contract_mgr_v2_content', 'upsert', {
           row_id: record.id,
           ocr_text: ocrText,
           ocr_service: mcp.server || 'markitdown',

--- a/apps/contract-mgr-v2/handlers/contract-v2-llm-extract/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-llm-extract/index.js
@@ -6,8 +6,8 @@ const DEFAULT_EXTRACT_CONFIG = {
   temperature: 0.3,
 };
 
-const CONTENT_TABLE = 'app_contract_v2_content';
-const ROWS_TABLE = 'app_contract_v2_rows';
+const CONTENT_TABLE = 'app_contract_mgr_v2_content';
+const ROWS_TABLE = 'app_contract_mgr_v2_rows';
 
 const CONTRACT_FIELDS = [
   { name: 'contract_number', label: '合同编号', guide: '查找合同编号，通常在合同首页顶部，格式如 HT-XXX 或 合同编号：XXX' },

--- a/apps/contract-mgr-v2/handlers/contract-v2-text-filter/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-text-filter/index.js
@@ -8,7 +8,7 @@ const DEFAULT_FILTER_CONFIG = {
 
 const CHUNK_MAX_LENGTH = parseInt(process.env.TEXT_FILTER_MAX_LENGTH) || 120000;
 const CONTEXT_SUMMARY_MAX_LENGTH = 2000;
-const CONTENT_TABLE = 'app_contract_v2_content';
+const CONTENT_TABLE = 'app_contract_mgr_v2_content';
 
 function getFilterConfig(app, stateName) {
   let config = app?.config;

--- a/apps/contract-mgr-v2/handlers/contract-v2-text-section/index.js
+++ b/apps/contract-mgr-v2/handlers/contract-v2-text-section/index.js
@@ -1,6 +1,6 @@
 import logger from '../../../lib/logger.js';
 
-const CONTENT_TABLE = 'app_contract_v2_content';
+const CONTENT_TABLE = 'app_contract_mgr_v2_content';
 
 export const availableOutputs = [
   { key: 'section_count', label: '章节数量', type: 'number' },

--- a/apps/contract-mgr-v2/manifest.json
+++ b/apps/contract-mgr-v2/manifest.json
@@ -47,7 +47,7 @@
   ],
   "extension_tables": [
     {
-      "name": "app_contract_v2_rows",
+      "name": "app_contract_mgr_v2_rows",
       "type": "primary",
       "fields": [
         { "name": "contract_number", "type": "VARCHAR(64)", "label": "合同编号", "source": "contract_number" },
@@ -59,7 +59,7 @@
       "indexes": ["contract_number", "party_a", "contract_amount", "contract_date"]
     },
     {
-      "name": "app_contract_v2_content",
+      "name": "app_contract_mgr_v2_content",
       "type": "content",
       "fields": [
         { "name": "ocr_text", "type": "LONGTEXT" },

--- a/apps/contract-mgr-v2/migrations/install.js
+++ b/apps/contract-mgr-v2/migrations/install.js
@@ -6,8 +6,8 @@ export default {
         'contract_v2_org_nodes',
         'contract_v2_main_records',
         'contract_v2_versions',
-        'app_contract_v2_rows',
-        'app_contract_v2_content'
+        'app_contract_mgr_v2_rows',
+        'app_contract_mgr_v2_content'
       )
     `, { type: sequelize.QueryTypes.SELECT });
 
@@ -89,7 +89,7 @@ export default {
     console.log('  ✓ Created contract_v2_versions table');
 
     await sequelize.query(`
-      CREATE TABLE IF NOT EXISTS app_contract_v2_content (
+      CREATE TABLE IF NOT EXISTS app_contract_mgr_v2_content (
         row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 mini_app_rows.id',
         ocr_text LONGTEXT NULL COMMENT 'OCR 原文',
         ocr_service VARCHAR(64) NULL COMMENT 'OCR 服务',
@@ -106,17 +106,17 @@ export default {
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同内容扩展表'
     `);
-    console.log('  ✓ Created app_contract_v2_content table');
+    console.log('  ✓ Created app_contract_mgr_v2_content table');
 
     await sequelize.query(`
-      ALTER TABLE app_contract_v2_content
-      ADD CONSTRAINT fk_app_contract_v2_content_row_id
+      ALTER TABLE app_contract_mgr_v2_content
+      ADD CONSTRAINT fk_app_contract_mgr_v2_content_row_id
       FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
     `);
-    console.log('  ✓ Added FK for app_contract_v2_content');
+    console.log('  ✓ Added FK for app_contract_mgr_v2_content');
 
     await sequelize.query(`
-      CREATE TABLE IF NOT EXISTS app_contract_v2_rows (
+      CREATE TABLE IF NOT EXISTS app_contract_mgr_v2_rows (
         row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 mini_app_rows.id',
         contract_number VARCHAR(64) NULL COMMENT '合同编号',
         party_a VARCHAR(128) NULL COMMENT '甲方',
@@ -131,22 +131,22 @@ export default {
         INDEX idx_contract_date (contract_date)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同元数据扩展表'
     `);
-    console.log('  ✓ Created app_contract_v2_rows table');
+    console.log('  ✓ Created app_contract_mgr_v2_rows table');
 
     await sequelize.query(`
-      ALTER TABLE app_contract_v2_rows
-      ADD CONSTRAINT fk_app_contract_v2_rows_row_id
+      ALTER TABLE app_contract_mgr_v2_rows
+      ADD CONSTRAINT fk_app_contract_mgr_v2_rows_row_id
       FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
     `);
-    console.log('  ✓ Added FK for app_contract_v2_rows');
+    console.log('  ✓ Added FK for app_contract_mgr_v2_rows');
   },
 
   async down(sequelize) {
-    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_rows`);
-    console.log('  ✓ Dropped app_contract_v2_rows table');
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_mgr_v2_rows`);
+    console.log('  ✓ Dropped app_contract_mgr_v2_rows table');
 
-    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_content`);
-    console.log('  ✓ Dropped app_contract_v2_content table');
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_mgr_v2_content`);
+    console.log('  ✓ Dropped app_contract_mgr_v2_content table');
 
     await sequelize.query(`DROP TABLE IF EXISTS contract_v2_versions`);
     console.log('  ✓ Dropped contract_v2_versions table');

--- a/apps/contract-mgr-v2/migrations/uninstall.js
+++ b/apps/contract-mgr-v2/migrations/uninstall.js
@@ -6,8 +6,8 @@ export default {
         'contract_v2_org_nodes',
         'contract_v2_main_records',
         'contract_v2_versions',
-        'app_contract_v2_rows',
-        'app_contract_v2_content'
+        'app_contract_mgr_v2_rows',
+        'app_contract_mgr_v2_content'
       )
     `, { type: sequelize.QueryTypes.SELECT });
 
@@ -15,11 +15,11 @@ export default {
   },
 
   async up(sequelize) {
-    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_rows`);
-    console.log('  ✓ Dropped app_contract_v2_rows table');
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_mgr_v2_rows`);
+    console.log('  ✓ Dropped app_contract_mgr_v2_rows table');
 
-    await sequelize.query(`DROP TABLE IF EXISTS app_contract_v2_content`);
-    console.log('  ✓ Dropped app_contract_v2_content table');
+    await sequelize.query(`DROP TABLE IF EXISTS app_contract_mgr_v2_content`);
+    console.log('  ✓ Dropped app_contract_mgr_v2_content table');
 
     await sequelize.query(`DROP TABLE IF EXISTS contract_v2_versions`);
     console.log('  ✓ Dropped contract_v2_versions table');
@@ -106,7 +106,7 @@ export default {
     console.log('  ✓ Recreated contract_v2_versions table');
 
     await sequelize.query(`
-      CREATE TABLE IF NOT EXISTS app_contract_v2_content (
+      CREATE TABLE IF NOT EXISTS app_contract_mgr_v2_content (
         row_id VARCHAR(32) PRIMARY KEY,
         ocr_text LONGTEXT NULL,
         ocr_service VARCHAR(64) NULL,
@@ -123,17 +123,17 @@ export default {
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
     `);
-    console.log('  ✓ Recreated app_contract_v2_content table');
+    console.log('  ✓ Recreated app_contract_mgr_v2_content table');
 
     await sequelize.query(`
-      ALTER TABLE app_contract_v2_content
-      ADD CONSTRAINT fk_app_contract_v2_content_row_id
+      ALTER TABLE app_contract_mgr_v2_content
+      ADD CONSTRAINT fk_app_contract_mgr_v2_content_row_id
       FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
     `);
-    console.log('  ✓ Added FK for app_contract_v2_content');
+    console.log('  ✓ Added FK for app_contract_mgr_v2_content');
 
     await sequelize.query(`
-      CREATE TABLE IF NOT EXISTS app_contract_v2_rows (
+      CREATE TABLE IF NOT EXISTS app_contract_mgr_v2_rows (
         row_id VARCHAR(32) PRIMARY KEY,
         contract_number VARCHAR(64) NULL,
         party_a VARCHAR(128) NULL,
@@ -148,13 +148,13 @@ export default {
         INDEX idx_contract_date (contract_date)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
     `);
-    console.log('  ✓ Recreated app_contract_v2_rows table');
+    console.log('  ✓ Recreated app_contract_mgr_v2_rows table');
 
     await sequelize.query(`
-      ALTER TABLE app_contract_v2_rows
-      ADD CONSTRAINT fk_app_contract_v2_rows_row_id
+      ALTER TABLE app_contract_mgr_v2_rows
+      ADD CONSTRAINT fk_app_contract_mgr_v2_rows_row_id
       FOREIGN KEY (row_id) REFERENCES mini_app_rows(id) ON DELETE CASCADE
     `);
-    console.log('  ✓ Added FK for app_contract_v2_rows');
+    console.log('  ✓ Added FK for app_contract_mgr_v2_rows');
   }
 };

--- a/docs/design/contract-v2-final-spec.md
+++ b/docs/design/contract-v2-final-spec.md
@@ -95,10 +95,10 @@ CREATE TABLE contract_v2_versions (
 );
 ```
 
-### 4. app_contract_v2_content（Extension Table）
+### 4. app_contract_mgr_v2_content（Extension Table）
 
 ```sql
-CREATE TABLE app_contract_v2_content (
+CREATE TABLE app_contract_mgr_v2_content (
   row_id VARCHAR(32) PRIMARY KEY,
   ocr_text LONGTEXT,
   ocr_service VARCHAR(64),
@@ -117,10 +117,10 @@ CREATE TABLE app_contract_v2_content (
 );
 ```
 
-### 5. app_contract_v2_rows（Extension Table）
+### 5. app_contract_mgr_v2_rows（Extension Table）
 
 ```sql
-CREATE TABLE app_contract_v2_rows (
+CREATE TABLE app_contract_mgr_v2_rows (
   row_id VARCHAR(32) PRIMARY KEY,
   contract_number VARCHAR(64),
   party_a VARCHAR(128),
@@ -162,10 +162,10 @@ pending_review → (用户确认) → confirmed
 | Handler | 类型 | 读 | 写 |
 |---------|------|----|----|
 | handler-submit-ocr | 共享 | record.data | MCP提交 |
-| contract-v2-check-ocr | v2专用 | MCP结果 | app_contract_v2_content.ocr_text |
-| contract-v2-text-filter | v2专用 | app_contract_v2_content.ocr_text | app_contract_v2_content.filtered_text |
-| contract-v2-llm-extract | v2专用 | app_contract_v2_content.filtered_text | app_contract_v2_rows + app_contract_v2_content |
-| contract-v2-text-section | v2专用 | app_contract_v2_content.filtered_text | app_contract_v2_content.sections |
+| contract-v2-check-ocr | v2专用 | MCP结果 | app_contract_mgr_v2_content.ocr_text |
+| contract-v2-text-filter | v2专用 | app_contract_mgr_v2_content.ocr_text | app_contract_mgr_v2_content.filtered_text |
+| contract-v2-llm-extract | v2专用 | app_contract_mgr_v2_content.filtered_text | app_contract_mgr_v2_rows + app_contract_mgr_v2_content |
+| contract-v2-text-section | v2专用 | app_contract_mgr_v2_content.filtered_text | app_contract_mgr_v2_content.sections |
 
 ---
 


### PR DESCRIPTION
平台安全校验要求 extension table 以 pp_{appId}_ 为前缀。appId 为 contract-mgr-v2，因此前缀必须是 pp_contract_mgr_v2_。

Closes #665