### PR TITLE
fix: 添加缺失的专家 Tab 标签 i18n 翻译键

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -275,6 +275,8 @@ export default {
     expertTabPersonality: 'Personality',
     expertTabModel: 'Model Config',
     expertBasicInfo: 'Basic Info',
+    expertPersonality: 'Personality',
+    expertModelConfig: 'Model Config',
     deleteExpertConfirm: 'Are you sure you want to delete expert "{name}"?',
     select: 'Select',
     selected: 'Selected',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -275,6 +275,8 @@ export default {
     expertTabPersonality: '人设配置',
     expertTabModel: '模型配置',
     expertBasicInfo: '基本信息',
+    expertPersonality: '人设配置',
+    expertModelConfig: '模型配置',
     deleteExpertConfirm: '确定要删除专家"{name}"吗？',
     select: '选择',
     selected: '已选择',


### PR DESCRIPTION
添加 settings.expertPersonality 和 settings.expertModelConfig 翻译键