### PR TITLE
refactor: 前端组件统一使用 element-plus

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -52,18 +52,18 @@
     <div class="header-right">
       <!-- 语言切换 -->
       <div class="lang-selector">
-        <select v-model="currentLocale" @change="handleLocaleChange" class="lang-select">
-          <option value="zh-CN">中文</option>
-          <option value="en-US">English</option>
-        </select>
+        <el-select v-model="currentLocale" @change="handleLocaleChange" size="small" style="width: 100px">
+          <el-option value="zh-CN" label="中文" />
+          <el-option value="en-US" label="English" />
+        </el-select>
       </div>
       
       <div class="user-menu" ref="menuRef">
-        <button class="btn-user" @click="showUserMenu = !showUserMenu">
+        <el-button class="btn-user" @click="showUserMenu = !showUserMenu">
           <span class="user-avatar">{{ userInitial }}</span>
           <span class="user-name">{{ userStore.user?.nickname }}</span>
           <span class="arrow">▼</span>
-        </button>
+        </el-button>
         <div class="user-dropdown" v-if="showUserMenu">
           <div class="dropdown-header">
             <div class="dropdown-username">{{ userStore.user?.nickname }}</div>
@@ -74,10 +74,10 @@
             <span class="item-icon">👤</span>
             <span>{{ $t('nav.personal') }}</span>
           </router-link>
-          <button class="dropdown-item" @click="handleLogout">
+          <el-button class="dropdown-item" text @click="handleLogout">
             <span class="item-icon">🚪</span>
             <span>{{ $t('nav.logout') }}</span>
-          </button>
+          </el-button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ModelSelector.vue
+++ b/frontend/src/components/ModelSelector.vue
@@ -1,21 +1,16 @@
 <template>
-  <div class="model-selector">
-    <select 
-      :value="modelValue" 
-      @change="handleChange"
-      class="model-select"
-    >
-      <option value="" disabled>{{ $t('chat.selectModel') || '选择模型' }}</option>
-      <option 
-        v-for="model in availableModels" 
-        :key="model.id" 
-        :value="model.id"
-      >
-        {{ model.name }}
-      </option>
-    </select>
-    <span class="select-icon">▼</span>
-  </div>
+  <el-select 
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+    :placeholder="$t('chat.selectModel') || '选择模型'"
+  >
+    <el-option 
+      v-for="model in availableModels" 
+      :key="model.id" 
+      :value="model.id"
+      :label="model.name"
+    />
+  </el-select>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/apps/GenericMiniApp.vue
+++ b/frontend/src/components/apps/GenericMiniApp.vue
@@ -53,7 +53,7 @@
         <thead>
           <tr>
             <th class="checkbox-col">
-              <input type="checkbox" :checked="isAllSelected" :indeterminate.prop="isPartialSelected" @change="toggleAll" />
+              <el-checkbox :model-value="isAllSelected" :indeterminate="isPartialSelected" @change="toggleAll" />
             </th>
             <th v-for="col in listColumns" :key="col.name">{{ col.label }}</th>
             <th>{{ $t('apps.status') }}</th>
@@ -63,7 +63,7 @@
         <tbody>
           <tr v-for="record in records" :key="record.id" :class="{ 'row-selected': isSelected(record) }">
             <td class="checkbox-col">
-              <input type="checkbox" :checked="isSelected(record)" @change="toggleRow(record)" />
+              <el-checkbox :model-value="isSelected(record)" @change="toggleRow(record)" />
             </td>
             <td v-for="col in listColumns" :key="col.name">
               {{ formatFieldValue(col._isExtension ? record[col.name] : record.data?.[col.name], col) }}

--- a/frontend/src/components/apps/fields/BooleanField.vue
+++ b/frontend/src/components/apps/fields/BooleanField.vue
@@ -1,13 +1,11 @@
 <template>
-  <label class="field-boolean">
-    <input
-      type="checkbox"
-      :checked="!!modelValue"
-      :disabled="readonly"
-      @change="$emit('update:model-value', ($event.target as HTMLInputElement).checked)"
-    />
-    <span>{{ field.label }}</span>
-  </label>
+  <el-checkbox
+    :model-value="!!modelValue"
+    :disabled="readonly"
+    @update:model-value="$emit('update:model-value', $event)"
+  >
+    {{ field.label }}
+  </el-checkbox>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/apps/fields/DateField.vue
+++ b/frontend/src/components/apps/fields/DateField.vue
@@ -1,10 +1,10 @@
 <template>
-  <input
+  <el-date-picker
+    :model-value="modelValue"
+    :disabled="readonly"
     type="date"
-    :value="modelValue"
-    :readonly="readonly"
-    class="field-input"
-    @input="$emit('update:model-value', ($event.target as HTMLInputElement).value)"
+    value-format="YYYY-MM-DD"
+    @update:model-value="$emit('update:model-value', $event)"
   />
 </template>
 

