### PR TITLE
fix: harden MCP transport and path handling

### DIFF
--- a/data/skills/mcp-client/index.js
+++ b/data/skills/mcp-client/index.js
@@ -18,7 +18,10 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import path from 'path';
+import { pathToFileURL } from 'url';
 import StatelessHTTPTransport from '../../../lib/mcp-stateless-http.js';
+import { getDataBasePath } from '../../../lib/paths.js';
 
 // ============== 全局状态 ==============
 
@@ -27,11 +30,32 @@ import StatelessHTTPTransport from '../../../lib/mcp-stateless-http.js';
 // 用户 MCP: serverName:userId -> connection
 const connections = new Map();
 
-// 工具定义缓存: serverName -> tools[]
+// 进行中的连接请求: connectionKey -> Promise
+// 防止并发建连导致重复连接
+const pendingConnections = new Map();
+
+// 工具定义缓存: connectionKey -> tools[]
+// 与连接池隔离维度一致：公共连接用 serverName，用户连接用 serverName:userId
 const toolsCache = new Map();
 
 // API 基础 URL（从环境变量获取）
 const API_BASE = process.env.API_BASE || 'http://localhost:3000';
+
+function defaultClientFactory() {
+  return new Client({
+    name: 'touwaka-mate-mcp-client',
+    version: '1.0.0',
+  }, {
+    capabilities: {
+      tools: {},
+      resources: {},
+      prompts: {},
+    },
+  });
+}
+
+let clientFactory = defaultClientFactory;
+let transportFactory = null;
 
 // ============== 日志函数 ==============
 
@@ -205,7 +229,7 @@ async function createTransport(serverConfig, credentials = null) {
     
     const headers = buildAuthHeaders(serverConfig.headers, credentials);
     const configuredTimeoutMs = Number(serverConfig.timeout_ms) || 600000;
-    const minTimeoutMs = Number(process.env.MCP_CLIENT_MIN_TIMEOUT_MS || 1200000);
+    const minTimeoutMs = Number(process.env.MCP_CLIENT_MIN_TIMEOUT_MS || 120000);
     const timeoutMs = Math.max(configuredTimeoutMs, minTimeoutMs);
     
     const isStateless = transportType === 'statelessHttp' || serverConfig.stateless === true;
@@ -266,6 +290,8 @@ async function createTransport(serverConfig, credentials = null) {
   });
 }
 
+transportFactory = createTransport;
+
 // ============== MCP Server 连接管理 ==============
 
 /**
@@ -283,46 +309,66 @@ async function connectServer(serverConfig, userId = null, credentials = null) {
     return connections.get(connectionKey).client;
   }
   
+  // 并发保护: 如果已有进行中的连接请求，等待该请求完成
+  if (pendingConnections.has(connectionKey)) {
+    log(`Connection in progress: ${connectionKey}, waiting...`);
+    return pendingConnections.get(connectionKey);
+  }
+  
   log(`Connecting to ${connectionKey} (transport: ${serverConfig.transport_type || 'stdio'})...`);
   log(`Server config: ${JSON.stringify({ name: serverConfig.name, transport_type: serverConfig.transport_type, url: serverConfig.url, command: serverConfig.command })}`);
   
-  try {
-    const client = new Client({
-      name: 'touwaka-mate-mcp-client',
-      version: '1.0.0',
-    }, {
-      capabilities: {
-        tools: {},
-        resources: {},
-        prompts: {},
-      },
-    });
-    
-    log(`Client created for ${connectionKey}, creating transport...`);
-    const transport = await createTransport(serverConfig, credentials);
-    log(`Transport created for ${connectionKey}, connecting...`);
-    
-    await client.connect(transport);
-    log(`Client connected for ${connectionKey}`);
-    
-    connections.set(connectionKey, {
-      client,
-      transport,
-      config: serverConfig,
-      userId,
-      startedAt: new Date().toISOString(),
-    });
-    
-    await cacheTools(serverConfig.name, client);
-    log(`Tools cached for ${connectionKey}`);
-    
-    log(`Connected: ${connectionKey}`);
-    return client;
-  } catch (err) {
-    log(`connectServer ERROR for ${connectionKey}: ${err.message}`);
-    log(`connectServer ERROR stack: ${err.stack}`);
-    throw err;
-  }
+  const connectPromise = (async () => {
+    let client = null;
+    let transport = null;
+    let clientConnected = false;
+
+    try {
+      client = clientFactory();
+      
+      log(`Client created for ${connectionKey}, creating transport...`);
+      transport = await transportFactory(serverConfig, credentials);
+      log(`Transport created for ${connectionKey}, connecting...`);
+      
+      await client.connect(transport);
+      clientConnected = true;
+      log(`Client connected for ${connectionKey}`);
+
+      await cacheTools(connectionKey, client);
+      log(`Tools cached for ${connectionKey}`);
+      
+      connections.set(connectionKey, {
+        client,
+        transport,
+        config: serverConfig,
+        userId,
+        startedAt: new Date().toISOString(),
+      });
+      
+      log(`Connected: ${connectionKey}`);
+      return client;
+    } catch (err) {
+      connections.delete(connectionKey);
+      toolsCache.delete(connectionKey);
+
+      if (clientConnected && client && typeof client.close === 'function') {
+        try {
+          await client.close();
+        } catch (closeErr) {
+          log(`Error closing failed connection ${connectionKey}: ${closeErr.message}`);
+        }
+      }
+
+      log(`connectServer ERROR for ${connectionKey}: ${err.message}`);
+      log(`connectServer ERROR stack: ${err.stack}`);
+      throw err;
+    } finally {
+      pendingConnections.delete(connectionKey);
+    }
+  })();
+  
+  pendingConnections.set(connectionKey, connectPromise);
+  return connectPromise;
 }
 
 /**
@@ -342,6 +388,7 @@ async function disconnectServer(connectionKey) {
   }
   
   connections.delete(connectionKey);
+  toolsCache.delete(connectionKey);
   log(`Disconnected: ${connectionKey}`);
   
   return { message: `Disconnected from ${connectionKey}` };
@@ -354,21 +401,61 @@ async function disconnectServer(connectionKey) {
  * @param {string} serverName - MCP Server 名称
  * @param {Client} client - MCP Client
  */
