### PR TITLE
feat: AppClock回调模式升级

### DIFF
--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -110,8 +110,10 @@ async function handleOcrSubmit(row, app, services) {
   const config = getStepResource(app, 'pending_ocr', {});
   const mcp = config.mcp || { server: 'markitdown', tool: 'submit_conversion_task' };
   
+  logger.info(`[tick] OCR MCP config: server=${mcp.server}, tool=${mcp.tool}`);
+  logger.info(`[tick] OCR file: ${file.file_name}, size=${buffer.length} bytes`);
+  
   try {
-    // 按 params_mapping 传递参数
     const params = {};
     if (mcp.params_mapping) {
       for (const [paramKey, sourcePath] of Object.entries(mcp.params_mapping)) {
@@ -122,18 +124,59 @@ async function handleOcrSubmit(row, app, services) {
         }
       }
     } else {
-      // 默认参数
       params.content = base64;
       params.filename = file.file_name;
     }
     
+    logger.info(`[tick] OCR request params: filename=${params.filename || params.name}, base64_length=${base64.length}`);
+    logger.debug(`[tick] OCR request full params keys: ${Object.keys(params).join(', ')}`);
+    
     const result = await services.callMcp(mcp.server, mcp.tool, params);
     
+    logger.info(`[tick] OCR response type: ${typeof result}`);
+    logger.debug(`[tick] OCR response: ${JSON.stringify(result).substring(0, 500)}`);
+    
     let taskId = '';
-    if (typeof result === 'string') {
-      taskId = result;
-    } else if (typeof result === 'object' && result !== null) {
-      taskId = result.task_id || result.id || result.result?.task_id || result.content?.task_id || '';
+    
+    const parsePrompt = `从以下 MCP 工具调用结果中提取 task_id（任务ID）。
+如果结果中包含任务ID，返回JSON格式：{"task_id": "提取的ID值"}
+如果没有找到task_id但有其他标识符（如id、job_id等），也提取出来。
+如果完全无法提取，返回：{"task_id": ""}
+
+MCP返回结果：
+${JSON.stringify(result).substring(0, 1000)}`;
+
+    try {
+      const parseResult = await services.callLlm('parse_task_id', {
+        instruction: parsePrompt,
+        response_format: 'json',
+        model_id: config.parse_model_id,
+        temperature: 0.1,
+      });
+      
+      const parsed = parseLlmResponse(parseResult);
+      if (parsed && parsed.task_id) {
+        taskId = parsed.task_id;
+        logger.info(`[tick] OCR task_id extracted by LLM: ${taskId}`);
+      }
+    } catch (e) {
+      logger.warn(`[tick] LLM parse failed, fallback to hardcoded: ${e.message}`);
+    }
+    
+    if (!taskId) {
+      if (typeof result === 'string') {
+        taskId = result;
+      } else if (typeof result === 'object' && result !== null) {
+        taskId = result.task_id || result.id || result.result?.task_id || '';
+        if (!taskId && result.content) {
+          try {
+            const parsed = JSON.parse(result.content);
+            taskId = parsed.task_id || parsed.id || '';
+          } catch (e) {
+            logger.warn(`[tick] Failed to parse result.content: ${e.message}`);
+          }
+        }
+      }
     }
     
     if (!taskId) {
@@ -152,6 +195,8 @@ async function handleOcrSubmit(row, app, services) {
   } catch (e) {
     await updateProcessStep(services, row.row_id, 'ocr_failed');
     logger.error(`[tick] OCR submit failed for ${row.row_id}: ${e.message}`);
+    logger.error(`[tick] OCR submit error stack: ${e.stack}`);
+    logger.error(`[tick] OCR submit error details: ${JSON.stringify({ name: e.name, message: e.message, code: e.code, cause: e.cause })}`);
   }
 }
 

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -145,29 +145,18 @@ async function handleOcrSubmit(row, app, services) {
     
     const result = await services.callMcp(mcp.server, mcp.tool, params);
     
-    logger.info(`[tick] OCR result type: ${typeof result}, preview: ${JSON.stringify(result).substring(0, 200)}`);
-    
-    let taskId;
+    let taskId = '';
     if (typeof result === 'string') {
-      try {
-        const parsed = JSON.parse(result);
-        taskId = parsed.task_id || parsed.id || parsed.result?.task_id || result.substring(0, 100);
-      } catch {
-        taskId = result.substring(0, 100);
-      }
-    } else if (typeof result === 'object') {
+      taskId = result;
+    } else if (typeof result === 'object' && result !== null) {
       taskId = result.task_id || result.id || result.result?.task_id || result.content?.task_id || '';
-      if (!taskId && result.result && typeof result.result === 'string') {
-        taskId = result.result.substring(0, 100);
-      }
     }
     
     if (!taskId) {
-      throw new Error('OCR returned no task_id');
+      logger.error(`[tick] OCR returned no task_id for ${row.row_id}, result: ${JSON.stringify(result).substring(0, 200)}`);
+      await updateProcessStep(services, row.row_id, 'ocr_failed');
+      return;
     }
-    
-    // 截断防止超长
-    taskId = String(taskId).substring(0, 200);
     
     await services.execute(`
       UPDATE ${CONTENT_TABLE} 

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -49,6 +49,7 @@ export async function tick(context) {
   const pending = await services.query(`
     SELECT id, status, data FROM mini_app_rows 
     WHERE app_id = ? AND status IN ('pending_ocr', 'ocr_submitted', 'pending_filter', 'pending_extract', 'pending_section')
+    ORDER BY created_at ASC
     LIMIT 5
   `, [app.id]);
   

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -1,4 +1,5 @@
 import logger from '../../../lib/logger.js';
+import path from 'path';
 import { splitIntoChunks, parseLlmResponse, getStepResource, getPrompt, buildLlmParams } from '../handlers/shared.js';
 
 const CONTENT_TABLE = 'app_contract_mgr_v2_content';
@@ -103,7 +104,7 @@ async function handleOcrSubmit(row, app, services) {
   }
   
   const files = await services.query(`
-    SELECT a.id, a.filename, a.content, a.base64
+    SELECT a.id, a.file_name, a.file_path, a.mime_type
     FROM attachments a
     WHERE a.id = ?
   `, [row.file_id]);
@@ -118,10 +119,14 @@ async function handleOcrSubmit(row, app, services) {
   const config = getStepResource(app, 'pending_ocr', {});
   const mcp = config.mcp || { server: 'markitdown', tool: 'submit_conversion_task' };
   
+  // 构建完整文件路径
+  const fullPath = path.join(process.cwd(), 'data', 'attachments', file.file_path);
+  
   try {
     const result = await services.callMcp(mcp.server, mcp.tool, {
-      content: file.base64 || file.content,
-      filename: file.filename
+      file_path: fullPath,
+      name: file.file_name,
+      mime_type: file.mime_type
     });
     
     let taskId;

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -103,31 +103,47 @@ async function handleOcrSubmit(row, app, services) {
     return;
   }
   
-  const files = await services.query(`
-    SELECT a.id, a.file_name, a.file_path, a.mime_type
+  // 获取文件信息（用于 params_mapping）
+  const fileInfo = await services.query(`
+    SELECT a.id, a.file_name, a.file_path
     FROM attachments a
     WHERE a.id = ?
   `, [row.file_id]);
   
-  if (!files || files.length === 0) {
+  if (!fileInfo || fileInfo.length === 0) {
     await updateProcessStep(services, row.row_id, 'ocr_failed');
     return;
   }
   
-  const file = files[0];
+  const file = fileInfo[0];
+  
+  // 读取文件为 base64
+  const fullPath = path.join(process.cwd(), 'data', 'attachments', file.file_path);
+  const fs = await import('fs/promises');
+  const buffer = await fs.readFile(fullPath);
+  const base64 = buffer.toString('base64');
   
   const config = getStepResource(app, 'pending_ocr', {});
   const mcp = config.mcp || { server: 'markitdown', tool: 'submit_conversion_task' };
   
-  // 构建完整文件路径
-  const fullPath = path.join(process.cwd(), 'data', 'attachments', file.file_path);
-  
   try {
-    const result = await services.callMcp(mcp.server, mcp.tool, {
-      file_path: fullPath,
-      name: file.file_name,
-      mime_type: file.mime_type
-    });
+    // 按 params_mapping 传递参数
+    const params = {};
+    if (mcp.params_mapping) {
+      for (const [paramKey, sourcePath] of Object.entries(mcp.params_mapping)) {
+        if (sourcePath === 'file.base64') {
+          params[paramKey] = base64;
+        } else if (sourcePath === 'file.name') {
+          params[paramKey] = file.file_name;
+        }
+      }
+    } else {
+      // 默认参数
+      params.content = base64;
+      params.filename = file.file_name;
+    }
+    
+    const result = await services.callMcp(mcp.server, mcp.tool, params);
     
     let taskId;
     if (typeof result === 'string') {

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -145,17 +145,29 @@ async function handleOcrSubmit(row, app, services) {
     
     const result = await services.callMcp(mcp.server, mcp.tool, params);
     
+    logger.info(`[tick] OCR result type: ${typeof result}, preview: ${JSON.stringify(result).substring(0, 200)}`);
+    
     let taskId;
     if (typeof result === 'string') {
       try {
         const parsed = JSON.parse(result);
-        taskId = parsed.task_id || parsed.id || result;
+        taskId = parsed.task_id || parsed.id || parsed.result?.task_id || result.substring(0, 100);
       } catch {
-        taskId = result;
+        taskId = result.substring(0, 100);
       }
-    } else {
-      taskId = result.task_id || result.id || JSON.stringify(result);
+    } else if (typeof result === 'object') {
+      taskId = result.task_id || result.id || result.result?.task_id || result.content?.task_id || '';
+      if (!taskId && result.result && typeof result.result === 'string') {
+        taskId = result.result.substring(0, 100);
+      }
     }
+    
+    if (!taskId) {
+      throw new Error('OCR returned no task_id');
+    }
+    
+    // 截断防止超长
+    taskId = String(taskId).substring(0, 200);
     
     await services.execute(`
       UPDATE ${CONTENT_TABLE} 

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -31,22 +31,6 @@ export async function tick(context) {
     return { skipped: true, reason: 'no_app' };
   }
   
-  const lastRun = await services.query(`
-    SELECT created_at FROM app_tick_log
-    WHERE registry_id = ? AND success = 1
-    ORDER BY created_at DESC LIMIT 1
-  `, [registry.id]);
-  
-  if (lastRun.length > 0) {
-    const elapsed = Date.now() - new Date(lastRun[0].created_at).getTime();
-    const minInterval = 1 * 60 * 1000;
-    
-    if (elapsed < minInterval) {
-      logger.info(`[tick] Skipped: last run ${Math.round(elapsed/1000)}s ago`);
-      return { skipped: true, reason: 'interval_not_reached' };
-    }
-  }
-  
   const pending = await services.query(`
     SELECT row_id, process_step, ocr_task_id, file_id, filter_carried_over, filter_chunk_index
     FROM ${CONTENT_TABLE}

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -23,7 +23,7 @@ const JSON_FORMAT_PROMPT = `
 }`;
 
 export async function tick(context) {
-  const { db, app, registry, services } = context;
+  const { app, registry, services } = context;
   
   if (!app) {
     logger.info('[tick] No app found');
@@ -47,11 +47,12 @@ export async function tick(context) {
   }
   
   const pending = await services.query(`
-    SELECT id, status, data FROM mini_app_rows 
-    WHERE app_id = ? AND status IN ('pending_ocr', 'ocr_submitted', 'pending_filter', 'pending_extract', 'pending_section')
+    SELECT row_id, process_step, ocr_task_id, file_id, filter_carried_over, filter_chunk_index
+    FROM ${CONTENT_TABLE}
+    WHERE process_step IN ('pending_ocr', 'ocr_submitted', 'pending_filter', 'pending_extract', 'pending_section')
     ORDER BY created_at ASC
     LIMIT 5
-  `, [app.id]);
+  `);
   
   if (pending.length === 0) {
     logger.info('[tick] No pending records');
@@ -65,7 +66,7 @@ export async function tick(context) {
       await processRow(row, app, services);
       processed++;
     } catch (e) {
-      logger.error(`[tick] Row ${row.id} failed: ${e.message}`);
+      logger.error(`[tick] Row ${row.row_id} failed: ${e.message}`);
     }
   }
   
@@ -74,14 +75,12 @@ export async function tick(context) {
 }
 
 async function processRow(row, app, services) {
-  const rowData = typeof row.data === 'string' ? JSON.parse(row.data || '{}') : (row.data || {});
-  
-  switch (row.status) {
+  switch (row.process_step) {
     case 'pending_ocr':
-      await handleOcrSubmit(row, rowData, app, services);
+      await handleOcrSubmit(row, app, services);
       break;
     case 'ocr_submitted':
-      await handleOcrCheck(row, rowData, app, services);
+      await handleOcrCheck(row, app, services);
       break;
     case 'pending_filter':
       await handleFilter(row, app, services);
@@ -95,25 +94,34 @@ async function processRow(row, app, services) {
   }
 }
 
-async function handleOcrSubmit(row, rowData, app, services) {
-  logger.info(`[tick] Submitting OCR for ${row.id}`);
+async function handleOcrSubmit(row, app, services) {
+  logger.info(`[tick] Submitting OCR for ${row.row_id}`);
   
-  const files = await services.getFiles(row.id);
+  if (!row.file_id) {
+    await updateProcessStep(services, row.row_id, 'ocr_failed');
+    return;
+  }
+  
+  const files = await services.query(`
+    SELECT a.id, a.filename, a.content, a.base64
+    FROM attachments a
+    WHERE a.id = ?
+  `, [row.file_id]);
+  
   if (!files || files.length === 0) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
+    await updateProcessStep(services, row.row_id, 'ocr_failed');
     return;
   }
   
   const file = files[0];
-  const attachment = file.attachment || file;
   
   const config = getStepResource(app, 'pending_ocr', {});
   const mcp = config.mcp || { server: 'markitdown', tool: 'submit_conversion_task' };
   
   try {
     const result = await services.callMcp(mcp.server, mcp.tool, {
-      content: attachment.base64 || attachment.content,
-      filename: attachment.filename || attachment.name
+      content: file.base64 || file.content,
+      filename: file.filename
     });
     
     let taskId;
@@ -128,25 +136,25 @@ async function handleOcrSubmit(row, rowData, app, services) {
       taskId = result.task_id || result.id || JSON.stringify(result);
     }
     
-    const newData = { ...rowData, _ocr_task_id: taskId };
-    await services.execute(
-      `UPDATE mini_app_rows SET status = 'ocr_submitted', data = ? WHERE id = ?`,
-      [JSON.stringify(newData), row.id]
-    );
+    await services.execute(`
+      UPDATE ${CONTENT_TABLE} 
+      SET process_step = 'ocr_submitted', ocr_task_id = ?
+      WHERE row_id = ?
+    `, [taskId, row.row_id]);
     
-    logger.info(`[tick] OCR submitted for ${row.id}, task_id=${taskId}`);
+    logger.info(`[tick] OCR submitted for ${row.row_id}, task_id=${taskId}`);
   } catch (e) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
-    logger.error(`[tick] OCR submit failed for ${row.id}: ${e.message}`);
+    await updateProcessStep(services, row.row_id, 'ocr_failed');
+    logger.error(`[tick] OCR submit failed for ${row.row_id}: ${e.message}`);
   }
 }
 
-async function handleOcrCheck(row, rowData, app, services) {
-  logger.info(`[tick] Checking OCR for ${row.id}`);
+async function handleOcrCheck(row, app, services) {
+  logger.info(`[tick] Checking OCR for ${row.row_id}`);
   
-  const taskId = rowData._ocr_task_id;
+  const taskId = row.ocr_task_id;
   if (!taskId) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
+    await updateProcessStep(services, row.row_id, 'ocr_failed');
     return;
   }
   
@@ -177,22 +185,20 @@ ${taskInfo}
       let ocrText = extractTextFromMcpResult(mcpResult);
       ocrText = ocrText.replace(/\\n/g, '\n');
       
-      await services.callExtension(CONTENT_TABLE, 'upsert', {
-        row_id: row.id,
-        ocr_text: ocrText,
-        ocr_service: mcp.server,
-        ocr_at: new Date()
-      });
+      await services.execute(`
+        UPDATE ${CONTENT_TABLE} 
+        SET process_step = 'pending_filter', ocr_text = ?, ocr_service = ?, ocr_at = NOW()
+        WHERE row_id = ?
+      `, [ocrText, mcp.server, row.row_id]);
       
-      await services.execute(`UPDATE mini_app_rows SET status = 'pending_filter' WHERE id = ?`, [row.id]);
-      logger.info(`[tick] OCR completed for ${row.id}, text length=${ocrText.length}`);
+      logger.info(`[tick] OCR completed for ${row.row_id}, text length=${ocrText.length}`);
     } else if (parsed.status === 'pending') {
-      logger.info(`[tick] OCR pending for ${row.id}, progress=${parsed.progress}`);
+      logger.info(`[tick] OCR pending for ${row.row_id}, progress=${parsed.progress}`);
     } else {
-      await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
+      await updateProcessStep(services, row.row_id, 'ocr_failed');
     }
   } catch (e) {
-    logger.error(`[tick] OCR check failed for ${row.id}: ${e.message}`);
+    logger.error(`[tick] OCR check failed for ${row.row_id}: ${e.message}`);
   }
 }
 
@@ -206,17 +212,21 @@ function extractTextFromMcpResult(mcpResult) {
 }
 
 async function handleFilter(row, app, services) {
-  logger.info(`[tick] Filtering text for ${row.id}`);
+  logger.info(`[tick] Filtering text for ${row.row_id}`);
   
-  const content = await services.callExtension(CONTENT_TABLE, 'read', {
-    row_id: row.id,
-    fields: ['ocr_text']
-  });
+  const content = await services.query(`
+    SELECT ocr_text, filter_carried_over, filter_chunk_index FROM ${CONTENT_TABLE}
+    WHERE row_id = ?
+  `, [row.row_id]);
   
-  if (!content || !content.ocr_text) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'filter_failed' WHERE id = ?`, [row.id]);
+  if (!content.length || !content[0].ocr_text) {
+    await updateProcessStep(services, row.row_id, 'filter_failed');
     return;
   }
+  
+  const ocrText = content[0].ocr_text;
+  const existingCarriedOver = content[0].filter_carried_over || '';
+  const existingChunkIndex = content[0].filter_chunk_index || 0;
   
   const filterConfig = getStepResource(app, 'pending_filter', { temperature: 0.3 });
   const filterPrompt = getPrompt(app, 'filter', '去除页码、水印、乱码，保留正文');
@@ -224,41 +234,59 @@ async function handleFilter(row, app, services) {
   
   let filteredText;
   
-  if (content.ocr_text.length <= maxLen) {
+  if (ocrText.length <= maxLen) {
     try {
       const response = await services.callLlm('filter_text', {
         instruction: filterPrompt + JSON_FORMAT_PROMPT,
-        ocr_text: content.ocr_text,
+        ocr_text: ocrText,
         response_format: 'json',
         ...buildLlmParams(filterConfig)
       });
       const parsed = parseLlmResponse(response);
-      filteredText = parsed?.processed_text || content.ocr_text;
+      filteredText = parsed?.processed_text || ocrText;
     } catch (e) {
-      filteredText = content.ocr_text;
+      filteredText = ocrText;
     }
+    
+    await services.execute(`
+      UPDATE ${CONTENT_TABLE} 
+      SET process_step = 'pending_extract', filtered_text = ?, filter_at = NOW(),
+          filter_carried_over = NULL, filter_chunk_index = 0
+      WHERE row_id = ?
+    `, [filteredText, row.row_id]);
+    
+    logger.info(`[tick] Filter completed for ${row.row_id}, length=${filteredText.length}`);
   } else {
-    filteredText = await filterWithSlidingWindow(content.ocr_text, filterPrompt, filterConfig, services);
+    const result = await filterWithSlidingWindow(ocrText, filterPrompt, filterConfig, services, row.row_id, existingCarriedOver, existingChunkIndex);
+    
+    if (result.completed) {
+      await services.execute(`
+        UPDATE ${CONTENT_TABLE} 
+        SET process_step = 'pending_extract', filtered_text = ?, filter_at = NOW(),
+            filter_carried_over = NULL, filter_chunk_index = 0
+        WHERE row_id = ?
+      `, [result.filteredText, row.row_id]);
+      logger.info(`[tick] Filter completed for ${row.row_id}, length=${result.filteredText.length}`);
+    } else {
+      await services.execute(`
+        UPDATE ${CONTENT_TABLE} 
+        SET filter_carried_over = ?, filter_chunk_index = ?
+        WHERE row_id = ?
+      `, [result.carriedOver, result.chunkIndex, row.row_id]);
+      logger.info(`[tick] Filter progress for ${row.row_id}, chunk ${result.chunkIndex}`);
+    }
   }
-  
-  await services.callExtension(CONTENT_TABLE, 'upsert', {
-    row_id: row.id,
-    filtered_text: filteredText,
-    filter_at: new Date()
-  });
-  
-  await services.execute(`UPDATE mini_app_rows SET status = 'pending_extract' WHERE id = ?`, [row.id]);
-  logger.info(`[tick] Filter completed for ${row.id}, length=${filteredText.length}`);
 }
 
-async function filterWithSlidingWindow(ocrText, filterPrompt, filterConfig, services) {
+async function filterWithSlidingWindow(ocrText, filterPrompt, filterConfig, services, rowId, existingCarriedOver, existingChunkIndex) {
   const maxLen = filterConfig.chunk_max_length || DEFAULT_CHUNK_MAX_LENGTH;
   const chunks = splitIntoChunks(ocrText, maxLen);
   
   const allProcessed = [];
-  let carriedOver = '';
+  let carriedOver = existingCarriedOver || '';
+  let startIndex = existingChunkIndex || 0;
   
-  for (let i = 0; i < chunks.length; i++) {
+  for (let i = startIndex; i < chunks.length; i++) {
     const chunkInput = carriedOver + (carriedOver ? '\n' : '') + chunks[i];
     
     try {
@@ -268,28 +296,50 @@ async function filterWithSlidingWindow(ocrText, filterPrompt, filterConfig, serv
         response_format: 'json',
         ...buildLlmParams(filterConfig)
       });
-      const result = parseLlmResponse(response);
-      allProcessed.push(result?.processed_text || chunkInput);
-      carriedOver = result?.carried_over || '';
+      const parsed = parseLlmResponse(response);
+      allProcessed.push(parsed?.processed_text || chunkInput);
+      carriedOver = parsed?.carried_over || '';
+      
+      logger.info(`[tick] Chunk ${i + 1}/${chunks.length} done for ${rowId}`);
     } catch (e) {
       allProcessed.push(chunkInput);
       carriedOver = '';
     }
   }
   
-  return allProcessed.join('\n');
+  if (carriedOver) {
+    try {
+      const response = await services.callLlm('filter_text', {
+        instruction: filterPrompt + JSON_FORMAT_PROMPT,
+        ocr_text: carriedOver,
+        response_format: 'json',
+        ...buildLlmParams(filterConfig)
+      });
+      const parsed = parseLlmResponse(response);
+      allProcessed.push(parsed?.processed_text || carriedOver);
+    } catch (e) {
+      allProcessed.push(carriedOver);
+    }
+  }
+  
+  return {
+    completed: true,
+    filteredText: allProcessed.join('\n'),
+    carriedOver: '',
+    chunkIndex: chunks.length
+  };
 }
 
 async function handleExtract(row, app, services) {
-  logger.info(`[tick] Extracting metadata for ${row.id}`);
+  logger.info(`[tick] Extracting metadata for ${row.row_id}`);
   
-  const content = await services.callExtension(CONTENT_TABLE, 'read', {
-    row_id: row.id,
-    fields: ['filtered_text']
-  });
+  const content = await services.query(`
+    SELECT filtered_text FROM ${CONTENT_TABLE}
+    WHERE row_id = ?
+  `, [row.row_id]);
   
-  if (!content || !content.filtered_text) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'extract_failed' WHERE id = ?`, [row.id]);
+  if (!content.length || !content[0].filtered_text) {
+    await updateProcessStep(services, row.row_id, 'extract_failed');
     return;
   }
   
@@ -310,7 +360,7 @@ ${exampleJson}
   try {
     const response = await services.callLlm('extract_metadata', {
       instruction: prompt,
-      ocr_text: content.filtered_text,
+      ocr_text: content[0].filtered_text,
       response_format: 'json',
       ...buildLlmParams(extractConfig)
     });
@@ -318,7 +368,7 @@ ${exampleJson}
     const metadata = parseLlmResponse(response);
     
     if (!metadata) {
-      await services.execute(`UPDATE mini_app_rows SET status = 'extract_failed' WHERE id = ?`, [row.id]);
+      await updateProcessStep(services, row.row_id, 'extract_failed');
       return;
     }
     
@@ -338,37 +388,45 @@ ${exampleJson}
       }
     }
     
-    await services.callExtension(ROWS_TABLE, 'upsert', {
-      row_id: row.id,
-      ...cleanMetadata
-    });
+    await services.execute(`
+      INSERT INTO ${ROWS_TABLE} (row_id, contract_number, party_a, party_b, parent_company, contract_amount, contract_date)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON DUPLICATE KEY UPDATE 
+        contract_number = VALUES(contract_number),
+        party_a = VALUES(party_a),
+        party_b = VALUES(party_b),
+        parent_company = VALUES(parent_company),
+        contract_amount = VALUES(contract_amount),
+        contract_date = VALUES(contract_date)
+    `, [row.row_id, cleanMetadata.contract_number || null, cleanMetadata.party_a || null, 
+        cleanMetadata.party_b || null, cleanMetadata.parent_company || null,
+        cleanMetadata.contract_amount || null, cleanMetadata.contract_date || null]);
     
-    await services.callExtension(CONTENT_TABLE, 'upsert', {
-      row_id: row.id,
-      extract_json: JSON.stringify(cleanMetadata),
-      extract_model: extractConfig.model_id,
-      extract_temperature: extractConfig.temperature,
-      extract_at: new Date()
-    });
+    await services.execute(`
+      UPDATE ${CONTENT_TABLE} 
+      SET process_step = 'pending_section', 
+          extract_json = ?, extract_model = ?, extract_temperature = ?, extract_at = NOW()
+      WHERE row_id = ?
+    `, [JSON.stringify(cleanMetadata), extractConfig.model_id || null, 
+        extractConfig.temperature || 0.3, row.row_id]);
     
-    await services.execute(`UPDATE mini_app_rows SET status = 'pending_section' WHERE id = ?`, [row.id]);
-    logger.info(`[tick] Extract completed for ${row.id}`);
+    logger.info(`[tick] Extract completed for ${row.row_id}`);
   } catch (e) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'extract_failed' WHERE id = ?`, [row.id]);
-    logger.error(`[tick] Extract failed for ${row.id}: ${e.message}`);
+    await updateProcessStep(services, row.row_id, 'extract_failed');
+    logger.error(`[tick] Extract failed for ${row.row_id}: ${e.message}`);
   }
 }
 
 async function handleSection(row, app, services) {
-  logger.info(`[tick] Analyzing sections for ${row.id}`);
+  logger.info(`[tick] Analyzing sections for ${row.row_id}`);
   
-  const content = await services.callExtension(CONTENT_TABLE, 'read', {
-    row_id: row.id,
-    fields: ['filtered_text']
-  });
+  const content = await services.query(`
+    SELECT filtered_text FROM ${CONTENT_TABLE}
+    WHERE row_id = ?
+  `, [row.row_id]);
   
-  if (!content || !content.filtered_text) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'section_failed' WHERE id = ?`, [row.id]);
+  if (!content.length || !content[0].filtered_text) {
+    await updateProcessStep(services, row.row_id, 'section_failed');
     return;
   }
   
@@ -386,7 +444,7 @@ async function handleSection(row, app, services) {
   try {
     const response = await services.callLlm('analyze_sections', {
       instruction: sectionPrompt + jsonFormat,
-      ocr_text: content.filtered_text,
+      ocr_text: content[0].filtered_text,
       response_format: 'json',
       ...buildLlmParams(sectionConfig)
     });
@@ -395,19 +453,25 @@ async function handleSection(row, app, services) {
     const sections = result?.sections || result;
     
     if (!Array.isArray(sections)) {
-      await services.execute(`UPDATE mini_app_rows SET status = 'section_failed' WHERE id = ?`, [row.id]);
+      await updateProcessStep(services, row.row_id, 'section_failed');
       return;
     }
     
-    await services.callExtension(CONTENT_TABLE, 'upsert', {
-      row_id: row.id,
-      sections: JSON.stringify(sections)
-    });
+    await services.execute(`
+      UPDATE ${CONTENT_TABLE} 
+      SET process_step = 'pending_review', sections = ?
+      WHERE row_id = ?
+    `, [JSON.stringify(sections), row.row_id]);
     
-    await services.execute(`UPDATE mini_app_rows SET status = 'pending_review' WHERE id = ?`, [row.id]);
-    logger.info(`[tick] Section completed for ${row.id}, found ${sections.length} sections`);
+    logger.info(`[tick] Section completed for ${row.row_id}, found ${sections.length} sections`);
   } catch (e) {
-    await services.execute(`UPDATE mini_app_rows SET status = 'section_failed' WHERE id = ?`, [row.id]);
-    logger.error(`[tick] Section failed for ${row.id}: ${e.message}`);
+    await updateProcessStep(services, row.row_id, 'section_failed');
+    logger.error(`[tick] Section failed for ${row.row_id}: ${e.message}`);
   }
+}
+
+async function updateProcessStep(services, rowId, newStep) {
+  await services.execute(`
+    UPDATE ${CONTENT_TABLE} SET process_step = ? WHERE row_id = ?
+  `, [newStep, rowId]);
 }

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -1,0 +1,412 @@
+import logger from '../../../lib/logger.js';
+import { splitIntoChunks, parseLlmResponse, getStepResource, getPrompt, buildLlmParams } from '../handlers/shared.js';
+
+const CONTENT_TABLE = 'app_contract_mgr_v2_content';
+const ROWS_TABLE = 'app_contract_mgr_v2_rows';
+
+const CONTRACT_FIELDS = [
+  { name: 'contract_number', label: '合同编号', guide: '查找合同编号，通常在合同首页顶部' },
+  { name: 'party_a', label: '甲方', guide: '查找甲方名称' },
+  { name: 'party_b', label: '乙方', guide: '查找乙方名称' },
+  { name: 'parent_company', label: '上级公司', guide: '如果甲方是子公司，推断上级公司' },
+  { name: 'contract_amount', label: '合同金额', guide: '查找合同总金额' },
+  { name: 'contract_date', label: '签订日期', guide: '查找签订日期，格式 YYYY-MM-DD' },
+];
+
+const DEFAULT_CHUNK_MAX_LENGTH = parseInt(process.env.TEXT_FILTER_MAX_LENGTH) || 50000;
+
+const JSON_FORMAT_PROMPT = `
+返回JSON格式：
+{
+  "processed_text": "本轮清洗后的完整章节内容",
+  "carried_over": "末尾不完整章节的原文"
+}`;
+
+export async function tick(context) {
+  const { db, app, registry, services } = context;
+  
+  if (!app) {
+    logger.info('[tick] No app found');
+    return { skipped: true, reason: 'no_app' };
+  }
+  
+  const lastRun = await services.query(`
+    SELECT created_at FROM app_tick_log
+    WHERE registry_id = ? AND success = 1
+    ORDER BY created_at DESC LIMIT 1
+  `, [registry.id]);
+  
+  if (lastRun.length > 0) {
+    const elapsed = Date.now() - new Date(lastRun[0].created_at).getTime();
+    const minInterval = 10 * 60 * 1000;
+    
+    if (elapsed < minInterval) {
+      logger.info(`[tick] Skipped: last run ${Math.round(elapsed/1000)}s ago`);
+      return { skipped: true, reason: 'interval_not_reached' };
+    }
+  }
+  
+  const pending = await services.query(`
+    SELECT id, status, data FROM mini_app_rows 
+    WHERE app_id = ? AND status IN ('pending_ocr', 'ocr_submitted', 'pending_filter', 'pending_extract', 'pending_section')
+    LIMIT 5
+  `, [app.id]);
+  
+  if (pending.length === 0) {
+    logger.info('[tick] No pending records');
+    return { skipped: true, reason: 'no_data' };
+  }
+  
+  let processed = 0;
+  
+  for (const row of pending) {
+    try {
+      await processRow(row, app, services);
+      processed++;
+    } catch (e) {
+      logger.error(`[tick] Row ${row.id} failed: ${e.message}`);
+    }
+  }
+  
+  logger.info(`[tick] Processed ${processed} records`);
+  return { success: true, processed };
+}
+
+async function processRow(row, app, services) {
+  const rowData = typeof row.data === 'string' ? JSON.parse(row.data || '{}') : (row.data || {});
+  
+  switch (row.status) {
+    case 'pending_ocr':
+      await handleOcrSubmit(row, rowData, app, services);
+      break;
+    case 'ocr_submitted':
+      await handleOcrCheck(row, rowData, app, services);
+      break;
+    case 'pending_filter':
+      await handleFilter(row, app, services);
+      break;
+    case 'pending_extract':
+      await handleExtract(row, app, services);
+      break;
+    case 'pending_section':
+      await handleSection(row, app, services);
+      break;
+  }
+}
+
+async function handleOcrSubmit(row, rowData, app, services) {
+  logger.info(`[tick] Submitting OCR for ${row.id}`);
+  
+  const files = await services.getFiles(row.id);
+  if (!files || files.length === 0) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
+    return;
+  }
+  
+  const file = files[0];
+  const attachment = file.attachment || file;
+  
+  const config = getStepResource(app, 'pending_ocr', {});
+  const mcp = config.mcp || { server: 'markitdown', tool: 'submit_conversion_task' };
+  
+  try {
+    const result = await services.callMcp(mcp.server, mcp.tool, {
+      content: attachment.base64 || attachment.content,
+      filename: attachment.filename || attachment.name
+    });
+    
+    let taskId;
+    if (typeof result === 'string') {
+      try {
+        const parsed = JSON.parse(result);
+        taskId = parsed.task_id || parsed.id || result;
+      } catch {
+        taskId = result;
+      }
+    } else {
+      taskId = result.task_id || result.id || JSON.stringify(result);
+    }
+    
+    const newData = { ...rowData, _ocr_task_id: taskId };
+    await services.execute(
+      `UPDATE mini_app_rows SET status = 'ocr_submitted', data = ? WHERE id = ?`,
+      [JSON.stringify(newData), row.id]
+    );
+    
+    logger.info(`[tick] OCR submitted for ${row.id}, task_id=${taskId}`);
+  } catch (e) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
+    logger.error(`[tick] OCR submit failed for ${row.id}: ${e.message}`);
+  }
+}
+
+async function handleOcrCheck(row, rowData, app, services) {
+  logger.info(`[tick] Checking OCR for ${row.id}`);
+  
+  const taskId = rowData._ocr_task_id;
+  if (!taskId) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
+    return;
+  }
+  
+  const config = getStepResource(app, 'ocr_submitted', {});
+  const mcp = config.mcp || { server: 'markitdown', tool: 'get_task' };
+  
+  try {
+    const mcpResult = await services.callMcp(mcp.server, mcp.tool || 'get_task', { task_id: taskId });
+    
+    const taskInfo = JSON.stringify(mcpResult, null, 2).substring(0, 1000);
+    
+    const judgePrompt = `判断OCR任务是否完成。
+任务返回信息：
+${taskInfo}
+
+返回JSON：{"status": "completed|pending|failed", "progress": 0-100}`;
+    
+    const judgeResult = await services.callLlm('judge_ocr_status', {
+      instruction: judgePrompt,
+      model_id: config.judge_model_id,
+      temperature: config.judge_temperature || 0.1,
+      response_format: 'json'
+    });
+    
+    const parsed = parseLlmResponse(judgeResult) || { status: 'pending', progress: 0 };
+    
+    if (parsed.status === 'completed') {
+      let ocrText = extractTextFromMcpResult(mcpResult);
+      ocrText = ocrText.replace(/\\n/g, '\n');
+      
+      await services.callExtension(CONTENT_TABLE, 'upsert', {
+        row_id: row.id,
+        ocr_text: ocrText,
+        ocr_service: mcp.server,
+        ocr_at: new Date()
+      });
+      
+      await services.execute(`UPDATE mini_app_rows SET status = 'pending_filter' WHERE id = ?`, [row.id]);
+      logger.info(`[tick] OCR completed for ${row.id}, text length=${ocrText.length}`);
+    } else if (parsed.status === 'pending') {
+      logger.info(`[tick] OCR pending for ${row.id}, progress=${parsed.progress}`);
+    } else {
+      await services.execute(`UPDATE mini_app_rows SET status = 'ocr_failed' WHERE id = ?`, [row.id]);
+    }
+  } catch (e) {
+    logger.error(`[tick] OCR check failed for ${row.id}: ${e.message}`);
+  }
+}
+
+function extractTextFromMcpResult(mcpResult) {
+  if (!mcpResult) return '';
+  if (typeof mcpResult === 'string') return mcpResult;
+  if (mcpResult.result) return typeof mcpResult.result === 'string' ? mcpResult.result : JSON.stringify(mcpResult.result);
+  if (mcpResult.content) return typeof mcpResult.content === 'string' ? mcpResult.content : JSON.stringify(mcpResult.content);
+  if (mcpResult.text) return mcpResult.text;
+  return JSON.stringify(mcpResult);
+}
+
+async function handleFilter(row, app, services) {
+  logger.info(`[tick] Filtering text for ${row.id}`);
+  
+  const content = await services.callExtension(CONTENT_TABLE, 'read', {
+    row_id: row.id,
+    fields: ['ocr_text']
+  });
+  
+  if (!content || !content.ocr_text) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'filter_failed' WHERE id = ?`, [row.id]);
+    return;
+  }
+  
+  const filterConfig = getStepResource(app, 'pending_filter', { temperature: 0.3 });
+  const filterPrompt = getPrompt(app, 'filter', '去除页码、水印、乱码，保留正文');
+  const maxLen = filterConfig.chunk_max_length || DEFAULT_CHUNK_MAX_LENGTH;
+  
+  let filteredText;
+  
+  if (content.ocr_text.length <= maxLen) {
+    try {
+      const response = await services.callLlm('filter_text', {
+        instruction: filterPrompt + JSON_FORMAT_PROMPT,
+        ocr_text: content.ocr_text,
+        response_format: 'json',
+        ...buildLlmParams(filterConfig)
+      });
+      const parsed = parseLlmResponse(response);
+      filteredText = parsed?.processed_text || content.ocr_text;
+    } catch (e) {
+      filteredText = content.ocr_text;
+    }
+  } else {
+    filteredText = await filterWithSlidingWindow(content.ocr_text, filterPrompt, filterConfig, services);
+  }
+  
+  await services.callExtension(CONTENT_TABLE, 'upsert', {
+    row_id: row.id,
+    filtered_text: filteredText,
+    filter_at: new Date()
+  });
+  
+  await services.execute(`UPDATE mini_app_rows SET status = 'pending_extract' WHERE id = ?`, [row.id]);
+  logger.info(`[tick] Filter completed for ${row.id}, length=${filteredText.length}`);
+}
+
+async function filterWithSlidingWindow(ocrText, filterPrompt, filterConfig, services) {
+  const maxLen = filterConfig.chunk_max_length || DEFAULT_CHUNK_MAX_LENGTH;
+  const chunks = splitIntoChunks(ocrText, maxLen);
+  
+  const allProcessed = [];
+  let carriedOver = '';
+  
+  for (let i = 0; i < chunks.length; i++) {
+    const chunkInput = carriedOver + (carriedOver ? '\n' : '') + chunks[i];
+    
+    try {
+      const response = await services.callLlm('filter_text', {
+        instruction: filterPrompt + JSON_FORMAT_PROMPT,
+        ocr_text: chunkInput,
+        response_format: 'json',
+        ...buildLlmParams(filterConfig)
+      });
+      const result = parseLlmResponse(response);
+      allProcessed.push(result?.processed_text || chunkInput);
+      carriedOver = result?.carried_over || '';
+    } catch (e) {
+      allProcessed.push(chunkInput);
+      carriedOver = '';
+    }
+  }
+  
+  return allProcessed.join('\n');
+}
+
+async function handleExtract(row, app, services) {
+  logger.info(`[tick] Extracting metadata for ${row.id}`);
+  
+  const content = await services.callExtension(CONTENT_TABLE, 'read', {
+    row_id: row.id,
+    fields: ['filtered_text']
+  });
+  
+  if (!content || !content.filtered_text) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'extract_failed' WHERE id = ?`, [row.id]);
+    return;
+  }
+  
+  const extractConfig = getStepResource(app, 'pending_extract', { temperature: 0.3 });
+  
+  const fieldDefs = CONTRACT_FIELDS.map(f => `- ${f.name} (${f.label}): ${f.guide}`).join('\n');
+  const exampleJson = CONTRACT_FIELDS.map(f => `  "${f.name}": "值"`).join(',\n');
+  
+  const prompt = `从文本中提取元数据。
+字段定义:
+${fieldDefs}
+
+返回JSON:
+{
+${exampleJson}
+}`;
+  
+  try {
+    const response = await services.callLlm('extract_metadata', {
+      instruction: prompt,
+      ocr_text: content.filtered_text,
+      response_format: 'json',
+      ...buildLlmParams(extractConfig)
+    });
+    
+    const metadata = parseLlmResponse(response);
+    
+    if (!metadata) {
+      await services.execute(`UPDATE mini_app_rows SET status = 'extract_failed' WHERE id = ?`, [row.id]);
+      return;
+    }
+    
+    const cleanMetadata = {};
+    for (const field of CONTRACT_FIELDS) {
+      const value = metadata[field.name];
+      if (!value) continue;
+      
+      if (field.name === 'contract_amount') {
+        const num = Number(String(value).replace(/[,，]/g, ''));
+        if (!isNaN(num)) cleanMetadata[field.name] = num;
+      } else if (field.name === 'contract_date') {
+        const dateStr = String(value).replace(/年/g, '-').replace(/月/g, '-').replace(/日/g, '');
+        if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(dateStr)) cleanMetadata[field.name] = dateStr;
+      } else {
+        cleanMetadata[field.name] = value;
+      }
+    }
+    
+    await services.callExtension(ROWS_TABLE, 'upsert', {
+      row_id: row.id,
+      ...cleanMetadata
+    });
+    
+    await services.callExtension(CONTENT_TABLE, 'upsert', {
+      row_id: row.id,
+      extract_json: JSON.stringify(cleanMetadata),
+      extract_model: extractConfig.model_id,
+      extract_temperature: extractConfig.temperature,
+      extract_at: new Date()
+    });
+    
+    await services.execute(`UPDATE mini_app_rows SET status = 'pending_section' WHERE id = ?`, [row.id]);
+    logger.info(`[tick] Extract completed for ${row.id}`);
+  } catch (e) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'extract_failed' WHERE id = ?`, [row.id]);
+    logger.error(`[tick] Extract failed for ${row.id}: ${e.message}`);
+  }
+}
+
+async function handleSection(row, app, services) {
+  logger.info(`[tick] Analyzing sections for ${row.id}`);
+  
+  const content = await services.callExtension(CONTENT_TABLE, 'read', {
+    row_id: row.id,
+    fields: ['filtered_text']
+  });
+  
+  if (!content || !content.filtered_text) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'section_failed' WHERE id = ?`, [row.id]);
+    return;
+  }
+  
+  const sectionConfig = getStepResource(app, 'pending_section', { temperature: 0.3 });
+  const sectionPrompt = getPrompt(app, 'section', '分析章节结构');
+  
+  const jsonFormat = `
+返回JSON:
+{
+  "sections": [
+    { "title": "章节标题", "level": 1, "index": 0, "summary": "摘要" }
+  ]
+}`;
+  
+  try {
+    const response = await services.callLlm('analyze_sections', {
+      instruction: sectionPrompt + jsonFormat,
+      ocr_text: content.filtered_text,
+      response_format: 'json',
+      ...buildLlmParams(sectionConfig)
+    });
+    
+    const result = parseLlmResponse(response);
+    const sections = result?.sections || result;
+    
+    if (!Array.isArray(sections)) {
+      await services.execute(`UPDATE mini_app_rows SET status = 'section_failed' WHERE id = ?`, [row.id]);
+      return;
+    }
+    
+    await services.callExtension(CONTENT_TABLE, 'upsert', {
+      row_id: row.id,
+      sections: JSON.stringify(sections)
+    });
+    
+    await services.execute(`UPDATE mini_app_rows SET status = 'pending_review' WHERE id = ?`, [row.id]);
+    logger.info(`[tick] Section completed for ${row.id}, found ${sections.length} sections`);
+  } catch (e) {
+    await services.execute(`UPDATE mini_app_rows SET status = 'section_failed' WHERE id = ?`, [row.id]);
+    logger.error(`[tick] Section failed for ${row.id}: ${e.message}`);
+  }
+}

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -39,7 +39,7 @@ export async function tick(context) {
   
   if (lastRun.length > 0) {
     const elapsed = Date.now() - new Date(lastRun[0].created_at).getTime();
-    const minInterval = 10 * 60 * 1000;
+    const minInterval = 1 * 60 * 1000;
     
     if (elapsed < minInterval) {
       logger.info(`[tick] Skipped: last run ${Math.round(elapsed/1000)}s ago`);

--- a/data/skills/mcp-client/index.js
+++ b/data/skills/mcp-client/index.js
@@ -204,27 +204,49 @@ async function createTransport(serverConfig, credentials = null) {
     }
     
     const headers = buildAuthHeaders(serverConfig.headers, credentials);
+    const timeoutMs = serverConfig.timeout_ms || 600000;
     
-    // 判断是否使用 StatelessHTTPTransport
-    // 1. 明确指定 statelessHttp
-    // 2. 或者 server 不支持 session（headers 中没有 mcp-session-id 提示）
     const isStateless = transportType === 'statelessHttp' || serverConfig.stateless === true;
     
-    const requestInit = { headers };
+    const customFetch = async (url, init) => {
+      log(`Custom fetch: url=${url}, method=${init?.method}, timeout=${timeoutMs}ms`);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        log(`Custom fetch timeout triggered after ${timeoutMs}ms`);
+        controller.abort();
+      }, timeoutMs);
+      
+      try {
+        const response = await fetch(url, { ...init, signal: controller.signal });
+        clearTimeout(timeoutId);
+        log(`Custom fetch response: status=${response.status}`);
+        return response;
+      } catch (err) {
+        clearTimeout(timeoutId);
+        if (err.name === 'AbortError') {
+          log(`Custom fetch aborted due to timeout`);
+          throw new Error(`Request timeout after ${timeoutMs}ms`);
+        }
+        log(`Custom fetch error: ${err.message}`);
+        throw err;
+      }
+    };
+    
+    const requestInit = { headers, fetch: customFetch };
     
     if (isStateless) {
       log(`Creating StatelessHTTP transport for ${serverConfig.name}: ${serverConfig.url}`);
-      log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
-      return new StatelessHTTPTransport(new URL(serverConfig.url), { requestInit });
+      log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}, timeout=${timeoutMs}ms`);
+      return new StatelessHTTPTransport(new URL(serverConfig.url), { requestInit: { headers }, timeout: timeoutMs });
     }
     
     const useSSE = transportType === 'sse' || serverConfig.url.endsWith('/sse') || serverConfig.use_sse;
     
     log(`Creating ${useSSE ? 'SSE' : 'StreamableHTTP'} transport for ${serverConfig.name}: ${serverConfig.url}`);
-    log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
+    log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}, timeout=${timeoutMs}ms`);
     
     const TransportClass = useSSE ? SSEClientTransport : StreamableHTTPClientTransport;
-    return new TransportClass(new URL(serverConfig.url), { requestInit });
+    return new TransportClass(new URL(serverConfig.url), { requestInit, fetch: customFetch });
   }
   
   // STDIO 模式（默认）
@@ -252,50 +274,53 @@ async function createTransport(serverConfig, credentials = null) {
  * @returns {Promise<Client>}
  */
 async function connectServer(serverConfig, userId = null, credentials = null) {
-  // 构建连接 key
   const connectionKey = userId ? `${serverConfig.name}:${userId}` : serverConfig.name;
   
-  // 检查是否已连接
   if (connections.has(connectionKey)) {
     log(`Already connected: ${connectionKey}`);
     return connections.get(connectionKey).client;
   }
   
   log(`Connecting to ${connectionKey} (transport: ${serverConfig.transport_type || 'stdio'})...`);
+  log(`Server config: ${JSON.stringify({ name: serverConfig.name, transport_type: serverConfig.transport_type, url: serverConfig.url, command: serverConfig.command })}`);
   
-  // 创建 MCP Client
-  const client = new Client({
-    name: 'touwaka-mate-mcp-client',
-    version: '1.0.0',
-  }, {
-    capabilities: {
-      tools: {},
-      resources: {},
-      prompts: {},
-    },
-  });
-  
-  // 创建 Transport（根据传输类型）
-  const transport = await createTransport(serverConfig, credentials);
-  
-  // 连接
-  await client.connect(transport);
-  
-  // 存储连接
-  connections.set(connectionKey, {
-    client,
-    transport,
-    config: serverConfig,
-    userId,
-    startedAt: new Date().toISOString(),
-  });
-  
-  // 获取并缓存工具定义
-  await cacheTools(serverConfig.name, client);
-  
-  log(`Connected: ${connectionKey}`);
-  
-  return client;
+  try {
+    const client = new Client({
+      name: 'touwaka-mate-mcp-client',
+      version: '1.0.0',
+    }, {
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+    });
+    
+    log(`Client created for ${connectionKey}, creating transport...`);
+    const transport = await createTransport(serverConfig, credentials);
+    log(`Transport created for ${connectionKey}, connecting...`);
+    
+    await client.connect(transport);
+    log(`Client connected for ${connectionKey}`);
+    
+    connections.set(connectionKey, {
+      client,
+      transport,
+      config: serverConfig,
+      userId,
+      startedAt: new Date().toISOString(),
+    });
+    
+    await cacheTools(serverConfig.name, client);
+    log(`Tools cached for ${connectionKey}`);
+    
+    log(`Connected: ${connectionKey}`);
+    return client;
+  } catch (err) {
+    log(`connectServer ERROR for ${connectionKey}: ${err.message}`);
+    log(`connectServer ERROR stack: ${err.stack}`);
+    throw err;
+  }
 }
 
 /**
@@ -430,39 +455,61 @@ async function getUserTools(userId, configData) {
  * @returns {Promise<object>} 工具结果
  */
 async function callTool(serverName, toolName, args, userId, configData) {
-  // 查找连接
-  let connectionKey = serverName; // 先尝试公共连接
-  let conn = connections.get(connectionKey);
+  log(`callTool start: server=${serverName}, tool=${toolName}, userId=${userId || 'none'}`);
   
-  // 如果公共连接不存在，尝试用户连接
+  let connectionKey = serverName;
+  let conn = connections.get(connectionKey);
+  log(`callTool: initial lookup for key=${connectionKey}, found=${conn ? 'yes' : 'no'}`);
+  
   if (!conn && userId) {
     connectionKey = `${serverName}:${userId}`;
     conn = connections.get(connectionKey);
+    log(`callTool: fallback lookup for key=${connectionKey}, found=${conn ? 'yes' : 'no'}`);
   }
   
-  // 如果连接不存在，尝试建立连接
   if (!conn) {
-    const serverConfig = (configData.servers || []).find(s => s.name === serverName);
+    const servers = configData.servers || [];
+    const serverConfig = servers.find(s => s.name === serverName);
+    log(`callTool: auto-connect search, servers count=${servers.length}, found=${serverConfig ? 'yes' : 'no'}`);
+    
     if (!serverConfig) {
+      log(`callTool: server '${serverName}' not found in config`);
       throw new Error(`MCP Server '${serverName}' not found`);
     }
     
-    // 获取凭证
     const credentials = getCredentials(userId, serverConfig.id, configData);
+    log(`callTool: auto-connect, is_public=${serverConfig.is_public}, has_credentials=${credentials ? 'yes' : 'no'}`);
+    log(`callTool: server config details: ${JSON.stringify({ name: serverConfig.name, transport_type: serverConfig.transport_type, url: serverConfig.url })}`);
     
-    // 建立连接
-    if (serverConfig.is_public) {
-      await connectServer(serverConfig);
-      conn = connections.get(serverName);
-    } else if (credentials) {
-      await connectServer(serverConfig, userId, credentials);
-      conn = connections.get(`${serverName}:${userId}`);
-    } else {
-      throw new Error(`No credentials available for ${serverName}. Please configure credentials in MCP management panel.`);
+    try {
+      if (serverConfig.is_public) {
+        log(`callTool: connecting to public server ${serverName}`);
+        await connectServer(serverConfig);
+        conn = connections.get(serverName);
+        log(`callTool: after public connect, conn=${conn ? 'found' : 'NOT FOUND'}`);
+      } else if (credentials) {
+        log(`callTool: connecting to private server ${serverName} for user ${userId || 'none'}`);
+        await connectServer(serverConfig, userId, credentials);
+        const connKey = userId ? `${serverName}:${userId}` : serverName;
+        conn = connections.get(connKey);
+        log(`callTool: after private connect, key=${connKey}, conn=${conn ? 'found' : 'NOT FOUND'}`);
+      } else {
+        throw new Error(`No credentials available for ${serverName}. Please configure credentials in MCP management panel.`);
+      }
+    } catch (connectErr) {
+      log(`callTool: auto-connect FAILED: ${connectErr.message}`);
+      log(`callTool: auto-connect error stack: ${connectErr.stack}`);
+      throw connectErr;
     }
+    
+    if (!conn) {
+      log(`callTool: CRITICAL - conn still undefined after connectServer`);
+      throw new Error(`Connection established but not found in pool for ${serverName}`);
+    }
+    
+    log(`callTool: auto-connect complete, conn found=${conn ? 'yes' : 'no'}, client exists=${conn?.client ? 'yes' : 'no'}`);
   }
   
-  // 处理文件路径：在驻留进程内读取文件并转 base64
   let processedArgs = args || {};
   if (args?.file_path && !args?.content) {
     const fs = await import('fs/promises');
@@ -478,7 +525,6 @@ async function callTool(serverName, toolName, args, userId, configData) {
       
       log(`File read: ${buffer.length} bytes, base64 length: ${base64.length}`);
       
-      // 只传 base64 内容和文件名，不传路径（远程服务器无法访问）
       processedArgs = {
         content: base64,
         filename: args.name || path.basename(filePath),
@@ -488,13 +534,29 @@ async function callTool(serverName, toolName, args, userId, configData) {
     }
   }
   
-  log(`Calling tool ${serverName}/${toolName} with args: ${JSON.stringify(Object.keys(processedArgs))}`);
+  const argsPreview = Object.keys(processedArgs).map(k => {
+    const v = processedArgs[k];
+    if (typeof v === 'string' && v.length > 100) return `${k}: [${v.length} chars]`;
+    return `${k}: ${typeof v}`;
+  }).join(', ');
+  log(`callTool: calling ${serverName}/${toolName}, args: ${argsPreview}`);
+  
+  if (!conn) {
+    throw new Error(`No connection available for ${serverName}`);
+  }
+  
+  if (!conn.client) {
+    log(`callTool: CRITICAL - conn exists but client is undefined for ${serverName}`);
+    throw new Error(`Connection exists but client is undefined for ${serverName}`);
+  }
   
   try {
     const response = await conn.client.callTool({
       name: toolName,
       arguments: processedArgs,
     });
+    
+    log(`callTool: response received, isError=${response.isError || false}, content count=${response.content?.length || 0}`);
     
     if (response.content) {
       const textContent = response.content
@@ -511,9 +573,10 @@ async function callTool(serverName, toolName, args, userId, configData) {
     
     return response;
   } catch (err) {
-    const msg = err.message || err.name || JSON.stringify(Object.keys(err)) || String(err);
-    log(`callTool failed: ${msg}`);
-    throw new Error(`Tool call failed (${serverName}/${toolName}): ${msg}`);
+    log(`callTool ERROR: ${serverName}/${toolName} - ${err.message}`);
+    log(`callTool ERROR stack: ${err.stack}`);
+    log(`callTool ERROR details: ${JSON.stringify({ name: err.name, message: err.message, code: err.code })}`);
+    throw new Error(`Tool call failed (${serverName}/${toolName}): ${err.message}`);
   }
 }
 

--- a/frontend/src/components/settings/McpTab.vue
+++ b/frontend/src/components/settings/McpTab.vue
@@ -514,7 +514,9 @@ const loadUserCredential = async (serverId: string) => {
   try {
     const result = await mcpApi.getUserCredentialForServer(serverId)
     userCredential.value = result
-    userCredentialForm.env_overrides = result?.env_overrides || ''
+    // credentials 是对象 { api_key: "xxx" }，转成 key=value 格式显示
+    const creds = result?.credentials || {}
+    userCredentialForm.env_overrides = Object.entries(creds).map(([k, v]) => `${k}=${v}`).join('\n')
   } catch (error: any) {
     toast.error(t('settings.mcp.loadCredentialFailed') + ': ' + error.message)
   } finally {
@@ -558,7 +560,9 @@ const loadDefaultCredential = async (serverId: string) => {
   try {
     const result = await mcpApi.getDefaultCredentialForServer(serverId)
     defaultCredential.value = result
-    defaultCredentialForm.env_overrides = result?.env_overrides || ''
+    // credentials 是对象 { api_key: "xxx" }，转成 key=value 格式显示
+    const creds = result?.credentials || {}
+    defaultCredentialForm.env_overrides = Object.entries(creds).map(([k, v]) => `${k}=${v}`).join('\n')
   } catch (error: any) {
     toast.error(t('settings.mcp.loadDefaultCredentialFailed') + ': ' + error.message)
   } finally {

--- a/lib/app-clock.js
+++ b/lib/app-clock.js
@@ -2,62 +2,35 @@ import logger from './logger.js';
 import Utils from './utils.js';
 import { Sequelize, Op } from 'sequelize';
 import path from 'path';
-import { createRequire } from 'module';
 import jwt from 'jsonwebtoken';
 import ExtensionTableService from '../server/services/extension-table.service.js';
 
 class AppClock {
   constructor(db, config = {}) {
     this.db = db;
-    this.intervalMs = config.intervalMs || 10000;
-    this.batchSize = config.batchSize || 10;
-    this.globalConcurrency = config.globalConcurrency || 5;
+    this.sequelize = db.sequelize;
+    this.intervalMs = config.intervalMs || 5000;
     this.residentSkillManager = config.residentSkillManager || null;
     this.llmService = config.llmService || null;
     this.skillLoader = config.skillLoader || null;
     this.extensionService = new ExtensionTableService(db);
     this.running = false;
     this.timer = null;
-    this.activeCount = 0;
+    this.lastWakeIndex = 0;
   }
 
   async start() {
     if (this.running) return;
     this.running = true;
-    logger.info(`[AppClock] Started (interval=${this.intervalMs}ms, batch=${this.batchSize}, concurrency=${this.globalConcurrency})`);
-
-    await this.recoverStuckRecords();
-
+    logger.info(`[AppClock] Started (interval=${this.intervalMs}ms, callback mode)`);
+    
     this.timer = setInterval(() => {
-      this.tick().catch(err => {
-        logger.error('[AppClock] Tick error:', err.message);
+      this.wakeNext().catch(err => {
+        logger.error('[AppClock] Wake error:', err.message);
       });
     }, this.intervalMs);
-
-    setImmediate(() => this.tick());
-  }
-
-  async recoverStuckRecords() {
-    try {
-      const MiniAppRow = this.db.getModel('mini_app_row');
-      if (!MiniAppRow) return;
-
-      const [affected] = await MiniAppRow.update(
-        { status: MiniAppRow.sequelize.literal("REPLACE(status, 'processing_', '')") },
-        {
-          where: {
-            status: { [Op.like]: 'processing_%' },
-          },
-          individualHooks: false,
-        }
-      );
-
-      if (affected > 0) {
-        logger.info(`[AppClock] Recovered ${affected} stuck records from processing_ state`);
-      }
-    } catch (err) {
-      logger.error(`[AppClock] Failed to recover stuck records: ${err.message}`);
-    }
+    
+    setImmediate(() => this.wakeNext());
   }
 
   stop() {
@@ -69,272 +42,173 @@ class AppClock {
     logger.info('[AppClock] Stopped');
   }
 
-  async triggerImmediate() {
-    logger.info('[AppClock] Immediate trigger requested');
-    await this.tick();
-  }
-
-  async tick() {
-    if (this.activeCount >= this.globalConcurrency) {
-      logger.info('[AppClock] Skipped tick: global concurrency reached');
+  async wakeNext() {
+    const AppClockRegistry = this.db.getModel('app_clock_registry');
+    
+    if (!AppClockRegistry) {
+      logger.warn('[AppClock] app_clock_registry model not available');
       return;
     }
-
-    try {
-      const AppState = this.db.getModel('app_state');
-      const MiniAppRow = this.db.getModel('mini_app_row');
-
-      if (!AppState || !MiniAppRow) {
-        logger.warn('[AppClock] Models not available');
-        return;
-      }
-
-      const activeStates = await AppState.findAll({
-        where: {
-          handler_id: { [Op.ne]: null },
-        },
-      });
-
-      if (activeStates.length > 0) {
-        logger.info(`[AppClock] Tick: found ${activeStates.length} active states`);
-      }
-
-      for (const state of activeStates) {
-        if (this.activeCount >= this.globalConcurrency) break;
-
-        const records = await MiniAppRow.findAll({
-          where: {
-            app_id: state.app_id,
-            status: state.name,
-          },
-          limit: Math.min(this.batchSize, this.globalConcurrency - this.activeCount),
-        });
-
-        if (records.length > 0) {
-          logger.info(`[AppClock] State ${state.name}: found ${records.length} records`);
-        }
-
-        for (const record of records) {
-          if (this.activeCount >= this.globalConcurrency) break;
-
-          const processingStatus = `processing_${state.name}`;
-
-          const claimed = await this.claimRecord(record, state.name, processingStatus);
-          if (!claimed) continue;
-
-          this.activeCount++;
-          logger.info(`[AppClock] Processing record ${record.id} (state=${state.name})`);
-          this.processRecord(state, record).finally(() => {
-            this.activeCount--;
-          });
-        }
-      }
-    } catch (error) {
-      logger.error('[AppClock] Tick error:', error.message);
+    
+    const activeEntries = await AppClockRegistry.findAll({
+      where: { is_active: true },
+      order: [['created_at', 'ASC']]
+    });
+    
+    if (activeEntries.length === 0) {
+      return;
     }
+    
+    const entry = activeEntries[this.lastWakeIndex % activeEntries.length];
+    this.lastWakeIndex++;
+    
+    logger.info(`[AppClock] Waking app: ${entry.app_id}`);
+    await this.invokeTick(entry);
   }
 
-  async processRecord(state, record) {
+  async invokeTick(entry) {
     const startTime = Date.now();
-    const AppRowHandler = this.db.getModel('app_row_handler');
-    const AppActionLog = this.db.getModel('app_action_log');
-    const MiniAppRow = this.db.getModel('mini_app_row');
-    const MiniAppFile = this.db.getModel('mini_app_file');
+    const AppTickLog = this.db.getModel('app_tick_log');
     const MiniApp = this.db.getModel('mini_app');
-    const Attachment = this.db.getModel('attachment');
-
-    let handler = null;
-
+    
     try {
-      handler = await AppRowHandler.findByPk(state.handler_id);
-      if (!handler || !handler.is_active) {
-        throw new Error(`Handler ${state.handler_id} not found or inactive`);
-      }
-
-      const app = await MiniApp.findByPk(state.app_id);
-      const fileQuery = {
-        where: { record_id: record.id },
-      };
-      if (Attachment) {
-        fileQuery.include = [{
-          model: Attachment,
-          as: 'attachment',
-        }];
-      }
-      const files = await MiniAppFile.findAll(fileQuery);
-
-      const filesWithAttachment = files.map(f => f.toJSON());
-
-const scriptModule = await this.loadScript(handler.handler);
+      const app = await MiniApp.findByPk(entry.app_id);
       
-      const recordData = typeof record.data === 'string' ? JSON.parse(record.data) : (record.data || {});
+      const scriptModule = await this.loadTickScript(entry, app);
+      const context = this.buildContext(app, entry);
       
-      const context = {
-        record: { ...record.toJSON(), data: recordData },
-        app: app ? app.toJSON() : null,
-        files: filesWithAttachment,
-        stateName: state.name,
-        services: {
-          callMcp: async (serviceName, method, params) => {
-            return await this.callMcp(serviceName, method, params);
-          },
-          callLlm: async (promptType, params) => {
-            return await this.callLlm(promptType, params);
-          },
-          callSkill: async (skillName, method, params) => {
-            return await this.callSkill(skillName, method, params);
-          },
-          callExtension: async (tableName, action, data) => {
-            return await this.extensionService.handle(app.id, tableName, action, data);
-          },
-        },
-      };
-
-      const processFn = scriptModule[handler.handler_function || 'process'];
-      if (typeof processFn !== 'function') {
-        throw new Error(`Handler function "${handler.handler_function || 'process'}" not found in ${handler.handler}`);
-      }
-
-      const result = await processFn(context);
-
+      const result = await scriptModule.tick(context);
       const duration = Date.now() - startTime;
-
-      if (result && result.pending) {
-        logger.info(`[AppClock] Record ${record.id} pending in ${state.name} (${duration}ms)`);
-        return;
-      }
-
-      if (result && result.success) {
-        const existingData = typeof record.data === 'string' ? JSON.parse(record.data) : (record.data || {});
-        const newData = { ...existingData, ...result.data };
-        
-        const updateData = {
-          data: JSON.stringify(newData),
-          title: result.data ? this.extractTitle(app, result.data) || record.title : record.title,
-          ai_extracted: true,
-          status: state.success_next_state || record.status,
-        };
-
-        await MiniAppRow.update(updateData, {
-          where: { id: record.id },
-          individualHooks: false,
-        });
-
-        await AppActionLog.create({
-          id: Utils.newID(20),
-          handler_id: handler.id,
-          record_id: record.id,
-          app_id: state.app_id,
-          trigger_status: state.name,
-          result_status: state.success_next_state,
-          success: true,
-          output_data: result.data ? JSON.stringify(result.data) : null,
-          duration,
-        });
-
-        logger.info(`[AppClock] Processed record ${record.id}: ${state.name} → ${state.success_next_state} (${duration}ms)`);
-      } else {
-        throw new Error((result && result.error) || 'Unknown error');
-      }
+      
+      await AppTickLog.create({
+        id: Utils.newID(20),
+        registry_id: entry.id,
+        app_id: entry.app_id,
+        success: true,
+        output_data: result ? JSON.stringify(result) : null,
+        duration
+      });
+      
+      logger.info(`[AppClock] App ${entry.app_id} tick completed (${duration}ms)`);
+      
     } catch (err) {
       const duration = Date.now() - startTime;
-
-      // 失败时更新实体字段 status
-      const failureStatus = state.failure_next_state || state.name;
-      await MiniAppRow.update(
-        { status: failureStatus },
-        {
-          where: { id: record.id },
-          individualHooks: false,
-        }
-      );
-
-      await AppActionLog.create({
+      
+      await AppTickLog.create({
         id: Utils.newID(20),
-        handler_id: handler ? handler.id : state.handler_id,
-        record_id: record.id,
-        app_id: state.app_id,
-        trigger_status: state.name,
-        result_status: failureStatus,
+        registry_id: entry.id,
+        app_id: entry.app_id,
         success: false,
         error_message: err.message,
-        duration,
+        duration
       });
-
-      logger.error(`[AppClock] Failed record ${record.id}: ${state.name} → ${failureStatus}: ${err.message} (${duration}ms)`);
+      
+      logger.error(`[AppClock] App ${entry.app_id} tick failed: ${err.message} (${duration}ms)`);
     }
   }
 
-  async claimRecord(record, originalStatus, processingStatus) {
-    const MiniAppRow = this.db.getModel('mini_app_row');
-
-    // 直接更新实体字段 status（不再修改 data）
-    const [affectedCount] = await MiniAppRow.update(
-      { status: processingStatus },
-      {
-        where: {
-          id: record.id,
-          status: originalStatus, // 乐观锁：只有状态未变的才能 claim
+  buildContext(app, entry) {
+    return {
+      db: this.db,
+      sequelize: this.sequelize,
+      app: app ? app.toJSON() : null,
+      registry: entry.toJSON(),
+      
+      services: {
+        callMcp: async (server, tool, params) => {
+          return await this.callMcp(server, tool, params);
         },
-        individualHooks: false,
+        
+        callLlm: async (promptType, params) => {
+          return await this.callLlm(promptType, params);
+        },
+        
+        callSkill: async (name, method, params) => {
+          return await this.callSkill(name, method, params);
+        },
+        
+        callExtension: async (table, action, data) => {
+          if (!app) {
+            throw new Error('App not found for callExtension');
+          }
+          return await this.extensionService.handle(app.id, table, action, data);
+        },
+        
+        getFiles: async (recordId) => {
+          const MiniAppFile = this.db.getModel('mini_app_file');
+          const Attachment = this.db.getModel('attachment');
+          
+          if (!MiniAppFile) {
+            throw new Error('mini_app_file model not available');
+          }
+          
+          const query = { where: { record_id: recordId } };
+          if (Attachment) {
+            query.include = [{ model: Attachment, as: 'attachment' }];
+          }
+          
+          return await MiniAppFile.findAll(query);
+        },
+        
+        query: async (sql, replacements = []) => {
+          return await this.sequelize.query(sql, {
+            replacements,
+            type: Sequelize.QueryTypes.SELECT
+          });
+        },
+        
+        execute: async (sql, replacements = []) => {
+          return await this.sequelize.query(sql, {
+            replacements,
+            type: Sequelize.QueryTypes.UPDATE
+          });
+        },
+        
+        log: async (action, data = {}) => {
+          const AppTickLog = this.db.getModel('app_tick_log');
+          await AppTickLog.create({
+            id: Utils.newID(20),
+            registry_id: entry.id,
+            app_id: entry.app_id,
+            success: true,
+            output_data: JSON.stringify({ action, ...data }),
+            duration: 0
+          });
+        },
+        
+        getModel: (modelName) => {
+          return this.db.getModel(modelName);
+        }
       }
-    );
-
-    if (affectedCount === 0) {
-      logger.info(`[AppClock] Record ${record.id} already claimed by another process`);
-      return false;
-    }
-    logger.info(`[AppClock] Record ${record.id} claimed (${originalStatus} → ${processingStatus})`);
-    return true;
+    };
   }
 
-  async loadScript(handlerPath) {
-    const fullPath = path.resolve(handlerPath);
-
-    const allowedPrefixes = [
-      path.resolve('scripts'),
-      path.resolve('apps'),
-    ];
-    const isAllowed = allowedPrefixes.some(prefix => fullPath.startsWith(prefix));
-    if (!isAllowed) {
-      throw new Error(`Script path not allowed: ${handlerPath}. Must be under scripts/ or data/skills/`);
+  async loadTickScript(entry, app) {
+    const appsDir = path.join(process.cwd(), 'apps');
+    
+    const defaultPath = path.join(appsDir, entry.app_id, 'tick');
+    
+    const scriptPath = entry.tick_script
+      ? path.join(appsDir, entry.app_id, entry.tick_script)
+      : defaultPath;
+    
+    const normalizedPath = path.normalize(scriptPath);
+    if (!normalizedPath.startsWith(path.normalize(appsDir))) {
+      throw new Error(`Script path not allowed: ${scriptPath}`);
     }
-
-    const require = createRequire(import.meta.url);
-
+    
     try {
-      const module = await import(`file://${fullPath.replace(/\\/g, '/')}/index.js`);
+      const module = await import(`file://${normalizedPath.replace(/\\/g, '/')}/index.js`);
       return module.default || module;
     } catch (e) {
-      try {
-        return require(fullPath);
-      } catch (e2) {
-        throw new Error(`Cannot load script: ${fullPath} - ${e2.message}`);
-      }
+      throw new Error(`Cannot load tick script: ${normalizedPath} - ${e.message}`);
     }
   }
 
-  extractTitle(app, data) {
-    if (!app || !app.fields) return '';
+  async callMcp(server, tool, params) {
+    logger.info(`[AppClock] callMcp: ${server}.${tool}`);
     
-    let fields = app.fields;
-    if (typeof fields === 'string') {
-      try { fields = JSON.parse(fields); } catch { return ''; }
-    }
-    if (!Array.isArray(fields)) return '';
-    
-    const titleField = fields.find(f => f.type === 'text' && f.required && f.ai_extractable);
-    if (titleField && data[titleField.name]) {
-      return String(data[titleField.name]);
-    }
-    return '';
-  }
-
-async callMcp(serviceName, method, params) {
-    logger.info(`[AppClock] callMcp: ${serviceName}.${method}`);
-
     if (this.residentSkillManager) {
-      // 查询记录创建者的信息生成真实 token
       const adminToken = await this.generateUserToken();
       
       const result = await this.residentSkillManager.invokeByName(
@@ -342,32 +216,30 @@ async callMcp(serviceName, method, params) {
         'invoke',
         {
           action: 'call_tool',
-          server_name: serviceName,
-          tool_name: method,
-          arguments: params,
+          server_name: server,
+          tool_name: tool,
+          arguments: params
         },
         {
           accessToken: adminToken,
-          isAdmin: true,
+          isAdmin: true
         },
         120000
       );
       return result;
     }
-
-    throw new Error(`MCP service "${serviceName}" not available: residentSkillManager not configured`);
+    
+    throw new Error(`MCP service "${server}" not available: residentSkillManager not configured`);
   }
 
   async generateUserToken() {
-    // 查询一个真实的管理员用户生成 token
     const User = this.db.getModel('user');
     const UserRole = this.db.getModel('user_role');
     const Role = this.db.getModel('role');
     
-    // 查询管理员用户
     const adminRole = await Role.findOne({
       where: { mark: 'admin' },
-      raw: true,
+      raw: true
     });
     
     if (!adminRole) {
@@ -376,7 +248,7 @@ async callMcp(serviceName, method, params) {
     
     const adminUserRole = await UserRole.findOne({
       where: { role_id: adminRole.id },
-      raw: true,
+      raw: true
     });
     
     if (!adminUserRole) {
@@ -385,14 +257,13 @@ async callMcp(serviceName, method, params) {
     
     const adminUser = await User.findOne({
       where: { id: adminUserRole.user_id, status: 'active' },
-      raw: true,
+      raw: true
     });
     
     if (!adminUser) {
       throw new Error('Admin user not found or inactive');
     }
     
-    // 生成真实用户 JWT token
     const jwtSecret = process.env.JWT_SECRET || 'your-secret-key';
     const token = jwt.sign(
       { userId: adminUser.id, role: 'admin', isAdmin: true },
@@ -400,13 +271,12 @@ async callMcp(serviceName, method, params) {
       { expiresIn: '1h' }
     );
     
-    logger.info(`[AppClock] Generated token for admin user: ${adminUser.id}`);
     return token;
   }
 
   async callLlm(promptType, params) {
     logger.info(`[AppClock] callLlm: ${promptType}`);
-
+    
     if (this.llmService) {
       const systemPrompt = `You are a data extraction assistant. Task: ${promptType}`;
       
@@ -421,48 +291,44 @@ async callMcp(serviceName, method, params) {
       
       const temperature = params.temperature ?? 0.3;
       const modelId = params.model_id;
-
-      if (promptType.includes('filter') || promptType.includes('section')) {
-        logger.info(`[AppClock] callLlm userPrompt length=${userPrompt.length}, has_ocr_text=${userPrompt.includes('ocr_text')}`);
-      }
-
+      
       if (params.schema || params.response_format === 'json') {
         const result = await this.llmService.judge(systemPrompt, userPrompt, {
           temperature,
           schema: params.schema,
           modelId,
           enableThinking: params.enable_thinking,
-          thinkingBudget: params.thinking_budget,
+          thinkingBudget: params.thinking_budget
         });
         return { text: JSON.stringify(result), parsed: result };
       }
-
+      
       const result = await this.llmService.generate(systemPrompt, userPrompt, {
         temperature,
         modelId,
         enableThinking: params.enable_thinking,
-        thinkingBudget: params.thinking_budget,
+        thinkingBudget: params.thinking_budget
       });
       return { text: result };
     }
-
+    
     throw new Error('LLM service not available: llmService not configured');
   }
 
-  async callSkill(skillName, method, params) {
-    logger.info(`[AppClock] callSkill: ${skillName}.${method}`);
-
+  async callSkill(name, method, params) {
+    logger.info(`[AppClock] callSkill: ${name}.${method}`);
+    
     if (this.skillLoader) {
       const result = await this.skillLoader.executeSkillTool(
-        skillName,
+        name,
         method,
         params,
         { isAdmin: true }
       );
       return result;
     }
-
-    throw new Error(`Skill "${skillName}" not available: skillLoader not configured`);
+    
+    throw new Error(`Skill "${name}" not available: skillLoader not configured`);
   }
 }
 

--- a/lib/app-clock.js
+++ b/lib/app-clock.js
@@ -1,6 +1,6 @@
 import logger from './logger.js';
 import Utils from './utils.js';
-import { Sequelize, Op } from 'sequelize';
+import { Sequelize } from 'sequelize';
 import path from 'path';
 import jwt from 'jsonwebtoken';
 import ExtensionTableService from '../server/services/extension-table.service.js';
@@ -160,7 +160,7 @@ class AppClock {
         execute: async (sql, replacements = []) => {
           return await this.sequelize.query(sql, {
             replacements,
-            type: Sequelize.QueryTypes.UPDATE
+            type: Sequelize.QueryTypes.RAW
           });
         },
         

--- a/lib/app-clock.js
+++ b/lib/app-clock.js
@@ -207,29 +207,43 @@ class AppClock {
 
   async callMcp(server, tool, params) {
     logger.info(`[AppClock] callMcp: ${server}.${tool}`);
+    logger.debug(`[AppClock] callMcp params keys: ${Object.keys(params || {}).join(', ')}`);
     
-    if (this.residentSkillManager) {
-      const adminToken = await this.generateUserToken();
-      
+    if (!this.residentSkillManager) {
+      throw new Error(`MCP service "${server}" not available: residentSkillManager not configured`);
+    }
+    
+    const adminToken = await this.generateUserToken();
+    
+    const invokeParams = {
+      action: 'call_tool',
+      server_name: server,
+      tool_name: tool,
+      arguments: params
+    };
+    
+    logger.info(`[AppClock] callMcp invoking mcp-client with action=call_tool, server=${server}, tool=${tool}`);
+    
+    try {
       const result = await this.residentSkillManager.invokeByName(
         'mcp-client',
         'invoke',
-        {
-          action: 'call_tool',
-          server_name: server,
-          tool_name: tool,
-          arguments: params
-        },
+        invokeParams,
         {
           accessToken: adminToken,
           isAdmin: true
         },
         120000
       );
+      
+      logger.info(`[AppClock] callMcp result type: ${typeof result}`);
+      logger.debug(`[AppClock] callMcp result preview: ${JSON.stringify(result).substring(0, 500)}`);
       return result;
+    } catch (e) {
+      logger.error(`[AppClock] callMcp failed: ${server}.${tool} - ${e.message}`);
+      logger.error(`[AppClock] callMcp error stack: ${e.stack}`);
+      throw e;
     }
-    
-    throw new Error(`MCP service "${server}" not available: residentSkillManager not configured`);
   }
 
   async generateUserToken() {

--- a/lib/mcp-stateless-http.js
+++ b/lib/mcp-stateless-http.js
@@ -7,15 +7,22 @@
  * 这个 Transport 跳过 GET SSE 步骤，只通过 POST 发送请求。
  */
 
+function transportLog(...args) {
+  process.stderr.write(`[StatelessHTTPTransport] ${new Date().toISOString()} ${args.join(' ')}\n`);
+}
+
 export class StatelessHTTPTransport {
   constructor(url, options = {}) {
     this._url = url;
     this._requestInit = options.requestInit || {};
+    this._timeout = options.timeout || 600000;
     this._started = false;
     
     this.onclose = null;
     this.onerror = null;
     this.onmessage = null;
+    
+    transportLog(`Created for URL: ${url}, timeout: ${this._timeout}ms`);
   }
   
   async start() {
@@ -23,10 +30,12 @@ export class StatelessHTTPTransport {
       throw new Error('Transport already started');
     }
     this._started = true;
+    transportLog(`Started`);
   }
   
   async close() {
     this._started = false;
+    transportLog(`Closed`);
     if (this.onclose) this.onclose();
   }
   
@@ -36,6 +45,7 @@ export class StatelessHTTPTransport {
     }
     
     const messages = Array.isArray(message) ? message : [message];
+    transportLog(`Sending ${messages.length} messages`);
     
     for (const msg of messages) {
       await this._sendSingle(msg);
@@ -50,28 +60,47 @@ export class StatelessHTTPTransport {
     };
     
     const body = JSON.stringify(message);
+    const msgPreview = JSON.stringify(message).substring(0, 200);
+    
+    transportLog(`Sending to ${this._url}`);
+    transportLog(`Message preview: ${msgPreview}`);
+    transportLog(`Headers: ${JSON.stringify(Object.keys(headers))}`);
+    transportLog(`Body size: ${body.length} bytes, timeout: ${this._timeout}ms`);
+    
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      transportLog(`Request aborted due to timeout (${this._timeout}ms)`);
+      controller.abort();
+    }, this._timeout);
     
     try {
       const response = await fetch(this._url, {
         method: 'POST',
         headers,
         body,
+        signal: controller.signal,
       });
+      
+      clearTimeout(timeoutId);
+      transportLog(`Response status: ${response.status}`);
+      transportLog(`Response content-type: ${response.headers.get('content-type')}`);
       
       if (!response.ok) {
         const text = await response.text().catch(() => '');
+        transportLog(`Response error body: ${text.substring(0, 200)}`);
         throw new Error(`HTTP ${response.status}: ${text.substring(0, 100)}`);
       }
       
       const contentType = response.headers.get('content-type') || '';
       
-      // 202 Accepted - notification 无响应体
       if (response.status === 202) {
+        transportLog(`Response 202 Accepted, no body`);
         return;
       }
       
       if (contentType.includes('application/json')) {
         const text = await response.text();
+        transportLog(`Response JSON length: ${text.length}`);
         if (!text || text.trim() === '') {
           return;
         }
@@ -80,10 +109,18 @@ export class StatelessHTTPTransport {
           this.onmessage(data);
         }
       } else if (contentType.includes('text/event-stream')) {
+        transportLog(`Handling SSE stream`);
         await this._handleSSE(response);
       }
       
     } catch (error) {
+      clearTimeout(timeoutId);
+      if (error.name === 'AbortError') {
+        transportLog(`ERROR: Request timeout (${this._timeout}ms)`);
+        error = new Error(`Request timeout after ${this._timeout}ms`);
+      }
+      transportLog(`ERROR: ${error.message}`);
+      transportLog(`ERROR stack: ${error.stack}`);
       if (this.onerror) {
         this.onerror(error);
       }

--- a/models/app_clock_registry.js
+++ b/models/app_clock_registry.js
@@ -1,0 +1,60 @@
+import _sequelize from 'sequelize';
+const { Model, Sequelize } = _sequelize;
+
+export default class app_clock_registry extends Model {
+  static init(sequelize, DataTypes) {
+    return super.init({
+      id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        primaryKey: true
+      },
+      app_id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        comment: "关联 mini_apps.id",
+        references: {
+          model: 'mini_apps',
+          key: 'id'
+        }
+      },
+      tick_script: {
+        type: DataTypes.STRING(64),
+        allowNull: true,
+        comment: "自定义脚本名，空则用默认 tick"
+      },
+      is_active: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+        defaultValue: true
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        defaultValue: Sequelize.Sequelize.fn('current_timestamp')
+      }
+    }, {
+      sequelize,
+      tableName: 'app_clock_registry',
+      timestamps: false,
+      freezeTableName: true,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [
+            { name: "id" },
+          ]
+        },
+        {
+          name: "idx_active",
+          using: "BTREE",
+          fields: [
+            { name: "is_active" },
+          ]
+        },
+      ]
+    });
+  }
+}

--- a/models/app_clock_registry.js
+++ b/models/app_clock_registry.js
@@ -3,65 +3,58 @@ const { Model, Sequelize } = _sequelize;
 
 export default class app_clock_registry extends Model {
   static init(sequelize, DataTypes) {
-  return super.init({
-    id: {
-      type: DataTypes.STRING(32),
-      allowNull: false,
-      primaryKey: true
-    },
-    app_id: {
-      type: DataTypes.STRING(32),
-      allowNull: false,
-      comment: "关联 mini_apps.id",
-      references: {
-        model: 'mini_apps',
-        key: 'id'
+    return super.init({
+      id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        primaryKey: true
+      },
+      app_id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        comment: "关联 mini_apps.id",
+        references: {
+          model: 'mini_apps',
+          key: 'id'
+        }
+      },
+      tick_script: {
+        type: DataTypes.STRING(64),
+        allowNull: true,
+        comment: "自定义脚本名，空则用默认 tick"
+      },
+      is_active: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+        defaultValue: true
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        defaultValue: Sequelize.Sequelize.fn('current_timestamp')
       }
-    },
-    tick_script: {
-      type: DataTypes.STRING(64),
-      allowNull: true,
-      comment: "自定义脚本名，空则用默认 tick"
-    },
-    is_active: {
-      type: DataTypes.BOOLEAN,
-      allowNull: true,
-      defaultValue: true
-    },
-    created_at: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: Sequelize.Sequelize.fn('current_timestamp')
-    }
-  }, {
-    sequelize,
-    tableName: 'app_clock_registry',
-    timestamps: false,
-    freezeTableName: true,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "app_id",
-        using: "BTREE",
-        fields: [
-          { name: "app_id" },
-        ]
-      },
-      {
-        name: "idx_active",
-        using: "BTREE",
-        fields: [
-          { name: "is_active" },
-        ]
-      },
-    ]
-  });
+    }, {
+      sequelize,
+      tableName: 'app_clock_registry',
+      timestamps: false,
+      freezeTableName: true,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [
+            { name: "id" },
+          ]
+        },
+        {
+          name: "idx_active",
+          using: "BTREE",
+          fields: [
+            { name: "is_active" },
+          ]
+        },
+      ]
+    });
   }
 }

--- a/models/app_clock_registry.js
+++ b/models/app_clock_registry.js
@@ -3,58 +3,65 @@ const { Model, Sequelize } = _sequelize;
 
 export default class app_clock_registry extends Model {
   static init(sequelize, DataTypes) {
-    return super.init({
-      id: {
-        type: DataTypes.STRING(32),
-        allowNull: false,
-        primaryKey: true
-      },
-      app_id: {
-        type: DataTypes.STRING(32),
-        allowNull: false,
-        comment: "关联 mini_apps.id",
-        references: {
-          model: 'mini_apps',
-          key: 'id'
-        }
-      },
-      tick_script: {
-        type: DataTypes.STRING(64),
-        allowNull: true,
-        comment: "自定义脚本名，空则用默认 tick"
-      },
-      is_active: {
-        type: DataTypes.BOOLEAN,
-        allowNull: true,
-        defaultValue: true
-      },
-      created_at: {
-        type: DataTypes.DATE,
-        allowNull: true,
-        defaultValue: Sequelize.Sequelize.fn('current_timestamp')
+  return super.init({
+    id: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+      primaryKey: true
+    },
+    app_id: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+      comment: "关联 mini_apps.id",
+      references: {
+        model: 'mini_apps',
+        key: 'id'
       }
-    }, {
-      sequelize,
-      tableName: 'app_clock_registry',
-      timestamps: false,
-      freezeTableName: true,
-      indexes: [
-        {
-          name: "PRIMARY",
-          unique: true,
-          using: "BTREE",
-          fields: [
-            { name: "id" },
-          ]
-        },
-        {
-          name: "idx_active",
-          using: "BTREE",
-          fields: [
-            { name: "is_active" },
-          ]
-        },
-      ]
-    });
+    },
+    tick_script: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+      comment: "自定义脚本名，空则用默认 tick"
+    },
+    is_active: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: true
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: Sequelize.Sequelize.fn('current_timestamp')
+    }
+  }, {
+    sequelize,
+    tableName: 'app_clock_registry',
+    timestamps: false,
+    freezeTableName: true,
+    indexes: [
+      {
+        name: "PRIMARY",
+        unique: true,
+        using: "BTREE",
+        fields: [
+          { name: "id" },
+        ]
+      },
+      {
+        name: "app_id",
+        using: "BTREE",
+        fields: [
+          { name: "app_id" },
+        ]
+      },
+      {
+        name: "idx_active",
+        using: "BTREE",
+        fields: [
+          { name: "is_active" },
+        ]
+      },
+    ]
+  });
   }
 }

--- a/models/app_tick_log.js
+++ b/models/app_tick_log.js
@@ -1,0 +1,82 @@
+import _sequelize from 'sequelize';
+const { Model, Sequelize } = _sequelize;
+
+export default class app_tick_log extends Model {
+  static init(sequelize, DataTypes) {
+    return super.init({
+      id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        primaryKey: true
+      },
+      registry_id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        comment: "关联 app_clock_registry.id",
+        references: {
+          model: 'app_clock_registry',
+          key: 'id'
+        }
+      },
+      app_id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        comment: "关联 mini_apps.id"
+      },
+      success: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+        defaultValue: true
+      },
+      output_data: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+        comment: "JSON 输出"
+      },
+      error_message: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      duration: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        defaultValue: 0,
+        comment: "耗时(ms)"
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        defaultValue: Sequelize.Sequelize.fn('current_timestamp')
+      }
+    }, {
+      sequelize,
+      tableName: 'app_tick_log',
+      timestamps: false,
+      freezeTableName: true,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [
+            { name: "id" },
+          ]
+        },
+        {
+          name: "idx_registry",
+          using: "BTREE",
+          fields: [
+            { name: "registry_id" },
+          ]
+        },
+        {
+          name: "idx_created",
+          using: "BTREE",
+          fields: [
+            { name: "created_at" },
+          ]
+        },
+      ]
+    });
+  }
+}

