### PR TITLE
feat: 合同列表改为卡片式布局+层级头+筛选

### DIFF
--- a/apps/contract-mgr-v2/manifest.json
+++ b/apps/contract-mgr-v2/manifest.json
@@ -36,7 +36,17 @@
       "name": "contract_type",
       "label": "合同类型",
       "type": "select",
-      "options": ["strategy", "framework", "development", "supply", "purchase", "quality", "nda", "technical", "other"],
+      "options": [
+        "strategy",
+        "framework",
+        "development",
+        "supply",
+        "purchase",
+        "quality",
+        "nda",
+        "technical",
+        "other"
+      ],
       "required": true
     },
     {
@@ -50,29 +60,92 @@
       "name": "app_contract_mgr_v2_rows",
       "type": "primary",
       "fields": [
-        { "name": "contract_number", "type": "VARCHAR(64)", "label": "合同编号", "source": "contract_number" },
-        { "name": "party_a", "type": "VARCHAR(128)", "label": "甲方", "source": "party_a" },
-        { "name": "parent_company", "type": "VARCHAR(128)", "label": "上级公司", "source": "parent_company" },
-        { "name": "contract_amount", "type": "DECIMAL(15,2)", "label": "合同金额", "source": "contract_amount" },
-        { "name": "contract_date", "type": "DATE", "label": "签订日期", "source": "contract_date" }
+        {
+          "name": "contract_number",
+          "type": "VARCHAR(64)",
+          "label": "合同编号",
+          "source": "contract_number"
+        },
+        {
+          "name": "party_a",
+          "type": "VARCHAR(128)",
+          "label": "甲方",
+          "source": "party_a"
+        },
+        {
+          "name": "parent_company",
+          "type": "VARCHAR(128)",
+          "label": "上级公司",
+          "source": "parent_company"
+        },
+        {
+          "name": "contract_amount",
+          "type": "DECIMAL(15,2)",
+          "label": "合同金额",
+          "source": "contract_amount"
+        },
+        {
+          "name": "contract_date",
+          "type": "DATE",
+          "label": "签订日期",
+          "source": "contract_date"
+        }
       ],
-      "indexes": ["contract_number", "party_a", "contract_amount", "contract_date"]
+      "indexes": [
+        "contract_number",
+        "party_a",
+        "contract_amount",
+        "contract_date"
+      ]
     },
     {
       "name": "app_contract_mgr_v2_content",
       "type": "content",
       "fields": [
-        { "name": "ocr_text", "type": "LONGTEXT" },
-        { "name": "ocr_service", "type": "VARCHAR(64)" },
-        { "name": "ocr_at", "type": "DATETIME" },
-        { "name": "filtered_text", "type": "LONGTEXT" },
-        { "name": "filter_at", "type": "DATETIME" },
-        { "name": "sections", "type": "JSON" },
-        { "name": "extract_prompt", "type": "TEXT" },
-        { "name": "extract_json", "type": "LONGTEXT" },
-        { "name": "extract_model", "type": "VARCHAR(64)" },
-        { "name": "extract_temperature", "type": "DECIMAL(3,2)" },
-        { "name": "extract_at", "type": "DATETIME" }
+        {
+          "name": "ocr_text",
+          "type": "LONGTEXT"
+        },
+        {
+          "name": "ocr_service",
+          "type": "VARCHAR(64)"
+        },
+        {
+          "name": "ocr_at",
+          "type": "DATETIME"
+        },
+        {
+          "name": "filtered_text",
+          "type": "LONGTEXT"
+        },
+        {
+          "name": "filter_at",
+          "type": "DATETIME"
+        },
+        {
+          "name": "sections",
+          "type": "JSON"
+        },
+        {
+          "name": "extract_prompt",
+          "type": "TEXT"
+        },
+        {
+          "name": "extract_json",
+          "type": "LONGTEXT"
+        },
+        {
+          "name": "extract_model",
+          "type": "VARCHAR(64)"
+        },
+        {
+          "name": "extract_temperature",
+          "type": "DECIMAL(3,2)"
+        },
+        {
+          "name": "extract_at",
+          "type": "DATETIME"
+        }
       ]
     }
   ],
@@ -103,18 +176,35 @@
       "versions",
       "dashboard"
     ],