--- a/frontend/src/components/apps/fields/FileField.vue
+++ b/frontend/src/components/apps/fields/FileField.vue
@@ -5,7 +5,7 @@
         <span class="file-icon">📄</span>
         <span class="file-name">{{ (modelValue as any).name || modelValue }}</span>
       </div>
-      <button class="btn-remove" @click="clearFile" type="button">×</button>
+      <el-button class="btn-remove" @click="clearFile">×</el-button>
     </div>
     <div v-else class="file-upload">
       <input

--- a/frontend/src/components/apps/fields/NumberField.vue
+++ b/frontend/src/components/apps/fields/NumberField.vue
@@ -1,11 +1,10 @@
 <template>
-  <input
-    type="number"
-    :value="modelValue"
-    :readonly="readonly"
-    class="field-input"
+  <el-input-number
+    :model-value="modelValue"
+    :disabled="readonly"
     :placeholder="field.label"
-    @input="$emit('update:model-value', ($event.target as HTMLInputElement).value ? Number(($event.target as HTMLInputElement).value) : null)"
+    controls-position="right"
+    @update:model-value="$emit('update:model-value', $event)"
   />
 </template>
 

--- a/frontend/src/components/apps/fields/RepeatingField.vue
+++ b/frontend/src/components/apps/fields/RepeatingField.vue
@@ -2,7 +2,7 @@
   <div class="repeating-field">
     <div class="repeating-header">
       <span class="repeating-label">{{ field.label }}</span>
-      <button v-if="!readonly" class="btn-add-row" @click="addRow">+ {{ t('apps.addRow') }}</button>
+      <el-button v-if="!readonly" size="small" @click="addRow">+ {{ t('apps.addRow') }}</el-button>
     </div>
 
     <div v-if="rows.length === 0" class="repeating-empty">
@@ -31,7 +31,7 @@
               />
             </td>
             <td v-if="!readonly" class="td-action">
-              <button class="btn-remove-row" @click="removeRow(rowIndex)" :title="t('apps.removeRow')">×</button>
+              <el-button size="small" type="danger" @click="removeRow(rowIndex)" :title="t('apps.removeRow')">×</el-button>
             </td>
           </tr>
         </tbody>

--- a/frontend/src/components/apps/fields/TextField.vue
+++ b/frontend/src/components/apps/fields/TextField.vue
@@ -1,11 +1,9 @@
 <template>
-  <input
-    type="text"
-    :value="modelValue"
-    :readonly="readonly"
-    class="field-input"
+  <el-input
+    :model-value="modelValue"
+    :disabled="readonly"
     :placeholder="field.label"
-    @input="$emit('update:model-value', ($event.target as HTMLInputElement).value)"
+    @update:model-value="$emit('update:model-value', $event)"
   />
 </template>
 

--- a/frontend/src/components/common/LangSelector.vue
+++ b/frontend/src/components/common/LangSelector.vue
@@ -1,11 +1,7 @@
 <template>
-  <div class="lang-selector">
-    <select v-model="currentLocale" class="lang-select">
-      <option v-for="lang in availableLocales" :key="lang.value" :value="lang.value">
-        {{ lang.label }}
-      </option>
-    </select>
-  </div>
+  <el-select v-model="currentLocale" size="small">
+    <el-option v-for="lang in availableLocales" :key="lang.value" :value="lang.value" :label="lang.label" />
+  </el-select>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -7,11 +7,11 @@
         <div class="embed-preview">
           <!-- 预览头部 -->
           <div class="embed-preview-header">
-            <button class="btn-back" @click="closeEmbedPreview" :title="$t('tasks.backToFiles') || '返回文件列表'">
+            <el-button class="btn-back" @click="closeEmbedPreview" :title="$t('tasks.backToFiles') || '返回文件列表'">
               <svg class="icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M19 12H5M12 19l-7-7 7-7"/>
               </svg>
-            </button>
+            </el-button>
             <div class="preview-title-row">
               <span class="preview-icon">{{ getFileIcon(previewFile?.name || '') }}</span>
               <span class="preview-filename">{{ previewFile?.name }}</span>
@@ -19,7 +19,7 @@
             <div class="preview-actions">
               <!-- HTML 源码/预览切换 -->
               <template v-if="previewType === 'html'">
-                <button
+                <el-button
                   class="btn-action"
                   :class="{ active: showHtmlSource }"
                   @click="toggleHtmlSourceMode"
@@ -27,11 +27,11 @@
                 >
                   <span class="action-icon">{{ showHtmlSource ? '👁️' : '📝' }}</span>
                   <span class="action-label">{{ showHtmlSource ? ($t('tasks.preview') || '预览') : ($t('tasks.source') || '源码') }}</span>
-                </button>
+                </el-button>
               </template>
               <!-- 自动刷新控制 -->
               <template v-if="previewType === 'html' || previewType === 'pdf' || previewType === 'markdown'">
-                <button
+                <el-button
                   class="btn-action"
                   :class="{ active: autoRefreshEnabled }"
                   @click="toggleAutoRefresh"
