### PR TITLE
fix: 统一 xlsx 技能路径规则与 FS 技能一致

### DIFF
--- a/data/skills/xlsx/SKILL.md
+++ b/data/skills/xlsx/SKILL.md
@@ -7,24 +7,15 @@ description: "Excel 文件处理。用于读取、写入、编辑 .xlsx/.xls/.cs
 
 ## 路径参数说明
 
-> **重要**：所有工具的 `path` 参数遵循以下规则：
-
-| 参数类型 | 说明 |
-|----------|------|
-| **相对路径** | 相对于工作目录，工具自动拼接基础路径。示例：`input/file.xlsx` |
-| **绝对路径** | 仅管理员可用，需在允许的路径范围内 |
-
-**基础路径规则**：
-- 管理员：项目根目录 或 `data/` 目录
-- 普通用户：`data/work/{user_id}/` 目录
+> **重要**：所有工具的 `path` 参数遵循以下规则（与 FS 技能一致）：
+> - 相对路径直接使用，依赖 VM 设置的工作目录
+> - **绝对路径不被允许**
 
 **示例**：
 ```javascript
 // 相对路径（推荐）
 read({ path: 'input/data.xlsx', scope: 'workbook' })
-
-// 绝对路径（仅管理员）
-read({ path: '/absolute/path/to/data.xlsx', scope: 'workbook' })
+read({ path: 'data/output.xlsx', scope: 'workbook' })
 ```
 
 ## 工具

--- a/data/skills/xlsx/index.js
+++ b/data/skills/xlsx/index.js
@@ -1,5 +1,7 @@
 /**
  * XLSX Skill - Excel 文件处理技能 (ExcelJS 版本)
+ * 
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
  */
 
 const ExcelJS = require('exceljs');
@@ -16,44 +18,14 @@ function getHyperFormula() {
   return HyperFormula;
 }
 
-const IS_ADMIN = process.env.IS_ADMIN === 'true';
-const IS_SKILL_CREATOR = process.env.IS_SKILL_CREATOR === 'true';
-const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
-const USER_ID = process.env.USER_ID || 'default';
-const USER_WORK_DIR = process.env.WORKING_DIRECTORY
-  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
-  : path.join(DATA_BASE_PATH, 'work', USER_ID);
-
-let ALLOWED_BASE_PATHS;
-if (IS_ADMIN) ALLOWED_BASE_PATHS = [DATA_BASE_PATH];
-else if (IS_SKILL_CREATOR) ALLOWED_BASE_PATHS = [path.join(DATA_BASE_PATH, 'skills'), path.join(DATA_BASE_PATH, 'work', USER_ID)];
-else ALLOWED_BASE_PATHS = [USER_WORK_DIR];
-
-function isPathAllowed(targetPath) {
-  let resolved = path.resolve(targetPath);
-  try { if (fs.existsSync(resolved)) resolved = fs.realpathSync(resolved); } catch (e) {}
-  return ALLOWED_BASE_PATHS.some(basePath => {
-    let resolvedBase = path.resolve(basePath);
-    try { if (fs.existsSync(resolvedBase)) resolvedBase = fs.realpathSync(resolvedBase); } catch (e) {}
-    return resolved.startsWith(resolvedBase);
-  });
-}
-
+/**
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可（与 FS 技能一致）
+ */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {
-    if (!isPathAllowed(relativePath)) throw new Error('Path not allowed: ' + relativePath);
-    return relativePath;
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  for (const basePath of ALLOWED_BASE_PATHS) {
-    const resolved = path.join(basePath, relativePath);
-    if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
-      if (!isPathAllowed(resolved)) throw new Error('Path not allowed: ' + resolved);
-      return resolved;
-    }
-  }
-  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
-  if (!isPathAllowed(defaultPath)) throw new Error('Path not allowed: ' + defaultPath);
-  return defaultPath;
+  return relativePath;
 }
 
 function readExcelFile(filePath) { return fs.readFileSync(resolvePath(filePath)); }


### PR DESCRIPTION
## 变更内容

统一 xlsx 技能的路径处理规则与 FS 技能一致：

1. **移除复杂权限逻辑** - 删除 `IS_ADMIN`, `IS_SKILL_CREATOR`, `ALLOWED_BASE_PATHS` 等变量
2. **简化 resolvePath** - 直接使用相对路径，与 FS 技能一致
3. **拒绝绝对路径** - 抛出明确错误信息
4. **更新文档** - SKILL.md 中路径说明与 FS 技能对齐

## 变更原因

用户反馈 xlsx 技能与 fs 技能的路径规则不一致：
- FS: 相对路径直接使用
- XLSX: 相对路径拼接到 data 目录

现已统一为 FS 风格。

Closes #736