-    "supported_formats": [".pdf", ".docx", ".doc", ".jpg", ".png"],
+    "supported_formats": [
+      ".pdf",
+      ".docx",
+      ".doc",
+      ".jpg",
+      ".png"
+    ],
     "max_file_size": 20971520,
     "batch_enabled": true,
     "batch_limit": 50,
     "step_resources": {
       "pending_ocr": {
         "type": "mcp",
-        "mcp": { "server": "markitdown", "tool": "submit_conversion_task", "params_mapping": { "content": "file.base64", "filename": "file.name" } }
+        "mcp": {
+          "server": "markitdown",
+          "tool": "submit_conversion_task",
+          "params_mapping": {
+            "content": "file.base64",
+            "filename": "file.name"
+          }
+        }
       },
       "ocr_submitted": {
         "type": "mcp",
-        "mcp": { "server": "markitdown", "tool": "get_task", "hide_params_mapping": true },
+        "mcp": {
+          "server": "markitdown",
+          "tool": "get_task",
+          "hide_params_mapping": true
+        },
         "judge_model_id": null,
         "judge_temperature": 0.1
       },

--- a/frontend/src/components/contract-v2/ContractList.vue
+++ b/frontend/src/components/contract-v2/ContractList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, computed } from 'vue'
 import { useContractV2Store } from '@/stores/contract-v2'
 import Pagination from '@/components/Pagination.vue'
 
@@ -7,6 +8,12 @@ const emit = defineEmits<{
 }>()
 
 const store = useContractV2Store()