@@ -40,31 +40,31 @@
                   <span class="action-icon">↻</span>
                   <span v-if="autoRefreshEnabled" class="action-label">{{ $t('tasks.refreshing') }}</span>
                   <span v-else class="action-label">{{ $t('tasks.auto') }}</span>
-                </button>
-                <button class="btn-action" @click="refreshPreview" :disabled="previewLoading" :title="$t('tasks.refreshNow')">
+                </el-button>
+                <el-button class="btn-action" @click="refreshPreview" :disabled="previewLoading" :title="$t('tasks.refreshNow')">
                   <span class="action-icon">⟳</span>
                   <span class="action-label">{{ $t('tasks.refreshLabel') }}</span>
-                </button>
+                </el-button>
               </template>
-              <button class="btn-action" @click="handleDownload(previewFile!)" :title="$t('tasks.downloadFile')">
+              <el-button class="btn-action" @click="handleDownload(previewFile!)" :title="$t('tasks.downloadFile')">
                 <span class="action-icon">↓</span>
                 <span class="action-label">{{ $t('tasks.downloadLabel') }}</span>
-              </button>
+              </el-button>
               <!-- 编辑/保存按钮（仅限可编辑文件） -->
               <template v-if="canEditFile && !previewLoading && !previewSaving">
-                <button v-if="!isEditing" class="btn-action btn-edit-primary" @click="startEdit" :title="$t('tasks.edit') || '编辑'">
+                <el-button v-if="!isEditing" class="btn-action btn-edit-primary" @click="startEdit" :title="$t('tasks.edit') || '编辑'">
                   <span class="action-icon">✏️</span>
                   <span class="action-label">{{ $t('tasks.edit') || '编辑' }}</span>
-                </button>
+                </el-button>
                 <template v-else>
-                  <button class="btn-action" @click="cancelEdit" :title="$t('common.cancel') || '取消'">
+                  <el-button class="btn-action" @click="cancelEdit" :title="$t('common.cancel') || '取消'">
                     <span class="action-icon">✖️</span>
                     <span class="action-label">{{ $t('common.cancel') || '取消' }}</span>
-                  </button>
-                  <button class="btn-action btn-save-primary" @click="saveEdit" :title="$t('common.save') || '保存'">
+                  </el-button>
+                  <el-button class="btn-action btn-save-primary" @click="saveEdit" :title="$t('common.save') || '保存'">
                     <span class="action-icon">💾</span>
                     <span class="action-label">{{ $t('common.save') || '保存' }}</span>
-                  </button>
+                  </el-button>
                 </template>
               </template>
             </div>
@@ -158,9 +158,9 @@
               <!-- 不支持的类型 -->
               <div v-else class="preview-unsupported">
                 <p>{{ $t('tasks.previewNotSupported') || '暂不支持此文件类型预览' }}</p>
-                <button class="btn-confirm" @click="handleDownload(previewFile!)">
+                <el-button type="primary" @click="handleDownload(previewFile!)">
                   {{ $t('tasks.download') || '下载文件' }}
-                </button>
+                </el-button>
               </div>
             </template>
           </div>
@@ -172,11 +172,11 @@
       <template v-else>
         <div class="workspace-header">
           <div class="workspace-info">
-            <button class="btn-back" @click="handleExitTask" :title="$t('tasks.backToList')">
+            <el-button class="btn-back" @click="handleExitTask" :title="$t('tasks.backToList')">
               <svg class="icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M9 11l3 3L22 4M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
               </svg>
-            </button>
+            </el-button>
             <div class="workspace-title">
               <span class="task-icon">📁</span>
               <span class="task-name">{{ taskStore.currentTask.title }}</span>
@@ -189,7 +189,7 @@
           </div>
           <div class="workspace-actions">
             <!-- 自动运行切换按钮 -->
-            <button
+            <el-button
               class="btn-autonomous"
               :class="{ active: isAutonomousMode }"
               @click="toggleAutonomousMode"
@@ -197,17 +197,17 @@
               :disabled="isTogglingAutonomous"
             >
               <span class="icon">{{ isAutonomousMode ? '🤖' : '⚙️' }}</span>
-            </button>
-            <button class="btn-refresh" @click="handleRefreshFiles" :title="$t('tasks.refresh') || '刷新'" :disabled="taskStore.isLoadingFiles">
+            </el-button>
+            <el-button class="btn-refresh" @click="handleRefreshFiles" :title="$t('tasks.refresh') || '刷新'" :disabled="taskStore.isLoadingFiles">
               <svg class="icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M23 4v6h-6M1 20v-6h6M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>
               </svg>
-            </button>
-            <button class="btn-upload" @click="triggerUpload" :title="$t('tasks.uploadFile')">
+            </el-button>
+            <el-button class="btn-upload" @click="triggerUpload" :title="$t('tasks.uploadFile')">
               <svg class="icon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M17 8l-5-5-5 5M12 3v12"/>
               </svg>
