### PR TITLE
refactor: 将 contract-v2 路由统一到 /apps 命名空间下

### DIFF
--- a/apps/contract-mgr-v2/manifest.json
+++ b/apps/contract-mgr-v2/manifest.json
@@ -353,6 +353,6 @@
       "failure_next": null
     }
   ],
-  "component": null,
+  "component": "ContractV2View",
   "visibility": "all"
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -125,11 +125,6 @@ const router = createRouter({
           name: 'app-detail',
           component: () => import('@/views/AppDetailView.vue'),
         },
-        {
-          path: 'contract-v2',
-          name: 'contract-v2',
-          component: () => import('@/views/contract-v2/ContractV2View.vue'),
-        },
       ],
     },
     {

--- a/frontend/src/views/AppDetailView.vue
+++ b/frontend/src/views/AppDetailView.vue
@@ -5,25 +5,34 @@
       <p>小程序未找到</p>
       <button class="btn-back" @click="goBack">← 返回</button>
     </div>
-    <GenericMiniApp v-else :app="currentApp" />
+    <component v-else :is="AppComponent" :app="currentApp" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { shallowRef, ref, onMounted, defineAsyncComponent, type Component } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { getApp, type MiniApp } from '@/api/mini-apps'
 import GenericMiniApp from '@/components/apps/GenericMiniApp.vue'
 
+const AppComponentMap: Record<string, Component> = {
+  'ContractV2View': defineAsyncComponent(() => import('@/views/contract-v2/ContractV2View.vue')),
+}
+
 const route = useRoute()
 const router = useRouter()
-const currentApp = ref<MiniApp | null>(null)
+const currentApp = shallowRef<MiniApp | null>(null)
+const AppComponent = shallowRef<Component>(GenericMiniApp as Component)
 const isLoading = ref(true)
 
 onMounted(async () => {
   try {
     const appId = route.params.appId as string
     currentApp.value = await getApp(appId)
+    const componentKey = currentApp.value?.component
+    if (componentKey && componentKey in AppComponentMap) {
+      AppComponent.value = AppComponentMap[componentKey]!
+    }
   } catch (error) {
     console.error('Failed to load app:', error)
   } finally {

--- a/frontend/src/views/AppsView.vue
+++ b/frontend/src/views/AppsView.vue
@@ -98,11 +98,7 @@ async function loadMyApps() {
 
 // 打开 App
 function openApp(app: MiniApp) {
-  if (app.id === 'contract-mgr-v2') {
-    router.push('/contract-v2')
-  } else {
-    router.push(`/apps/${app.id}`)
-  }
+  router.push(`/apps/${app.id}`)
 }
 
 // 处理应用安装完成


### PR DESCRIPTION
## Summary

- 删除 router 中 contract-v2 专用路由，统一所有 app 走 `/apps/:appId`
- AppDetailView 增加动态组件解析：根据 `app.component` 字段选择专用组件或 GenericMiniApp
- AppsView 删除硬编码特判，统一导航逻辑
- manifest.json 的 `component` 字段改为 `"ContractV2View"`

## 变更说明

| 文件 | 改动 |
|------|------|
| `frontend/src/router/index.ts` | 删除 contract-v2 专用路由 |
| `frontend/src/views/AppDetailView.vue` | 新增 app.component 动态组件解析机制 |
| `frontend/src/views/AppsView.vue` | 删除特判，统一 `router.push(`/apps/${app.id}`)` |
| `apps/contract-mgr-v2/manifest.json` | `component: null` → `"ContractV2View"` |

## 架构意义

所有 App 统一走 `/apps/:appId` 路径，实现 Custom Apps 框架：
- `component = null` → GenericMiniApp（零代码模板）
- `component = "ContractV2View"` → 专用组件

新增专用 app 只需：manifest 添加 `component` 字段 + AppDetailView 注册映射，无需改路由、导航逻辑。

Closes #696