### PR TITLE
fix: 普通用户 branding 初始化链路

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,16 +7,20 @@
 import { onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 import { useUserStore } from '@/stores/user'
+import { useSystemSettingsStore } from '@/stores/systemSettings'
 import { useI18n } from 'vue-i18n'
 import Toast from '@/components/common/Toast.vue'
 
 const userStore = useUserStore()
+const systemSettingsStore = useSystemSettingsStore()
 const { locale } = useI18n()
 
 onMounted(() => {
   // 初始化语言设置
   // 注意：用户状态由路由守卫处理，避免重复加载
   const init = async () => {
+    await systemSettingsStore.loadBranding()
+
     // 如果用户已登录且已加载偏好设置，应用语言设置
     if (userStore.isLoggedIn && userStore.preferences?.language) {
       locale.value = userStore.preferences.language

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -182,6 +182,10 @@ router.beforeEach(async (to, from) => {
   }
 
   const systemSettingsStore = useSystemSettingsStore()
+  if (!systemSettingsStore.brandingLoaded) {
+    await systemSettingsStore.loadBranding()
+  }
+
   const appName = systemSettingsStore.brandingSettings?.app_name || 'Touwaka Mate'
   document.title = to.meta.title ? `${to.meta.title} - ${appName}` : appName
   document.documentElement.setAttribute('lang', getLocale())

--- a/frontend/src/stores/systemSettings.ts
+++ b/frontend/src/stores/systemSettings.ts
@@ -65,6 +65,8 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   const settings = ref<SystemSettings | null>(null)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
+  const brandingLoaded = ref(false)
+  let brandingPromise: Promise<BrandingSettings> | null = null
 
   // 默认配置（用于初始化）
   const defaultSettings: SystemSettings = {
@@ -182,18 +184,40 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   }
 
   const loadBranding = async (): Promise<BrandingSettings> => {
-    try {
-      const response = await apiClient.get('/branding')
-      const data = response.data.data
-      if (settings.value) {
-        settings.value.branding = data
-      } else {
-        settings.value = { ...defaultSettings, branding: data } as SystemSettings
-      }
-      return data
-    } catch {
-      return { app_name: 'Touwaka Mate', logo_icon: '🤖' }
+    if (brandingLoaded.value && settings.value?.branding) {
+      return settings.value.branding
     }
+
+    if (brandingPromise) {
+      return brandingPromise
+    }
+
+    brandingPromise = (async () => {
+      try {
+        const response = await apiClient.get('/branding')
+        const data = response.data.data
+        if (settings.value) {
+          settings.value.branding = data
+        } else {
+          settings.value = { ...defaultSettings, branding: data } as SystemSettings
+        }
+        brandingLoaded.value = true
+        return data
+      } catch {
+        const fallback = { ...defaultSettings.branding }
+        if (settings.value) {
+          settings.value.branding = fallback
+        } else {
+          settings.value = { ...defaultSettings, branding: fallback }
+        }
+        brandingLoaded.value = true
+        return fallback
+      } finally {
+        brandingPromise = null
+      }
+    })()
+
+    return brandingPromise
   }
 
   return {
@@ -208,6 +232,7 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
     toolSettings,
     registrationSettings,
     brandingSettings,
+    brandingLoaded,
     loadSettings,
     updateSettings,
     resetSettings,


### PR DESCRIPTION
Closes #793

## Summary
- 在应用启动与路由切换阶段统一加载 branding，修复普通用户仍显示默认 title 和 logo 的问题
- 为 branding 加载增加前端请求去重与状态标记，避免重复请求
- 保持改动范围收敛在前端 branding 初始化链路