-            </button>
+            </el-button>
           </div>
           <input
             ref="fileInputRef"
@@ -260,22 +260,24 @@
               </div>
               <!-- 文件操作菜单 -->
               <div v-if="file.type === 'file'" class="file-menu" @click.stop>
-                <button class="btn-menu-trigger" @click="toggleFileMenu(file)" :title="$t('tasks.moreActions') || '更多操作'">
+                <el-button class="btn-menu-trigger" @click="toggleFileMenu(file)" :title="$t('tasks.moreActions') || '更多操作'">
                   ⋯
-                </button>
+                </el-button>
                 <div v-if="activeMenuFile?.path === file.path" class="file-menu-dropdown">
-                  <button class="menu-item" @click="handleDownload(file)">
+                  <el-button class="menu-item" text @click="handleDownload(file)">
                     <span class="menu-icon">↓</span>
                     <span>{{ $t('tasks.download') || '下载' }}</span>
-                  </button>
-                  <button
+                  </el-button>
+                  <el-button
                     v-if="canDeleteFile(file)"
                     class="menu-item menu-item-danger"
+                    text
+                    type="danger"
                     @click="confirmDeleteFile(file)"
                   >
                     <span class="menu-icon">🗑</span>
                     <span>{{ $t('tasks.delete') || '删除' }}</span>
-                  </button>
+                  </el-button>
                 </div>
               </div>
             </div>
@@ -290,24 +292,23 @@
       <div class="tasks-header">
         <h2 class="title">{{ $t('tasks.title') }}</h2>
         <div class="header-actions">
-          <select v-model="statusFilter" class="status-filter">
-            <option value="all">{{ $t('tasks.allStatus') || '全部' }}</option>
-            <option value="active">{{ $t('tasks.activeStatus') || '进行中' }}</option>
-            <option value="archived">{{ $t('tasks.archivedStatus') || '已归档' }}</option>
-          </select>
-          <button class="btn-create" @click="openCreateDialog" :title="$t('tasks.create')">
+          <el-select v-model="statusFilter" size="small" style="width: 100px">
+            <el-option value="all" :label="$t('tasks.allStatus') || '全部'" />
+            <el-option value="active" :label="$t('tasks.activeStatus') || '进行中'" />
+            <el-option value="archived" :label="$t('tasks.archivedStatus') || '已归档'" />
+          </el-select>
+          <el-button type="primary" @click="openCreateDialog" :title="$t('tasks.create')">
             <span class="icon">+</span>
-          </button>
+          </el-button>
         </div>
       </div>
 
       <!-- 搜索框 -->
       <div class="search-box">
-        <input
+        <el-input
           v-model="searchQuery"
-          type="text"
           :placeholder="$t('tasks.searchPlaceholder')"
-          class="search-input"
+          clearable
         />
       </div>
 
@@ -350,7 +351,7 @@
               <div class="task-actions" @click.stop>
                 <!-- 自动运行切换按钮（仅 active 或 autonomous 相关状态显示） -->
                 <template v-if="task.status === 'active' || isAutonomousStatus(task.status)">
-                  <button
+                  <el-button
                     class="btn-task"
                     :class="{ 'btn-autonomous-active': isAutonomousStatus(task.status) }"
                     @click="handleToggleAutonomousFromList(task, $event)"
@@ -358,38 +359,39 @@
                   >
                     <span class="btn-icon">{{ isAutonomousStatus(task.status) ? '🤖' : '⚙️' }}</span>
                     <span class="btn-label">{{ isAutonomousStatus(task.status) ? ($t('tasks.autonomous') || '自动') : ($t('tasks.autoRun') || '自运') }}</span>
-                  </button>
+                  </el-button>
                 </template>
-                <button
+                <el-button
                   v-if="task.status === 'active' || isAutonomousStatus(task.status)"
                   class="btn-task btn-archive"
                   @click="handleArchiveTask(task)"
                 >
                   <span class="btn-icon">📦</span>
                   <span class="btn-label">{{ $t('tasks.archive') || '归档' }}</span>
-                </button>
-                <button
+                </el-button>
+                <el-button
                   v-else
                   class="btn-task btn-restore"
                   @click="handleRestoreTask(task)"
                 >
                   <span class="btn-icon">↩️</span>
                   <span class="btn-label">{{ $t('tasks.restore') || '恢复' }}</span>
-                </button>
-                <button
+                </el-button>
+                <el-button
                   class="btn-task btn-edit"
                   @click="openEditDialog(task)"
                 >
                   <span class="btn-icon">✏️</span>
                   <span class="btn-label">{{ $t('tasks.edit') || '编辑' }}</span>
-                </button>
-                <button
+                </el-button>
+                <el-button
                   class="btn-task btn-delete"
+                  type="danger"
                   @click="handleDeleteTask(task)"
                 >
                   <span class="btn-icon">🗑️</span>
                   <span class="btn-label">{{ $t('tasks.delete') || '删除' }}</span>