--- a/models/app_tick_log.js
+++ b/models/app_tick_log.js
@@ -3,80 +3,78 @@ const { Model, Sequelize } = _sequelize;
 
 export default class app_tick_log extends Model {
   static init(sequelize, DataTypes) {
-    return super.init({
-      id: {
-        type: DataTypes.STRING(32),
-        allowNull: false,
-        primaryKey: true
-      },
-      registry_id: {
-        type: DataTypes.STRING(32),
-        allowNull: false,
-        comment: "关联 app_clock_registry.id",
-        references: {
-          model: 'app_clock_registry',
-          key: 'id'
-        }
-      },
-      app_id: {
-        type: DataTypes.STRING(32),
-        allowNull: false,
-        comment: "关联 mini_apps.id"
-      },
-      success: {
-        type: DataTypes.BOOLEAN,
-        allowNull: true,
-        defaultValue: true
-      },
-      output_data: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-        comment: "JSON 输出"
-      },
-      error_message: {
-        type: DataTypes.TEXT,
-        allowNull: true
-      },
-      duration: {
-        type: DataTypes.INTEGER,
-        allowNull: true,
-        defaultValue: 0,
-        comment: "耗时(ms)"
-      },
-      created_at: {
-        type: DataTypes.DATE,
-        allowNull: true,
-        defaultValue: Sequelize.Sequelize.fn('current_timestamp')
+  return super.init({
+    id: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+      primaryKey: true
+    },
+    registry_id: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+      references: {
+        model: 'app_clock_registry',
+        key: 'id'
       }
-    }, {
-      sequelize,
-      tableName: 'app_tick_log',
-      timestamps: false,
-      freezeTableName: true,
-      indexes: [
-        {
-          name: "PRIMARY",
-          unique: true,
-          using: "BTREE",
-          fields: [
-            { name: "id" },
-          ]
-        },
-        {
-          name: "idx_registry",
-          using: "BTREE",
-          fields: [
-            { name: "registry_id" },
-          ]
-        },
-        {
-          name: "idx_created",
-          using: "BTREE",
-          fields: [
-            { name: "created_at" },
-          ]
-        },
-      ]
-    });
+    },
+    app_id: {
+      type: DataTypes.STRING(32),
+      allowNull: false
+    },
+    success: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: true
+    },
+    output_data: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      comment: "JSON 输出"
+    },
+    error_message: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    duration: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: 0,
+      comment: "耗时(ms)"
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: Sequelize.Sequelize.fn('current_timestamp')
+    }
+  }, {
+    sequelize,
+    tableName: 'app_tick_log',
+    timestamps: false,
+    freezeTableName: true,
+    indexes: [
+      {
+        name: "PRIMARY",
+        unique: true,
+        using: "BTREE",
+        fields: [
+          { name: "id" },
+        ]
+      },
+      {
+        name: "idx_registry",
+        using: "BTREE",
+        fields: [
+          { name: "registry_id" },
+        ]
+      },
+      {
+        name: "idx_created",
+        using: "BTREE",
+        fields: [
+          { name: "created_at" },
+        ]
+      },
+    ]
+  });
   }
 }

