### PR TITLE
fix: 统一 6 个技能路径规则与 FS 技能一致

### DIFF
--- a/data/skills/compression/index.js
+++ b/data/skills/compression/index.js
@@ -4,6 +4,8 @@
  * ZIP file operations for creating and extracting archives.
  * Uses adm-zip library (no child_process required).
  * 
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
+ * 
  * @module compression-skill
  */
 
@@ -18,44 +20,17 @@ try {
   // Will handle in execute function
 }
 
-// Allowed base directories
-const ALLOWED_BASE_PATHS = [
-  process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data'),
-];
-
 // Maximum file size for compression (500MB)
 const MAX_FILE_SIZE = 500 * 1024 * 1024;
 
 /**
- * Check if path is within allowed directories
- */
-function isPathAllowed(targetPath) {
-  const resolved = path.resolve(targetPath);
-  return ALLOWED_BASE_PATHS.some(basePath => {
-    const resolvedBase = path.resolve(basePath);
-    return resolved.startsWith(resolvedBase);
-  });
-}
-
-/**
- * Resolve path relative to allowed base directories
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可（与 FS 技能一致）
  */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {
-    if (!isPathAllowed(relativePath)) {
-      throw new Error(`Path not allowed: ${relativePath}`);
-    }
-    return relativePath;
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  
-  for (const basePath of ALLOWED_BASE_PATHS) {
-    const resolved = path.join(basePath, relativePath);
-    if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
-      return resolved;
-    }
-  }
-  
-  return path.join(ALLOWED_BASE_PATHS[0], relativePath);
+  return relativePath;
 }
 
 /**

--- a/data/skills/docx/index.js
+++ b/data/skills/docx/index.js
@@ -18,6 +18,8 @@
  * - mammoth: 文档读取和转换
  * - adm-zip: ZIP 操作
  * - xml2js: XML 解析
+ * 
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
  */
 
 const fs = require('fs');
@@ -50,82 +52,14 @@ function getXml2js() {
   return xml2js;
 }
 
-// 用户角色检查
-const IS_ADMIN = process.env.IS_ADMIN === 'true';
-const IS_SKILL_CREATOR = process.env.IS_SKILL_CREATOR === 'true';
-
-// 允许的基础路径
-const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
-const USER_ID = process.env.USER_ID || 'default';
-const USER_WORK_DIR = process.env.WORKING_DIRECTORY
-  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
-  : path.join(DATA_BASE_PATH, 'work', USER_ID);
-
-// 根据用户角色设置允许的路径
-let ALLOWED_BASE_PATHS;
-if (IS_ADMIN) {
-  // 管理员：可以访问整个 data/ 目录
-  ALLOWED_BASE_PATHS = [DATA_BASE_PATH];
-} else if (IS_SKILL_CREATOR) {
-  // 技能创建者：可以访问 skills/ 和自己的工作目录
-  ALLOWED_BASE_PATHS = [
-    path.join(DATA_BASE_PATH, 'skills'),
-    path.join(DATA_BASE_PATH, 'work', USER_ID)
-  ];
-} else {
-  // 普通用户：只能访问自己的工作目录
-  ALLOWED_BASE_PATHS = [USER_WORK_DIR];
-}
-
 /**
- * 检查路径是否被允许
- */
-function isPathAllowed(targetPath) {
-  let resolved = path.resolve(targetPath);
-  
-  try {
-    if (fs.existsSync(resolved)) {
-      resolved = fs.realpathSync(resolved);
-    }
-  } catch (e) {}
-  
-  return ALLOWED_BASE_PATHS.some(basePath => {
-    let resolvedBase = path.resolve(basePath);
-    try {
-      if (fs.existsSync(resolvedBase)) {
-        resolvedBase = fs.realpathSync(resolvedBase);
-      }
-    } catch (e) {}
-    return resolved.startsWith(resolvedBase);
-  });
-}
-
-/**
- * 解析路径（支持相对路径）
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可（与 FS 技能一致）
  */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {
-    if (!isPathAllowed(relativePath)) {
-      throw new Error(`Path not allowed: ${relativePath}`);
-    }
-    return relativePath;
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  
-  for (const basePath of ALLOWED_BASE_PATHS) {
-    const resolved = path.join(basePath, relativePath);
-    if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
-      if (!isPathAllowed(resolved)) {
-        throw new Error(`Path not allowed: ${resolved}`);
-      }
-      return resolved;
-    }
-  }
-  
-  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
-  if (!isPathAllowed(defaultPath)) {
-    throw new Error(`Path not allowed: ${defaultPath}`);
-  }
-  return defaultPath;
+  return relativePath;
 }
 
 /**

--- a/data/skills/echarts/index.js
+++ b/data/skills/echarts/index.js
@@ -10,6 +10,8 @@
  * 依赖：
  * - echarts: 图表库
  * - sharp: SVG 转 PNG（项目已安装）
+ * 
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
  */
 
 const echarts = require('echarts');
