### PR TITLE
enhancement: 我的应用页面card布局改为每行固定4个

### DIFF
--- a/frontend/src/views/AppsView.vue
+++ b/frontend/src/views/AppsView.vue
@@ -211,7 +211,7 @@ watch(currentTab, (tab) => {
 
 .apps-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 20px;
 }
 


### PR DESCRIPTION
## Summary

将"我的应用"页面的 card 布局从自适应网格改为每行固定 4 个。

## Changes

- `AppsView.vue`: `.apps-grid` 的 `grid-template-columns` 从 `repeat(auto-fill, minmax(280px, 1fr))` 改为 `repeat(4, 1fr)`

Closes #701