### PR TITLE
fix: AppDetailView syntax fix and dynamic file upload config

### DIFF
--- a/apps/contract-mgr-v2/manifest.json
+++ b/apps/contract-mgr-v2/manifest.json
@@ -186,7 +186,7 @@
       ".jpg",
       ".png"
     ],
-    "max_file_size": 20971520,
+    "max_file_size": 52428800,
     "batch_enabled": true,
     "batch_limit": 50,
     "step_resources": {

--- a/frontend/src/components/apps/fields/FileField.vue
+++ b/frontend/src/components/apps/fields/FileField.vue
@@ -53,8 +53,7 @@ const progress = ref(0)
 const error = ref('')
 
 const accept = computed(() => {
-  // 从 App config 中获取支持的格式
-  return '.pdf,.docx,.doc,.jpg,.png'
+  return props.app?.config?.supported_formats?.join(',') || '.pdf,.docx,.doc,.jpg,.png'
 })
 
 const placeholder = computed(() => {
@@ -88,10 +87,10 @@ async function handleFileChange(event: Event) {
   const file = target.files?.[0]
   if (!file) return
 
-  // 检查文件大小 (20MB)
-  const maxSize = 20 * 1024 * 1024
+  const maxSize = props.app?.config?.max_file_size || 50 * 1024 * 1024
+  const maxSizeMB = Math.round(maxSize / 1024 / 1024)
   if (file.size > maxSize) {
-    error.value = `文件大小超过限制 (最大 20MB)`
+    error.value = `文件大小超过限制 (最大 ${maxSizeMB}MB)`
     toast.error(error.value)
     return
   }

--- a/frontend/src/views/AppDetailView.vue
+++ b/frontend/src/views/AppDetailView.vue
@@ -34,6 +34,7 @@ onMounted(async () => {
     const componentKey = currentApp.value?.component
     if (componentKey && componentKey in AppComponentMap) {
       AppComponent.value = AppComponentMap[componentKey]!
+    }
   } catch (error) {
     console.error('Failed to load app:', error)
   } finally {

--- a/server/controllers/attachment.controller.js
+++ b/server/controllers/attachment.controller.js
@@ -38,6 +38,15 @@ const ALLOWED_MIME_TYPES = [
   'text/plain',
   'text/markdown',
   'application/json',
+  // Word 文档
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  // Excel 表格
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  // PowerPoint 演示文稿
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   // 压缩包
   'application/zip',
   'application/x-zip-compressed'
@@ -56,6 +65,13 @@ const MAGIC_NUMBERS = {
   'text/plain': [0x54, 0x58, 0x54],        // TXT: TXT
   'application/json': [0x7B, 0x22],        // JSON: {"
   'text/markdown': null,                    // Markdown 是文本，跳过验证
+  // Office 文档 (都是 ZIP 格式)
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [0x50, 0x4B, 0x03, 0x04],
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [0x50, 0x4B, 0x03, 0x04],
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': [0x50, 0x4B, 0x03, 0x04],
+  'application/msword': [0xD0, 0xCF, 0x11, 0xE0],  // DOC (OLE compound)
+  'application/vnd.ms-excel': [0xD0, 0xCF, 0x11, 0xE0],  // XLS (OLE compound)
+  'application/vnd.ms-powerpoint': [0xD0, 0xCF, 0x11, 0xE0],  // PPT (OLE compound)
 };
 
 const DEFAULT_MAX_UPLOAD_SIZE_MB = 50;

--- a/server/services/mini-app.service.js
+++ b/server/services/mini-app.service.js
@@ -163,6 +163,16 @@ class MiniAppService {
 
     const appJson = app.toJSON();
     appJson.states = states;
+
+    // 解析 config 字段（JSON 字符串 -> 对象）
+    if (appJson.config && typeof appJson.config === 'string') {
+      try {
+        appJson.config = JSON.parse(appJson.config);
+      } catch {
+        appJson.config = {};
+      }
+    }
+
     return appJson;
   }
 


### PR DESCRIPTION
- Fix missing closing brace in AppDetailView.vue if block - FileField.vue: read format/size limits from App config dynamically - attachment.controller.js: add Office document MIME types and magic numbers - mini-app.service.js: parse config JSON string to object - contract-mgr-v2/manifest.json: adjust max_file_size to 50MB