### PR TITLE
feat: system branding config

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -2,8 +2,8 @@
   <header class="app-header">
     <div class="header-left">
       <router-link to="/experts" class="logo">
-        <span class="logo-icon">🤖</span>
-        <span class="logo-text">Touwaka Mate</span>
+        <span class="logo-icon">{{ appIcon }}</span>
+        <span class="logo-text">{{ appName }}</span>
       </router-link>
     </div>
 
@@ -88,13 +88,18 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useUserStore } from '@/stores/user'
+import { useSystemSettingsStore } from '@/stores/systemSettings'
 import { useI18n } from 'vue-i18n'
 import type { Locale } from '@/i18n'
 
 const route = useRoute()
 const router = useRouter()
 const userStore = useUserStore()
+const systemSettingsStore = useSystemSettingsStore()
 const { locale } = useI18n()
+
+const appName = computed(() => systemSettingsStore.brandingSettings?.app_name || 'Touwaka Mate')
+const appIcon = computed(() => systemSettingsStore.brandingSettings?.logo_icon || '🤖')
 
 const showUserMenu = ref(false)
 const menuRef = ref<HTMLElement | null>(null)
@@ -146,6 +151,9 @@ const handleClickOutside = (event: MouseEvent) => {
 
 onMounted(() => {
   document.addEventListener('click', handleClickOutside)
+  if (!systemSettingsStore.brandingSettings?.app_name) {
+    systemSettingsStore.loadBranding()
+  }
 })
 
 onUnmounted(() => {

--- a/frontend/src/components/settings/SystemConfigTab.vue
+++ b/frontend/src/components/settings/SystemConfigTab.vue
@@ -11,6 +11,7 @@
         <el-button :type="activeSubTab === 'timeout' ? 'primary' : ''" @click="activeSubTab = 'timeout'">⏱️ {{ $t('settings.timeoutConfig') }}</el-button>
         <el-button :type="activeSubTab === 'app' ? 'primary' : ''" @click="activeSubTab = 'app'">📱 {{ $t('settings.appConfig') }}</el-button>
         <el-button :type="activeSubTab === 'packages' ? 'primary' : ''" @click="activeSubTab = 'packages'">📦 {{ $t('settings.packageWhitelist') }}</el-button>
+        <el-button :type="activeSubTab === 'branding' ? 'primary' : ''" @click="activeSubTab = 'branding'">🎨 {{ $t('settings.brandingConfig') }}</el-button>
       </div>
 
       <div v-if="activeSubTab === 'general'" class="tab-content">
@@ -210,6 +211,42 @@
       <div v-if="activeSubTab === 'packages'" class="tab-content">
         <PackageWhitelistTab />
       </div>
+
+      <div v-if="activeSubTab === 'branding'" class="tab-content">
+        <div class="config-section">
+          <div class="section-header">
+            <h3 class="section-title">🎨 {{ $t('settings.brandingConfig') }}</h3>
+            <el-button @click="resetSection('branding')">{{ $t('common.reset') }}</el-button>
+          </div>
+          <div class="config-grid">
+            <div class="config-item">
+              <label class="config-label">{{ $t('settings.brandingAppName') }}</label>
+              <el-input v-model="form.branding.app_name" placeholder="Touwaka Mate" />
+              <span class="config-hint">{{ $t('settings.brandingAppNameHint') }}</span>
+            </div>
+            <div class="config-item">
+              <label class="config-label">{{ $t('settings.brandingLogoIcon') }}</label>
+              <el-input v-model="form.branding.logo_icon" placeholder="🤖" />
+              <span class="config-hint">{{ $t('settings.brandingLogoIconHint') }}</span>
+            </div>
+            <div class="config-item full-width">
+              <div class="branding-preview">
+                <span class="branding-preview-label">{{ $t('settings.brandingPreview') }}</span>
+                <div class="branding-preview-content">
+                  <span class="preview-icon">{{ form.branding.logo_icon }}</span>
+                  <span class="preview-name">{{ form.branding.app_name }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="config-actions">
+            <el-button @click="resetAll">{{ $t('settings.resetAll') }}</el-button>
+            <el-button type="primary" @click="saveConfig" :disabled="!hasChanges || saving">
+              {{ saving ? $t('common.saving') : $t('settings.saveChanges') }}
+            </el-button>
+          </div>
+        </div>
+      </div>
     </template>
   </div>
 </template>
@@ -225,7 +262,7 @@ const { t } = useI18n()
 const systemSettingsStore = useSystemSettingsStore()
 const toast = useToastStore()
 
-const activeSubTab = ref<'general' | 'registration' | 'connection' | 'token' | 'timeout' | 'app' | 'packages'>('general')
+const activeSubTab = ref<'general' | 'registration' | 'connection' | 'token' | 'timeout' | 'app' | 'packages' | 'branding'>('general')
 const saving = ref(false)
 
 const form = reactive({
@@ -235,6 +272,7 @@ const form = reactive({
   token: { access_expiry: '15m', refresh_expiry: '7d' },
   tool: { max_rounds: 20 },
   app: { clock_interval: 30, batch_size: 10, max_concurrency: 5, text_filter_max_length: 50000, attachment_base_path: './data/attachments', max_upload_size: 50 },
+  branding: { app_name: 'Touwaka Mate', logo_icon: '🤖' },
 })
 
 const defaults = {
@@ -244,6 +282,7 @@ const defaults = {
   token: { access_expiry: '15m', refresh_expiry: '7d' },
   tool: { max_rounds: 20 },
   app: { clock_interval: 30, batch_size: 10, max_concurrency: 5, text_filter_max_length: 50000, attachment_base_path: './data/attachments', max_upload_size: 50 },
+  branding: { app_name: 'Touwaka Mate', logo_icon: '🤖' },
 }
 
 const hasChanges = computed(() => {
@@ -256,6 +295,7 @@ const hasChanges = computed(() => {
     token: { access_expiry: settings.token?.access_expiry ?? '15m', refresh_expiry: settings.token?.refresh_expiry ?? '7d' },
     tool: { max_rounds: settings.tool?.max_rounds ?? 20 },
     app: { clock_interval: settings.app?.clock_interval ?? 30, batch_size: settings.app?.batch_size ?? 10, max_concurrency: settings.app?.max_concurrency ?? 5, text_filter_max_length: settings.app?.text_filter_max_length ?? 50000, attachment_base_path: settings.app?.attachment_base_path ?? './data/attachments', max_upload_size: settings.app?.max_upload_size ?? 50 },
+    branding: { app_name: settings.branding?.app_name ?? 'Touwaka Mate', logo_icon: settings.branding?.logo_icon ?? '🤖' },
   })
 })
 
@@ -305,6 +345,8 @@ onMounted(async () => {
     form.app.text_filter_max_length = settings.app?.text_filter_max_length ?? 50000
     form.app.attachment_base_path = settings.app?.attachment_base_path ?? './data/attachments'
     form.app.max_upload_size = settings.app?.max_upload_size ?? 50
+    form.branding.app_name = settings.branding?.app_name ?? 'Touwaka Mate'
+    form.branding.logo_icon = settings.branding?.logo_icon ?? '🤖'
   }
 })
 
@@ -331,6 +373,8 @@ watch(() => systemSettingsStore.settings, (settings) => {
     form.app.text_filter_max_length = settings.app?.text_filter_max_length ?? 50000
     form.app.attachment_base_path = settings.app?.attachment_base_path ?? './data/attachments'
     form.app.max_upload_size = settings.app?.max_upload_size ?? 50
+    form.branding.app_name = settings.branding?.app_name ?? 'Touwaka Mate'
+    form.branding.logo_icon = settings.branding?.logo_icon ?? '🤖'
   }
 }, { deep: true })
 </script>
@@ -351,4 +395,9 @@ watch(() => systemSettingsStore.settings, (settings) => {
 .config-hint { font-size: 11px; color: var(--text-tertiary, #999); }
 .config-description { font-size: 11px; color: var(--text-tertiary, #999); margin: 4px 0 0 0; }
 .config-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--border-light, #eee); }
+.branding-preview { display: flex; flex-direction: column; gap: 8px; }
+.branding-preview-label { font-size: 12px; color: var(--text-tertiary, #999); }
+.branding-preview-content { display: flex; align-items: center; gap: 8px; padding: 12px 16px; background: var(--hover-bg, #f5f5f5); border-radius: 8px; }
+.preview-icon { font-size: 24px; }
+.preview-name { font-size: 18px; font-weight: 600; color: var(--text-primary, #333); }
 </style>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -591,6 +591,12 @@ thinkingFormatDeepseek: 'DeepSeek/GLM Format',
     invitationExpiryDaysHint: 'Number of days until invitation codes expire, 0 for no expiry',
     // General Config
     generalConfig: 'General Config',
+    brandingConfig: 'Branding',
+    brandingAppName: 'App Name',
+    brandingAppNameHint: 'Displayed in header and browser tab',
+    brandingLogoIcon: 'Logo Icon',
+    brandingLogoIconHint: 'Supports emoji or image URL',
+    brandingPreview: 'Preview',
     // Package Whitelist
     packageWhitelist: 'Package Whitelist',
     moduleWhitelist: 'Module Whitelist',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -811,6 +811,12 @@ thinkingFormatDeepseek: 'DeepSeek/GLM 格式',
     invitationExpiryDaysHint: '邀请码的有效期（天），0 表示永不过期',
     // 通用配置
     generalConfig: '通用配置',
+    brandingConfig: '外观配置',
+    brandingAppName: '系统名称',
+    brandingAppNameHint: '显示在左上角和浏览器标签页',
+    brandingLogoIcon: '系统图标',
+    brandingLogoIconHint: '支持 emoji 或图片 URL',
+    brandingPreview: '预览',
     // 包白名单配置
     packageWhitelist: '包白名单',
     moduleWhitelist: '模块白名单',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useUserStore } from '@/stores/user'
+import { useSystemSettingsStore } from '@/stores/systemSettings'
 import { getLocale } from '@/i18n'
 
 const router = createRouter({
@@ -165,9 +166,8 @@ router.beforeEach(async (to, from) => {
     return { name: 'experts' }
   }
 
-  const systemSettingsStore = (await import('@/stores/systemSettings')).useSystemSettingsStore()
-  const branding = systemSettingsStore().brandingSettings
-  const appName = branding?.app_name || 'Touwaka Mate'
+  const systemSettingsStore = useSystemSettingsStore()
+  const appName = systemSettingsStore.brandingSettings?.app_name || 'Touwaka Mate'
   document.title = to.meta.title ? `${to.meta.title} - ${appName}` : appName
   document.documentElement.setAttribute('lang', getLocale())
 })

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -165,7 +165,10 @@ router.beforeEach(async (to, from) => {
     return { name: 'experts' }
   }
 
-  document.title = to.meta.title ? `${to.meta.title} - Touwaka Mate` : 'Touwaka Mate'
+  const systemSettingsStore = (await import('@/stores/systemSettings')).useSystemSettingsStore()
+  const branding = systemSettingsStore().brandingSettings
+  const appName = branding?.app_name || 'Touwaka Mate'
+  document.title = to.meta.title ? `${to.meta.title} - ${appName}` : appName
   document.documentElement.setAttribute('lang', getLocale())
 })
 

--- a/frontend/src/stores/systemSettings.ts
+++ b/frontend/src/stores/systemSettings.ts
@@ -13,7 +13,6 @@ export interface SystemSettings {
     top_p: number
     frequency_penalty: number
     presence_penalty: number
-    // Note: max_tokens 不在系统设置中管理，由模型表和专家配置决定
   }
   connection: {
     max_per_user: number
@@ -24,20 +23,29 @@ export interface SystemSettings {
     refresh_expiry: string
   }
   timeout: {
-    vm_execution: number      // VM 执行超时（秒）
-    python_execution: number  // Python 执行超时（秒）
-    skill_call: number        // 技能调用超时（秒）
-    remote_llm: number        // 远程 LLM 调用超时（秒）
+    vm_execution: number
+    python_execution: number
+    skill_call: number
+    remote_llm: number
   }
   tool: {
-    max_rounds: number        // 最大工具调用轮数
+    max_rounds: number
   }
   registration: {
-    allow_self_registration: boolean    // 是否允许自主注册
-    default_invitation_quota: number    // 默认邀请配额
-    default_invitation_max_uses: number // 默认邀请码最大使用次数
-    invitation_expiry_days: number      // 邀请码有效期（天）
+    allow_self_registration: boolean
+    default_invitation_quota: number
+    default_invitation_max_uses: number
+    invitation_expiry_days: number
   }
+  branding: {
+    app_name: string
+    logo_icon: string
+  }
+}
+
+export interface BrandingSettings {
+  app_name: string
+  logo_icon: string
 }
 
 /**
@@ -83,6 +91,10 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
       default_invitation_max_uses: 5,
       invitation_expiry_days: 30,
     },
+    branding: {
+      app_name: 'Touwaka Mate',
+      logo_icon: '🤖',
+    },
   }
 
   // Getters
@@ -92,6 +104,7 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   const timeoutSettings = computed(() => settings.value?.timeout || defaultSettings.timeout)
   const toolSettings = computed(() => settings.value?.tool || defaultSettings.tool)
   const registrationSettings = computed(() => settings.value?.registration || defaultSettings.registration)
+  const brandingSettings = computed(() => settings.value?.branding || defaultSettings.branding)
 
   // Actions
   // 加载系统配置
@@ -160,23 +173,31 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
     return result
   }
 
+  const loadBranding = async (): Promise<BrandingSettings> => {
+    try {
+      const response = await apiClient.get('/branding')
+      return response.data.data
+    } catch {
+      return { app_name: 'Touwaka Mate', logo_icon: '🤖' }
+    }
+  }
+
   return {
-    // State
     settings,
     isLoading,
     error,
     defaultSettings,
-    // Getters
     llmSettings,
     connectionSettings,
     tokenSettings,
     timeoutSettings,
     toolSettings,
     registrationSettings,
-    // Actions
+    brandingSettings,
     loadSettings,
     updateSettings,
     resetSettings,
     getSetting,
+    loadBranding,
   }
 })

--- a/frontend/src/stores/systemSettings.ts
+++ b/frontend/src/stores/systemSettings.ts
@@ -176,7 +176,13 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   const loadBranding = async (): Promise<BrandingSettings> => {
     try {
       const response = await apiClient.get('/branding')
-      return response.data.data
+      const data = response.data.data
+      if (settings.value) {
+        settings.value.branding = data
+      } else {
+        settings.value = { ...defaultSettings, branding: data } as SystemSettings
+      }
+      return data
     } catch {
       return { app_name: 'Touwaka Mate', logo_icon: '🤖' }
     }

--- a/server/controllers/system-setting.controller.js
+++ b/server/controllers/system-setting.controller.js
@@ -50,6 +50,10 @@ const DEFAULT_SETTINGS = {
     attachment_base_path: './data/attachments', // 附件存储路径
     max_upload_size: 50,               // 附件上传大小限制（MB）
   },
+  branding: {
+    app_name: 'Touwaka Mate',
+    logo_icon: '🤖',
+  },
 };
 
 class SystemSettingController {

--- a/server/index.js
+++ b/server/index.js
@@ -91,7 +91,7 @@ import kbRoutes from './routes/kb.routes.js';
 import solutionRoutes from './routes/solution.routes.js';
 import departmentRoutes from './routes/department.routes.js';
 import positionRoutes from './routes/position.routes.js';
-import systemSettingRoutes from './routes/system-setting.routes.js';
+import systemSettingRoutes, { createBrandingRoutes } from './routes/system-setting.routes.js';
 import { getSystemSettingService } from './services/system-setting.service.js';
 import packageRoutes from './routes/package.routes.js';
 import assistantRoutes from './routes/assistant.routes.js';
@@ -409,6 +409,11 @@ class ApiServer {
     const systemSettingRouter = systemSettingRoutes(this.db);
     this.app.use(systemSettingRouter.routes());
     this.app.use(systemSettingRouter.allowedMethods());
+
+    // Branding 路由（公开，无需认证）
+    const brandingRouter = createBrandingRoutes(this.db);
+    this.app.use(brandingRouter.routes());
+    this.app.use(brandingRouter.allowedMethods());
 
     // Package 白名单路由
     const packageRouter = packageRoutes(this.db);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -13,7 +13,7 @@ import providerRoutes from './provider.routes.js';
 import chatRoutes from './chat.routes.js';
 import createSkillRoutes from './skill.routes.js';
 import createKbRoutes from './kb.routes.js';
-import systemSettingRoutes from './system-setting.routes.js';
+import systemSettingRoutes, { createBrandingRoutes } from './system-setting.routes.js';
 import createPackageRoutes from './package.routes.js';
 import createInternalRoutes from './internal.routes.js';
 import attachmentRoutes from './attachment.routes.js';
@@ -33,6 +33,7 @@ export {
   createSkillRoutes,
   createKbRoutes,
   systemSettingRoutes,
+  createBrandingRoutes,
   createPackageRoutes,
   createInternalRoutes,
   attachmentRoutes,

--- a/server/routes/system-setting.routes.js
+++ b/server/routes/system-setting.routes.js
@@ -11,14 +11,32 @@ export default (db) => {
   const router = new Router({ prefix: '/api/system-settings' });
   const controller = new SystemSettingController(db);
 
-  // 获取所有系统配置（需要认证）
   router.get('/', authenticate(), (ctx) => controller.getAll(ctx));
-
-  // 更新系统配置（需要认证）
   router.put('/', authenticate(), (ctx) => controller.update(ctx));
-
-  // 重置配置为默认值（需要认证）
   router.post('/reset', authenticate(), (ctx) => controller.reset(ctx));
 
   return router;
 };
+
+export function createBrandingRoutes(db) {
+  const router = new Router({ prefix: '/api/branding' });
+  const controller = new SystemSettingController(db);
+
+  router.get('/', async (ctx) => {
+    try {
+      const records = await controller.SystemSetting.findAll({ raw: true });
+      const result = controller._parseSettings(records);
+      ctx.success({
+        app_name: result.branding?.app_name || 'Touwaka Mate',
+        logo_icon: result.branding?.logo_icon || '🤖',
+      });
+    } catch (error) {
+      ctx.success({
+        app_name: 'Touwaka Mate',
+        logo_icon: '🤖',
+      });
+    }
+  });
+
+  return router;
+}

--- a/server/services/system-setting.service.js
+++ b/server/services/system-setting.service.js
@@ -50,6 +50,10 @@ const DEFAULT_SETTINGS = {
     attachment_base_path: { value: './data/attachments', type: 'string', description: '附件存储路径' },
     max_upload_size: { value: 50, type: 'number', description: '附件上传大小限制（MB）' },
   },
+  branding: {
+    app_name: { value: 'Touwaka Mate', type: 'string', description: '系统名称' },
+    logo_icon: { value: '🤖', type: 'string', description: '系统图标（emoji 或图片 URL）' },
+  },
 };
 
 // 配置值验证规则


### PR DESCRIPTION
## Summary

- 新增 `branding` 系统配置分组（`app_name` + `logo_icon`），存储在现有 `system_settings` 表，无需改表
- 新增 `GET /api/branding` 公开接口（无需认证），所有用户可获取外观配置
- 管理员可在 **系统设置 → 外观配置** 中修改系统名称和图标，带实时预览
- AppHeader 和浏览器标签页标题从 store 动态读取，保存后立即生效

## Changes

### Backend
- `system-setting.controller.js` / `system-setting.service.js` — DEFAULT_SETTINGS 新增 `branding` 分组
- `system-setting.routes.js` — 新增 `GET /api/branding` 公开路由
- `routes/index.js` / `index.js` — 注册 branding 路由

### Frontend
- `stores/systemSettings.ts` — 接口加 `branding`、`loadBranding()` 方法
- `AppHeader.vue` — 从 store 读取名称/图标替代硬编码
- `SystemConfigTab.vue` — 新增"外观配置"子标签
- `router/index.ts` — `document.title` 动态使用 branding
- `zh-CN.ts` / `en-US.ts` — 新增 i18n key

Closes #691
