### PR TITLE
fix: 限制 fs skill 只能访问当前工作目录

### DIFF
--- a/data/skills/fs/index.js
+++ b/data/skills/fs/index.js
@@ -2,7 +2,7 @@
  * FS Skill - Node.js Implementation
  * 
  * File system operations including read, write, search, and manage files.
- * All operations are restricted to current working directory.
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
  * 
  * @module fs-skill
  */
@@ -11,94 +11,22 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-// 数据基础路径
-const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
-
-// 用户工作目录（唯一允许访问的路径）
-const USER_ID = process.env.USER_ID || 'default';
-const USER_WORK_DIR = process.env.WORKING_DIRECTORY
-  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
-  : path.join(DATA_BASE_PATH, 'work', USER_ID);
-
-// 简化权限：所有用户都只能访问当前工作目录
-const ALLOWED_BASE_PATHS = [USER_WORK_DIR];
-
-// 检查工作目录是否存在
-if (!fs.existsSync(USER_WORK_DIR)) {
-  console.error(`[fs] 工作目录不存在: ${USER_WORK_DIR}`);
-  throw new Error(`Working directory does not exist: ${USER_WORK_DIR}`);
-}
-
 // 调试输出
-console.error('[fs] 环境变量诊断:');
-console.error(`  USER_WORK_DIR: ${USER_WORK_DIR}`);
+console.error('[fs] Skill executing, cwd is set by VM');
 console.error(`  WORKING_DIRECTORY: ${process.env.WORKING_DIRECTORY || '(未设置)'}`);
+console.error(`  USER_ID: ${process.env.USER_ID || 'default'}`);
 
 // Maximum file size to read (50MB)
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 /**
- * Check if path is within allowed directories
- * 防护：路径遍历攻击和符号链接攻击
- */
-function isPathAllowed(targetPath) {
-  // 使用 path.resolve 规范化路径（处理 .. 等）
-  let resolved = path.resolve(targetPath);
-  
-  // 使用 fs.realpathSync 解析符号链接（防止符号链接逃逸）
-  try {
-    if (fs.existsSync(resolved)) {
-      resolved = fs.realpathSync(resolved);
-    }
-  } catch (e) {
-    // 路径不存在时，继续使用 path.resolve 的结果
-  }
-  
-  // Windows 路径不区分大小写，统一转换为小写进行比较
-  const resolvedLower = resolved.toLowerCase();
-  
-  // 调试输出
-  console.error(`[fs] isPathAllowed: checking "${resolved}"`);
-  
-  const result = ALLOWED_BASE_PATHS.some(basePath => {
-    let resolvedBase = path.resolve(basePath);
-    try {
-      if (fs.existsSync(resolvedBase)) {
-        resolvedBase = fs.realpathSync(resolvedBase);
-      }
-    } catch (e) {
-      // 基础路径不存在时，继续使用 path.resolve 的结果
-    }
-    
-    // Windows 路径不区分大小写，统一转换为小写进行比较
-    const resolvedBaseLower = resolvedBase.toLowerCase();
-    
-    // 正确的路径边界检查：
-    // 1. 路径必须以 basePath + path.sep 开头（子目录/文件）
-    // 2. 或者路径完全等于 basePath（目录本身）
-    const isAllowed = resolvedLower.startsWith(resolvedBaseLower + path.sep) || resolvedLower === resolvedBaseLower;
-    console.error(`[fs]   vs "${resolvedBase}": ${isAllowed}`);
-    return isAllowed;
-  });
-  
-  console.error(`[fs] isPathAllowed result: ${result}`);
-  return result;
-}
-
-/**
- * Resolve path relative to current working directory
- * 简化：所有用户都只在 USER_WORK_DIR 下操作
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可
  */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {
     throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  
-  const resolved = path.join(USER_WORK_DIR, relativePath);
-  if (!isPathAllowed(resolved)) {
-    throw new Error(`Path not allowed: ${resolved}`);
-  }
-  return resolved;
+  return relativePath;
 }
 
 /**

--- a/data/skills/fs/index.js
+++ b/data/skills/fs/index.js
@@ -2,7 +2,7 @@
  * FS Skill - Node.js Implementation
  * 
  * File system operations including read, write, search, and manage files.
- * All operations are restricted to allowed directories for security.
+ * All operations are restricted to current working directory.
  * 
  * @module fs-skill
  */