--- a/models/app_tick_log.js
+++ b/models/app_tick_log.js
@@ -3,78 +3,80 @@ const { Model, Sequelize } = _sequelize;
 
 export default class app_tick_log extends Model {
   static init(sequelize, DataTypes) {
-  return super.init({
-    id: {
-      type: DataTypes.STRING(32),
-      allowNull: false,
-      primaryKey: true
-    },
-    registry_id: {
-      type: DataTypes.STRING(32),
-      allowNull: false,
-      references: {
-        model: 'app_clock_registry',
-        key: 'id'
+    return super.init({
+      id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        primaryKey: true
+      },
+      registry_id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        comment: "关联 app_clock_registry.id",
+        references: {
+          model: 'app_clock_registry',
+          key: 'id'
+        }
+      },
+      app_id: {
+        type: DataTypes.STRING(32),
+        allowNull: false,
+        comment: "关联 mini_apps.id"
+      },
+      success: {
+        type: DataTypes.BOOLEAN,
+        allowNull: true,
+        defaultValue: true
+      },
+      output_data: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+        comment: "JSON 输出"
+      },
+      error_message: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      duration: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        defaultValue: 0,
+        comment: "耗时(ms)"
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: true,
+        defaultValue: Sequelize.Sequelize.fn('current_timestamp')
       }
-    },
-    app_id: {
-      type: DataTypes.STRING(32),
-      allowNull: false
-    },
-    success: {
-      type: DataTypes.BOOLEAN,
-      allowNull: true,
-      defaultValue: true
-    },
-    output_data: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-      comment: "JSON 输出"
-    },
-    error_message: {
-      type: DataTypes.TEXT,
-      allowNull: true
-    },
-    duration: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-      defaultValue: 0,
-      comment: "耗时(ms)"
-    },
-    created_at: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: Sequelize.Sequelize.fn('current_timestamp')
-    }
-  }, {
-    sequelize,
-    tableName: 'app_tick_log',
-    timestamps: false,
-    freezeTableName: true,
-    indexes: [
-      {
-        name: "PRIMARY",
-        unique: true,
-        using: "BTREE",
-        fields: [
-          { name: "id" },
-        ]
-      },
-      {
-        name: "idx_registry",
-        using: "BTREE",
-        fields: [
-          { name: "registry_id" },
-        ]
-      },
-      {
-        name: "idx_created",
-        using: "BTREE",
-        fields: [
-          { name: "created_at" },
-        ]
-      },
-    ]
-  });
+    }, {
+      sequelize,
+      tableName: 'app_tick_log',
+      timestamps: false,
+      freezeTableName: true,
+      indexes: [
+        {
+          name: "PRIMARY",
+          unique: true,
+          using: "BTREE",
+          fields: [
+            { name: "id" },
+          ]
+        },
+        {
+          name: "idx_registry",
+          using: "BTREE",
+          fields: [
+            { name: "registry_id" },
+          ]
+        },
+        {
+          name: "idx_created",
+          using: "BTREE",
+          fields: [
+            { name: "created_at" },
+          ]
+        },
+      ]
+    });
   }
 }

