### PR TITLE
refactor: extract LLMPayloadCache to separate module

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -47,6 +47,7 @@ import TopicDetector from './topic-detector.js';
 import RAGService from './rag-service.js';
 import InternalLLMService from './internal-llm-service.js';
 import { MinimalContextOrganizer } from './context-organizer/minimal-organizer.js';
+import LLMPayloadCache from './chat/llm-payload-cache.js';
 import logger from './logger.js';
 import Utils from './utils.js';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
@@ -73,9 +74,9 @@ class ChatService {
     // 活跃对话缓存（按 topicId）
     this.activeChats = new Map();
     
-    // LLM Payload 缓存（按 user_id:expert_id 存储，仅用于用户对话调试）
-    // 不存入数据库，服务重启后丢失
-    this.llmPayloadCache = new Map();
+    // LLM Payload 缓存 - 委托给独立模块
+    // 仅用于用户对话调试，服务重启后丢失
+    this.llmPayloadCache = new LLMPayloadCache();
   }
 
   // ============================================================
@@ -90,12 +91,7 @@ class ChatService {
    * @param {Object} payload - LLM 请求 payload
    */
   saveLLMPayload(user_id, expert_id, payload) {
-    const cacheKey = `${user_id}:${expert_id}`;
-    this.llmPayloadCache.set(cacheKey, {
-      ...payload,
-      cached_at: new Date().toISOString(),
-    });
-    logger.debug(`[ChatService] LLM Payload 已缓存: ${cacheKey}`);
+    this.llmPayloadCache.save(user_id, expert_id, payload);
   }
 
   /**
@@ -105,8 +101,7 @@ class ChatService {
    * @returns {Object|null} LLM Payload 或 null
    */
   getLLMPayload(user_id, expert_id) {
-    const cacheKey = `${user_id}:${expert_id}`;
-    return this.llmPayloadCache.get(cacheKey) || null;
+    return this.llmPayloadCache.get(user_id, expert_id);
   }
 
   /**

--- a/lib/chat/llm-payload-cache.js
+++ b/lib/chat/llm-payload-cache.js
@@ -1,0 +1,63 @@
+/**
+ * LLM Payload 缓存模块
+ * 
+ * 负责缓存 LLM 请求的 payload，用于调试和日志分析
+ * 
+ * 【基础设施层】
+ * 用途：仅用于用户对话调试，服务重启后丢失
+ */
+
+import logger from '../logger.js';
+
+class LLMPayloadCache {
+  constructor() {
+    this.cache = new Map();
+  }
+
+  /**
+   * 保存 LLM Payload 到缓存
+   * @param {string} user_id - 用户ID
+   * @param {string} expert_id - 专家ID
+   * @param {Object} payload - LLM 请求 payload
+   */
+  save(user_id, expert_id, payload) {
+    const cacheKey = `${user_id}:${expert_id}`;
+    this.cache.set(cacheKey, {
+      ...payload,
+      cached_at: new Date().toISOString(),
+    });
+    logger.debug(`[LLMPayloadCache] Payload 已缓存: ${cacheKey}`);
+  }
+
+  /**
+   * 获取最近一次 LLM Payload
+   * @param {string} user_id - 用户ID
+   * @param {string} expert_id - 专家ID
+   * @returns {Object|null} LLM Payload 或 null
+   */
+  get(user_id, expert_id) {
+    const cacheKey = `${user_id}:${expert_id}`;
+    return this.cache.get(cacheKey) || null;
+  }
+
+  /**
+   * 清除指定用户的缓存
+   * @param {string} user_id - 用户ID
+   * @param {string} expert_id - 专家ID
+   */
+  clear(user_id, expert_id) {
+    const cacheKey = `${user_id}:${expert_id}`;
+    this.cache.delete(cacheKey);
+    logger.debug(`[LLMPayloadCache] 缓存已清除: ${cacheKey}`);
+  }
+
+  /**
+   * 清除所有缓存
+   */
+  clearAll() {
+    this.cache.clear();
+    logger.info('[LLMPayloadCache] 所有缓存已清除');
+  }
+}
+
+export default LLMPayloadCache;


### PR DESCRIPTION
## Summary
- Extract LLMPayloadCache to lib/chat/llm-payload-cache.js
- ChatService now delegates to LLMPayloadCache instance
- First step in ChatService layered architecture refactoring

## Changes
- New file: lib/chat/llm-payload-cache.js (61 lines)
- Modified: lib/chat-service.js (-5 net lines, delegates to cache)

## Testing
- Module loads correctly
- Lint passes
- No breaking changes to external API