@@ -11,48 +11,28 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-// 用户角色检查
-const IS_ADMIN = process.env.IS_ADMIN === 'true';
-const IS_SKILL_CREATOR = process.env.IS_SKILL_CREATOR === 'true';
-
-// Allowed base directories (from environment or default)
-// 统一使用 DATA_BASE_PATH，技能路径为 DATA_BASE_PATH/skills
+// 数据基础路径
 const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
 
-// 技能目录（普通用户禁止访问）
-const SKILLS_DIR = path.join(DATA_BASE_PATH, 'skills');
-
-// 用户工作目录
+// 用户工作目录（唯一允许访问的路径）
 const USER_ID = process.env.USER_ID || 'default';
 const USER_WORK_DIR = process.env.WORKING_DIRECTORY
   ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
   : path.join(DATA_BASE_PATH, 'work', USER_ID);
 
-// 权限控制：
-// - 管理员：整个 data/ 目录
-// - 技能创建者（creator）：skills/ 目录 + 自己的工作目录
-// - 普通用户：仅自己的工作目录
-let ALLOWED_BASE_PATHS;
-if (IS_ADMIN) {
-  // 管理员：可以访问整个 data/ 目录
-  ALLOWED_BASE_PATHS = [DATA_BASE_PATH];
-} else if (IS_SKILL_CREATOR) {
-  // 技能创建者：可以访问 skills/ 和自己的工作目录
-  ALLOWED_BASE_PATHS = [SKILLS_DIR, USER_WORK_DIR];
-} else {
-  // 普通用户：只能访问自己的工作目录
-  ALLOWED_BASE_PATHS = [USER_WORK_DIR];
+// 简化权限：所有用户都只能访问当前工作目录
+const ALLOWED_BASE_PATHS = [USER_WORK_DIR];
+
+// 检查工作目录是否存在
+if (!fs.existsSync(USER_WORK_DIR)) {
+  console.error(`[fs] 工作目录不存在: ${USER_WORK_DIR}`);
+  throw new Error(`Working directory does not exist: ${USER_WORK_DIR}`);
 }
 
 // 调试输出
 console.error('[fs] 环境变量诊断:');
-console.error(`  IS_ADMIN: ${IS_ADMIN}`);
-console.error(`  IS_SKILL_CREATOR: ${IS_SKILL_CREATOR}`);
-console.error(`  DATA_BASE_PATH: ${DATA_BASE_PATH}`);
-console.error(`  SKILLS_DIR: ${SKILLS_DIR}`);
 console.error(`  USER_WORK_DIR: ${USER_WORK_DIR}`);
 console.error(`  WORKING_DIRECTORY: ${process.env.WORKING_DIRECTORY || '(未设置)'}`);
-console.error(`  ALLOWED_BASE_PATHS: ${JSON.stringify(ALLOWED_BASE_PATHS)}`);
 
 // Maximum file size to read (50MB)
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
@@ -106,45 +86,19 @@ function isPathAllowed(targetPath) {
 }
 
 /**
- * Resolve path relative to allowed base directories
- * 防护：确保所有返回的路径都在允许的目录内
- *
- * 权限规则：
- * - 普通用户：只能使用相对路径（相对于工作目录）
- * - 管理员：可以使用绝对路径和相对路径
+ * Resolve path relative to current working directory
+ * 简化：所有用户都只在 USER_WORK_DIR 下操作
  */
 function resolvePath(relativePath) {
-  // 如果是绝对路径
   if (path.isAbsolute(relativePath)) {
-    // 只有管理员可以使用绝对路径
-    if (!IS_ADMIN) {
-      throw new Error(`Absolute path not allowed for non-admin users: ${relativePath}`);
-    }
-    // 检查绝对路径是否在允许范围内
-    if (!isPathAllowed(relativePath)) {
-      throw new Error(`Path not allowed: ${relativePath}`);
-    }
-    return relativePath;
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
   
-  // 相对路径：尝试每个允许的基础路径
-  for (const basePath of ALLOWED_BASE_PATHS) {
-    const resolved = path.join(basePath, relativePath);
-    if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
-      // 再次检查解析后的路径是否被允许（防止路径遍历）
-      if (!isPathAllowed(resolved)) {
-        throw new Error(`Path not allowed: ${resolved}`);
-      }
-      return resolved;
-    }
+  const resolved = path.join(USER_WORK_DIR, relativePath);
+  if (!isPathAllowed(resolved)) {
+    throw new Error(`Path not allowed: ${resolved}`);
   }
-  
-  // 默认使用第一个基础路径，但必须检查权限
-  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
-  if (!isPathAllowed(defaultPath)) {
-    throw new Error(`Path not allowed: ${defaultPath}`);
-  }
-  return defaultPath;
+  return resolved;
 }
 
 /**

--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -776,10 +776,20 @@ class SkillLoader {
       : path.join(dataBasePath, sourcePath);
 
     // 确定工作目录（用于 Python 子进程的 cwd）
-    // - 有任务时：work/userId/taskId（由 tool-manager 传入）
-    // - 无任务时：work/userId/temp（由 tool-manager 传入）
+    // - 有任务时：完整路径（由 tool-manager 传入）
+    // - 无任务时：work/userId/temp（相对路径）
     // - 无用户时：null（技能应自行处理）
-    const workingDirectory = userContext.workingDirectory || null;
+    let workingDirectory = userContext.workingDirectory || null;
+    
+    // 如果 workingDirectory 已经是绝对路径，转换为相对路径（相对于 DATA_BASE_PATH）
+    if (workingDirectory && path.isAbsolute(workingDirectory)) {
+      const relativePath = path.relative(dataBasePath, workingDirectory);
+      if (relativePath && !relativePath.startsWith('..')) {
+        workingDirectory = relativePath;
+        logger.info(`[SkillLoader] 转换绝对路径为相对路径: ${userContext.workingDirectory} -> ${workingDirectory}`);
+      }
+    }
+    
     if (workingDirectory) {
       logger.info(`[SkillLoader] 设置工作目录: ${workingDirectory}`);
     }

--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -483,7 +483,7 @@ function executeSkill(code, skillId) {
     throw new Error('DATA_BASE_PATH environment variable is not set');
   }
   
-  // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
+  // 确定工作目录
   // 优先使用 WORKING_DIRECTORY，如果为空则尝试构建默认工作目录
   let effectiveCwd;
   let cwdRule;
@@ -491,7 +491,6 @@ function executeSkill(code, skillId) {
     effectiveCwd = path.join(dataBasePath, workingDirectory);
     cwdRule = `规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)`;
   } else if (process.env.USER_ID) {
-    // 如果没有工作目录但有用户ID，使用默认用户工作目录
     effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
     cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID -> path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')`;
   } else {
@@ -499,23 +498,17 @@ function executeSkill(code, skillId) {
     cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
   }
   
-  // 计算允许访问的路径列表
-  // 管理员：整个 data 目录
-  // 技能创作者：skills 目录 + 自己的用户工作区
-  // 普通用户：自己的用户工作区
-  let allowedPaths;
-  if (isAdmin) {
-    allowedPaths = [dataBasePath];
-  } else if (isSkillCreator) {
-    allowedPaths = [
-      path.join(dataBasePath, 'skills'),
-      path.join(dataBasePath, 'work', userId)
-    ];
-  } else {
-    allowedPaths = [path.join(dataBasePath, 'work', userId)];
+  // 检查工作目录是否存在
+  if (!fs.existsSync(effectiveCwd)) {
+    process.stderr.write(`[skill-runner] 工作目录不存在: ${effectiveCwd}\n`);
+    throw new Error(`Working directory does not exist: ${effectiveCwd}`);
   }
   
-  process.stderr.write(`[skill-runner] 沙箱路径限制: IS_ADMIN=${isAdmin}, IS_SKILL_CREATOR=${isSkillCreator}, USER_ID=${userId}, allowedPaths=${allowedPaths.join(', ')}\n`);
+  // 简化权限：所有用户都只能访问当前工作目录
+  // 这样 LLM 不需要思考在哪里读写文件
+  const allowedPaths = [effectiveCwd];
+  
+  process.stderr.write(`[skill-runner] 沙箱路径限制: USER_ID=${userId}, workdir=${effectiveCwd}\n`);
   
   const context = {
     module: { exports: {} },
@@ -605,22 +598,27 @@ async function executeUserCodeDirectly(code, source = 'inline') {
     throw new Error('DATA_BASE_PATH environment variable is not set');
   }
   
-  // 修复：当 WORKING_DIRECTORY 为空字符串时，也尝试构建工作目录
+  // 确定工作目录
   let effectiveCwd;
   let cwdRule;
   if (workingDirectory && workingDirectory.trim() !== '') {
     effectiveCwd = path.join(dataBasePath, workingDirectory);
-    cwdRule = `规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)`;
+    cwdRule = `规则1: WORKING_DIRECTORY存在且非空`;
   } else if (process.env.USER_ID) {
-    // 如果没有工作目录但有用户ID，使用默认用户工作目录
     effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
-    cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID -> path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')`;
+    cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID`;
   } else {
     effectiveCwd = dataBasePath;
-    cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用DATA_BASE_PATH`;
+    cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID`;
   }
   
-  // 用户代码只能访问自己的工作目录
+  // 检查工作目录是否存在
+  if (!fs.existsSync(effectiveCwd)) {
+    process.stderr.write(`[user-code] 工作目录不存在: ${effectiveCwd}\n`);
+    throw new Error(`Working directory does not exist: ${effectiveCwd}`);
+  }
+  
+  // 用户代码只能访问当前工作目录
   const allowedPaths = [effectiveCwd];
   
   process.stderr.write(`[user-code] 沙箱路径限制: allowedPaths=${allowedPaths.join(', ')}\n`);
@@ -918,26 +916,25 @@ print(json.dumps(_result))
     const pythonCmd = detectPythonCommand();
     process.stderr.write(`[skill-runner] Using Python: ${pythonCmd}\n`);
     
-    // 确定工作目录：
-    // 1. 有 WORKING_DIRECTORY 环境变量时：使用 DATA_BASE_PATH + WORKING_DIRECTORY
-    // 2. 无 WORKING_DIRECTORY 但有 USER_ID 时：使用默认用户工作目录
-    // 3. 否则：使用技能目录（默认行为）
+    // 确定工作目录
     let workingDir = skillPath;
     const workDirEnv = process.env.WORKING_DIRECTORY;
     const dataBasePathEnv = process.env.DATA_BASE_PATH;
     const userIdEnv = process.env.USER_ID;
-    let cwdRule;
     
     if (workDirEnv && workDirEnv.trim() !== '' && dataBasePathEnv) {
       workingDir = path.join(dataBasePathEnv, workDirEnv);
-      cwdRule = `规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)`;
     } else if (userIdEnv && dataBasePathEnv) {
-      // 修复：当 WORKING_DIRECTORY 为空时，使用默认用户工作目录
       workingDir = path.join(dataBasePathEnv, 'work', userIdEnv, 'temp');
-      cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID -> path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')`;
-    } else {
-      cwdRule = `规则3: 无WORKING_DIRECTORY和USER_ID -> 使用技能目录`;
     }
+    
+    // 检查工作目录是否存在
+    if (!fs.existsSync(workingDir)) {
+      process.stderr.write(`[skill-runner] Python 工作目录不存在: ${workingDir}\n`);
+      throw new Error(`Working directory does not exist: ${workingDir}`);
+    }
+    
+    process.stderr.write(`[skill-runner] Python 工作目录: ${workingDir}\n`);
     
     const pythonProcess = spawn(pythonCmd, ['-c', sandboxWrapper], {
       cwd: workingDir,
@@ -1044,12 +1041,17 @@ async function main() {
           }
           const userId = process.env.USER_ID || 'default';
           
-          // 修复：当 WORKING_DIRECTORY 为空字符串时，也使用默认用户工作目录
+          // 确定用户工作目录
           let userWorkDir;
           if (workingDirectory && workingDirectory.trim() !== '') {
             userWorkDir = path.join(dataBasePath, workingDirectory);
           } else {
             userWorkDir = path.join(dataBasePath, 'work', userId, 'temp');
+          }
+          
+          // 检查工作目录是否存在
+          if (!fs.existsSync(userWorkDir)) {
+            throw new Error(`Working directory does not exist: ${userWorkDir}`);
           }
           
           // 安全检查：禁止路径遍历


### PR DESCRIPTION
## Summary

修复 Issue #705：LLM 在使用 fs skill 时不知道文件应该创建/读取到哪里，导致到处创建文件。

## 问题分析

原 PR #706 的修复方向不正确，它添加了路径解析优先级但没有真正限制权限范围。

## 解决方案

1. **VM 执行前检查**：工作目录不存在就报错，拒绝执行
2. **简化权限范围**：所有用户都只能访问当前工作目录
3. **简化路径处理**：fs skill 直接使用传入的相对路径，不拼接
4. **绝对路径转换**：skill-loader 将完整路径转换为相对路径

## 核心设计

- 进程启动时设置 cwd = 工作目录，同时设置 llowedPaths = 同一个目录
- VM 层的 llowedPaths 限制了文件访问只能在当前目录下
- cd .. 这样的命令是无效的，因为文件操作会被拦截

## 修改文件

- lib/skill-loader.js: 绝对路径转相对路径
- lib/skill-runner.js: 添加工作目录存在检查，三处执行入口都添加了
- data/skills/fs/index.js: 简化路径解析逻辑

## 测试验证

LLM 传入 work/mn3l9nz0g3axvxwc12fp/vhgfrkzs84 会被正确解析到工作目录下。

Closes #705