-async function cacheTools(serverName, client) {
+async function cacheTools(cacheKey, client) {
   try {
-    // 使用新版 SDK API
     const result = await client.listTools();
     const tools = result.tools || [];
-    toolsCache.set(serverName, tools);
+    toolsCache.set(cacheKey, tools);
     
-    log(`Cached ${tools.length} tools for ${serverName}`);
+    log(`Cached ${tools.length} tools for ${cacheKey}`);
     
-    // 返回工具列表
-    return tools;
+    return { tools, success: true };
   } catch (err) {
-    log(`Failed to get tools from ${serverName}: ${err.message}`);
-    return [];
+    log(`Failed to get tools from ${cacheKey}: ${err.message}`);
+    throw err;
   }
+}
+
+function resolveEffectiveWorkingDirectory(userContext = {}) {
+  const dataBasePath = getDataBasePath();
+  const workingDirectory = userContext.workingDirectory || '';
+
+  if (workingDirectory && String(workingDirectory).trim() !== '') {
+    return path.isAbsolute(workingDirectory)
+      ? path.resolve(workingDirectory)
+      : path.resolve(path.join(dataBasePath, workingDirectory));
+  }
+
+  if (userContext.userId) {
+    return path.resolve(path.join(dataBasePath, 'work', String(userContext.userId), 'temp'));
+  }
+
+  return path.resolve(dataBasePath);
+}
+
+function resolveFilePathWithinWorkingDirectory(filePath, userContext = {}) {
+  if (!filePath || String(filePath).trim() === '') {
+    throw new Error('file_path is empty');
+  }
+
+  const baseDir = resolveEffectiveWorkingDirectory(userContext);
+  const normalizedInput = String(filePath).trim();
+  const absolutePath = path.isAbsolute(normalizedInput)
+    ? path.resolve(normalizedInput)
+    : path.resolve(baseDir, normalizedInput);
+
+  const isAllowed = absolutePath === baseDir || absolutePath.startsWith(baseDir + path.sep);
+  if (!isAllowed) {
+    throw new Error(
+      `Path not allowed in MCP file_path: ${absolutePath}\n` +
+      `Allowed paths: ${baseDir}`
+    );
+  }
+
+  return {
+    absolutePath,
+    baseDir,
+  };
 }
 
 /**
@@ -386,8 +473,9 @@ async function getUserTools(userId, configData) {
     
     // 公共 MCP：所有用户可用
     if (server.is_public) {
+      const cacheKey = server.name;
       // 确保公共连接已建立
-      if (!connections.has(server.name)) {
+      if (!connections.has(cacheKey)) {
         try {
           await connectServer(server);
         } catch (err) {
@@ -396,7 +484,7 @@ async function getUserTools(userId, configData) {
         }
       }
       
-      const tools = toolsCache.get(server.name) || [];
+      const tools = toolsCache.get(cacheKey) || [];
       for (const tool of tools) {
         allTools.push({
           name: `mcp_${server.name}_${tool.name}`,
@@ -425,7 +513,7 @@ async function getUserTools(userId, configData) {
           }
         }
         
-        const tools = toolsCache.get(server.name) || [];
+        const tools = toolsCache.get(connectionKey) || [];
         for (const tool of tools) {
           allTools.push({
             name: `mcp_${server.name}_${tool.name}`,
@@ -456,7 +544,7 @@ async function getUserTools(userId, configData) {
  * @param {object} configData - 配置数据
  * @returns {Promise<object>} 工具结果
  */
-async function callTool(serverName, toolName, args, userId, configData) {
+async function callTool(serverName, toolName, args, userId, configData, workingDirectory = '') {
   log(`callTool start: server=${serverName}, tool=${toolName}, userId=${userId || 'none'}`);
   
   let connectionKey = serverName;
@@ -515,21 +603,25 @@ async function callTool(serverName, toolName, args, userId, configData) {
   let processedArgs = args || {};
   if (args?.file_path && !args?.content) {
     const fs = await import('fs/promises');
-    const path = await import('path');
     
     const filePath = args.file_path;
     log(`Reading file from path: ${filePath}`);
     
     try {
-      const buffer = await fs.readFile(filePath);
+      const { absolutePath, baseDir } = resolveFilePathWithinWorkingDirectory(filePath, {
+        userId,
+        workingDirectory,
+      });
+      log(`Resolved file_path within allowed dir: baseDir=${baseDir}, absolutePath=${absolutePath}`);
+
+      const buffer = await fs.readFile(absolutePath);
       const base64 = buffer.toString('base64');
-      const mimeType = args.mime_type || 'application/octet-stream';
       
       log(`File read: ${buffer.length} bytes, base64 length: ${base64.length}`);
       
       processedArgs = {
         content: base64,
-        filename: args.name || path.basename(filePath),
+        filename: args.name || path.basename(absolutePath),
       };
     } catch (err) {
       throw new Error(`Failed to read file: ${err.message}`);
@@ -593,12 +685,13 @@ async function callTool(serverName, toolName, args, userId, configData) {
 async function processCommand(command, params, user) {
   const userId = user.userId || null;
   const accessToken = user.accessToken || null;
+  const workingDirectory = user.workingDirectory || '';
   
   switch (command) {
     case 'invoke':
       // invoke 是各种操作的包装器
       const action = params.action || 'list_tools';
-      return await processAction(action, params, userId, accessToken);
+      return await processAction(action, params, userId, accessToken, workingDirectory);
     
     case 'ping':
       return { 
@@ -609,14 +702,14 @@ async function processCommand(command, params, user) {
       };
     
     default:
-      return await processAction(command, params, userId, accessToken);
+      return await processAction(command, params, userId, accessToken, workingDirectory);
   }
 }
 
 /**
  * 处理具体操作
  */
-async function processAction(action, params, userId, accessToken) {
+async function processAction(action, params, userId, accessToken, workingDirectory = '') {
   // 不需要 fetchConfig 的 action
   if (action === 'shutdown') {
     for (const [key] of connections) {
@@ -640,24 +733,31 @@ async function processAction(action, params, userId, accessToken) {
         params.tool_name,
         params.arguments,
         userId,
-        configData
+        configData,
+        workingDirectory
       );
     
     case 'list_servers': {
       const servers = configData.servers || [];
       return {
-        servers: servers.map(s => ({
-          id: s.id,
-          name: s.name,
-          display_name: s.display_name,
-          description: s.description,
-          transport_type: s.transport_type || 'stdio',
-          is_public: s.is_public,
-          requires_credentials: s.requires_credentials,
-          is_enabled: s.is_enabled,
-          connected: connections.has(s.name) || (userId && connections.has(`${s.name}:${userId}`)),
-          tools_count: (toolsCache.get(s.name) || []).length,
-        })),
+        servers: servers.map(s => {
+          const publicConnKey = s.name;
+          const userConnKey = userId ? `${s.name}:${userId}` : s.name;
+          const isConnected = connections.has(publicConnKey) || connections.has(userConnKey);
+          const toolsCount = (toolsCache.get(publicConnKey) || toolsCache.get(userConnKey) || []).length;
+          return {
+            id: s.id,
+            name: s.name,
+            display_name: s.display_name,
+            description: s.description,
+            transport_type: s.transport_type || 'stdio',
+            is_public: s.is_public,
+            requires_credentials: s.requires_credentials,
+            is_enabled: s.is_enabled,
+            connected: isConnected,
+            tools_count: toolsCount,
+          };
+        }),
       };
     }
     
@@ -680,12 +780,22 @@ async function processAction(action, params, userId, accessToken) {
       if (!params.server_name) {
         // 刷新所有已有连接
         const allTools = [];
+        const refreshErrors = [];
         for (const [key, conn] of connections) {
-          const serverName = key.split(':')[0];
-          const tools = await cacheTools(serverName, conn.client);
-          allTools.push(...tools);
+          try {
+            const result = await cacheTools(key, conn.client);
+            allTools.push(...result.tools);
+          } catch (err) {
+            refreshErrors.push({ key, error: err.message });
+            log(`Refresh failed for ${key}: ${err.message}`);
+          }
         }
-        return { message: 'Tools cache refreshed', servers_refreshed: connections.size, tools: allTools };
+        return {
+          message: `Refreshed ${connections.size - refreshErrors.length}/${connections.size} connections`,
+          servers_refreshed: connections.size - refreshErrors.length,
+          tools: allTools,
+          refresh_errors: refreshErrors.length > 0 ? refreshErrors : undefined,
+        };
       }
       
       // 刷新指定 server
@@ -708,8 +818,8 @@ async function processAction(action, params, userId, accessToken) {
         return { message: `No connection for ${params.server_name}`, servers_refreshed: 0, tools: [] };
       }
       
-      const tools = await cacheTools(params.server_name, conn.client);
-      return { message: `Tools refreshed for ${params.server_name}`, servers_refreshed: 1, tools };
+      const result = await cacheTools(connectionKey, conn.client);
+      return { message: `Tools refreshed for ${params.server_name}`, servers_refreshed: 1, tools: result.tools };
     }
     
     case 'init': {
@@ -868,8 +978,57 @@ async function main() {
   log('Ready, waiting for commands on stdin');
 }
 
+export const __testing = {
+  resetState() {
+    connections.clear();
+    pendingConnections.clear();
+    toolsCache.clear();
+    clientFactory = defaultClientFactory;
+    transportFactory = createTransport;
+  },
+  setClientFactory(factory) {
+    clientFactory = factory;
+  },
+  setTransportFactory(factory) {
+    transportFactory = factory;
+  },
+  setConnection(key, value) {
+    connections.set(key, value);
+  },
+  setToolsCache(key, value) {
+    toolsCache.set(key, value);
+  },
+  resolveEffectiveWorkingDirectory,
+  resolveFilePathWithinWorkingDirectory,
+  getConnectionKeys() {
+    return Array.from(connections.keys());
+  },
+  getToolsCacheKeys() {
+    return Array.from(toolsCache.keys());
+  },
+  connectServer,
+  disconnectServer,
+  getUserTools,
+  cacheTools,
+  processAction,
+};
+
+function isMainModule() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  try {
+    return pathToFileURL(process.argv[1]).href === import.meta.url;
+  } catch {
+    return false;
+  }
+}
+
 // 启动
-main().catch(err => {
-  process.stderr.write(`Fatal error: ${err.message}\n`);
-  process.exit(1);
-});
+if (isMainModule()) {
+  main().catch(err => {
+    process.stderr.write(`Fatal error: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/lib/mcp-stateless-http.js
+++ b/lib/mcp-stateless-http.js
@@ -80,8 +80,7 @@ export class StatelessHTTPTransport {
         body,
         signal: controller.signal,
       });
-      
-      clearTimeout(timeoutId);
+
       transportLog(`Response status: ${response.status}`);
       transportLog(`Response content-type: ${response.headers.get('content-type')}`);
       
@@ -94,12 +93,14 @@ export class StatelessHTTPTransport {
       const contentType = response.headers.get('content-type') || '';
       
       if (response.status === 202) {
+        clearTimeout(timeoutId);
         transportLog(`Response 202 Accepted, no body`);
         return;
       }
       
       if (contentType.includes('application/json')) {
         const text = await response.text();
+        clearTimeout(timeoutId);
         transportLog(`Response JSON length: ${text.length}`);
         if (!text || text.trim() === '') {
           return;
@@ -109,8 +110,11 @@ export class StatelessHTTPTransport {
           this.onmessage(data);
         }
       } else if (contentType.includes('text/event-stream')) {
+        clearTimeout(timeoutId);
         transportLog(`Handling SSE stream`);
-        await this._handleSSE(response);
+        await this._handleSSE(response, controller);
+      } else {
+        clearTimeout(timeoutId);
       }
       
     } catch (error) {
@@ -128,14 +132,37 @@ export class StatelessHTTPTransport {
     }
   }
   
-  async _handleSSE(response) {
+  async _readSSEChunk(reader, controller) {
+    let timeoutId = null;
+
+    try {
+      return await Promise.race([
+        reader.read(),
+        new Promise((_, reject) => {
+          timeoutId = setTimeout(() => {
+            transportLog(`SSE read timeout after ${this._timeout}ms`);
+            if (controller && typeof controller.abort === 'function') {
+              controller.abort();
+            }
+            reject(new Error(`SSE read timeout after ${this._timeout}ms`));
+          }, this._timeout);
+        }),
+      ]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  async _handleSSE(response, controller) {
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
-    
+
     try {
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await this._readSSEChunk(reader, controller);
         if (done) break;
         
         buffer += decoder.decode(value, { stream: true });
@@ -160,9 +187,12 @@ export class StatelessHTTPTransport {
         }
       }
     } catch (error) {
-      if (this.onerror) {
-        this.onerror(error);
+      try {
+        await reader.cancel(error);
+      } catch {
+        // Ignore reader cancel errors during shutdown/abort.
       }
+      throw error;
     }
   }
 }

--- a/lib/resident-skill-manager.js
+++ b/lib/resident-skill-manager.js
@@ -241,6 +241,7 @@ class ResidentProcess {
           accessToken: userContext.accessToken || '',
           expertId: userContext.expertId || '',
           isAdmin: userContext.isAdmin || false,
+          workingDirectory: userContext.workingDirectory || '',
         },
       });
     });

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -792,13 +792,17 @@ class ToolManager {
 
       // 转换 MCP 工具为 OpenAI 格式
       const mcpTools = result.tools.map(tool => {
-        // MCP 工具名格式: mcp_{serverName}_{toolName}
-        const toolId = `mcp_${tool.serverName}_${tool.name}`;
+        // mcp-client list_tools 返回结构:
+        // { name: "mcp_{server}_{tool}", server_name, original_name, description, inputSchema, ... }
+        // name 已经是完整的工具 ID（如 mcp_github_search_repos）
+        const toolId = tool.name;
+        const serverName = tool.server_name;
+        const origName = tool.original_name;
         
         // 注册到 MCP 工具注册表
         this.mcpToolRegistry.set(toolId, {
-          serverName: tool.serverName,
-          toolName: tool.name,
+          serverName: serverName,
+          toolName: origName,
           description: tool.description,
           inputSchema: tool.inputSchema,
         });
@@ -807,13 +811,13 @@ class ToolManager {
           type: 'function',
           function: {
             name: toolId,
-            description: `[MCP/${tool.serverName}] ${tool.description}`,
+            description: `[MCP/${serverName}] ${tool.description}`,
             parameters: tool.inputSchema || { type: 'object', properties: {} },
           },
           _meta: {
             mcp: true,
-            serverName: tool.serverName,
-            toolName: tool.name,
+            serverName: serverName,
+            toolName: origName,
           },
         };
       });
@@ -1941,6 +1945,12 @@ class ToolManager {
     try {
       const startTime = Date.now();
       const userId = context.userId || context.user_id || '';
+      let workingDirectory = null;
+      if (context.taskContext?.fullWorkspacePath) {
+        workingDirectory = context.taskContext.fullWorkspacePath;
+      } else if (userId) {
+        workingDirectory = `work/${userId}/temp`;
+      }
 
       // 调用 MCP Client 驻留进程执行工具
       const result = await residentSkillManager.invokeByName(
@@ -1948,11 +1958,11 @@ class ToolManager {
         'invoke',
         {
           action: 'call_tool',
-          serverName,
-          toolName,
+          server_name: serverName,
+          tool_name: toolName,
           arguments: params,
         },
-        { userId },
+        { userId, workingDirectory },
         120000  // MCP 工具可能需要较长时间，设置 2 分钟超时
       );
 

--- a/server/routes/mcp.routes.js
+++ b/server/routes/mcp.routes.js
@@ -53,6 +53,26 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
   const requireAuth = authMiddleware.authenticate();
   const requireAdmin = authMiddleware.requireAdmin();
 
+  function validateTransportConfig(transportType, config = {}) {
+    const resolvedType = transportType || 'stdio';
+
+    if (resolvedType === 'stdio') {
+      if (!config.command) {
+        return 'STDIO 模式缺少必要字段：command';
+      }
+      return null;
+    }
+
+    if (['http', 'sse', 'statelessHttp', 'streamableHttp'].includes(resolvedType)) {
+      if (!config.url) {
+        return `${resolvedType} 模式缺少必要字段：url`;
+      }
+      return null;
+    }
+
+    return `不支持的 transport_type: ${resolvedType}`;
+  }
+
   // ============== MCP Server 管理 ==============
 
   /**
@@ -187,13 +207,9 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         return;
       }
 
-      // 先清除该 server 的旧工具缓存
-      await MCPToolsCache.destroy({
-        where: { mcp_server_id: id },
-      });
-
       // 尝试通过驻留进程刷新
       let refreshedTools = [];
+      let refreshSucceeded = false;
       try {
         const result = await residentSkillManager.invokeByName(
           'mcp-client',
@@ -209,20 +225,26 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
           30000
         );
         refreshedTools = result?.tools || [];
+        refreshSucceeded = true;
       } catch (err) {
-        logger.warn(`Refresh tools via resident process failed: ${err.message}, returning empty list`);
+        logger.warn(`Refresh tools via resident process failed: ${err.message}, keeping existing cache`);
       }
 
-      // 写入缓存
-      for (const tool of refreshedTools) {
-        await MCPToolsCache.create({
-          id: Utils.newID(16),
-          mcp_server_id: id,
-          tool_name: tool.name,
-          description: tool.description || '',
-          input_schema: tool.inputSchema ? JSON.stringify(tool.inputSchema) : null,
-          cached_at: new Date(),
+      // 只在刷新成功时替换缓存
+      if (refreshSucceeded) {
+        await MCPToolsCache.destroy({
+          where: { mcp_server_id: id },
         });
+        for (const tool of refreshedTools) {
+          await MCPToolsCache.create({
+            id: Utils.newID(16),
+            mcp_server_id: id,
+            tool_name: tool.name,
+            description: tool.description || '',
+            input_schema: tool.inputSchema ? JSON.stringify(tool.inputSchema) : null,
+            cached_at: new Date(),
+          });
+        }
       }
 
       const tools = await MCPToolsCache.findAll({
@@ -232,9 +254,10 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
 
       ctx.success({
         tools,
-        message: refreshedTools.length > 0
+        refresh_succeeded: refreshSucceeded,
+        message: refreshSucceeded
           ? `已刷新 ${refreshedTools.length} 个工具`
-          : '驻留进程未就绪，工具列表已清空。请启动 mcp-client 驻留进程后重试。',
+          : '刷新失败，保留已有工具缓存。请检查 mcp-client 驻留进程状态。',
       });
 
     } catch (error) {
@@ -273,17 +296,14 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         return;
       }
 
-      // 根据传输类型验证对应字段
-      if (transport_type === 'stdio') {
-        if (!command) {
-          ctx.error('STDIO 模式缺少必要字段：command');
-          return;
-        }
-      } else if (transport_type === 'http') {
-        if (!url) {
-          ctx.error('HTTP 模式缺少必要字段：url');
-          return;
-        }
+      const validationError = validateTransportConfig(transport_type, {
+        command,
+        url,
+      });
+      if (validationError) {
+        ctx.status = 400;
+        ctx.error(validationError);
+        return;
       }
 
       // 检查名称是否已存在
@@ -347,6 +367,21 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
       if (!server) {
         ctx.status = 404;
         ctx.error('MCP Server 不存在');
+        return;
+      }
+
+      const nextTransportType = updateData.transport_type !== undefined
+        ? updateData.transport_type
+        : server.transport_type;
+      const nextCommand = updateData.command !== undefined ? updateData.command : server.command;
+      const nextUrl = updateData.url !== undefined ? updateData.url : server.url;
+      const validationError = validateTransportConfig(nextTransportType, {
+        command: nextCommand,
+        url: nextUrl,
+      });
+      if (validationError) {
+        ctx.status = 400;
+        ctx.error(validationError);
         return;
       }
 

--- a/tests/mcp-reliability.test.js
+++ b/tests/mcp-reliability.test.js
@@ -1,0 +1,284 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import ToolManager from '../lib/tool-manager.js';
+import StatelessHTTPTransport from '../lib/mcp-stateless-http.js';
+import { __testing as mcpClientTesting } from '../data/skills/mcp-client/index.js';
+
+function createToolManager() {
+  return {
+    mcpToolRegistry: new Map(),
+    getMcpToolDefinitions: ToolManager.prototype.getMcpToolDefinitions,
+    getToolInfo: ToolManager.prototype.getToolInfo,
+    executeMcpTool: ToolManager.prototype.executeMcpTool,
+  };
+}
+
+test('ToolManager maps MCP tool definitions using resident payload contract', async () => {
+  const originalResidentSkillManager = global.residentSkillManager;
+  global.residentSkillManager = {
+    async invokeByName() {
+      return {
+        tools: [
+          {
+            name: 'mcp_github_search_repositories',
+            server_name: 'github',
+            original_name: 'search_repositories',
+            description: 'Search repositories',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                query: { type: 'string' },
+              },
+            },
+          },
+        ],
+      };
+    },
+  };
+
+  try {
+    const toolManager = createToolManager();
+    const definitions = await toolManager.getMcpToolDefinitions({ userId: 'user-1' });
+
+    assert.equal(definitions.length, 1);
+    assert.equal(definitions[0].function.name, 'mcp_github_search_repositories');
+    assert.equal(definitions[0].function.description, '[MCP/github] Search repositories');
+
+    const info = toolManager.getToolInfo('mcp_github_search_repositories');
+    assert.equal(info.serverName, 'github');
+    assert.equal(info.toolName, 'search_repositories');
+  } finally {
+    global.residentSkillManager = originalResidentSkillManager;
+  }
+});
+
+test('ToolManager sends snake_case params when invoking MCP tools', async () => {
+  const originalResidentSkillManager = global.residentSkillManager;
+  let capturedPayload = null;
+
+  global.residentSkillManager = {
+    async invokeByName(skillName, toolName, payload, userContext) {
+      capturedPayload = { skillName, toolName, payload, userContext };
+      return { ok: true };
+    },
+  };
+
+  try {
+    const toolManager = createToolManager();
+    toolManager.mcpToolRegistry.set('mcp_alpha_echo', {
+      serverName: 'alpha',
+      toolName: 'echo',
+    });
+
+    const result = await toolManager.executeMcpTool(
+      'mcp_alpha_echo',
+      { text: 'hello' },
+      { userId: 'user-1', taskContext: { fullWorkspacePath: 'work/user-1/task-1' } },
+      'MCP/alpha/echo'
+    );
+
+    assert.equal(result.success, true);
+    assert.deepEqual(capturedPayload, {
+      skillName: 'mcp-client',
+      toolName: 'invoke',
+      payload: {
+        action: 'call_tool',
+        server_name: 'alpha',
+        tool_name: 'echo',
+        arguments: { text: 'hello' },
+      },
+      userContext: {
+        userId: 'user-1',
+        workingDirectory: 'work/user-1/task-1',
+      },
+    });
+  } finally {
+    global.residentSkillManager = originalResidentSkillManager;
+  }
+});
+
+test('connectServer rolls back state when tool caching fails after connect', async () => {
+  mcpClientTesting.resetState();
+
+  let closeCount = 0;
+  mcpClientTesting.setClientFactory(() => ({
+    async connect() {
+      return undefined;
+    },
+    async listTools() {
+      throw new Error('listTools failed');
+    },
+    async close() {
+      closeCount += 1;
+    },
+  }));
+  mcpClientTesting.setTransportFactory(async () => ({ kind: 'fake-transport' }));
+
+  await assert.rejects(
+    () => mcpClientTesting.connectServer({ name: 'alpha', transport_type: 'http', url: 'http://example.test/mcp' }),
+    /listTools failed/
+  );
+
+  assert.deepEqual(mcpClientTesting.getConnectionKeys(), []);
+  assert.deepEqual(mcpClientTesting.getToolsCacheKeys(), []);
+  assert.equal(closeCount, 1);
+
+  mcpClientTesting.resetState();
+});
+
+test('getUserTools reads private tool cache using connectionKey isolation', async () => {
+  mcpClientTesting.resetState();
+
+  mcpClientTesting.setConnection('alpha:user-1', { client: {} });
+  mcpClientTesting.setToolsCache('alpha:user-1', [
+    {
+      name: 'private_tool',
+      description: 'Private tool',
+      inputSchema: { type: 'object', properties: {} },
+    },
+  ]);
+
+  const tools = await mcpClientTesting.getUserTools('user-1', {
+    servers: [
+      {
+        id: 'server-1',
+        name: 'alpha',
+        is_enabled: true,
+        is_public: false,
+        requires_credentials: true,
+      },
+    ],
+    user_credentials: [
+      {
+        mcp_server_id: 'server-1',
+        is_enabled: true,
+        credentials: { token: 'secret' },
+      },
+    ],
+    default_credentials: [],
+  });
+
+  assert.deepEqual(tools.map(tool => tool.name), ['mcp_alpha_private_tool']);
+
+  mcpClientTesting.resetState();
+});
+
+test('StatelessHTTPTransport times out stalled SSE reads', async () => {
+  const transport = new StatelessHTTPTransport(new URL('http://example.test/mcp'), {
+    timeout: 20,
+  });
+
+  let aborted = 0;
+  const controller = {
+    abort() {
+      aborted += 1;
+    },
+  };
+
+  const response = {
+    body: {
+      getReader() {
+        return {
+          read() {
+            return new Promise(() => {});
+          },
+          async cancel() {
+            return undefined;
+          },
+        };
+      },
+    },
+  };
+
+  await assert.rejects(
+    () => transport._handleSSE(response, controller),
+    /SSE read timeout after 20ms/
+  );
+  assert.equal(aborted, 1);
+});
+
+test('MCP file_path resolves relative paths inside working directory', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-file-path-'));
+  const originalDataBasePath = process.env.DATA_BASE_PATH;
+
+  try {
+    process.env.DATA_BASE_PATH = tempRoot;
+    const workDir = path.join(tempRoot, 'work', 'user-1', 'task-1');
+    await fs.mkdir(workDir, { recursive: true });
+    const nestedFile = path.join(workDir, 'docs', 'report.txt');
+    await fs.mkdir(path.dirname(nestedFile), { recursive: true });
+    await fs.writeFile(nestedFile, 'hello world', 'utf8');
+
+    const result = mcpClientTesting.resolveFilePathWithinWorkingDirectory('docs/report.txt', {
+      userId: 'user-1',
+      workingDirectory: 'work/user-1/task-1',
+    });
+
+    assert.equal(result.baseDir, path.resolve(workDir));
+    assert.equal(result.absolutePath, path.resolve(nestedFile));
+  } finally {
+    if (originalDataBasePath === undefined) {
+      delete process.env.DATA_BASE_PATH;
+    } else {
+      process.env.DATA_BASE_PATH = originalDataBasePath;
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('MCP file_path rejects paths escaping working directory', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-file-path-'));
+  const originalDataBasePath = process.env.DATA_BASE_PATH;
+
+  try {
+    process.env.DATA_BASE_PATH = tempRoot;
+    const workDir = path.join(tempRoot, 'work', 'user-1', 'task-1');
+    await fs.mkdir(workDir, { recursive: true });
+
+    assert.throws(
+      () => mcpClientTesting.resolveFilePathWithinWorkingDirectory('../secret.txt', {
+        userId: 'user-1',
+        workingDirectory: 'work/user-1/task-1',
+      }),
+      /Path not allowed in MCP file_path/
+    );
+  } finally {
+    if (originalDataBasePath === undefined) {
+      delete process.env.DATA_BASE_PATH;
+    } else {
+      process.env.DATA_BASE_PATH = originalDataBasePath;
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('MCP file_path without working directory falls back to user temp workspace', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-file-path-'));
+  const originalDataBasePath = process.env.DATA_BASE_PATH;
+
+  try {
+    process.env.DATA_BASE_PATH = tempRoot;
+    const userTempDir = path.join(tempRoot, 'work', 'user-1', 'temp');
+    await fs.mkdir(userTempDir, { recursive: true });
+    const allowedFile = path.join(userTempDir, 'note.txt');
+    await fs.writeFile(allowedFile, 'ok', 'utf8');
+
+    const result = mcpClientTesting.resolveFilePathWithinWorkingDirectory('note.txt', {
+      userId: 'user-1',
+    });
+
+    assert.equal(result.baseDir, path.resolve(userTempDir));
+    assert.equal(result.absolutePath, path.resolve(allowedFile));
+  } finally {
+    if (originalDataBasePath === undefined) {
+      delete process.env.DATA_BASE_PATH;
+    } else {
+      process.env.DATA_BASE_PATH = originalDataBasePath;
+    }
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/test-markitdown.js
+++ b/tests/test-markitdown.js
@@ -1,9 +1,9 @@
 import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 
-const MCP_URL = 'https://ocr1.g.erik.top/mcp';
-const MCP_TOKEN = 'Bearer sk-a9Fbq0tS65VQhG0AA296F9E2F9Ab4975A41f5aEdF97d571a';
-const PDF_PATH = resolve('D:\\tmp\\奇瑞质量协议签章版.pdf');
+const MCP_URL = process.env.MCP_TEST_URL || 'http://localhost:3000/mcp';
+const MCP_TOKEN = process.env.MCP_TEST_TOKEN || 'test-token-placeholder';
+const PDF_PATH = process.env.MCP_TEST_PDF_PATH || resolve('test-assets/sample.pdf');
 
 console.log('=== markitdown MCP 诊断测试 ===\n');
 
@@ -11,7 +11,7 @@ async function postMCP(message) {
   const res = await fetch(MCP_URL, {
     method: 'POST',
     headers: {
-      'Authorization': MCP_TOKEN,
+      'Authorization': `Bearer ${MCP_TOKEN}`,
       'Content-Type': 'application/json',
       'Accept': 'application/json, text/event-stream',
     },
@@ -67,7 +67,7 @@ async function run() {
   try {
     const getRes = await fetch(MCP_URL, {
       method: 'GET',
-      headers: { 'Authorization': MCP_TOKEN },
+      headers: { 'Authorization': `Bearer ${MCP_TOKEN}` },
     });
     console.log(`  HTTP ${getRes.status} ${getRes.statusText}`);
     const getBody = await getRes.text();

--- a/tests/test-mcp-http-direct.js
+++ b/tests/test-mcp-http-direct.js
@@ -5,10 +5,11 @@
  * 使用场景：验证 MCP Server 是否可正常连接
  */
 
+import http from 'http';
 import https from 'https';
 
-const MCP_URL = 'https://markitdown.g.erik.top/mcp/';
-const MCP_TOKEN = 'Bearer sk-a9Fbq0tS65VQhG0AA296F9E2F9Ab4975A41f5aEdF97d571a';
+const MCP_URL = process.env.MCP_TEST_URL || 'http://localhost:3000/mcp/';
+const MCP_TOKEN = process.env.MCP_TEST_TOKEN || 'test-token-placeholder';
 
 async function testMcpConnection() {
   console.log('=== MCP HTTP Direct Connection Test ===\n');
@@ -62,13 +63,15 @@ function sendRequest(body) {
   return new Promise((resolve, reject) => {
     const postData = JSON.stringify(body);
     
+    const urlObj = new URL(MCP_URL);
+    const requestModule = urlObj.protocol === 'https:' ? https : http;
     const options = {
-      hostname: 'markitdown.g.erik.top',
-      port: 443,
-      path: '/mcp/',
+      hostname: urlObj.hostname,
+      port: urlObj.port || (urlObj.protocol === 'https:' ? 443 : 80),
+      path: urlObj.pathname + urlObj.search,
       method: 'POST',
       headers: {
-        'Authorization': MCP_TOKEN,
+        'Authorization': `Bearer ${MCP_TOKEN}`,
         'Content-Type': 'application/json',
         'Accept': 'application/json, text/event-stream',
         'Content-Length': Buffer.byteLength(postData)
@@ -76,7 +79,7 @@ function sendRequest(body) {
       timeout: 10000
     };
     
-    const req = https.request(options, (res) => {
+    const req = requestModule.request(options, (res) => {
       console.log('Status:', res.statusCode);
       console.log('Content-Type:', res.headers['content-type']);
       console.log('mcp-session-id:', res.headers['mcp-session-id'] || 'none');

--- a/tests/test-mcp-stateless.js
+++ b/tests/test-mcp-stateless.js
@@ -11,8 +11,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import StatelessHTTPTransport from '../lib/mcp-stateless-http.js';
 
-const MCP_URL = 'https://markitdown.g.erik.top/mcp/';
-const MCP_TOKEN = 'Bearer sk-a9Fbq0tS65VQhG0AA296F9E2F9Ab4975A41f5aEdF97d571a';
+const MCP_URL = process.env.MCP_TEST_URL || 'http://localhost:3000/mcp/';
+const MCP_TOKEN = process.env.MCP_TEST_TOKEN || 'test-token-placeholder';
 
 console.log('=== StatelessHTTP MCP Connection Test ===\n');
 console.log('URL:', MCP_URL);
@@ -20,7 +20,7 @@ console.log('URL:', MCP_URL);
 async function testConnection() {
   // 创建 Transport
   const headers = {
-    'Authorization': MCP_TOKEN,
+    'Authorization': `Bearer ${MCP_TOKEN}`,
     'Content-Type': 'application/json',
     'Accept': 'application/json, text/event-stream',
   };


### PR DESCRIPTION
## Summary
- harden MCP transport handling by fixing tool contract mismatches, refresh safety, SSE timeout behavior, and connection rollback
- align MCP file path access with the existing skill workspace boundary model and pass working directory through the resident call chain
- add MCP reliability regression coverage and update local diagnostic scripts for token and protocol handling