@@ -17,72 +19,14 @@ const path = require('path');
 const fs = require('fs');
 const sharp = require('sharp');
 
-// 用户角色检查
-const IS_ADMIN = process.env.IS_ADMIN === 'true';
-
-// 允许的基础路径
-const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
-const USER_ID = process.env.USER_ID || 'default';
-const USER_WORK_DIR = process.env.WORKING_DIRECTORY
-  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
-  : path.join(DATA_BASE_PATH, 'work', USER_ID);
-
-const PROJECT_ROOT = process.cwd();
-const ALLOWED_BASE_PATHS = IS_ADMIN
-  ? [PROJECT_ROOT, DATA_BASE_PATH]
-  : [USER_WORK_DIR];
-
 /**
- * 检查路径是否被允许
- */
-function isPathAllowed(targetPath) {
-  let resolved = path.resolve(targetPath);
-  
-  try {
-    if (fs.existsSync(resolved)) {
-      resolved = fs.realpathSync(resolved);
-    }
-  } catch (e) {
-    // 路径不存在时，继续使用 path.resolve 的结果
-  }
-  
-  return ALLOWED_BASE_PATHS.some(basePath => {
-    let resolvedBase = path.resolve(basePath);
-    try {
-      if (fs.existsSync(resolvedBase)) {
-        resolvedBase = fs.realpathSync(resolvedBase);
-      }
-    } catch (e) {}
-    return resolved.startsWith(resolvedBase);
-  });
-}
-
-/**
- * 解析路径（支持相对路径）
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可（与 FS 技能一致）
  */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {
-    if (!isPathAllowed(relativePath)) {
-      throw new Error(`Path not allowed: ${relativePath}`);
-    }
-    return relativePath;
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  
-  for (const basePath of ALLOWED_BASE_PATHS) {
-    const resolved = path.join(basePath, relativePath);
-    if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
-      if (!isPathAllowed(resolved)) {
-        throw new Error(`Path not allowed: ${resolved}`);
-      }
-      return resolved;
-    }
-  }
-  
-  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
-  if (!isPathAllowed(defaultPath)) {
-    throw new Error(`Path not allowed: ${defaultPath}`);
-  }
-  return defaultPath;
+  return relativePath;
 }
 
 /**

--- a/data/skills/fapiao/index.js
+++ b/data/skills/fapiao/index.js
@@ -7,6 +7,8 @@
  * - extract: 提取发票结构化数据（支持增值税发票、普通发票、电子发票）
  * 
  * 依赖：pdfjs-dist (Mozilla PDF.js)
+ * 
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
  */
 
 const fs = require('fs').promises;
@@ -21,46 +23,14 @@ if (pdfjsLib.GlobalWorkerOptions) {
   pdfjsLib.GlobalWorkerOptions.workerSrc = '';
 }
 
