### PR TITLE
fix: 合同处理与比对流程超时配置统一修复

### DIFF
--- a/apps/contract-mgr/manifest.json
+++ b/apps/contract-mgr/manifest.json
@@ -145,28 +145,33 @@
     "step_resources": {
       "pending_ocr": {
         "type": "mcp",
-        "mcp": { "server": "markitdown", "tool": "submit_conversion_task", "params_mapping": { "content": "file.base64", "filename": "file.name" } }
+        "mcp": { "server": "markitdown", "tool": "submit_conversion_task", "params_mapping": { "content": "file.base64", "filename": "file.name" } },
+        "timeout_ms": 1200000
       },
       "ocr_submitted": {
         "type": "mcp",
         "mcp": { "server": "markitdown", "tool": "get_task", "hide_params_mapping": true },
         "judge_model_id": null,
-        "judge_temperature": 0.1
+        "judge_temperature": 0.1,
+        "timeout_ms": 600000
       },
       "pending_filter": {
         "type": "internal_llm",
         "model_id": null,
-        "temperature": 0.3
+        "temperature": 0.3,
+        "timeout_ms": 600000
       },
       "pending_extract": {
         "type": "internal_llm",
         "model_id": null,
-        "temperature": 0.3
+        "temperature": 0.3,
+        "timeout_ms": 600000
       },
       "pending_section": {
         "type": "internal_llm",
         "model_id": null,
-        "temperature": 0.3
+        "temperature": 0.3,
+        "timeout_ms": 600000
       }
     }
   },

