### PR TITLE
fix: add EOF retry for LLM calls

### DIFF
--- a/lib/llm-retry.js
+++ b/lib/llm-retry.js
@@ -35,7 +35,9 @@ export function isRetryableError(error) {
   // Socket 相关错误
   if (message.includes('socket hang up') ||
       message.includes('connection reset') ||
-      message.includes('broken pipe')) {
+      message.includes('broken pipe') ||
+      message.includes('EOF') ||
+      message.includes('do request failed')) {
     return true;
   }
 


### PR DESCRIPTION
## Background
EOF and "do request failed" errors occur when LLM service (e.g., Ollama) crashes due to large context. Current retry logic doesn't handle these errors.

## Changes
- Add EOF to retryable errors list
- Add "do request failed" to retryable errors list

## Testing
- Code review passed

Closes #743