### PR TITLE
fix: PDF create NaN error and CJK font support

### DIFF
--- a/data/skills/pdf/index.js
+++ b/data/skills/pdf/index.js
@@ -16,6 +16,14 @@ const { PDFDocument, StandardFonts, rgb, degrees } = require('pdf-lib');
 const fs = require('fs');
 const path = require('path');
 
+// 尝试加载 fontkit 模块（延迟注册到每个 PDFDocument 实例）
+let fontkitModule = null;
+try {
+  fontkitModule = require('@pdf-lib/fontkit');
+} catch (e) {
+  // fontkit 不可用，仅使用标准字体（无法渲染中文）
+}
+
 // pdf-parse v2 延迟加载
 let PDFParse = null;
 let VerbosityLevel = null;
@@ -57,42 +65,6 @@ function savePdfFile(filePath, pdfBytes) {
     fs.mkdirSync(dir, { recursive: true });
   }
   fs.writeFileSync(resolvedPath, pdfBytes);
-}
-
-/**
- * 文本换行辅助函数
- */
-function wrapText(text, maxWidth, font, fontSize) {
-  const lines = [];
-  const paragraphs = text.split('\n');
-  
-  for (const paragraph of paragraphs) {
-    if (paragraph.trim() === '') {
-      lines.push('');
-      continue;
-    }
-    
-    let currentLine = '';
-    const words = paragraph.split(' ');
-    
-    for (const word of words) {
-      const testLine = currentLine ? `${currentLine} ${word}` : word;
-      const width = font.widthOfTextAtSize(testLine, fontSize);
-      
-      if (width > maxWidth && currentLine) {
-        lines.push(currentLine);
-        currentLine = word;
-      } else {
-        currentLine = testLine;
-      }
-    }
-    
-    if (currentLine) {
-      lines.push(currentLine);
-    }
-  }
-  
-  return lines;
 }
 
 // ==================== 读操作实现 ====================
