### PR TITLE
fix: 移除 internal-llm-service.js 中多余的闭合括号

### DIFF
--- a/lib/internal-llm-service.js
+++ b/lib/internal-llm-service.js
@@ -253,7 +253,6 @@ const response = await this.callWithRetry(model, messages, {
       ...(options.response_format && { response_format: options.response_format }),
       ...(shouldDisableThinking && { chat_template_kwargs: { enable_thinking: false } }),
     });
-    });
     return response.content;
   }
 


### PR DESCRIPTION
## Summary
- 移除 lib/internal-llm-service.js 中多余的 }); 闭合括号，该行导致语法错误