### PR TITLE
fix: reduce frontend build memory pressure

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "run-p type-check \"build-only {@}\" --",
+    "build": "run-s type-check build-only",
     "preview": "vite preview",
-    "build-only": "vite build",
+    "build-only": "node --max-old-space-size=4096 ./node_modules/vite/bin/vite.js build",
     "type-check": "vue-tsc --build",
     "lint": "run-s lint:*",
     "lint:oxlint": "oxlint . --fix",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,10 +8,10 @@ import Components from 'unplugin-vue-components/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [
     vue(),
-    vueDevTools(),
+    ...(command === 'serve' ? [vueDevTools()] : []),
     AutoImport({
       resolvers: [ElementPlusResolver()],
     }),
@@ -64,7 +64,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    sourcemap: true,
+    sourcemap: false,
     rollupOptions: {
       output: {
         manualChunks: {
@@ -76,4 +76,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
## Summary
- reduce frontend build memory pressure by running type check and Vite build sequentially instead of in parallel
- increase the dedicated Node heap for `npm run build-only` and keep Vue devtools out of production builds
- disable production sourcemaps to lower memory usage during low-memory VPS deployments