-                </button>
+                </el-button>
               </div>
             </div>
           </div>
@@ -411,40 +413,38 @@
       <div class="dialog">
         <div class="dialog-header">
           <h3>{{ isEditMode ? ($t('tasks.editTitle') || '编辑任务') : ($t('tasks.createTitle') || '创建任务') }}</h3>
-          <button class="btn-close" @click="closeTaskDialog">×</button>
+          <el-button class="btn-close" text @click="closeTaskDialog">×</el-button>
         </div>
         <div class="dialog-body">
           <div class="form-group">
             <label>{{ $t('tasks.titleLabel') || '标题' }}</label>
-            <input
+            <el-input
               v-model="taskForm.title"
-              type="text"
               :placeholder="$t('tasks.titlePlaceholder') || '输入任务标题'"
-              class="form-input"
               @keyup.enter="handleSubmitTask"
             />
           </div>
           <div class="form-group">
             <label>{{ $t('tasks.descriptionLabel') || '描述' }}</label>
-            <textarea
+            <el-input
               v-model="taskForm.description"
+              type="textarea"
               :placeholder="$t('tasks.descriptionPlaceholder') || '输入任务描述（可选）'"
-              class="form-textarea"
-              rows="3"
-            ></textarea>
+              :rows="3"
+            />
           </div>
         </div>
         <div class="dialog-footer">
-          <button class="btn-cancel" @click="closeTaskDialog">
+          <el-button @click="closeTaskDialog">
             {{ $t('common.cancel') || '取消' }}
-          </button>
-          <button
-            class="btn-confirm"
+          </el-button>
+          <el-button
+            type="primary"
             @click="handleSubmitTask"
             :disabled="!taskForm.title.trim() || isSubmitting"
           >
             {{ isSubmitting ? ($t('common.saving') || '保存中...') : ($t('common.save') || '保存') }}
-          </button>
+          </el-button>
         </div>
       </div>
     </div>
@@ -454,18 +454,18 @@
       <div class="dialog dialog-small">
         <div class="dialog-header">
           <h3>{{ $t('tasks.deleteConfirm') || '确认删除' }}</h3>
-          <button class="btn-close" @click="showDeleteConfirm = false">×</button>
+          <el-button class="btn-close" text @click="showDeleteConfirm = false">×</el-button>
         </div>
         <div class="dialog-body">
           <p>{{ $t('tasks.deleteConfirmMessage', { title: taskToDelete?.title }) || `确定要删除任务"${taskToDelete?.title}"吗？此操作不可恢复。` }}</p>
         </div>
         <div class="dialog-footer">
-          <button class="btn-cancel" @click="showDeleteConfirm = false">
+          <el-button @click="showDeleteConfirm = false">
             {{ $t('common.cancel') || '取消' }}
-          </button>
-          <button class="btn-confirm btn-danger" @click="confirmDeleteTask">
+          </el-button>
+          <el-button type="danger" @click="confirmDeleteTask">
             {{ $t('common.delete') || '删除' }}
-          </button>
+          </el-button>
         </div>
       </div>
     </div>
@@ -475,18 +475,18 @@
       <div class="dialog dialog-small">
         <div class="dialog-header">
           <h3>{{ $t('tasks.deleteConfirm') || '确认删除' }}</h3>
-          <button class="btn-close" @click="showDeleteFileConfirm = false">×</button>
+          <el-button class="btn-close" text @click="showDeleteFileConfirm = false">×</el-button>
         </div>
         <div class="dialog-body">
           <p>{{ $t('tasks.deleteFileConfirmMessage', { name: fileToDelete?.name }) || `确定要删除文件"${fileToDelete?.name}"吗？此操作不可恢复。` }}</p>
         </div>
         <div class="dialog-footer">
-          <button class="btn-cancel" @click="showDeleteFileConfirm = false">
+          <el-button @click="showDeleteFileConfirm = false">
             {{ $t('common.cancel') || '取消' }}
-          </button>
-          <button class="btn-confirm btn-danger" @click="handleDeleteFile">
+          </el-button>
+          <el-button type="danger" @click="handleDeleteFile">
             {{ $t('common.delete') || '删除' }}
-          </button>
+          </el-button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/settings/StateDesigner.vue
+++ b/frontend/src/components/settings/StateDesigner.vue
@@ -40,16 +40,16 @@
           </span>
         </div>
         <div class="state-card-actions">
-          <button v-if="index > 0" class="btn-tiny" @click.stop="moveState(index, -1)">↑</button>
-          <button v-if="index < states.length - 1" class="btn-tiny" @click.stop="moveState(index, 1)">↓</button>
-          <button class="btn-tiny btn-danger" @click.stop="removeState(index)">×</button>
+          <el-button v-if="index > 0" size="small" @click.stop="moveState(index, -1)">↑</el-button>
+          <el-button v-if="index < states.length - 1" size="small" @click.stop="moveState(index, 1)">↓</el-button>
+          <el-button size="small" type="danger" @click.stop="removeState(index)">×</el-button>
         </div>
       </div>
     </div>
 