--- a/apps/contract-mgr/tick/index.js
+++ b/apps/contract-mgr/tick/index.js
@@ -139,7 +139,7 @@ async function handleOcrSubmit(record, app, services) {
   }
   
   try {
-    const result = await services.callMcp(mcp.server, mcp.tool, params);
+    const result = await services.callMcp(mcp.server, mcp.tool, params, config.timeout_ms ?? 1200000);
     
     logger.info(`[contract-mgr tick] OCR response: ${JSON.stringify(result).substring(0, 500)}`);
     
@@ -158,6 +158,7 @@ ${JSON.stringify(result).substring(0, 1000)}`;
       const parsed = await services.llm.extractJson(parsePrompt, '', {
         modelId: ocrSubmittedConfig.judge_model_id || null,
         temperature: 0.1,
+        timeout: ocrSubmittedConfig.timeout_ms ?? 600000,
         defaultValue: { task_id: '' },
       });
 
@@ -209,13 +210,14 @@ async function handleOcrCheck(record, app, services) {
   const mcp = config.mcp || { server: 'markitdown', tool: 'get_task' };
   
   try {
-    const result = await services.callMcp(mcp.server, mcp.tool || 'get_task', { task_id: taskId });
+    const result = await services.callMcp(mcp.server, mcp.tool || 'get_task', { task_id: taskId }, config.timeout_ms ?? 600000);
     
     const judgePrompt = `判断OCR任务是否完成。任务返回信息：${JSON.stringify(result).substring(0, 1000)}。返回JSON：{"status": "completed|pending|failed", "progress": 0-100}`;
     
     const judgeResult = await services.llm.extractJson(judgePrompt, '', {
       modelId: config.judge_model_id || null,
       temperature: config.judge_temperature || 0.1,
+      timeout: config.timeout_ms ?? 600000,
       defaultValue: { status: 'pending', progress: 0 },
     });
 
@@ -263,6 +265,7 @@ async function handleFilter(record, app, services) {
     const filteredText = await services.llm.generateText(filterPrompt, ocrText, {
       modelId: config.model_id || null,
       temperature: config.temperature || 0.3,
+      timeout: config.timeout_ms ?? 600000,
     }) || ocrText;
     
     await services.execute(
@@ -298,6 +301,7 @@ async function handleExtract(record, app, services) {
     const metadata = await services.llm.extractJson(extractPrompt, contentRows[0].filtered_text, {
       modelId: config.model_id || null,
       temperature: config.temperature || 0.3,
+      timeout: config.timeout_ms ?? 600000,
     });
     
     if (metadata) {
@@ -342,6 +346,7 @@ async function handleSection(record, app, services) {
     const result = await services.llm.extractJson(sectionPrompt, contentRows[0].filtered_text, {
       modelId: config.model_id || null,
       temperature: config.temperature || 0.3,
+      timeout: config.timeout_ms ?? 600000,
     });
     const sections = result?.sections || [];
     

--- a/data/skills/mcp-client/index.js
+++ b/data/skills/mcp-client/index.js
@@ -204,7 +204,9 @@ async function createTransport(serverConfig, credentials = null) {
     }
     
     const headers = buildAuthHeaders(serverConfig.headers, credentials);
-    const timeoutMs = serverConfig.timeout_ms || 600000;
+    const configuredTimeoutMs = Number(serverConfig.timeout_ms) || 600000;
+    const minTimeoutMs = Number(process.env.MCP_CLIENT_MIN_TIMEOUT_MS || 1200000);
+    const timeoutMs = Math.max(configuredTimeoutMs, minTimeoutMs);
     
     const isStateless = transportType === 'statelessHttp' || serverConfig.stateless === true;
     

--- a/frontend/src/api/mini-apps.ts
+++ b/frontend/src/api/mini-apps.ts
@@ -437,7 +437,7 @@ export async function compareRecords(
   appId: string,
   rowIdA: string,
   rowIdB: string,
-  options?: { model_id?: string; temperature?: number; concurrency?: number },
+  options?: { model_id?: string; temperature?: number; concurrency?: number; timeout_ms?: number },
   signal?: AbortSignal
 ): Promise<CompareResult> {
   return apiRequest<CompareResult>(

--- a/lib/app-clock.js
+++ b/lib/app-clock.js
@@ -121,8 +121,8 @@ class AppClock {
       services: {
         llm: this.llmService,
         
-        callMcp: async (server, tool, params) => {
-          return await this.callMcp(server, tool, params);
+        callMcp: async (server, tool, params, timeoutMs) => {
+          return await this.callMcp(server, tool, params, timeoutMs);
         },
         
         callSkill: async (name, method, params) => {
@@ -237,7 +237,7 @@ class AppClock {
     }
   }
 
-  async callMcp(server, tool, params) {
+  async callMcp(server, tool, params, timeoutMs = 120000) {
     logger.info(`[AppClock] callMcp: ${server}.${tool}`);
     logger.debug(`[AppClock] callMcp params keys: ${Object.keys(params || {}).join(', ')}`);
     
@@ -265,7 +265,7 @@ class AppClock {
           accessToken: adminToken,
           isAdmin: true
         },
-        120000
+        timeoutMs
       );
       
       logger.info(`[AppClock] callMcp result type: ${typeof result}`);

--- a/lib/resident-skill-manager.js
+++ b/lib/resident-skill-manager.js
@@ -65,7 +65,7 @@ class ResidentProcess {
    * @param {string} summary - 摘要（不含敏感信息）
    * @param {string} status - success/error/pending
    */
-  addCommunication(direction, taskId, type, summary, status) {
+  addCommunication(direction, taskId, type, summary, status, detail = null) {
     const record = {
       timestamp: new Date().toISOString(),
       direction,
@@ -74,6 +74,10 @@ class ResidentProcess {
       summary,
       status,
     };
+
+    if (detail !== null && detail !== undefined) {
+      record.detail = detail;
+    }
     
     this.communications.push(record);
     
@@ -314,8 +318,14 @@ class ResidentProcess {
       // Issue #433: 更新统计和通讯记录
       if (error) {
         this.errorCount++;
-        this.addCommunication('in', task_id, 'response', `错误: ${error.substring(0, 50)}`, 'error');
-        task.reject(new Error(error));
+        const errorText = this.normalizeErrorText(error);
+        const errorSummary = errorText.length > 120
+          ? `错误: ${errorText.substring(0, 120)}...`
+          : `错误: ${errorText}`;
+        this.addCommunication('in', task_id, 'response', errorSummary, 'error', {
+          error: errorText,
+        });
+        task.reject(new Error(errorText));
       } else {
         this.successCount++;
         const resultSummary = this.generateResultSummary(result);
@@ -338,6 +348,23 @@ class ResidentProcess {
       return `返回: {${keys.slice(0, 3).join(', ')}${keys.length > 3 ? '...' : ''}}`;
     }
     return '返回: 数据';
+  }
+
+  /**
+   * 标准化错误文本，避免调试信息丢失
+   */
+  normalizeErrorText(error) {
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message || String(error);
+
+    try {
+      const json = JSON.stringify(error);
+      if (json && json !== '{}') return json;
+    } catch {
+      // ignore
+    }
+
+    return String(error);
   }
 
   /**

--- a/server/controllers/mini-app.controller.js
+++ b/server/controllers/mini-app.controller.js
@@ -388,7 +388,7 @@ class MiniAppController {
   async compareRecords(ctx) {
     try {
       const { appId } = ctx.params;
-      const { row_id_a, row_id_b, model_id, temperature, concurrency } = ctx.request.body;
+      const { row_id_a, row_id_b, model_id, temperature, concurrency, timeout_ms } = ctx.request.body;
 
       if (!row_id_a || !row_id_b) {
         ctx.error('row_id_a and row_id_b are required', 400);
@@ -403,6 +403,7 @@ class MiniAppController {
         model_id,
         temperature,
         concurrency,
+        timeout_ms,
       });
       ctx.success(result);
     } catch (error) {

--- a/server/services/mini-app.service.js
+++ b/server/services/mini-app.service.js
@@ -952,11 +952,15 @@ async batchUpload(appId, userId, attachmentIds) {
     const modelId = options.model_id || null;
     const temperature = options.temperature ?? 0.3;
     const concurrency = Math.max(1, Math.min(options.concurrency || 3, 10));
+    const timeoutCandidate = Number(
+      options.timeout_ms ?? appConfig?.compare?.timeout_ms ?? appConfig?.compare_timeout_ms ?? 600000
+    );
+    const timeoutMs = Math.max(60000, Math.min(Number.isFinite(timeoutCandidate) ? timeoutCandidate : 600000, 1800000));
 
-    logger.info(`[compareRecords] Model: ${modelId || 'default'}, Temperature: ${temperature}, Concurrency: ${concurrency}`);
+    logger.info(`[compareRecords] Model: ${modelId || 'default'}, Temperature: ${temperature}, Concurrency: ${concurrency}, Timeout: ${timeoutMs}ms`);
 
     logger.info(`[compareRecords] Step 1: LLM section matching`);
-    const matchedSections = await this._matchSectionsWithLlm(contentA.sections, contentB.sections, modelId, temperature);
+    const matchedSections = await this._matchSectionsWithLlm(contentA.sections, contentB.sections, modelId, temperature, timeoutMs);
 
     const matchedItems = matchedSections.filter(m => m.type === 'matched');
     const linesA = contentA.filtered_text.split('\n');
@@ -978,7 +982,12 @@ async batchUpload(appId, userId, attachmentIds) {
             text_a: textA,
             text_b: textB,
           }),
-          { modelId, temperature, defaultValue: { change_type: 'error', summary: 'LLM call failed' } }
+          {
+            modelId,
+            temperature,
+            timeout: timeoutMs,
+            defaultValue: { change_type: 'error', summary: 'LLM call failed' },
+          }
         );
 
         logger.info(`[compareRecords] Section done: ${match.sectionA.title} -> ${result.change_type} (${Date.now() - sectionStart}ms)`);
@@ -1096,7 +1105,7 @@ async batchUpload(appId, userId, attachmentIds) {
     return { filtered_text: content.filtered_text, sections };
   }
 
-  async _matchSectionsWithLlm(sectionsA, sectionsB, modelId, temperature) {
+  async _matchSectionsWithLlm(sectionsA, sectionsB, modelId, temperature, timeoutMs = 600000) {
     const listA = sectionsA.map((s, i) => ({ id: s.id || `a-${i}`, title: s.title }));
     const listB = sectionsB.map((s, i) => ({ id: s.id || `b-${i}`, title: s.title }));
 
@@ -1133,7 +1142,12 @@ ${JSON.stringify(listB, null, 2)}
       result = await this.llmService.extractJson(
         matchPrompt,
         JSON.stringify({}),
-        { modelId, temperature: Math.min(temperature, 0.3), defaultValue: null }
+        {
+          modelId,
+          temperature: Math.min(temperature, 0.3),
+          timeout: timeoutMs,
+          defaultValue: null,
+        }
       );
 
       logger.info(`[matchSections] LLM matching done (${Date.now() - startTime}ms)`);


### PR DESCRIPTION
## 变更概述

修复合同处理与比对流程中多个阶段的超时配置，解决大文件/大文本处理失败问题。

## 修复内容

### 1. 合同处理各阶段超时统一
- **pending_ocr**：MCP 提交超时改为 20 分钟（大文件上传）
- **pending_filter**：LLM 文本过滤 10 分钟
- **pending_extract**：元数据提取 10 分钟
- **pending_section**：章节分析 10 分钟
- **ocr_submitted**：OCR 状态轮询 10 分钟（新增）

### 2. 合同比对功能超时修复
- 章节匹配与逐章节比对 LLM 调用均透传 timeout
- 默认 10 分钟，前端可通过 `timeout_ms` 覆盖
- 超时范围限制：60s ~ 30min

### 3. MCP 客户端传输层修复
- 增加最小超时门槛（环境变量 `MCP_CLIENT_MIN_TIMEOUT_MS`，默认 20 分钟）
- 即使服务器配置较短，也会强制使用最小值

## 关键变更

| 文件 | 变更 |
|------|------|
| `apps/contract-mgr/tick/index.js` | LLM/MCP 调用透传 timeout 参数 |
| `apps/contract-mgr/manifest.json` | 各阶段 timeout_ms 配置 |
| `lib/app-clock.js` | callMcp 签名扩展 |
| `server/services/mini-app.service.js` | 比对超时计算与透传 |
| `data/skills/mcp-client/index.js` | 传输层最小超时门槛 |

## 测试建议

1. 上传大文件（20MB）观察 OCR 提交是否在 20 分钟内完成
2. 处理超长文本（>100KB）观察各阶段是否正常完成
3. 检查日志中 `Custom fetch timeout=...ms` 是否为 1200000

Closes #783