### PR TITLE
fix: 销售合同管理v2 筛选重置问题修复

### DIFF
--- a/frontend/src/api/contract-v2.ts
+++ b/frontend/src/api/contract-v2.ts
@@ -22,6 +22,8 @@ export interface ContractMainRecord {
   current_version_id: string | null
   version_count: number
   status: 'draft' | 'active' | 'expired' | 'terminated'
+  party_a?: string | null
+  total_amount?: number | null
   created_by: string
   created_at: string
   updated_at: string

--- a/frontend/src/components/contract-v2/ContractList.vue
+++ b/frontend/src/components/contract-v2/ContractList.vue
@@ -38,9 +38,18 @@ const statusLabels: Record<string, { label: string; type: string }> = {
   terminated: { label: '终止', type: 'danger' },
 }
 
-const filterStatus = ref('')
-const filterType = ref('')
-const searchText = ref('')
+const filterStatus = computed({
+  get: () => store.filterStatus,
+  set: (val) => { store.filterStatus = val }
+})
+const filterType = computed({
+  get: () => store.filterType,
+  set: (val) => { store.filterType = val }
+})
+const searchText = computed({
+  get: () => store.searchText,
+  set: (val) => { store.searchText = val }
+})
 
 const showCreateDialog = ref(false)
 const createForm = ref({

--- a/frontend/src/stores/contract-v2.ts
+++ b/frontend/src/stores/contract-v2.ts
@@ -53,11 +53,21 @@ export const useContractV2Store = defineStore('contract-v2', () => {
   const contractsPageSize = ref(20)
   const contractsLoading = ref(false)
 
+  const filterStatus = ref<string>('')
+  const filterType = ref<string>('')
+  const searchText = ref<string>('')
+
   const currentContract = ref<ContractMainRecord | null>(null)
   const currentContractVersions = ref<ContractVersion[]>([])
 
   const dashboard = ref<DashboardData | null>(null)
   const dashboardLoading = ref(false)
+
+  function resetFilters() {
+    filterStatus.value = ''
+    filterType.value = ''
+    searchText.value = ''
+  }
 
   async function loadTree() {
     treeLoading.value = true
@@ -247,6 +257,10 @@ export const useContractV2Store = defineStore('contract-v2', () => {
     contractsPage,
     contractsPageSize,
     contractsLoading,
+    filterStatus,
+    filterType,
+    searchText,
+    resetFilters,
     currentContract,
     currentContractVersions,
     dashboard,

--- a/frontend/src/views/contract-v2/ContractV2View.vue
+++ b/frontend/src/views/contract-v2/ContractV2View.vue
@@ -30,6 +30,7 @@ watch(() => store.selectedNodeId, (nodeId) => {
     include_children: true,
     page: 1,
   })
+  store.resetFilters()
   showDetail.value = false
 }, { immediate: false })
 


### PR DESCRIPTION
## Summary
修复Issue #716: 销售合同管理v2 UI/UX问题

### P0修复
- 组织节点切换时自动重置筛选条件（状态、类型、搜索关键词）
- 筛选状态统一由store管理，跨组件同步

### Changes
- store新增 ilterStatus, ilterType, searchText 状态和 esetFilters() 方法
- ContractList筛选改为computed双向绑定store
- watch selectedNodeId 时调用 resetFilters()

### Testing
- type-check 通过

Closes #716