-    <button class="btn-secondary" @click="addState">
+    <el-button @click="addState">
       + {{ $t('settings.appManagement.stateDesigner.addState', '添加状态') }}
-    </button>
+    </el-button>
 
     <!-- 流转可视化 -->
     <div v-if="states.length > 1" class="state-flow">
@@ -70,49 +70,44 @@
       <div class="form-row">
         <div class="form-item">
           <label class="form-label">{{ $t('settings.appManagement.stateDesigner.stateName', '状态标识') }} *</label>
-          <input v-model="selectedState.name" type="text" class="form-input" placeholder="pending_ocr" />
+          <el-input v-model="selectedState.name" placeholder="pending_ocr" />
           <p class="form-hint">{{ $t('settings.appManagement.stateDesigner.stateNameHint', '英文标识，用于系统内部') }}</p>
         </div>
         <div class="form-item">
           <label class="form-label">{{ $t('settings.appManagement.stateDesigner.stateLabel', '显示名称') }} *</label>
-          <input v-model="selectedState.label" type="text" class="form-input" :placeholder="$t('settings.appManagement.stateDesigner.stateLabelPlaceholder', '待OCR')" />
+          <el-input v-model="selectedState.label" :placeholder="$t('settings.appManagement.stateDesigner.stateLabelPlaceholder', '待OCR')" />
         </div>
       </div>
       <div class="form-item-group">
-        <label class="form-label checkbox">
-          <input v-model="selectedState.is_initial" type="checkbox" @change="handleInitialChange" />
+        <el-checkbox v-model="selectedState.is_initial" @change="handleInitialChange">
           {{ $t('settings.appManagement.stateDesigner.initial', '初始状态') }}
-        </label>
-        <label class="form-label checkbox">
-          <input v-model="selectedState.is_terminal" type="checkbox" />
+        </el-checkbox>
+        <el-checkbox v-model="selectedState.is_terminal">
           {{ $t('settings.appManagement.stateDesigner.terminal', '终态') }}
-        </label>
-        <label class="form-label checkbox">
-          <input v-model="selectedState.is_error" type="checkbox" />
+        </el-checkbox>
+        <el-checkbox v-model="selectedState.is_error">
           {{ $t('settings.appManagement.stateDesigner.error', '错误状态') }}
-        </label>
+        </el-checkbox>
       </div>
       <div class="form-item">
         <label class="form-label">{{ $t('settings.appManagement.stateDesigner.handler', '处理脚本') }}</label>
-        <select v-model="selectedState.handler_id" class="form-input">
-          <option value="">{{ $t('settings.appManagement.stateDesigner.noHandler', '无（手动处理）') }}</option>
-          <option v-for="h in handlers" :key="h.id" :value="h.id">{{ h.name }}</option>
-        </select>
+        <el-select v-model="selectedState.handler_id" clearable>
+          <el-option value="" :label="$t('settings.appManagement.stateDesigner.noHandler', '无（手动处理）')" />
+          <el-option v-for="h in handlers" :key="h.id" :value="h.id" :label="h.name" />
+        </el-select>
       </div>
       <div class="form-row">
         <div class="form-item">
           <label class="form-label">{{ $t('settings.appManagement.stateDesigner.successNext', '成功后转到') }}</label>
-          <select v-model="selectedState.success_next_state" class="form-input">
-            <option value="">-</option>
-            <option v-for="s in otherStates(selectedState.name)" :key="s.name" :value="s.name">{{ s.label || s.name }}</option>
-          </select>
+          <el-select v-model="selectedState.success_next_state" clearable>
+            <el-option v-for="s in otherStates(selectedState.name)" :key="s.name" :value="s.name" :label="s.label || s.name" />
+          </el-select>
         </div>
         <div class="form-item">
           <label class="form-label">{{ $t('settings.appManagement.stateDesigner.failureNext', '失败后转到') }}</label>
-          <select v-model="selectedState.failure_next_state" class="form-input">
-            <option value="">-</option>
-            <option v-for="s in otherStates(selectedState.name)" :key="s.name" :value="s.name">{{ s.label || s.name }}</option>
-          </select>
+          <el-select v-model="selectedState.failure_next_state" clearable>
+            <el-option v-for="s in otherStates(selectedState.name)" :key="s.name" :value="s.name" :label="s.label || s.name" />
+          </el-select>
         </div>
       </div>
     </div>

--- a/frontend/src/views/KnowledgeBaseView.vue
+++ b/frontend/src/views/KnowledgeBaseView.vue
@@ -94,38 +94,38 @@
         <div class="pagination-debug" v-if="false">
           totalPages: {{ totalPages }}, currentPage: {{ currentPage }}, totalCount: {{ totalCount }}
         </div>
-        <button
-          class="page-btn"
+        <el-button
+          size="small"
           :disabled="currentPage === 1"
           @click="changePage(currentPage - 1)"
         >
           ← {{ $t('pagination.prev') }}
