### PR TITLE
fix: 更新 docx SKILL.md 路径说明

### DIFF
--- a/data/skills/docx/SKILL.md
+++ b/data/skills/docx/SKILL.md
@@ -7,24 +7,15 @@ description: "Word 文档处理。用于读取、写入、编辑、模板填充 
 
 ## 路径参数说明
 
-> **重要**：所有工具的 `path` 参数遵循以下规则：
-
-| 参数类型 | 说明 |
-|----------|------|
-| **相对路径** | 相对于工作目录，工具自动拼接基础路径。示例：`input/file.docx` |
-| **绝对路径** | 仅管理员可用，需在允许的路径范围内 |
-
-**基础路径规则**：
-- 管理员：项目根目录 或 `data/` 目录
-- 普通用户：`data/work/{user_id}/` 目录
+> **重要**：所有工具的 `path` 参数遵循以下规则（与 FS 技能一致）：
+> - 相对路径直接使用，依赖 VM 设置的工作目录
+> - **绝对路径不被允许**
 
 **示例**：
 ```javascript
 // 相对路径（推荐）
 read({ path: 'input/document.docx', scope: 'text' })
-
-// 绝对路径（仅管理员）
-read({ path: '/absolute/path/to/document.docx', scope: 'text' })
+read({ path: 'data/output.docx', scope: 'text' })
 ```
 
 ## 工具列表


### PR DESCRIPTION
## 变更内容

修复 PR #740 审计发现的遗漏问题：

- 更新 `docx/SKILL.md` 路径说明，与统一规则一致
- 移除旧的"管理员可用绝对路径"说明
- 简化为与 FS/xlsx 技能一致的路径规则文档

## 关联

审计 PR #740 时发现 docx/SKILL.md 未同步更新。