### PR TITLE
fix: split runtime skill path handling

### DIFF
--- a/data/skills/mcp-client/index.js
+++ b/data/skills/mcp-client/index.js
@@ -21,7 +21,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import path from 'path';
 import { pathToFileURL } from 'url';
 import StatelessHTTPTransport from '../../../lib/mcp-stateless-http.js';
-import { getDataBasePath } from '../../../lib/paths.js';
+import { getDataBasePath, getWorkspaceRoot } from '../../../lib/paths.js';
 
 // ============== 全局状态 ==============
 
@@ -427,7 +427,7 @@ function resolveEffectiveWorkingDirectory(userContext = {}) {
   }
 
   if (userContext.userId) {
-    return path.resolve(path.join(dataBasePath, 'work', String(userContext.userId), 'temp'));
+    return path.resolve(path.join(getWorkspaceRoot(), String(userContext.userId), 'temp'));
   }
 
   return path.resolve(dataBasePath);

--- a/data/skills/pdf/index.js
+++ b/data/skills/pdf/index.js
@@ -593,10 +593,11 @@ async function loadCJKFont(pdfDoc) {
   pdfDoc.registerFontkit(fontkitModule);
   
   const fontPaths = [
+    process.env.FONTS_BASE_PATH ? path.join(process.env.FONTS_BASE_PATH, 'simhei.ttf') : null,
     path.join(process.env.SKILL_PATH || '', '..', '..', 'fonts', 'simhei.ttf'),
     path.join(process.cwd(), '..', 'fonts', 'simhei.ttf'),
     'data/fonts/simhei.ttf',
-  ];
+  ].filter(Boolean);
   
   for (const fontPath of fontPaths) {
     try {

--- a/lib/firejail-executor.js
+++ b/lib/firejail-executor.js
@@ -9,7 +9,7 @@ import { spawn, exec } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import logger from './logger.js';
-import { getDataBasePath } from './paths.js';
+import { getWorkspaceRoot } from './paths.js';
 
 // 项目根目录
 const PROJECT_ROOT = path.resolve(process.cwd());
@@ -237,8 +237,7 @@ class FirejailExecutor {
    * @returns {string} 工作目录路径
    */
   getUserWorkDir(userId) {
-    const dataBasePath = getDataBasePath();
-    return path.join(dataBasePath, 'work', userId);
+    return path.join(getWorkspaceRoot(), userId);
   }
 
   /**

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -6,21 +6,24 @@
 
 import path from 'path';
 
+function resolvePathValue(envPath, fallbackSegments = []) {
+  if (envPath) {
+    return path.isAbsolute(envPath) ? envPath : path.join(process.cwd(), envPath);
+  }
+  return path.join(process.cwd(), ...fallbackSegments);
+}
+
 /**
  * 获取数据基础路径
  * 严格从环境变量读取，未设置时报错
  */
 export function getDataBasePath() {
-  const envPath = process.env.DATA_BASE_PATH;
-  if (!envPath) {
-    throw new Error('DATA_BASE_PATH environment variable is not set');
-  }
-  return path.isAbsolute(envPath) ? envPath : path.join(process.cwd(), envPath);
+  return resolvePathValue(process.env.DATA_BASE_PATH, ['data']);
 }
 
 /**
  * 获取工作空间根目录
- * 基于 DATA_BASE_PATH 派生
+ * 默认使用 DATA_BASE_PATH/work
  */
 export function getWorkspaceRoot() {
   return path.join(getDataBasePath(), 'work');
@@ -28,9 +31,18 @@ export function getWorkspaceRoot() {
 
 /**
  * 获取技能目录路径
+ * 优先使用 SKILLS_BASE_PATH，默认回退到 data/skills
  */
 export function getSkillsPath() {
-  return path.join(getDataBasePath(), 'skills');
+  return resolvePathValue(process.env.SKILLS_BASE_PATH, ['data', 'skills']);
+}
+
+/**
+ * 获取字体目录路径
+ * 优先使用 FONTS_BASE_PATH，默认回退到 data/fonts
+ */
+export function getFontsPath() {
+  return resolvePathValue(process.env.FONTS_BASE_PATH, ['data', 'fonts']);
 }
 
 /**
@@ -57,7 +69,19 @@ export function getSkillPath(sourcePath) {
   if (!sourcePath) {
     return null;
   }
-  return path.isAbsolute(sourcePath) 
-    ? sourcePath 
-    : path.join(getDataBasePath(), sourcePath);
+
+  if (path.isAbsolute(sourcePath)) {
+    return sourcePath;
+  }
+
+  const normalizedPath = sourcePath.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (normalizedPath.startsWith('skills/')) {
+    return path.join(getSkillsPath(), normalizedPath.slice('skills/'.length));
+  }
+
+  if (normalizedPath.startsWith('data/skills/')) {
+    return path.join(getSkillsPath(), normalizedPath.slice('data/skills/'.length));
+  }
+
+  return path.join(getSkillsPath(), normalizedPath);
 }

--- a/lib/resident-skill-manager.js
+++ b/lib/resident-skill-manager.js
@@ -13,7 +13,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from './logger.js';
-import { getDataBasePath } from './paths.js';
+import { getSkillPath } from './paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -100,8 +100,8 @@ class ResidentProcess {
 
     const skillPath = this.skill.source_path;
     const scriptPath = this.tool.script_path || 'index.js';
-    const dataBasePath = getDataBasePath();
-    const fullPath = path.join(dataBasePath, skillPath, scriptPath);
+    const resolvedSkillPath = getSkillPath(skillPath);
+    const fullPath = path.join(resolvedSkillPath, scriptPath);
 
     logger.info(`Starting resident process: ${this.tool.name} from ${fullPath}`);
 

--- a/lib/sandboxie-executor.js
+++ b/lib/sandboxie-executor.js
@@ -9,7 +9,7 @@ import { spawn, exec } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import logger from './logger.js';
-import { getDataBasePath } from './paths.js';
+import { getWorkspaceRoot } from './paths.js';
 
 // 项目根目录
 const PROJECT_ROOT = path.resolve(process.cwd());
@@ -306,8 +306,7 @@ Enabled=y
    * @returns {string} 工作目录路径
    */
   getUserWorkDir(userId) {
-    const dataBasePath = getDataBasePath();
-    return path.join(dataBasePath, 'work', userId);
+    return path.join(getWorkspaceRoot(), userId);
   }
 
   /**

--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -22,7 +22,7 @@ import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
 import logger from './logger.js';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
-import { getDataBasePath } from './paths.js';
+import { getDataBasePath, getSkillsPath, getSkillPath, getWorkspaceRoot, getFontsPath } from './paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -42,9 +42,8 @@ class SkillLoader {
    */
   constructor(db, options = {}) {
     this.db = db;
-    // 默认使用 DATA_BASE_PATH/skills 目录
-    const dataBasePath = getDataBasePath();
-    this.skillsBasePath = options.skillsBasePath || path.join(dataBasePath, 'skills');
+    // 默认使用独立的 skills 目录配置
+    this.skillsBasePath = options.skillsBasePath || getSkillsPath();
 
     // 技能缓存
     this.skillCache = new Map();
@@ -516,6 +515,8 @@ class SkillLoader {
       ...systemEnv,
       SKILL_ID: SkillLoader.USER_CODE_SKILL_ID,
       DATA_BASE_PATH: dataBasePath,
+      SKILLS_BASE_PATH: getSkillsPath(),
+      FONTS_BASE_PATH: getFontsPath(),
       USER_ID: String(userContext.userId || ''),
       EXPERT_ID: String(userContext.expertId || ''),
       IS_ADMIN: userContext.isAdmin ? 'true' : 'false',
@@ -759,7 +760,7 @@ class SkillLoader {
     // 最小化系统环境变量白名单（仅保留必要的）
     // 注意：移除 INTERNAL_API_SECRET，技能应使用用户 Token 认证
     // 注意：API_BASE 在下面单独设置，不需要从系统环境变量继承
-    const allowedSystemVars = ['PATH', 'NODE_ENV', 'HOME', 'TMPDIR', 'LANG', 'TZ', 'DATA_BASE_PATH'];
+    const allowedSystemVars = ['PATH', 'NODE_ENV', 'HOME', 'TMPDIR', 'LANG', 'TZ', 'DATA_BASE_PATH', 'SKILLS_BASE_PATH', 'FONTS_BASE_PATH'];
     const systemEnv = Object.fromEntries(
       allowedSystemVars
         .filter(key => process.env[key])
@@ -768,7 +769,7 @@ class SkillLoader {
 
     // 系统保留的环境变量名（不可被用户参数覆盖）
     const RESERVED_ENV_VARS = [
-      'SKILL_ID', 'DATA_BASE_PATH', 'SKILL_CONFIG', 'NODE_OPTIONS', 'SCRIPT_PATH',
+      'SKILL_ID', 'DATA_BASE_PATH', 'SKILLS_BASE_PATH', 'FONTS_BASE_PATH', 'SKILL_CONFIG', 'NODE_OPTIONS', 'SCRIPT_PATH',
       'USER_ACCESS_TOKEN', 'USER_ID', 'EXPERT_ID', 'API_BASE', 'WORKING_DIRECTORY',  // 安全关键参数
       'ALLOWED_NODE_MODULES', 'ALLOWED_PYTHON_PACKAGES',  // 包白名单
       'VM_TIMEOUT', 'PYTHON_TIMEOUT',  // 超时配置
@@ -796,9 +797,7 @@ class SkillLoader {
       throw new Error(`Skill ${skillId} has no source_path configured`);
     }
     
-    const skillPath = path.isAbsolute(sourcePath)
-      ? sourcePath
-      : path.join(dataBasePath, sourcePath);
+    const skillPath = getSkillPath(sourcePath);
 
     // 确定工作目录（用于 Python 子进程的 cwd）
     // - 有任务时：完整路径（由 tool-manager 传入）
@@ -825,7 +824,9 @@ class SkillLoader {
       SKILL_ID: skillId,          // 2. 当前技能ID
       SKILL_PATH: skillPath,      // 3. 技能目录路径（解决 source_path 不匹配问题）
       SCRIPT_PATH: scriptPath,    // 4. 工具入口脚本路径（相对于技能目录）
-      DATA_BASE_PATH: dataBasePath,  // 5. 数据基础路径（技能目录为 DATA_BASE_PATH/skills）
+      DATA_BASE_PATH: dataBasePath,  // 5. 数据基础路径（默认 data 目录根）
+      SKILLS_BASE_PATH: getSkillsPath(),
+      FONTS_BASE_PATH: getFontsPath(),
       SKILL_CONFIG: JSON.stringify(config),  // 6. 完整配置JSON
       // 用户认证信息（用于 API 调用）
       USER_ACCESS_TOKEN: userContext.accessToken || '',  // 7. 用户 JWT Token

--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -38,6 +38,34 @@ const __dirname = path.dirname(__filename);
 // 缓存检测到的 Python 命令
 let cachedPythonCmd = null;
 
+function resolveEnvPath(envValue, fallbackSegments = []) {
+  if (envValue) {
+    return path.isAbsolute(envValue) ? envValue : path.join(process.cwd(), envValue);
+  }
+  return path.join(process.cwd(), ...fallbackSegments);
+}
+
+function getEffectiveDataBasePath() {
+  return resolveEnvPath(process.env.DATA_BASE_PATH, ['data']);
+}
+
+function resolveWorkingDirectoryPath(workingDirectory, userId = process.env.USER_ID || '') {
+  const dataBasePath = getEffectiveDataBasePath();
+  const workspaceRoot = path.join(dataBasePath, 'work');
+
+  if (workingDirectory && workingDirectory.trim() !== '') {
+    return path.isAbsolute(workingDirectory)
+      ? path.resolve(workingDirectory)
+      : path.resolve(path.join(dataBasePath, workingDirectory));
+  }
+
+  if (userId) {
+    return path.resolve(path.join(workspaceRoot, userId, 'temp'));
+  }
+
+  return path.resolve(dataBasePath);
+}
+
 /**
  * 检测系统上可用的 Python 命令
  * 优先级: PYTHON_PATH 环境变量 > python3 > python
@@ -476,22 +504,24 @@ function executeSkill(code, skillId) {
   const userId = process.env.USER_ID || 'default';
   
   // 确定工作目录（用于 process.cwd()）
-  // 优先使用 WORKING_DIRECTORY，否则回退到 DATA_BASE_PATH
+  // 优先使用 WORKING_DIRECTORY，否则回退到 DATA_BASE_PATH/work / DATA_BASE_PATH
   const workingDirectory = process.env.WORKING_DIRECTORY;
-  const dataBasePath = process.env.DATA_BASE_PATH;
-  if (!dataBasePath) {
-    throw new Error('DATA_BASE_PATH environment variable is not set');
-  }
+  const dataBasePath = getEffectiveDataBasePath();
+  const workspaceRoot = path.join(dataBasePath, 'work');
   
   // 确定工作目录
   // 优先使用 WORKING_DIRECTORY，如果为空则尝试构建默认工作目录
   let effectiveCwd;
   let cwdRule;
   if (workingDirectory && workingDirectory.trim() !== '') {
-    effectiveCwd = path.join(dataBasePath, workingDirectory);
-    cwdRule = `规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)`;
+    effectiveCwd = path.isAbsolute(workingDirectory)
+      ? path.resolve(workingDirectory)
+      : path.resolve(path.join(dataBasePath, workingDirectory));
+    cwdRule = path.isAbsolute(workingDirectory)
+      ? '规则1: WORKING_DIRECTORY存在且为绝对路径 -> 直接使用'
+      : '规则1: WORKING_DIRECTORY存在且非空 -> path.join(DATA_BASE_PATH, WORKING_DIRECTORY)';
   } else if (process.env.USER_ID) {
-    effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
+    effectiveCwd = path.join(workspaceRoot, process.env.USER_ID, 'temp');
     cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID -> path.join(DATA_BASE_PATH, 'work', USER_ID, 'temp')`;
   } else {
     effectiveCwd = dataBasePath;
@@ -593,19 +623,19 @@ async function executeUserCodeDirectly(code, source = 'inline') {
   
   // 确定工作目录
   const workingDirectory = process.env.WORKING_DIRECTORY;
-  const dataBasePath = process.env.DATA_BASE_PATH;
-  if (!dataBasePath) {
-    throw new Error('DATA_BASE_PATH environment variable is not set');
-  }
+  const dataBasePath = getEffectiveDataBasePath();
+  const workspaceRoot = path.join(dataBasePath, 'work');
   
   // 确定工作目录
   let effectiveCwd;
   let cwdRule;
   if (workingDirectory && workingDirectory.trim() !== '') {
-    effectiveCwd = path.join(dataBasePath, workingDirectory);
+    effectiveCwd = path.isAbsolute(workingDirectory)
+      ? path.resolve(workingDirectory)
+      : path.resolve(path.join(dataBasePath, workingDirectory));
     cwdRule = `规则1: WORKING_DIRECTORY存在且非空`;
   } else if (process.env.USER_ID) {
-    effectiveCwd = path.join(dataBasePath, 'work', process.env.USER_ID, 'temp');
+    effectiveCwd = path.join(workspaceRoot, process.env.USER_ID, 'temp');
     cwdRule = `规则2: WORKING_DIRECTORY为空但有USER_ID`;
   } else {
     effectiveCwd = dataBasePath;
@@ -755,10 +785,8 @@ async function executePythonSkill(skillPath, scriptPath, toolName, params, conte
     const isAdmin = process.env.IS_ADMIN === 'true';
     const isSkillCreator = process.env.IS_SKILL_CREATOR === 'true';
     const userId = process.env.USER_ID || 'default';
-    const dataBasePath = process.env.DATA_BASE_PATH;
-    if (!dataBasePath) {
-      throw new Error('DATA_BASE_PATH environment variable is not set');
-    }
+    const dataBasePath = getEffectiveDataBasePath();
+    const workspaceRoot = path.join(dataBasePath, 'work');
     
     // 计算允许访问的路径列表（与 Node.js 沙箱保持一致）
     let allowedPaths;
@@ -766,11 +794,13 @@ async function executePythonSkill(skillPath, scriptPath, toolName, params, conte
       allowedPaths = [dataBasePath];
     } else if (isSkillCreator) {
       allowedPaths = [
-        path.join(dataBasePath, 'skills'),
-        path.join(dataBasePath, 'work', userId)
+        process.env.SKILLS_BASE_PATH
+          ? resolveEnvPath(process.env.SKILLS_BASE_PATH)
+          : path.join(process.cwd(), 'data', 'skills'),
+        path.join(workspaceRoot, userId)
       ];
     } else {
-      allowedPaths = [path.join(dataBasePath, 'work', userId)];
+      allowedPaths = [path.join(workspaceRoot, userId)];
     }
     
     const allowedPathsJson = JSON.stringify(allowedPaths);
@@ -919,13 +949,12 @@ print(json.dumps(_result))
     // 确定工作目录
     let workingDir = skillPath;
     const workDirEnv = process.env.WORKING_DIRECTORY;
-    const dataBasePathEnv = process.env.DATA_BASE_PATH;
     const userIdEnv = process.env.USER_ID;
     
-    if (workDirEnv && workDirEnv.trim() !== '' && dataBasePathEnv) {
-      workingDir = path.join(dataBasePathEnv, workDirEnv);
-    } else if (userIdEnv && dataBasePathEnv) {
-      workingDir = path.join(dataBasePathEnv, 'work', userIdEnv, 'temp');
+    if (workDirEnv && workDirEnv.trim() !== '') {
+      workingDir = resolveWorkingDirectoryPath(workDirEnv, userIdEnv);
+    } else if (userIdEnv) {
+      workingDir = resolveWorkingDirectoryPath('', userIdEnv);
     }
     
     // 检查工作目录是否存在
@@ -1035,19 +1064,10 @@ async function main() {
         // 如果提供了脚本路径，从文件加载代码
         if (script_path) {
           const workingDirectory = process.env.WORKING_DIRECTORY;
-          const dataBasePath = process.env.DATA_BASE_PATH;
-          if (!dataBasePath) {
-            throw new Error('DATA_BASE_PATH environment variable is not set');
-          }
           const userId = process.env.USER_ID || 'default';
           
           // 确定用户工作目录
-          let userWorkDir;
-          if (workingDirectory && workingDirectory.trim() !== '') {
-            userWorkDir = path.join(dataBasePath, workingDirectory);
-          } else {
-            userWorkDir = path.join(dataBasePath, 'work', userId, 'temp');
-          }
+          const userWorkDir = resolveWorkingDirectoryPath(workingDirectory, userId);
           
           // 检查工作目录是否存在
           if (!fs.existsSync(userWorkDir)) {

--- a/server/controllers/skill.controller.js
+++ b/server/controllers/skill.controller.js
@@ -8,10 +8,10 @@
 
 import logger from '../../lib/logger.js';
 import Utils from '../../lib/utils.js';
-import { parseSkillMd, validateSkillPath } from '../../lib/skill-parser.js';
+import { parseSkillMd } from '../../lib/skill-parser.js';
 import fsOriginal from 'fs';
 import path from 'path';
-import { getDataBasePath } from '../../lib/paths.js';
+import { getSkillPath, getSkillsPath } from '../../lib/paths.js';
 
 class SkillController {
   constructor(db) {
@@ -428,9 +428,8 @@ class SkillController {
         return;
       }
 
-      // 安全验证：确保路径在允许的目录内
-      const PROJECT_ROOT = process.cwd();
-      const pathValidation = await validateSkillPath(source_path, PROJECT_ROOT, ['data', 'skills']);
+      // 安全验证：确保路径在当前技能目录根内
+      const pathValidation = this.#validateSkillSourcePath(source_path);
       
       if (!pathValidation.valid) {
         ctx.error(pathValidation.error || 'Invalid skill path', 400);
@@ -944,17 +943,43 @@ class SkillController {
     // 统一路径分隔符为正斜杠，便于判断（兼容 Windows 和 Unix）
     sourcePath = sourcePath.replace(/\\/g, '/');
     
-    // 规范化 source_path：skills/xxx → data/skills/xxx
-    if (sourcePath.startsWith('skills/')) {
-      sourcePath = 'data/' + sourcePath;  // skills/pdf → data/skills/pdf
-    } else if (!sourcePath.startsWith('data/') && !path.isAbsolute(sourcePath)) {
-      sourcePath = path.join('data/skills', sourcePath);
-    }
-    
     return {
-      path: path.isAbsolute(sourcePath) ? sourcePath : path.join(PROJECT_ROOT, sourcePath),
+      path: getSkillPath(sourcePath),
       error: null
     };
+  }
+
+  /**
+   * 校验技能源码路径是否位于技能目录根内
+   * 兼容 skills/foo、data/skills/foo、foo、绝对路径 四种输入
+   */
+  #validateSkillSourcePath(sourcePath) {
+    if (!sourcePath || sourcePath.trim() === '') {
+      return { valid: false, fullPath: '', error: 'source_path is required' };
+    }
+
+    const fullPath = getSkillPath(sourcePath);
+    const skillsBasePath = path.resolve(getSkillsPath());
+    const normalizedFullPath = path.resolve(fullPath);
+    const isAllowed = normalizedFullPath === skillsBasePath || normalizedFullPath.startsWith(skillsBasePath + path.sep);
+
+    if (!isAllowed) {
+      return {
+        valid: false,
+        fullPath: normalizedFullPath,
+        error: `Invalid path: skill must be inside ${skillsBasePath}`,
+      };
+    }
+
+    if (!fsOriginal.existsSync(normalizedFullPath)) {
+      return {
+        valid: false,
+        fullPath: normalizedFullPath,
+        error: `Directory not found: ${sourcePath}`,
+      };
+    }
+
+    return { valid: true, fullPath: normalizedFullPath };
   }
 
   /**
@@ -990,9 +1015,8 @@ class SkillController {
         }
         skillPath = result.path;
       } else {
-        // 未注册目录，直接使用 data/skills/:name
-        const dataBasePath = getDataBasePath();
-        skillPath = path.join(dataBasePath, 'skills', id);
+        // 未注册目录，直接使用 skills 目录下的同名目录
+        skillPath = path.join(getSkillsPath(), id);
       }
 
       logger.info('[listFiles] Computed skillPath:', { skillPath, exists: skillPath ? fsOriginal.existsSync(skillPath) : false });
@@ -1081,9 +1105,8 @@ class SkillController {
         }
         skillPath = result.path;
       } else {
-        // 未注册目录，直接使用 data/skills/:name
-        const dataBasePath = getDataBasePath();
-        skillPath = path.join(dataBasePath, 'skills', id);
+        // 未注册目录，直接使用 skills 目录下的同名目录
+        skillPath = path.join(getSkillsPath(), id);
       }
 
       if (!skillPath || !fsOriginal.existsSync(skillPath)) {
@@ -1140,8 +1163,7 @@ class SkillController {
    */
   async listDirectories(ctx) {
     try {
-      const dataBasePath = getDataBasePath();
-      const skillsDir = path.join(dataBasePath, 'skills');
+      const skillsDir = getSkillsPath();
 
       // 确保 data/skills 目录存在
       if (!fsOriginal.existsSync(skillsDir)) {
@@ -1158,7 +1180,7 @@ class SkillController {
 
         const dirName = item.name;
         const dirPath = path.join(skillsDir, dirName);
-        const relativePath = `data/skills/${dirName}`;
+          const relativePath = `skills/${dirName}`;
 
         // 尝试读取 SKILL.md 获取描述
         let description = '';
@@ -1210,8 +1232,7 @@ class SkillController {
         return;
       }
 
-      const dataBasePath = getDataBasePath();
-      const skillsDir = path.join(dataBasePath, 'skills');
+      const skillsDir = getSkillsPath();
       const newDirPath = path.join(skillsDir, name);
 
       // 检查目录是否已存在
@@ -1239,7 +1260,7 @@ ${description || '新技能描述'}
 
       ctx.success({
         name,
-        path: `data/skills/${name}`,
+        path: `skills/${name}`,
         message: '技能目录创建成功',
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- split built-in skill path resolution from the generic runtime data base path while keeping workspace defaults on `DATA_BASE_PATH/work`
- align resident skill startup, skill registration, directory browsing, and font lookup with the same `SKILLS_BASE_PATH` and `FONTS_BASE_PATH` rules
- preserve the existing local `data/` defaults so current non-Docker layouts continue to work without mandatory migration

Closes #798