-// ============================================
-// 路径安全检查
-// ============================================
-
-const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
-const USER_ID = process.env.USER_ID || 'default';
-const USER_WORK_DIR = process.env.WORKING_DIRECTORY
-  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
-  : path.join(DATA_BASE_PATH, 'work', USER_ID);
-
-const IS_ADMIN = process.env.IS_ADMIN === 'true';
-
-let ALLOWED_BASE_PATHS;
-if (IS_ADMIN) {
-  ALLOWED_BASE_PATHS = [DATA_BASE_PATH];
-} else {
-  ALLOWED_BASE_PATHS = [USER_WORK_DIR];
-}
-
-function isPathAllowed(targetPath) {
-  let resolved = path.resolve(targetPath);
-  return ALLOWED_BASE_PATHS.some(basePath => {
-    let resolvedBase = path.resolve(basePath);
-    return resolved.startsWith(resolvedBase);
-  });
-}
-
-function resolvePath(filePath) {
-  if (path.isAbsolute(filePath)) {
-    if (!isPathAllowed(filePath)) {
-      throw new Error(`Path not allowed: ${filePath}`);
-    }
-    return filePath;
+/**
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可（与 FS 技能一致）
+ */
+function resolvePath(relativePath) {
+  if (path.isAbsolute(relativePath)) {
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  
-  const resolved = path.join(ALLOWED_BASE_PATHS[0], filePath);
-  if (!isPathAllowed(resolved)) {
-    throw new Error(`Path not allowed: ${resolved}`);
-  }
-  return resolved;
+  return relativePath;
 }
 
 // ============================================

--- a/data/skills/pdf/index.js
+++ b/data/skills/pdf/index.js
@@ -8,6 +8,8 @@
  * 依赖：
  * - pdf-lib: PDF 操作核心库
  * - pdf-parse v2.4+: 文本提取、图片提取、表格提取、页面渲染
+ * 
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
  */
 
 const { PDFDocument, StandardFonts, rgb, degrees } = require('pdf-lib');
@@ -27,82 +29,14 @@ function getPdfParse() {
   return { PDFParse, VerbosityLevel };
 }
 
-// 用户角色检查
-const IS_ADMIN = process.env.IS_ADMIN === 'true';
-const IS_SKILL_CREATOR = process.env.IS_SKILL_CREATOR === 'true';
-
-// 允许的基础路径
-const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
-const USER_ID = process.env.USER_ID || 'default';
-const USER_WORK_DIR = process.env.WORKING_DIRECTORY
-  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
-  : path.join(DATA_BASE_PATH, 'work', USER_ID);
-
-// 根据用户角色设置允许的路径
-let ALLOWED_BASE_PATHS;
-if (IS_ADMIN) {
-  // 管理员：可以访问整个 data/ 目录
-  ALLOWED_BASE_PATHS = [DATA_BASE_PATH];
-} else if (IS_SKILL_CREATOR) {
-  // 技能创建者：可以访问 skills/ 和自己的工作目录
-  ALLOWED_BASE_PATHS = [
-    path.join(DATA_BASE_PATH, 'skills'),
-    path.join(DATA_BASE_PATH, 'work', USER_ID)
-  ];
-} else {
-  // 普通用户：只能访问自己的工作目录
-  ALLOWED_BASE_PATHS = [USER_WORK_DIR];
-}
-
 /**
- * 检查路径是否被允许
- */
-function isPathAllowed(targetPath) {
-  let resolved = path.resolve(targetPath);
-  
-  try {
-    if (fs.existsSync(resolved)) {
-      resolved = fs.realpathSync(resolved);
-    }
-  } catch (e) {}
-  
-  return ALLOWED_BASE_PATHS.some(basePath => {
-    let resolvedBase = path.resolve(basePath);
-    try {
-      if (fs.existsSync(resolvedBase)) {
-        resolvedBase = fs.realpathSync(resolvedBase);
-      }
-    } catch (e) {}
-    return resolved.startsWith(resolvedBase);
-  });
-}
-
-/**
- * 解析路径（支持相对路径）
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可（与 FS 技能一致）
  */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {
-    if (!isPathAllowed(relativePath)) {
-      throw new Error(`Path not allowed: ${relativePath}`);
-    }
-    return relativePath;
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  
-  for (const basePath of ALLOWED_BASE_PATHS) {
-    const resolved = path.join(basePath, relativePath);
-    if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
-      if (!isPathAllowed(resolved)) {
-        throw new Error(`Path not allowed: ${resolved}`);
-      }
-      return resolved;
-    }
-  }
-  
-  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
-  if (!isPathAllowed(defaultPath)) {
-    throw new Error(`Path not allowed: ${defaultPath}`);
-  }
-  return defaultPath;
+  return relativePath;
 }
 
 /**

--- a/data/skills/pptx/index.js
+++ b/data/skills/pptx/index.js
@@ -16,6 +16,8 @@
  * 依赖：
  * - pptxgenjs 4.0+: 演示文稿创建
  * - adm-zip: ZIP 操作（读取现有 PPTX）
+ * 
+ * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
  */
 
 const fs = require('fs');
@@ -38,81 +40,16 @@ function getPptxGenJS() {
   return pptxgenjs;
 }
 
-// ==================== 路径与权限管理 ====================
-
-// 用户角色检查
-const IS_ADMIN = process.env.IS_ADMIN === 'true';
-const IS_SKILL_CREATOR = process.env.IS_SKILL_CREATOR === 'true';
-
-// 允许的基础路径
-const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.join(process.cwd(), 'data');
-const USER_ID = process.env.USER_ID || 'default';
-const USER_WORK_DIR = process.env.WORKING_DIRECTORY
-  ? path.join(DATA_BASE_PATH, process.env.WORKING_DIRECTORY)
-  : path.join(DATA_BASE_PATH, 'work', USER_ID);
-
-// 根据用户角色设置允许的路径
-let ALLOWED_BASE_PATHS;
-if (IS_ADMIN) {
-  ALLOWED_BASE_PATHS = [DATA_BASE_PATH];
-} else if (IS_SKILL_CREATOR) {
-  ALLOWED_BASE_PATHS = [
-    path.join(DATA_BASE_PATH, 'skills'),
-    path.join(DATA_BASE_PATH, 'work', USER_ID)
-  ];
-} else {
-  ALLOWED_BASE_PATHS = [USER_WORK_DIR];
-}
+// ==================== 路径处理 ====================
 
 /**
- * 检查路径是否被允许
- */
-function isPathAllowed(targetPath) {
-  let resolved = path.resolve(targetPath);
-  
-  try {
-    if (fs.existsSync(resolved)) {
-      resolved = fs.realpathSync(resolved);
-    }
-  } catch (e) {}
-  
-  return ALLOWED_BASE_PATHS.some(basePath => {
-    let resolvedBase = path.resolve(basePath);
-    try {
-      if (fs.existsSync(resolvedBase)) {
-        resolvedBase = fs.realpathSync(resolvedBase);
-      }
-    } catch (e) {}
-    return resolved.startsWith(resolvedBase);
-  });
-}
-
-/**
- * 解析路径（支持相对路径）
+ * Resolve path - VM 已设置 cwd，直接使用相对路径即可（与 FS 技能一致）
  */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {
-    if (!isPathAllowed(relativePath)) {
-      throw new Error(`Path not allowed: ${relativePath}`);
-    }
-    return relativePath;
+    throw new Error(`Absolute path not allowed: ${relativePath}. Use relative path instead.`);
   }
-  
-  for (const basePath of ALLOWED_BASE_PATHS) {
-    const resolved = path.join(basePath, relativePath);
-    if (fs.existsSync(resolved) || isPathAllowed(resolved)) {
-      if (!isPathAllowed(resolved)) {
-        throw new Error(`Path not allowed: ${resolved}`);
-      }
-      return resolved;
-    }
-  }
-  
-  const defaultPath = path.join(ALLOWED_BASE_PATHS[0], relativePath);
-  if (!isPathAllowed(defaultPath)) {
-    throw new Error(`Path not allowed: ${defaultPath}`);
-  }
-  return defaultPath;
+  return relativePath;
 }
 
 /**


### PR DESCRIPTION
## 变更内容

统一以下 6 个技能的路径处理规则与 FS 技能一致：

| 技能 | 删除代码行数 |
|------|-------------|
| pptx | ~70 行 |
| pdf | ~60 行 |
| fapiao | ~40 行 |
| echarts | ~60 行 |
| docx | ~70 行 |
| compression | ~30 行 |

### 变更详情

1. 移除复杂权限逻辑：`IS_ADMIN`, `IS_SKILL_CREATOR`, `ALLOWED_BASE_PATHS`, `isPathAllowed`
2. 简化 `resolvePath`：直接使用相对路径，拒绝绝对路径
3. 添加注释说明：进程 cwd 由 VM 设置，直接使用相对路径即可

### 统一后的路径规则

- 相对路径：直接使用，依赖 VM 设置的工作目录
- 绝对路径：直接拒绝，抛出明确错误信息
- 所有技能路径处理逻辑完全一致