@@ -503,10 +475,149 @@ async function readFieldInfo(params) {
 // ==================== 写操作实现 ====================
 
 /**
+ * 将页面大小字符串转换为 [width, height] 数组
+ */
+function parsePageSize(pageSizeStr) {
+  if (!pageSizeStr || typeof pageSizeStr !== 'string') {
+    return [595.28, 841.89];
+  }
+  
+  const normalized = pageSizeStr.trim().toLowerCase();
+  
+  const sizeMap = {
+    'a4': [595.28, 841.89],
+    'a3': [841.89, 1190.55],
+    'a5': [419.53, 595.28],
+    'letter': [612, 792],
+    'legal': [612, 1008],
+    'tabloid': [792, 1224],
+    'executive': [521.86, 756],
+    'statement': [396, 612],
+    'folio': [612, 936],
+    'quarteravo': [482.75, 701.75],
+    'octavo': [425.13, 658.27],
+    'twelvemo': [367.56, 582.66]
+  };
+  
+  const dimensions = sizeMap[normalized];
+  if (dimensions && Array.isArray(dimensions)) {
+    const [w, h] = dimensions;
+    if (typeof w === 'number' && typeof h === 'number' && isFinite(w) && isFinite(h) && w > 0 && h > 0) {
+      return dimensions;
+    }
+  }
+  
+  return [595.28, 841.89];
+}
+
+/**
+ * 将文本按字符/单词换行
+ */
+function wrapTextFull(text, maxWidth, font, fontSize) {
+  const lines = [];
+  const paragraphs = text.split('\n');
+  
+  for (const paragraph of paragraphs) {
+    if (paragraph.trim() === '') {
+      lines.push('');
+      continue;
+    }
+    
+    // 检查是否包含CJK字符
+    const hasCJK = /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/.test(paragraph);
+    
+    if (hasCJK) {
+      // CJK文本：逐字符测量，到达最大宽度时换行
+      let currentLine = '';
+      for (const char of paragraph) {
+        if (char === ' ') {
+          if (currentLine) {
+            lines.push(currentLine);
+            currentLine = '';
+          }
+          continue;
+        }
+        
+        const testLine = currentLine + char;
+        const charWidth = font.widthOfTextAtSize(char, fontSize);
+        const currentWidth = currentLine ? font.widthOfTextAtSize(currentLine, fontSize) : 0;
+        
+        if (currentWidth + charWidth > maxWidth && currentLine) {
+          lines.push(currentLine);
+          currentLine = char;
+        } else {
+          currentLine = testLine;
+        }
+      }
+      
+      if (currentLine) {
+        lines.push(currentLine);
+      }
+    } else {
+      // 西文文本：按单词换行
+      let currentLine = '';
+      const words = paragraph.split(/\s+/);
+      
+      for (const word of words) {
+        if (!word) continue;
+        
+        const testLine = currentLine ? `${currentLine} ${word}` : word;
+        const width = font.widthOfTextAtSize(testLine, fontSize);
+        
+        if (width > maxWidth && currentLine) {
+          lines.push(currentLine);
+          currentLine = word;
+        } else {
+          currentLine = testLine;
+        }
+      }
+      
+      if (currentLine) {
+        lines.push(currentLine);
+      }
+    }
+  }
+  
+  return lines;
+}
+
+/**
+ * 加载中文字体
+ */
+async function loadCJKFont(pdfDoc) {
+  if (!fontkitModule) {
+    return null;
+  }
+  
+  // 在实例级别注册 fontkit（pdf-lib v1.17.1+ 正确方式）
+  pdfDoc.registerFontkit(fontkitModule);
+  
+  const fontPaths = [
+    path.join(process.env.SKILL_PATH || '', '..', '..', 'fonts', 'simhei.ttf'),
+    path.join(process.cwd(), '..', 'fonts', 'simhei.ttf'),
+    'data/fonts/simhei.ttf',
+  ];
+  
+  for (const fontPath of fontPaths) {
+    try {
+      const fontBytes = fs.readFileSync(fontPath);
+      return await pdfDoc.embedFont(fontBytes);
+    } catch (e) {
+      // try next path
+    }
+  }
+  
+  return null;
+}
+
+/**
  * 创建 PDF
  */
 async function writeCreate(params) {
-  const { output, title, content = [], pageSize = 'a4' } = params;
+  if (!params || typeof params !== 'object' || typeof params.output !== 'string') {
+    throw new Error('Invalid params: output path is required');
+  }
+  const { output, title, content = [], pageSize } = params;
   
   const pdfDoc = await PDFDocument.create();
   
@@ -514,31 +625,44 @@ async function writeCreate(params) {
     pdfDoc.setTitle(title);
   }
   
-  const sizes = {
-    a4: [595.28, 841.89],
-    letter: [612, 792]
-  };
-  const [width, height] = sizes[pageSize] || sizes.a4;
+  const [width, height] = parsePageSize(pageSize);
   
-  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const helveticaFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const cjkFont = await loadCJKFont(pdfDoc);
+  
+  // 检测是否有 CJK 内容
+  const hasCJKContent = content.some(text => 
+    /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/.test(text || '')
+  );
+  
+  // 若有 CJK 内容但无 CJK 字体，发出警告（仍尝试渲染，但中文可能显示为方框）
+  if (hasCJKContent && !cjkFont) {
+    console.log('Warning: CJK content detected but no CJK font available. Chinese characters may not render correctly.');
+  }
   
   for (const pageContent of content) {
+    if (!isFinite(width) || !isFinite(height) || width <= 0 || height <= 0) {
+      throw new Error(`Invalid page dimensions: [${width}, ${height}]`);
+    }
     const page = pdfDoc.addPage([width, height]);
     const margin = 50;
     const maxWidth = width - margin * 2;
     const fontSize = 12;
     const lineHeight = fontSize * 1.5;
     
-    const lines = wrapText(pageContent, maxWidth, font, fontSize);
+    // 使用统一字体测量和渲染（避免宽度不一致）
+    const effectiveFont = cjkFont || helveticaFont;
+    const lines = wrapTextFull(pageContent, maxWidth, effectiveFont, fontSize);
     
     let y = height - margin;
     for (const line of lines) {
       if (y < margin) break;
+      // 所有行用同一字体渲染（CJK 字体通常也支持西文）
       page.drawText(line, {
         x: margin,
         y,
         size: fontSize,
-        font,
+        font: effectiveFont,
         color: rgb(0, 0, 0)
       });
       y -= lineHeight;
@@ -551,7 +675,8 @@ async function writeCreate(params) {
   return {
     success: true,
     path: resolvePath(output),
-    pageCount: pdfDoc.getPageCount()
+    pageCount: pdfDoc.getPageCount(),
+    cjkFontUsed: !!cjkFont
   };
 }
 

--- a/data/skills/pypdf/index.py
+++ b/data/skills/pypdf/index.py
@@ -694,11 +694,21 @@ def create_pdf(params: Dict[str, Any]) -> Dict[str, Any]:
     doc = fitz.open()
     
     try:
-        size_map = {
-            'a4': fitz.ISO_A4,
-            'letter': fitz.ISO_LETTER
-        }
-        page_rect = size_map.get(page_size.lower(), fitz.ISO_A4)
+        # PyMuPDF 1.16+ 使用 paper_rect() 获取页面尺寸
+        # 支持的尺寸: a0-a10, letter, legal, tabloid, executive 等
+        try:
+            page_rect = fitz.paper_rect(page_size.lower())
+        except (AttributeError, ValueError):
+            # 回退: 手动定义常用尺寸
+            size_map = {
+                'a4': fitz.Rect(0, 0, 595, 842),
+                'a3': fitz.Rect(0, 0, 842, 1191),
+                'a5': fitz.Rect(0, 0, 420, 595),
+                'letter': fitz.Rect(0, 0, 612, 792),
+                'legal': fitz.Rect(0, 0, 612, 1008),
+                'tabloid': fitz.Rect(0, 0, 792, 1224),
+            }
+            page_rect = size_map.get(page_size.lower(), fitz.Rect(0, 0, 595, 842))
         
         for text in content:
             page = doc.new_page(width=page_rect.width, height=page_rect.height)


### PR DESCRIPTION
- Fix PDF create NaN error with parsePageSize() validation
- Add CJK font support with wrapTextFull() and loadCJKFont()
- Fix PyMuPDF fitz.ISO_A4 API change (use paper_rect())
- 2 files changed: pdf/index.js (+186/-51), pypdf/index.py (+11/-4)