-        </button>
+        </el-button>
         <div class="page-info">
           <span>{{ $t('pagination.info', { total: totalCount }) }}</span>
           <span class="page-numbers">
-            <button
+            <el-button
               v-for="page in visiblePages"
               :key="page"
-              class="page-num"
-              :class="{ active: page === currentPage }"
+              size="small"
+              :type="page === currentPage ? 'primary' : ''"
               @click="changePage(page)"
             >
               {{ page }}
-            </button>
+            </el-button>
           </span>
           <!-- 每页数量选择器 -->
           <el-select v-model="pageSize" @change="handlePageSizeChange" style="width: 100px">
             <el-option v-for="size in pageSizeOptions" :key="size" :label="size + '/页'" :value="size" />
           </el-select>
         </div>
-        <button
-          class="page-btn"
+        <el-button
+          size="small"
           :disabled="currentPage === totalPages"
           @click="changePage(currentPage + 1)"
         >
           {{ $t('pagination.next') }} →
-        </button>
+        </el-button>
       </div>
     </template>
 
@@ -138,38 +138,34 @@
         <div class="dialog-body">
           <div class="form-group">
             <label class="form-label">{{ $t('knowledgeBase.nameLabel') }}</label>
-            <input
+            <el-input
               v-model="formData.name"
-              type="text"
-              class="form-input"
               :placeholder="$t('knowledgeBase.namePlaceholder')"
             />
           </div>
           <div class="form-group">
             <label class="form-label">{{ $t('knowledgeBase.descriptionLabel') }}</label>
-            <textarea
+            <el-input
               v-model="formData.description"
-              class="form-textarea"
+              type="textarea"
               :placeholder="$t('knowledgeBase.descriptionPlaceholder')"
-              rows="3"
-            ></textarea>
+              :rows="3"
+            />
           </div>
           <div class="form-group">
             <label class="form-label">{{ $t('knowledgeBase.visibilityLabel') }}</label>
-            <select v-model="formData.visibility" class="form-select">
-              <option value="owner">{{ $t('knowledgeBase.visibility.owner') }}</option>
-              <option value="department">{{ $t('knowledgeBase.visibility.department') }}</option>
-              <option value="all">{{ $t('knowledgeBase.visibility.all') }}</option>
-            </select>
+            <el-select v-model="formData.visibility">
+              <el-option value="owner" :label="$t('knowledgeBase.visibility.owner')" />
+              <el-option value="department" :label="$t('knowledgeBase.visibility.department')" />
+              <el-option value="all" :label="$t('knowledgeBase.visibility.all')" />
+            </el-select>
             <p class="form-hint">{{ $t('knowledgeBase.visibilityHint') }}</p>
           </div>
           <div class="form-group">
             <label class="form-label">{{ $t('knowledgeBase.embeddingModelLabel') }}</label>
-            <select v-model="formData.embedding_model_id" class="form-select" :disabled="embeddingModels.length === 0">
-              <option v-for="model in embeddingModels" :key="model.id" :value="model.id">
-                {{ model.name }}
-              </option>
-            </select>
+            <el-select v-model="formData.embedding_model_id" :disabled="embeddingModels.length === 0">
+              <el-option v-for="model in embeddingModels" :key="model.id" :value="model.id" :label="model.name" />
+            </el-select>
             <p v-if="embeddingModels.length === 0" class="form-error">
               {{ $t('knowledgeBase.noEmbeddingModelError') || '请先配置 Embedding 模型' }}
             </p>
@@ -177,14 +173,14 @@
           </div>
         </div>
         <div class="dialog-footer">
-          <button class="btn-cancel" @click="closeDialog">{{ $t('common.cancel') }}</button>
-          <button
-            class="btn-primary"
+          <el-button @click="closeDialog">{{ $t('common.cancel') }}</el-button>
+          <el-button
+            type="primary"
             :disabled="!formData.name.trim() || isSubmitting"
             @click="submitForm"
           >
             {{ isSubmitting ? $t('common.saving') : $t('common.save') }}
-          </button>
+          </el-button>
         </div>
       </div>
     </div>
@@ -211,10 +207,10 @@
           <p>{{ $t('knowledgeBase.deleteConfirmMessage', { name: deletingKb.name }) }}</p>
         </div>
         <div class="dialog-footer">
-          <button class="btn-cancel" @click="deletingKb = null">{{ $t('common.cancel') }}</button>
-          <button class="btn-danger" @click="confirmDelete">
+          <el-button @click="deletingKb = null">{{ $t('common.cancel') }}</el-button>
+          <el-button type="danger" @click="confirmDelete">
             {{ $t('common.delete') }}
-          </button>
+          </el-button>
         </div>
       </div>
     </div>
@@ -255,7 +251,7 @@
           </div>
         </div>
         <div class="dialog-footer">
