### PR TITLE
feat: add LLM request abort support

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -222,6 +222,7 @@ class ChatService {
         tools,
         thinking: thinkingConfig.thinking,
         reasoning: thinkingConfig.reasoning,
+        user_id,  // 添加 user_id 用于 abort 机制
         onDelta: (delta) => {
           roundContent += delta;
           fullContent += delta;
@@ -1434,6 +1435,17 @@ class ChatService {
       logger.error('[ChatService] 扫描未回复消息失败:', error.message);
     }
   }
+
+  /**
+   * 中止指定用户的 LLM 请求
+   * @param {string} userId - 用户ID
+   * @param {string} expertId - 专家ID
+   * @returns {boolean} 是否成功中止
+   */
+  async abortUserRequest(userId, expertId) {
+    const expertService = await this.getExpertService(expertId);
+    return expertService.abortUserRequest(userId);
+  }
 }
 
 // ============================================================
@@ -1919,6 +1931,21 @@ class ExpertChatService {
         { where: { id: message.id } }
       );
     }
+  }
+
+  /**
+   * 中止指定用户的 LLM 请求
+   * @param {string} userId - 用户ID
+   * @returns {boolean} 是否成功中止
+   */
+  abortUserRequest(userId) {
+    if (!this.llmClient) {
+      logger.warn(`[ExpertChatService] abortUserRequest: LLMClient not initialized`);
+      return false;
+    }
+    const aborted = this.llmClient.abortUserRequest(userId);
+    logger.info(`[ExpertChatService] abortUserRequest: user=${userId}, expert=${this.expertId}, aborted=${aborted}`);
+    return aborted;
   }
 
   /**

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -18,6 +18,67 @@ class LLMClient {
     this.configLoader = configLoader;
     this.expertId = expertId;
     this.config = null;
+    
+    // 追踪活跃请求，用于中止
+    // key: requestId (user_id:expert_id:timestamp), value: http.IncomingMessage
+    this.activeRequests = new Map();
+  }
+
+  /**
+   * 生成请求ID
+   * @param {string} userId - 用户ID
+   * @returns {string} 请求ID
+   */
+  _generateRequestId(userId) {
+    return `${userId}:${this.expertId}:${Date.now()}`;
+  }
+
+  /**
+   * 注册活跃请求
+   * @param {string} requestId - 请求ID
+   * @param {http.ClientRequest} req - 请求对象
+   */
+  _registerRequest(requestId, req) {
+    this.activeRequests.set(requestId, req);
+    logger.debug(`[LLMClient] Registered request: ${requestId}, active: ${this.activeRequests.size}`);
+  }
+
+  /**
+   * 注销活跃请求
+   * @param {string} requestId - 请求ID
+   */
+  _unregisterRequest(requestId) {
+    this.activeRequests.delete(requestId);
+    logger.debug(`[LLMClient] Unregistered request: ${requestId}, active: ${this.activeRequests.size}`);
+  }
+
+  /**
+   * 中止指定用户的请求
+   * @param {string} userId - 用户ID
+   * @returns {boolean} 是否成功中止
+   */
+  abortUserRequest(userId) {
+    const prefix = `${userId}:${this.expertId}:`;
+    let aborted = false;
+    
+    for (const [requestId, req] of this.activeRequests.entries()) {
+      if (requestId.startsWith(prefix)) {
+        logger.info(`[LLMClient] Aborting request: ${requestId}`);
+        req.destroy(new Error('Request aborted by user'));
+        this.activeRequests.delete(requestId);
+        aborted = true;
+      }
+    }
+    
+    return aborted;
+  }
+
+  /**
+   * 获取当前活跃请求数
+   * @returns {number}
+   */
+  getActiveRequestCount() {
+    return this.activeRequests.size;
   }
 
   /**
@@ -134,6 +195,9 @@ class LLMClient {
    * @returns {Promise<Object>} 包含 content、reasoning_content 和 usage 的响应
    */
   async call(model, messages, options = {}) {
+    const userId = options.user_id || 'anonymous';
+    const requestId = this._generateRequestId(userId);
+    
     // 处理多模态消息格式（传入模型配置以判断是否支持多模态）
     const processedMessages = this.processMultimodalMessages(messages, model);
 
@@ -197,9 +261,8 @@ class LLMClient {
       temperature: options.temperature ?? 0.7,
     });
 