--- a/models/init-models.js
+++ b/models/init-models.js
@@ -2,6 +2,8 @@ import _sequelize from "sequelize";
 const DataTypes = _sequelize.DataTypes;
 import _ai_model from  "./ai_model.js";
 import _app_action_log from  "./app_action_log.js";
+import _app_clock_registry from  "./app_clock_registry.js";
+import _app_tick_log from  "./app_tick_log.js";
 import _app_contract_mgr_compare from  "./app_contract_mgr_compare.js";
 import _app_contract_mgr_content from  "./app_contract_mgr_content.js";
 import _app_contract_mgr_row from  "./app_contract_mgr_row.js";
@@ -60,6 +62,8 @@ import _user from  "./user.js";
 export default function initModels(sequelize) {
   const ai_model = _ai_model.init(sequelize, DataTypes);
   const app_action_log = _app_action_log.init(sequelize, DataTypes);
+  const app_clock_registry = _app_clock_registry.init(sequelize, DataTypes);
+  const app_tick_log = _app_tick_log.init(sequelize, DataTypes);
   const app_contract_mgr_compare = _app_contract_mgr_compare.init(sequelize, DataTypes);
   const app_contract_mgr_content = _app_contract_mgr_content.init(sequelize, DataTypes);
   const app_contract_mgr_row = _app_contract_mgr_row.init(sequelize, DataTypes);
@@ -271,6 +275,8 @@ export default function initModels(sequelize) {
   return {
     ai_model,
     app_action_log,
+    app_clock_registry,
+    app_tick_log,
     app_contract_mgr_compare,
     app_contract_mgr_content,
     app_contract_mgr_row,

--- a/models/init-models.js
+++ b/models/init-models.js
@@ -3,7 +3,6 @@ const DataTypes = _sequelize.DataTypes;
 import _ai_model from  "./ai_model.js";
 import _app_action_log from  "./app_action_log.js";
 import _app_clock_registry from  "./app_clock_registry.js";
-import _app_tick_log from  "./app_tick_log.js";
 import _app_contract_mgr_compare from  "./app_contract_mgr_compare.js";
 import _app_contract_mgr_content from  "./app_contract_mgr_content.js";
 import _app_contract_mgr_row from  "./app_contract_mgr_row.js";
@@ -11,6 +10,7 @@ import _app_contract_mgr_v2_content from  "./app_contract_mgr_v2_content.js";
 import _app_contract_mgr_v2_row from  "./app_contract_mgr_v2_row.js";
 import _app_row_handler from  "./app_row_handler.js";
 import _app_state from  "./app_state.js";
+import _app_tick_log from  "./app_tick_log.js";
 import _assistant_message from  "./assistant_message.js";
 import _assistant_request from  "./assistant_request.js";
 import _assistant from  "./assistant.js";
@@ -63,7 +63,6 @@ export default function initModels(sequelize) {
   const ai_model = _ai_model.init(sequelize, DataTypes);
   const app_action_log = _app_action_log.init(sequelize, DataTypes);
   const app_clock_registry = _app_clock_registry.init(sequelize, DataTypes);
-  const app_tick_log = _app_tick_log.init(sequelize, DataTypes);
   const app_contract_mgr_compare = _app_contract_mgr_compare.init(sequelize, DataTypes);
   const app_contract_mgr_content = _app_contract_mgr_content.init(sequelize, DataTypes);
   const app_contract_mgr_row = _app_contract_mgr_row.init(sequelize, DataTypes);
@@ -71,6 +70,7 @@ export default function initModels(sequelize) {
   const app_contract_mgr_v2_row = _app_contract_mgr_v2_row.init(sequelize, DataTypes);
   const app_row_handler = _app_row_handler.init(sequelize, DataTypes);
   const app_state = _app_state.init(sequelize, DataTypes);
+  const app_tick_log = _app_tick_log.init(sequelize, DataTypes);
   const assistant_message = _assistant_message.init(sequelize, DataTypes);
   const assistant_request = _assistant_request.init(sequelize, DataTypes);
   const assistant = _assistant.init(sequelize, DataTypes);
@@ -135,6 +135,8 @@ export default function initModels(sequelize) {
   ai_model.hasMany(expert, { as: "reflective_model_experts", foreignKey: "reflective_model_id"});
   knowledge_basis.belongsTo(ai_model, { as: "embedding_model", foreignKey: "embedding_model_id"});
   ai_model.hasMany(knowledge_basis, { as: "knowledge_bases", foreignKey: "embedding_model_id"});
+  app_tick_log.belongsTo(app_clock_registry, { as: "registry", foreignKey: "registry_id"});
+  app_clock_registry.hasMany(app_tick_log, { as: "app_tick_logs", foreignKey: "registry_id"});
   app_action_log.belongsTo(app_row_handler, { as: "handler", foreignKey: "handler_id"});
   app_row_handler.hasMany(app_action_log, { as: "app_action_logs", foreignKey: "handler_id"});
   app_state.belongsTo(app_row_handler, { as: "handler", foreignKey: "handler_id"});
@@ -203,6 +205,8 @@ export default function initModels(sequelize) {
   mini_app_row.hasMany(mini_app_file, { as: "mini_app_files", foreignKey: "record_id"});
   app_action_log.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
   mini_app.hasMany(app_action_log, { as: "app_action_logs", foreignKey: "app_id"});
+  app_clock_registry.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
+  mini_app.hasMany(app_clock_registry, { as: "app_clock_registries", foreignKey: "app_id"});
   app_state.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
   mini_app.hasMany(app_state, { as: "app_states", foreignKey: "app_id"});
   mini_app_role_access.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
@@ -276,7 +280,6 @@ export default function initModels(sequelize) {
     ai_model,
     app_action_log,
     app_clock_registry,
-    app_tick_log,
     app_contract_mgr_compare,
     app_contract_mgr_content,
     app_contract_mgr_row,
@@ -284,6 +287,7 @@ export default function initModels(sequelize) {
     app_contract_mgr_v2_row,
     app_row_handler,
     app_state,
+    app_tick_log,
     assistant_message,
     assistant_request,
     assistant,

--- a/models/init-models.js
+++ b/models/init-models.js
@@ -3,6 +3,7 @@ const DataTypes = _sequelize.DataTypes;
 import _ai_model from  "./ai_model.js";
 import _app_action_log from  "./app_action_log.js";
 import _app_clock_registry from  "./app_clock_registry.js";
+import _app_tick_log from  "./app_tick_log.js";
 import _app_contract_mgr_compare from  "./app_contract_mgr_compare.js";
 import _app_contract_mgr_content from  "./app_contract_mgr_content.js";
 import _app_contract_mgr_row from  "./app_contract_mgr_row.js";
@@ -10,7 +11,6 @@ import _app_contract_mgr_v2_content from  "./app_contract_mgr_v2_content.js";
 import _app_contract_mgr_v2_row from  "./app_contract_mgr_v2_row.js";
 import _app_row_handler from  "./app_row_handler.js";
 import _app_state from  "./app_state.js";
-import _app_tick_log from  "./app_tick_log.js";
 import _assistant_message from  "./assistant_message.js";
 import _assistant_request from  "./assistant_request.js";
 import _assistant from  "./assistant.js";
@@ -63,6 +63,7 @@ export default function initModels(sequelize) {
   const ai_model = _ai_model.init(sequelize, DataTypes);
   const app_action_log = _app_action_log.init(sequelize, DataTypes);
   const app_clock_registry = _app_clock_registry.init(sequelize, DataTypes);
+  const app_tick_log = _app_tick_log.init(sequelize, DataTypes);
   const app_contract_mgr_compare = _app_contract_mgr_compare.init(sequelize, DataTypes);
   const app_contract_mgr_content = _app_contract_mgr_content.init(sequelize, DataTypes);
   const app_contract_mgr_row = _app_contract_mgr_row.init(sequelize, DataTypes);
@@ -70,7 +71,6 @@ export default function initModels(sequelize) {
   const app_contract_mgr_v2_row = _app_contract_mgr_v2_row.init(sequelize, DataTypes);
   const app_row_handler = _app_row_handler.init(sequelize, DataTypes);
   const app_state = _app_state.init(sequelize, DataTypes);
-  const app_tick_log = _app_tick_log.init(sequelize, DataTypes);
   const assistant_message = _assistant_message.init(sequelize, DataTypes);
   const assistant_request = _assistant_request.init(sequelize, DataTypes);
   const assistant = _assistant.init(sequelize, DataTypes);
@@ -135,8 +135,6 @@ export default function initModels(sequelize) {
   ai_model.hasMany(expert, { as: "reflective_model_experts", foreignKey: "reflective_model_id"});
   knowledge_basis.belongsTo(ai_model, { as: "embedding_model", foreignKey: "embedding_model_id"});
   ai_model.hasMany(knowledge_basis, { as: "knowledge_bases", foreignKey: "embedding_model_id"});
-  app_tick_log.belongsTo(app_clock_registry, { as: "registry", foreignKey: "registry_id"});
-  app_clock_registry.hasMany(app_tick_log, { as: "app_tick_logs", foreignKey: "registry_id"});
   app_action_log.belongsTo(app_row_handler, { as: "handler", foreignKey: "handler_id"});
   app_row_handler.hasMany(app_action_log, { as: "app_action_logs", foreignKey: "handler_id"});
   app_state.belongsTo(app_row_handler, { as: "handler", foreignKey: "handler_id"});
@@ -205,8 +203,6 @@ export default function initModels(sequelize) {
   mini_app_row.hasMany(mini_app_file, { as: "mini_app_files", foreignKey: "record_id"});
   app_action_log.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
   mini_app.hasMany(app_action_log, { as: "app_action_logs", foreignKey: "app_id"});
-  app_clock_registry.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
-  mini_app.hasMany(app_clock_registry, { as: "app_clock_registries", foreignKey: "app_id"});
   app_state.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
   mini_app.hasMany(app_state, { as: "app_states", foreignKey: "app_id"});
   mini_app_role_access.belongsTo(mini_app, { as: "app", foreignKey: "app_id"});
@@ -280,6 +276,7 @@ export default function initModels(sequelize) {
     ai_model,
     app_action_log,
     app_clock_registry,
+    app_tick_log,
     app_contract_mgr_compare,
     app_contract_mgr_content,
     app_contract_mgr_row,
@@ -287,7 +284,6 @@ export default function initModels(sequelize) {
     app_contract_mgr_v2_row,
     app_row_handler,
     app_state,
-    app_tick_log,
     assistant_message,
     assistant_request,
     assistant,

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -1173,6 +1173,69 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== contract-mgr-v2 状态自主管理 ====================
+  // Issue #693: content 表新增状态字段，移除 mini_app_rows 依赖
+  {
+    name: 'app_contract_mgr_v2_content add process_step',
+    check: async (conn) => await hasColumn(conn, 'app_contract_mgr_v2_content', 'process_step'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE app_contract_mgr_v2_content
+        ADD COLUMN process_step VARCHAR(32) DEFAULT 'pending_ocr' COMMENT '处理步骤',
+        ADD COLUMN ocr_task_id VARCHAR(64) NULL COMMENT 'OCR任务ID',
+        ADD COLUMN filter_carried_over LONGTEXT NULL COMMENT '滑动窗口中间状态',
+        ADD COLUMN filter_chunk_index INT DEFAULT 0 COMMENT '当前处理chunk索引',
+        ADD COLUMN file_id VARCHAR(32) NULL COMMENT '关联文件ID',
+        ADD INDEX idx_process_step (process_step)
+      `);
+      
+      // 根据现有数据推断状态
+      await conn.execute(`
+        UPDATE app_contract_mgr_v2_content 
+        SET process_step = 'done' 
+        WHERE sections IS NOT NULL AND filtered_text IS NOT NULL
+      `);
+      await conn.execute(`
+        UPDATE app_contract_mgr_v2_content 
+        SET process_step = 'pending_section' 
+        WHERE filtered_text IS NOT NULL AND sections IS NULL AND extract_json IS NOT NULL
+      `);
+      await conn.execute(`
+        UPDATE app_contract_mgr_v2_content 
+        SET process_step = 'pending_extract' 
+        WHERE filtered_text IS NOT NULL AND extract_json IS NULL
+      `);
+      await conn.execute(`
+        UPDATE app_contract_mgr_v2_content 
+        SET process_step = 'pending_filter' 
+        WHERE ocr_text IS NOT NULL AND filtered_text IS NULL
+      `);
+      
+      console.log('  ✓ Added process_step and related columns to app_contract_mgr_v2_content');
+    }
+  },
+
+  // 移除 content 表的外键约束，允许独立存在
+  {
+    name: 'app_contract_mgr_v2_content drop foreign key',
+    check: async (conn) => {
+      const [rows] = await conn.execute(`
+        SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE() 
+        AND TABLE_NAME = 'app_contract_mgr_v2_content'
+        AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+      `);
+      return rows.length === 0;
+    },
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE app_contract_mgr_v2_content
+        DROP FOREIGN KEY fk_app_contract_mgr_v2_content_row_id
+      `);
+      console.log('  ✓ Removed foreign key from app_contract_mgr_v2_content');
+    }
+  },
+
 ];
 
 /**

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -1182,7 +1182,7 @@ const MIGRATIONS = [
       await conn.execute(`
         ALTER TABLE app_contract_mgr_v2_content
         ADD COLUMN process_step VARCHAR(32) DEFAULT 'pending_ocr' COMMENT '处理步骤',
-        ADD COLUMN ocr_task_id VARCHAR(128) NULL COMMENT 'OCR任务ID',
+        ADD COLUMN ocr_task_id VARCHAR(255) NULL COMMENT 'OCR任务ID',
         ADD COLUMN filter_carried_over LONGTEXT NULL COMMENT '滑动窗口中间状态',
         ADD COLUMN filter_chunk_index INT DEFAULT 0 COMMENT '当前处理chunk索引',
         ADD COLUMN file_id VARCHAR(32) NULL COMMENT '关联文件ID',
@@ -1251,9 +1251,9 @@ const MIGRATIONS = [
     migrate: async (conn) => {
       await conn.execute(`
         ALTER TABLE app_contract_mgr_v2_content
-        MODIFY COLUMN ocr_task_id VARCHAR(128) NULL COMMENT 'OCR任务ID'
+        MODIFY COLUMN ocr_task_id VARCHAR(255) NULL COMMENT 'OCR任务ID'
       `);
-      console.log('  ✓ Extended ocr_task_id to VARCHAR(128)');
+      console.log('  ✓ Extended ocr_task_id to VARCHAR(255)');
     }
   },
 

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -1182,7 +1182,7 @@ const MIGRATIONS = [
       await conn.execute(`
         ALTER TABLE app_contract_mgr_v2_content
         ADD COLUMN process_step VARCHAR(32) DEFAULT 'pending_ocr' COMMENT '处理步骤',
-        ADD COLUMN ocr_task_id VARCHAR(64) NULL COMMENT 'OCR任务ID',
+        ADD COLUMN ocr_task_id VARCHAR(128) NULL COMMENT 'OCR任务ID',
         ADD COLUMN filter_carried_over LONGTEXT NULL COMMENT '滑动窗口中间状态',
         ADD COLUMN filter_chunk_index INT DEFAULT 0 COMMENT '当前处理chunk索引',
         ADD COLUMN file_id VARCHAR(32) NULL COMMENT '关联文件ID',
@@ -1233,6 +1233,27 @@ const MIGRATIONS = [
         DROP FOREIGN KEY fk_app_contract_mgr_v2_content_row_id
       `);
       console.log('  ✓ Removed foreign key from app_contract_mgr_v2_content');
+    }
+  },
+
+  // 扩展 ocr_task_id 字段长度（适配长 task_id）
+  {
+    name: 'app_contract_mgr_v2_content extend ocr_task_id',
+    check: async (conn) => {
+      const [rows] = await conn.execute(`
+        SELECT CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE() 
+        AND TABLE_NAME = 'app_contract_mgr_v2_content'
+        AND COLUMN_NAME = 'ocr_task_id'
+      `);
+      return rows.length > 0 && rows[0].CHARACTER_MAXIMUM_LENGTH >= 128;
+    },
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE app_contract_mgr_v2_content
+        MODIFY COLUMN ocr_task_id VARCHAR(128) NULL COMMENT 'OCR任务ID'
+      `);
+      console.log('  ✓ Extended ocr_task_id to VARCHAR(128)');
     }
   },
 

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -17,6 +17,7 @@ import mysql from 'mysql2/promise';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import crypto from 'crypto';
 
 const DB_CONFIG = {
   host: process.env.DB_HOST || 'localhost',
@@ -1097,6 +1098,78 @@ const MIGRATIONS = [
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='合同比对结果表'
       `);
       console.log('  ✓ Created app_contract_mgr_compares table');
+    }
+  },
+
+  // ==================== AppClock 回调模式表 ====================
+  // Issue #693: AppClock 回调模式升级
+  {
+    name: 'app_clock_registry create table',
+    check: async (conn) => await hasTable(conn, 'app_clock_registry'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        CREATE TABLE app_clock_registry (
+          id VARCHAR(32) PRIMARY KEY,
+          app_id VARCHAR(32) NOT NULL COMMENT '关联 mini_apps.id',
+          tick_script VARCHAR(64) NULL COMMENT '自定义脚本名，空则用默认 tick',
+          is_active BIT(1) DEFAULT 1,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (app_id) REFERENCES mini_apps(id) ON DELETE CASCADE,
+          INDEX idx_active (is_active)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='App调度注册表'
+      `);
+      console.log('  ✓ Created app_clock_registry table');
+    }
+  },
+
+  {
+    name: 'app_tick_log create table',
+    check: async (conn) => await hasTable(conn, 'app_tick_log'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        CREATE TABLE app_tick_log (
+          id VARCHAR(32) PRIMARY KEY,
+          registry_id VARCHAR(32) NOT NULL,
+          app_id VARCHAR(32) NOT NULL,
+          success BIT(1) DEFAULT 1,
+          output_data TEXT COMMENT 'JSON 输出',
+          error_message TEXT,
+          duration INT DEFAULT 0 COMMENT '耗时(ms)',
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (registry_id) REFERENCES app_clock_registry(id) ON DELETE CASCADE,
+          INDEX idx_registry (registry_id),
+          INDEX idx_created (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='App执行日志'
+      `);
+      console.log('  ✓ Created app_tick_log table');
+    }
+  },
+
+  // ==================== 注册现有 App 到 app_clock_registry ====================
+  // Issue #693: 现有 contract-mgr-v2 注册
+  {
+    name: 'register contract-mgr-v2 to app_clock_registry',
+    check: async (conn) => {
+      const [rows] = await conn.execute(`
+        SELECT id FROM app_clock_registry WHERE app_id = 'contract-mgr-v2'
+      `);
+      return rows.length > 0;
+    },
+    migrate: async (conn) => {
+      const [apps] = await conn.execute(`
+        SELECT id FROM mini_apps WHERE id = 'contract-mgr-v2'
+      `);
+      
+      if (apps.length > 0) {
+        const id = crypto.randomBytes(10).toString('hex').slice(0, 20);
+        await conn.execute(`
+          INSERT INTO app_clock_registry (id, app_id, tick_script, is_active)
+          VALUES (?, 'contract-mgr-v2', NULL, 1)
+        `, [id]);
+        console.log('  ✓ Registered contract-mgr-v2 to app_clock_registry');
+      } else {
+        console.log('  ⏭️  Skipped: contract-mgr-v2 not found in mini_apps');
+      }
     }
   },
 

--- a/server/controllers/internal.controller.js
+++ b/server/controllers/internal.controller.js
@@ -684,19 +684,31 @@ class InternalController {
           requires_credentials: s.requires_credentials,
           credential_fields: s.credential_fields,
         })),
-        default_credentials: defaultCredentials.map(c => ({
-          id: c.id,
-          mcp_server_id: c.mcp_server_id,
-          credentials: c.credentials,
-          is_enabled: c.is_enabled,
-        })),
-        user_credentials: userCredentials.map(c => ({
-          id: c.id,
-          user_id: c.user_id,
-          mcp_server_id: c.mcp_server_id,
-          credentials: c.credentials,
-          is_enabled: c.is_enabled,
-        })),
+        default_credentials: defaultCredentials.map(c => {
+          let parsedCreds = c.credentials;
+          if (typeof parsedCreds === 'string') {
+            try { parsedCreds = JSON.parse(parsedCreds); } catch { }
+          }
+          return {
+            id: c.id,
+            mcp_server_id: c.mcp_server_id,
+            credentials: parsedCreds,
+            is_enabled: c.is_enabled,
+          };
+        }),
+        user_credentials: userCredentials.map(c => {
+          let parsedCreds = c.credentials;
+          if (typeof parsedCreds === 'string') {
+            try { parsedCreds = JSON.parse(parsedCreds); } catch { }
+          }
+          return {
+            id: c.id,
+            user_id: c.user_id,
+            mcp_server_id: c.mcp_server_id,
+            credentials: parsedCreds,
+            is_enabled: c.is_enabled,
+          };
+        }),
       });
 
     } catch (error) {

--- a/server/routes/mcp.routes.js
+++ b/server/routes/mcp.routes.js
@@ -663,6 +663,12 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         raw: true,
       });
 
+      if (credential && typeof credential.credentials === 'string') {
+        try {
+          credential.credentials = JSON.parse(credential.credentials);
+        } catch { }
+      }
+
       ctx.success(credential || null);
 
     } catch (error) {
@@ -679,7 +685,7 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
     try {
       const userId = ctx.state.session.id;
       const { serverId } = ctx.params;
-      const { env_overrides } = ctx.request.body;
+      const rawInput = ctx.request.body;
 
       const server = await MCPServer.findOne({
         where: { id: serverId, is_enabled: true },
@@ -692,27 +698,38 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         return;
       }
 
+      let credentialsObj;
+      if (rawInput.env_overrides) {
+        credentialsObj = parseCredentialInput(rawInput.env_overrides);
+      } else if (typeof rawInput === 'string') {
+        credentialsObj = parseCredentialInput(rawInput);
+      } else {
+        credentialsObj = rawInput;
+      }
+
+      const credentialsJson = JSON.stringify(credentialsObj);
+
       let existing = await MCPUserCredential.findOne({
         where: { user_id: userId, mcp_server_id: serverId },
       });
 
       if (existing) {
-        existing.credentials = { env_overrides };
+        existing.credentials = credentialsJson;
         existing.is_enabled = true;
         await existing.save();
         logger.info(`MCP user credential updated: user=${userId}, server=${serverId}`);
-        ctx.success(existing);
+        ctx.success({ ...existing.toJSON(), credentials: credentialsObj });
       } else {
         const credentialId = Utils.newID(16);
         const created = await MCPUserCredential.create({
           id: credentialId,
           user_id: userId,
           mcp_server_id: serverId,
-          credentials: { env_overrides },
+          credentials: credentialsJson,
           is_enabled: true,
         });
         logger.info(`MCP user credential created: user=${userId}, server=${serverId}`);
-        ctx.success(created);
+        ctx.success({ ...created.toJSON(), credentials: credentialsObj });
       }
 
     } catch (error) {
@@ -865,6 +882,12 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         raw: true,
       });
 
+      if (credential && typeof credential.credentials === 'string') {
+        try {
+          credential.credentials = JSON.parse(credential.credentials);
+        } catch { }
+      }
+
       ctx.success(credential || null);
 
     } catch (error) {
@@ -874,6 +897,37 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
   });
 
   /**
+   * 解析凭证输入，支持两种格式：
+   * - JSON: {"api_key": "xxx"} 直接解析
+   * - key=value: api_key=xxx 解析成 {api_key: "xxx"}
+   */
+  function parseCredentialInput(input) {
+    if (!input || typeof input !== 'string') return {};
+    
+    const trimmed = input.trim();
+    
+    // 尝试 JSON 解析
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        return JSON.parse(trimmed);
+      } catch {}
+    }
+    
+    // 解析 key=value 格式（支持多行）
+    const result = {};
+    const lines = trimmed.split('\n');
+    for (const line of lines) {
+      const eqIdx = line.indexOf('=');
+      if (eqIdx > 0) {
+        const key = line.slice(0, eqIdx).trim();
+        const value = line.slice(eqIdx + 1).trim();
+        if (key) result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  /**
    * 设置特定 Server 的系统默认凭证（管理员）
    * POST /api/mcp/default-credentials/:serverId
    */
@@ -881,7 +935,7 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
     try {
       const userId = ctx.state.session.id;
       const { serverId } = ctx.params;
-      const { env_overrides } = ctx.request.body;
+      const rawInput = ctx.request.body;
 
       const server = await MCPServer.findOne({
         where: { id: serverId, is_enabled: true },
@@ -894,27 +948,39 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         return;
       }
 
+      // 直接解析 body（可能包含 env_overrides 字段或直接是 key=value）
+      let credentialsObj;
+      if (rawInput.env_overrides) {
+        credentialsObj = parseCredentialInput(rawInput.env_overrides);
+      } else if (typeof rawInput === 'string') {
+        credentialsObj = parseCredentialInput(rawInput);
+      } else {
+        credentialsObj = rawInput;
+      }
+
       let existing = await MCPCredential.findOne({
         where: { mcp_server_id: serverId },
       });
 
+      const credentialsJson = JSON.stringify(credentialsObj);
+      
       if (existing) {
-        existing.credentials = { env_overrides };
+        existing.credentials = credentialsJson;
         existing.is_enabled = true;
         await existing.save();
         logger.info(`MCP default credential updated: server=${serverId}, by=${userId}`);
-        ctx.success(existing);
+        ctx.success({ ...existing.toJSON(), credentials: credentialsObj });
       } else {
         const credentialId = Utils.newID(16);
         const created = await MCPCredential.create({
           id: credentialId,
           mcp_server_id: serverId,
-          credentials: { env_overrides },
+          credentials: credentialsJson,
           is_enabled: true,
           created_by: userId,
         });
         logger.info(`MCP default credential created: server=${serverId}, by=${userId}`);
-        ctx.success(created);
+        ctx.success({ ...created.toJSON(), credentials: credentialsObj });
       }
 
     } catch (error) {

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -19,8 +19,7 @@ class AppMarketService {
   ensureModels() {
     if (!this.models.MiniApp) {
       this.models.MiniApp = this.db.getModel('mini_app');
-      this.models.AppState = this.db.getModel('app_state');
-      this.models.AppRowHandler = this.db.getModel('app_row_handler');
+      this.models.AppClockRegistry = this.db.getModel('app_clock_registry');
       this.models.SystemSetting = this.db.getModel('system_setting');
       this.models.McpServer = this.db.getModel('mcp_server');
     }
@@ -409,16 +408,15 @@ class AppMarketService {
       'utf-8'
     );
     
-    // 9. 安装 handlers（返回 handlerId 映射）
-    const { installed: installedHandlers, handlerIdMap } = await this.installHandlers(appId, manifest);
-    
-    // 10. 插入数据库（extension_tables 存入 config）
+    // 9. 插入数据库（extension_tables 存入 config）
     const config = {
       ...manifest.config,
       extension_tables: manifest.extension_tables || []
     };
     await this.installAppMetadata(manifest, userId, visibility, config);
-    await this.installStates(appId, manifest, handlerIdMap);
+    
+    // 10. 注册到 app_clock_registry
+    await this.registerToClockRegistry(appId);
     
     logger.info(`App ${appId} installed successfully`);
     
@@ -426,8 +424,7 @@ class AppMarketService {
       success: true,
       app_id: appId,
       name: manifest.name,
-      version: manifest.version,
-      installed_handlers: installedHandlers
+      version: manifest.version
     };
   }
 
@@ -455,11 +452,24 @@ class AppMarketService {
   }
 
   /**
-   * 安装状态定义到数据库
-   * @param {string} appId
-   * @param {object} manifest
-   * @param {Map} handlerIdMap - handler名称 → app_row_handlers.id 的映射
+   * 注册 App 到 app_clock_registry
    */
+  async registerToClockRegistry(appId) {
+    this.ensureModels();
+    
+    const Utils = await import('../../lib/utils.js');
+    
+    await this.models.AppClockRegistry.create({
+      id: Utils.default.newID(20),
+      app_id: appId,
+      tick_script: null,
+      is_active: true
+    });
+    
+    logger.info(`App ${appId} registered to app_clock_registry`);
+  }
+
+  // ==================== 废弃方法（保留以兼容旧数据） ====================
   async installStates(appId, manifest, handlerIdMap = new Map()) {
     if (!manifest.states || manifest.states.length === 0) return;
     

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -20,6 +20,8 @@ class AppMarketService {
     if (!this.models.MiniApp) {
       this.models.MiniApp = this.db.getModel('mini_app');
       this.models.AppClockRegistry = this.db.getModel('app_clock_registry');
+      this.models.AppState = this.db.getModel('app_state');
+      this.models.AppRowHandler = this.db.getModel('app_row_handler');
       this.models.SystemSetting = this.db.getModel('system_setting');
       this.models.McpServer = this.db.getModel('mcp_server');
     }

--- a/server/services/contract-v2.service.js
+++ b/server/services/contract-v2.service.js
@@ -255,11 +255,13 @@ class ContractV2Service {
       });
       if (existing) throw new Error(`版本号 ${versionNumber} 已存在`);
 
+      const rowId = Utils.newID(20);
       const isFirst = existingCount === 0;
+      
       const version = await this.models.Version.create({
         id: Utils.newID(20),
         contract_id: contractId,
-        row_id: data.row_id,
+        row_id: rowId,
         file_id: data.file_id || null,
         version_number: versionNumber,
         version_name: data.version_name || null,
@@ -269,6 +271,16 @@ class ContractV2Service {
         created_by: userId,
       }, { transaction: t });
 
+      // 创建 content 记录，启动处理流程
+      await this.db.sequelize.query(`
+        INSERT INTO app_contract_mgr_v2_content 
+        (row_id, process_step, file_id, created_at, updated_at)
+        VALUES (?, 'pending_ocr', ?, NOW(), NOW())
+      `, {
+        replacements: [rowId, data.file_id || null],
+        transaction: t
+      });
+
       await contract.update({
         version_count: existingCount + 1,
         current_version_id: isFirst ? version.id : contract.current_version_id,
@@ -276,7 +288,7 @@ class ContractV2Service {
       }, { transaction: t });
 
       await t.commit();
-      return version.toJSON();
+      return { ...version.toJSON(), row_id: rowId };
     } catch (e) {
       await t.rollback();
       throw e;

--- a/server/services/mini-app.service.js
+++ b/server/services/mini-app.service.js
@@ -594,6 +594,11 @@ class MiniAppService {
     if (!app) throw new Error('App not found');
     if (!app.is_active) throw new Error('App is not active');
 
+    // contract-mgr-v2 使用独立的 content 表管理状态
+    if (appId === 'contract-mgr-v2') {
+      return await this.batchUploadForContractMgrV2(userId, attachmentIds);
+    }
+
     const initialState = await this.models.AppState.findOne({
       where: { app_id: appId, is_initial: true },
     });
@@ -624,6 +629,37 @@ class MiniAppService {
       });
 
       records.push(record);
+    }
+
+    return {
+      upload_time: new Date().toISOString(),
+      count: records.length,
+      records,
+    };
+  }
+
+  async batchUploadForContractMgrV2(userId, attachmentIds) {
+    const records = [];
+    
+    for (const attId of attachmentIds) {
+      const attachment = await this.models.Attachment.findByPk(attId);
+      if (!attachment) continue;
+      if (attachment.created_by && attachment.created_by !== userId) continue;
+
+      const rowId = Utils.newID(20);
+      
+      await this.db.sequelize.query(`
+        INSERT INTO app_contract_mgr_v2_content 
+        (row_id, process_step, file_id, created_at, updated_at)
+        VALUES (?, 'pending_ocr', ?, NOW(), NOW())
+      `, { replacements: [rowId, attId] });
+
+      records.push({
+        id: rowId,
+        process_step: 'pending_ocr',
+        file_id: attId,
+        title: attachment.file_name || 'Unknown',
+      });
     }
 
     return {


### PR DESCRIPTION
## Summary

- AppClock 回调模式升级：Clock 只唤醒，App 完全自主处理
- 新增表：`app_clock_registry`、`app_tick_log`
- 重写 `lib/app-clock.js` 为回调模式
- `contract-mgr-v2` tick.js 整合所有 handler 逻辑

## Changes

1. **新架构设计**
   - Clock 固定 5 秒串行唤醒一个 App
   - App 自己判断是否执行、频次、内部状态
   - 主程序不再管理 App 的记录和状态

2. **新增文件**
   - `models/app_clock_registry.js` - App 调度注册表
   - `models/app_tick_log.js` - 执行日志表
   - `apps/contract-mgr-v2/tick/index.js` - 整合所有 handler 逻辑

3. **修改文件**
   - `lib/app-clock.js` - 完全重写为回调模式
   - `server/services/app-market.service.js` - 安装时注册到 app_clock_registry
   - `scripts/upgrade-database.js` - 新增迁移项
   - `models/init-models.js` - 注册新 model

## Test plan

- 数据库迁移执行成功
- contract-mgr-v2 已注册到 app_clock_registry
- 待启动服务验证 Clock 唤醒逻辑

Closes #693