-          <button class="btn-cancel" @click="closeGlobalSearchDialog">{{ $t('common.close') }}</button>
+          <el-button @click="closeGlobalSearchDialog">{{ $t('common.close') }}</el-button>
         </div>
       </div>
     </div>

--- a/frontend/src/views/SolutionsView.vue
+++ b/frontend/src/views/SolutionsView.vue
@@ -67,23 +67,23 @@
 
       <!-- Pagination -->
       <div class="pagination" v-if="totalPages > 1">
-        <button
-          class="page-btn"
+        <el-button
+          size="small"
           :disabled="currentPage === 1"
           @click="changePage(currentPage - 1)"
         >
           ← {{ $t('pagination.prev', '上一页') }}
-        </button>
+        </el-button>
         <div class="page-info">
           <span>{{ $t('pagination.info', { total: totalCount }, `共 ${totalCount} 条`) }}</span>
         </div>
-        <button
-          class="page-btn"
+        <el-button
+          size="small"
           :disabled="currentPage === totalPages"
           @click="changePage(currentPage + 1)"
         >
           {{ $t('pagination.next', '下一页') }} →
-        </button>
+        </el-button>
       </div>
     </template>
 
@@ -96,60 +96,54 @@
         <div class="dialog-body">
           <div class="form-group">
             <label class="form-label">{{ $t('solutions.name', '名称') }} *</label>
-            <input
+            <el-input
               v-model="formData.name"
-              type="text"
-              class="form-input"
               :placeholder="$t('solutions.namePlaceholder', '输入解决方案名称')"
             />
           </div>
           <div class="form-group">
             <label class="form-label">{{ $t('solutions.slug', 'URL标识') }}</label>
-            <input
+            <el-input
               v-model="formData.slug"
-              type="text"
-              class="form-input"
               :placeholder="$t('solutions.slugPlaceholder', '自动生成或自定义')"
             />
           </div>
           <div class="form-group">
             <label class="form-label">{{ $t('solutions.description', '描述') }}</label>
-            <textarea
+            <el-input
               v-model="formData.description"
-              class="form-textarea"
-              rows="2"
+              type="textarea"
+              :rows="2"
               :placeholder="$t('solutions.descriptionPlaceholder', '简要描述该解决方案')"
-            ></textarea>
+            />
           </div>
           <div class="form-group">
             <label class="form-label">{{ $t('solutions.tags', '标签') }}</label>
-            <input
+            <el-input
               v-model="tagsInput"
-              type="text"
-              class="form-input"
               :placeholder="$t('solutions.tagsPlaceholder', '多个标签用逗号分隔')"
             />
           </div>
           <div class="form-group">
             <label class="form-label">{{ $t('solutions.guide', '执行指南') }} (Markdown)</label>
-            <textarea
+            <el-input
               v-model="formData.guide"
-              class="form-textarea form-textarea-large"
-              rows="12"
+              type="textarea"
+              :rows="12"
               :placeholder="$t('solutions.guidePlaceholder', '使用 Markdown 格式编写执行指南...')"
-            ></textarea>
+            />
           </div>
         </div>
         <div class="dialog-footer">
-          <button class="btn-cancel" @click="closeDialog">
+          <el-button @click="closeDialog">
             {{ $t('common.cancel', '取消') }}
-          </button>
-          <button v-if="isEditing" class="btn-delete" @click="deleteSolution">
+          </el-button>
+          <el-button v-if="isEditing" type="danger" @click="deleteSolution">
             {{ $t('common.delete', '删除') }}
-          </button>
-          <button class="btn-save" @click="saveSolution" :disabled="isSaving">
+          </el-button>
+          <el-button type="primary" @click="saveSolution" :disabled="isSaving">
             {{ isSaving ? $t('common.saving', '保存中...') : $t('common.save', '保存') }}
-          </button>
+          </el-button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- 将前端原生 HTML 元素统一替换为 element-plus 组件
- 修改了 14 个文件，替换约 50+ 处原生元素

## Changes

### Phase 1 - 核心组件
- `TasksTab.vue`: ~20处 button → el-button，select/input 替换
- `StateDesigner.vue`: button/select/checkbox/input 全面替换
- `AppHeader.vue`: 语言选择 select → el-select

### Phase 2 - 基础字段组件
- `TextField.vue`: input → el-input
- `BooleanField.vue`: checkbox → el-checkbox
- `NumberField.vue`: input → el-input-number
- `DateField.vue`: input → el-date-picker
- `RepeatingField.vue`: button → el-button
- `GenericMiniApp.vue`: checkbox → el-checkbox

### Phase 3 - 其他组件
- `LangSelector.vue`, `ModelSelector.vue`: select → el-select
- `FileField.vue`: button → el-button
- `KnowledgeBaseView.vue`, `SolutionsView.vue`: 表单和分页按钮替换

## Benefits

1. UI 样式统一，视觉效果更佳
2. 自动获得 loading、disabled、hover 等交互状态
3. 更好的国际化支持（element-plus 内置）
4. 更好的可访问性（aria 属性）

Closes #751