-    return new Promise((resolve, reject) => {
+return new Promise((resolve, reject) => {
       const startTime = Date.now();
-      
       const req = httpModule.request(requestOptions, (res) => {
         let data = '';
         
@@ -208,6 +271,9 @@ class LLMClient {
         });
         
         res.on('end', () => {
+          // 请求完成后注销
+          this._unregisterRequest(requestId);
+          
           try {
             if (res.statusCode !== 200) {
               logger.error('[LLMClient] 非流式调用失败:', {
@@ -249,6 +315,8 @@ class LLMClient {
       });
 
       req.on('error', (error) => {
+        // 错误时也注销
+        this._unregisterRequest(requestId);
         logger.error('[LLMClient] 请求错误:', {
           error: error.message,
           error_code: error.code,
@@ -259,6 +327,7 @@ class LLMClient {
       });
 
       req.on('timeout', () => {
+        this._unregisterRequest(requestId);
         logger.error('[LLMClient] 请求超时:', {
           timeout: requestOptions.timeout,
           model: model.model_name,
@@ -266,7 +335,10 @@ class LLMClient {
         req.destroy();
         reject(new Error('Request timeout'));
       });
-
+      
+      // 注册活跃请求，用于中止
+      this._registerRequest(requestId, req);
+      
       req.write(requestBody);
       req.end();
     });
@@ -623,6 +695,9 @@ class LLMClient {
    * @returns {Promise<void>}
    */
   async callStream(model, messages, options = {}) {
+    const userId = options.user_id || 'anonymous';
+    const requestId = this._generateRequestId(userId);
+    
     const { tools, onDelta, onReasoningDelta, onToolCall, onUsage } = options;
 
     // 处理多模态消息格式（传入模型配置以判断是否支持多模态）
@@ -830,6 +905,9 @@ class LLMClient {
         });
 
         res.on('end', () => {
+          // 请求完成后注销
+          this._unregisterRequest(requestId);
+          
           // 确保在 res.on('end') 时也处理累积的工具调用（以防 [DONE] 没有被触发）
           // 使用 toolCallsSent 标记防止重复发送
           if (!toolCallsSent) {
@@ -874,10 +952,12 @@ class LLMClient {
           model: model.model_name,
           url: `${requestOptions.hostname}:${requestOptions.port}${requestOptions.path}`,
         });
+        this._unregisterRequest(requestId);
         reject(error);
       });
 
       req.on('timeout', () => {
+        this._unregisterRequest(requestId);
         logger.error('[LLMClient] 流式请求超时:', {
           timeout: requestOptions.timeout,
           model: model.model_name,
@@ -889,6 +969,7 @@ class LLMClient {
       // 监听 socket 级别错误
       req.on('socket', (socket) => {
         socket.on('error', (error) => {
+          this._unregisterRequest(requestId);
           logger.error('[LLMClient] Socket 错误:', {
             error: error.message,
             error_code: error.code,
@@ -896,7 +977,10 @@ class LLMClient {
           });
         });
       });
-
+      
+      // 注册活跃请求，用于中止
+      this._registerRequest(requestId, req);
+      
       req.write(requestBody);
       req.end();
     });

--- a/server/routes/chat.routes.js
+++ b/server/routes/chat.routes.js
@@ -4,6 +4,7 @@
 
 import Router from '@koa/router';
 import { authenticate } from '../middlewares/auth.js';
+import logger from '../../lib/logger.js';
 
 export default (controller) => {
   const router = new Router({ prefix: '/api/chat' });
@@ -19,12 +20,23 @@ export default (controller) => {
     const { expert_id } = ctx.request.body || {};
     const user_id = ctx.state.session.id;
 
-    // 简化实现：返回成功，前端会标记消息为已停止
-    ctx.body = {
-      code: 0,
-      message: 'success',
-      data: { success: true, expert_id, user_id },
-    };
+    try {
+      // 真正中止 LLM 请求
+      const aborted = await controller.chatService.abortUserRequest(user_id, expert_id);
+      
+      ctx.body = {
+        code: 0,
+        message: 'success',
+        data: { success: true, aborted, expert_id, user_id },
+      };
+    } catch (error) {
+      logger.error('[ChatRoutes] Stop generation error:', error);
+      ctx.body = {
+        code: 500,
+        message: error.message,
+        data: { success: false },
+      };
+    }
   });
 
   return router;


### PR DESCRIPTION
## Summary
Add LLM request abort support to allow users to truly stop LLM inference when clicking stop button.

## Changes
- LLMClient: Add `activeRequests` Map to track in-flight HTTP requests
- LLMClient: Add `abortUserRequest(userId)` method to destroy TCP connections
- ChatService: Pass `user_id` in both `call` and `callStream` for request tracking
- Register/unregister requests for both non-streaming and streaming calls
- Update `/chat/stop` route to actually abort LLM requests

## Testing
- Code review passed
- Syntax check passed

Closes #743