+
+const nodeTypeLabels: Record<string, string> = {
+  group: '集团',
+  party: '甲方',
+  project: '项目',
+}
 
 const contractTypeLabels: Record<string, string> = {
   strategy: '战略合同',
@@ -27,6 +34,27 @@ const statusLabels: Record<string, { label: string; type: string }> = {
   terminated: { label: '终止', type: 'danger' },
 }
 
+const filterStatus = ref('')
+const filterType = ref('')
+const searchText = ref('')
+
+const filteredContracts = computed(() => {
+  let list = store.contracts
+  if (searchText.value) {
+    const q = searchText.value.toLowerCase()
+    list = list.filter(c =>
+      c.contract_name.toLowerCase().includes(q)
+    )
+  }
+  if (filterStatus.value) {
+    list = list.filter(c => c.status === filterStatus.value)
+  }
+  if (filterType.value) {
+    list = list.filter(c => c.contract_type === filterType.value)
+  }
+  return list
+})
+
 function handlePageChange(page: number) {
   store.loadContracts({
     org_node_id: store.selectedNodeId || undefined,
@@ -39,39 +67,61 @@ function handlePageChange(page: number) {
 
 <template>
   <div class="contract-list">
-    <div class="contract-list-header">
-      <span class="contract-list-count">共 {{ store.contractsTotal }} 份合同</span>
+    <div v-if="store.selectedNode" class="contract-list-node-header">
+      <el-tag size="large" effect="plain">
+        {{ nodeTypeLabels[store.selectedNode.node_type] || store.selectedNode.node_type }}
+      </el-tag>
+      <span class="contract-list-node-name">{{ store.selectedNode.name }}</span>
+      <span class="contract-list-node-count">共 {{ store.contractsTotal }} 份合同</span>
+    </div>
+    <div v-else class="contract-list-node-header">
+      <span class="contract-list-node-name">全部合同</span>
+      <span class="contract-list-node-count">共 {{ store.contractsTotal }} 份</span>
     </div>
 
-    <el-table
-      :data="store.contracts"
-      v-loading="store.contractsLoading"
-      stripe
-    >
-      <el-table-column prop="contract_name" label="合同名称" min-width="200">
-        <template #default="{ row }">
-          <span class="contract-name-link" @click="emit('click-contract', row.id)">{{ row.contract_name }}</span>
-        </template>
-      </el-table-column>
-      <el-table-column prop="contract_type" label="类型" width="120">
-        <template #default="{ row }">
-          {{ contractTypeLabels[row.contract_type] || row.contract_type || '-' }}
-        </template>
-      </el-table-column>
-      <el-table-column prop="version_count" label="版本数" width="80" align="center" />
-      <el-table-column prop="status" label="状态" width="80" align="center">
-        <template #default="{ row }">
-          <el-tag size="small" :type="(statusLabels[row.status]?.type as any) || 'info'" disable-transitions>
-            {{ statusLabels[row.status]?.label || row.status }}
+    <div class="contract-list-filters">
+      <el-input
+        v-model="searchText"
+        placeholder="搜索合同名称"
+        prefix-icon="Search"
+        clearable
+        style="width: 220px;"
+      />
+      <el-select v-model="filterStatus" placeholder="全部状态" clearable style="width: 120px;">
+        <el-option v-for="(v, k) in statusLabels" :key="k" :label="v.label" :value="k" />
+      </el-select>
+      <el-select v-model="filterType" placeholder="全部类型" clearable style="width: 130px;">
+        <el-option v-for="(v, k) in contractTypeLabels" :key="k" :label="v" :value="k" />
+      </el-select>
+    </div>
+
+    <div class="contract-list-cards" v-loading="store.contractsLoading">
+      <div v-if="filteredContracts.length === 0 && !store.contractsLoading" class="contract-list-empty">
+        <el-empty description="暂无合同" />
+      </div>
+      <div
+        v-for="contract in filteredContracts"
+        :key="contract.id"
+        class="contract-card"
+        @click="emit('click-contract', contract.id)"
+      >
+        <div class="contract-card-header">
+          <span class="contract-card-name">{{ contract.contract_name }}</span>
+          <el-tag size="small" :type="(statusLabels[contract.status]?.type as any) || 'info'" disable-transitions>
+            {{ statusLabels[contract.status]?.label || contract.status }}
           </el-tag>
-        </template>
-      </el-table-column>
-      <el-table-column prop="updated_at" label="更新时间" width="170">
-        <template #default="{ row }">
-          {{ row.updated_at?.slice(0, 16)?.replace('T', ' ') }}
-        </template>
-      </el-table-column>
-    </el-table>
+        </div>
+        <div class="contract-card-meta">
+          <span class="contract-card-type">
+            {{ contractTypeLabels[contract.contract_type] || contract.contract_type || '-' }}
+          </span>
+          <span class="contract-card-versions">{{ contract.version_count }} 个版本</span>
+          <span class="contract-card-date">
+            {{ contract.updated_at?.slice(0, 10) }}
+          </span>
+        </div>
+      </div>
+    </div>
 
     <div class="contract-list-pagination" v-if="store.contractsTotal > store.contractsPageSize">
       <Pagination
@@ -91,30 +141,98 @@ function handlePageChange(page: number) {
   flex-direction: column;
 }
 
-.contract-list-header {
+.contract-list-node-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 2px solid var(--el-border-color);
+}
+
+.contract-list-node-name {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.contract-list-node-count {
+  font-size: 13px;
+  color: var(--el-text-color-secondary);
+  margin-left: auto;
+}
+
+.contract-list-filters {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.contract-list-cards {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.contract-list-empty {
+  padding: 40px 0;
+}
+
+.contract-card {
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  padding: 14px 18px;
+  margin-bottom: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.contract-card:hover {
+  border-color: var(--el-color-primary-light-5);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.contract-card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
-.contract-list-count {
+.contract-card-name {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--el-text-color-primary);
+}
+
+.contract-card:hover .contract-card-name {
+  color: var(--el-color-primary);
+}
+
+.contract-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
   font-size: 13px;
   color: var(--el-text-color-secondary);
 }
 
-.contract-name-link {
-  color: var(--el-color-primary);
-  cursor: pointer;
+.contract-card-type {
+  background: var(--el-fill-color-light);
+  padding: 2px 8px;
+  border-radius: 4px;
 }
 
-.contract-name-link:hover {
-  text-decoration: underline;
+.contract-card-versions {
+  color: var(--el-color-primary);
+}
+
+.contract-card-date {
+  margin-left: auto;
 }
 
 .contract-list-pagination {
   display: flex;
   justify-content: center;
   margin-top: 16px;
+  padding-top: 12px;
 }
 </style>

--- a/frontend/src/stores/contract-v2.ts
+++ b/frontend/src/stores/contract-v2.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import {
   getOrgTree,
@@ -31,6 +31,21 @@ export const useContractV2Store = defineStore('contract-v2', () => {
   const tree = ref<OrgNode[]>([])
   const treeLoading = ref(false)
   const selectedNodeId = ref<string | null>(null)
+
+  const selectedNode = computed<OrgNode | null>(() => {
+    if (!selectedNodeId.value) return null
+    const find = (nodes: OrgNode[]): OrgNode | null => {
+      for (const n of nodes) {
+        if (n.id === selectedNodeId.value) return n
+        if (n.children) {
+          const found = find(n.children)
+          if (found) return found
+        }
+      }
+      return null
+    }
+    return find(tree.value)
+  })
 
   const contracts = ref<ContractMainRecord[]>([])
   const contractsTotal = ref(0)
@@ -226,6 +241,7 @@ export const useContractV2Store = defineStore('contract-v2', () => {
     tree,
     treeLoading,
     selectedNodeId,
+    selectedNode,
     contracts,
     contractsTotal,
     contractsPage,


### PR DESCRIPTION
- 合同列表从 el-table 改为卡片式布局
- 顶部显示当前选中节点名称+类型标签（集团/甲方/项目）+合同数量
- 增加搜索框、状态下拉、类型下拉筛选
- store 新增 selectedNode computed

Closes #665