### PR TITLE
feat: 登录页视觉重构 — 双栏品牌区 + i18n 全量覆盖

### DIFF
--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -949,6 +949,8 @@ thinkingFormatDeepseek: 'DeepSeek/GLM Format',
   // Login page
   login: {
     subtitle: 'Sign in to your account',
+    kicker: 'Welcome back',
+    welcomeSubtitle: 'Enter your AI expert workspace and continue where you left off.',
     account: 'Username / Email',
     accountPlaceholder: 'Enter your username or email',
     accountRequired: 'Please enter your account',
@@ -959,6 +961,19 @@ thinkingFormatDeepseek: 'DeepSeek/GLM Format',
     error: 'Login failed, please check your username/email and password',
     noAccount: "Don't have an account?",
     register: 'Sign up now',
+    brand: {
+      badge: 'AI Expert Workspace',
+      eyebrow: 'Touwaka Mate',
+      title: 'Unify expert copies, skills, and conversation workflows in a single interface.',
+      description: 'Sign in to access the expert system, context memory, and skill panels for a more natural and consistent AI collaboration experience.',
+      metricValue1: 'Dual Minds',
+      metricLabel1: 'Expressive & reflective dual-mind architecture',
+      metricValue2: 'Experts + Skills',
+      metricLabel2: 'Unified orchestration of experts, copies, and skills',
+      point1: 'Manage experts, topics, skill directory, and debugging in one place',
+      point2: 'Preserve conversational context to reduce information loss across sessions',
+      point3: 'A persistent AI console for ongoing work — not just a one-off chat window',
+    },
   },
 
   // App info

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -884,6 +884,8 @@ thinkingFormatDeepseek: 'DeepSeek/GLM 格式',
   // 登录页面
   login: {
     subtitle: '登录您的账号',
+    kicker: 'Welcome back',
+    welcomeSubtitle: '进入您的 AI 专家工作台，继续上一次的上下文与任务流。',
     account: '用户名 / 邮箱',
     accountPlaceholder: '请输入用户名或邮箱',
     accountRequired: '请输入账号',
@@ -894,6 +896,19 @@ thinkingFormatDeepseek: 'DeepSeek/GLM 格式',
     error: '登录失败，请检查用户名/邮箱和密码',
     noAccount: '还没有账号？',
     register: '立即注册',
+    brand: {
+      badge: 'AI Expert Workspace',
+      eyebrow: 'Touwaka Mate',
+      title: '让专家副本、技能和对话工作流在同一个界面里协同。',
+      description: '登录后即可进入专家系统、上下文记忆与技能调用面板，持续保持更自然、更稳定的 AI 协作体验。',
+      metricValue1: 'Dual Minds',
+      metricLabel1: '表达与反思双心智架构',
+      metricValue2: 'Experts + Skills',
+      metricLabel2: '专家、副本、技能统一编排',
+      point1: '统一管理专家、话题、技能目录与调试能力',
+      point2: '延续上下文记忆，降低多轮协作中的信息损耗',
+      point3: '更适合持续工作的 AI 控制台，而不是一次性聊天窗口',
+    },
   },
 
   // 应用信息

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,68 +1,106 @@
 <template>
   <div class="login-view">
-    <div class="login-card">
-      <div class="card-header">
-        <div class="header-content">
-          <h1 class="login-title">{{ $t('app.title') }}</h1>
-          <p class="login-subtitle">{{ $t('login.subtitle') }}</p>
+    <div class="login-shell">
+      <section class="login-brand-panel">
+        <div class="brand-badge">{{ $t('login.brand.badge') }}</div>
+        <div class="brand-copy">
+          <p class="brand-eyebrow">{{ $t('login.brand.eyebrow') }}</p>
+          <h1 class="brand-title">{{ $t('login.brand.title') }}</h1>
+          <p class="brand-description">
+            {{ $t('login.brand.description') }}
+          </p>
         </div>
-        <LangSelector />
-      </div>
 
-      <el-form
-        ref="formRef"
-        :model="form"
-        :rules="rules"
-        label-position="top"
-        @submit.prevent="handleLogin"
-      >
-        <el-form-item :label="$t('login.account')" prop="account">
-          <el-input
-            v-model="form.account"
-            :placeholder="$t('login.accountPlaceholder')"
-            @keyup.enter="handleLogin"
-          />
-        </el-form-item>
+        <div class="brand-metrics">
+          <div class="metric-card">
+            <span class="metric-value">{{ $t('login.brand.metricValue1') }}</span>
+            <span class="metric-label">{{ $t('login.brand.metricLabel1') }}</span>
+          </div>
+          <div class="metric-card">
+            <span class="metric-value">{{ $t('login.brand.metricValue2') }}</span>
+            <span class="metric-label">{{ $t('login.brand.metricLabel2') }}</span>
+          </div>
+        </div>
 
-        <el-form-item :label="$t('login.password')" prop="password">
-          <el-input
-            v-model="form.password"
-            type="password"
-            :placeholder="$t('login.passwordPlaceholder')"
-            show-password
-            @keyup.enter="handleLogin"
-          />
-        </el-form-item>
+        <ul class="brand-points">
+          <li>{{ $t('login.brand.point1') }}</li>
+          <li>{{ $t('login.brand.point2') }}</li>
+          <li>{{ $t('login.brand.point3') }}</li>
+        </ul>
+      </section>
 
-        <el-alert
-          v-if="error"
-          :title="error"
-          type="error"
-          :closable="false"
-          show-icon
-          class="login-error"
-        />
+      <section class="login-card">
+        <div class="card-header">
+          <div class="header-content">
+            <p class="login-kicker">{{ $t('login.kicker') }}</p>
+            <h2 class="login-title">{{ $t('login.subtitle') }}</h2>
+            <p class="login-subtitle">{{ $t('login.welcomeSubtitle') }}</p>
+          </div>
+          <div class="header-actions">
+            <LangSelector />
+          </div>
+        </div>
 
-        <el-button
-          type="primary"
-          size="large"
-          class="btn-login"
-          :loading="loading"
-          @click="handleLogin"
+        <el-form
+          ref="formRef"
+          :model="form"
+          :rules="rules"
+          label-position="top"
+          class="login-form"
+          @submit.prevent="handleLogin"
         >
-          {{ loading ? $t('common.loading') : $t('login.submit') }}
-        </el-button>
-      </el-form>
+          <el-form-item :label="$t('login.account')" prop="account">
+            <el-input
+              v-model="form.account"
+              :placeholder="$t('login.accountPlaceholder')"
+              size="large"
+              @keyup.enter="handleLogin"
+            />
+          </el-form-item>
 
-      <div class="login-footer">
-        <p>{{ $t('login.noAccount') }} <router-link to="/register">{{ $t('login.register') }}</router-link></p>
-      </div>
+          <el-form-item :label="$t('login.password')" prop="password">
+            <el-input
+              v-model="form.password"
+              type="password"
+              :placeholder="$t('login.passwordPlaceholder')"
+              size="large"
+              show-password
+              @keyup.enter="handleLogin"
+            />
+          </el-form-item>
+
+          <el-alert
+            v-if="error"
+            :title="error"
+            type="error"
+            :closable="false"
+            show-icon
+            class="login-error"
+          />
+
+          <el-button
+            type="primary"
+            size="large"
+            class="btn-login"
+            :loading="loading"
+            @click="handleLogin"
+          >
+            {{ loading ? $t('common.loading') : $t('login.submit') }}
+          </el-button>
+        </el-form>
+
+        <div class="login-footer">
+          <p>{{ $t('login.noAccount') }} <router-link to="/register">{{ $t('login.register') }}</router-link></p>
+        </div>
+      </section>
     </div>
 
     <div class="login-decoration">
+      <div class="decoration-grid"></div>
       <div class="decoration-circle"></div>
       <div class="decoration-circle"></div>
       <div class="decoration-circle"></div>
+      <div class="decoration-glow"></div>
     </div>
   </div>
 </template>
@@ -119,82 +157,255 @@ const handleLogin = async () => {
 
 <style scoped>
 .login-view {
+  min-height: 100vh;
+  padding: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background:
+    radial-gradient(circle at top left, rgba(93, 95, 239, 0.34), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(66, 211, 255, 0.2), transparent 28%),
+    linear-gradient(135deg, #0f172a 0%, #111827 45%, #172554 100%);
   position: relative;
   overflow: hidden;
 }
 
+.login-shell {
+  width: min(1180px, 100%);
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(360px, 420px);
+  gap: 32px;
+  align-items: stretch;
+  position: relative;
+  z-index: 1;
+}
+
+.login-brand-panel {
+  padding: 48px;
+  border-radius: 28px;
+  color: #eff6ff;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.66), rgba(15, 23, 42, 0.32));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 640px;
+}
+
+.brand-badge {
+  width: fit-content;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #c4b5fd;
+  background: rgba(76, 29, 149, 0.28);
+  border: 1px solid rgba(196, 181, 253, 0.2);
+}
+
+.brand-copy {
+  margin-top: 32px;
+}
+
+.brand-eyebrow {
+  margin: 0 0 12px;
+  font-size: 14px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #93c5fd;
+}
+
+.brand-title {
+  margin: 0;
+  font-size: clamp(34px, 4vw, 52px);
+  line-height: 1.08;
+  font-weight: 700;
+  max-width: 10ch;
+}
+
+.brand-description {
+  margin: 24px 0 0;
+  max-width: 620px;
+  font-size: 16px;
+  line-height: 1.75;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.brand-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 40px;
+}
+
+.metric-card {
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.metric-value {
+  display: block;
+  font-size: 18px;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.metric-label {
+  display: block;
+  margin-top: 8px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.brand-points {
+  margin: 40px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 14px;
+}
+
+.brand-points li {
+  position: relative;
+  padding-left: 26px;
+  font-size: 14px;
+  line-height: 1.7;
+  color: rgba(226, 232, 240, 0.84);
+}
+
+.brand-points li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 9px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #8b5cf6 0%, #38bdf8 100%);
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.45);
+}
+
 .login-card {
   width: 100%;
-  max-width: 400px;
-  padding: 48px;
-  background: white;
-  border-radius: 16px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  z-index: 1;
+  padding: 36px;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(18px);
 }
 
 .card-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 32px;
+  gap: 20px;
+  margin-bottom: 28px;
 }
 
 .header-content {
   flex: 1;
 }
 
-.login-title {
-  font-size: 28px;
+.header-actions {
+  flex-shrink: 0;
+}
+
+.login-kicker {
+  margin: 0 0 10px;
+  font-size: 12px;
   font-weight: 700;
-  text-align: center;
-  margin: 0 0 8px 0;
-  color: #333;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #6366f1;
+}
+
+.login-title {
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1.15;
+  margin: 0;
+  color: #0f172a;
 }
 
 .login-subtitle {
   font-size: 14px;
-  text-align: center;
-  color: #666;
-  margin: 0;
+  line-height: 1.7;
+  color: #475569;
+  margin: 12px 0 0;
+}
+
+.login-form {
+  margin-top: 8px;
 }
 
 :deep(.el-form) {
   --el-form-item-label-font-size: 13px;
-  --el-form-item-label-color: #555;
+  --el-form-item-label-color: #334155;
+}
+
+:deep(.el-form-item) {
+  margin-bottom: 22px;
+}
+
+:deep(.el-input__wrapper) {
+  min-height: 50px;
+  border-radius: 14px;
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.22);
+  background: rgba(248, 250, 252, 0.95);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+:deep(.el-input__wrapper.is-focus) {
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.65), 0 0 0 5px rgba(99, 102, 241, 0.08);
+  transform: translateY(-1px);
 }
 
 .login-error {
-  margin-bottom: 16px;
+  margin: 4px 0 18px;
+}
+
+:deep(.login-error .el-alert) {
+  border-radius: 14px;
 }
 
 .btn-login {
   width: 100%;
-  height: 48px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  height: 52px;
+  margin-top: 6px;
+  border: none;
+  border-radius: 14px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 55%, #0ea5e9 100%);
+  box-shadow: 0 18px 32px rgba(79, 70, 229, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
 .btn-login:hover {
-  opacity: 0.95;
-  transform: translateY(-1px);
+  opacity: 0.98;
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px rgba(79, 70, 229, 0.34);
 }
 
 .login-footer {
-  text-align: center;
   font-size: 13px;
-  color: #666;
-  margin-top: 24px;
+  color: #64748b;
+  margin-top: 22px;
+  text-align: center;
 }
 
 .login-footer a {
-  color: #667eea;
+  color: #4f46e5;
   text-decoration: none;
-  font-weight: 500;
+  font-weight: 700;
 }
 
 .login-footer a:hover {
@@ -203,36 +414,122 @@ const handleLogin = async () => {
 
 .login-decoration {
   position: absolute;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   overflow: hidden;
   pointer-events: none;
+}
+
+.decoration-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(circle at center, black 28%, transparent 78%);
 }
 
 .decoration-circle {
   position: absolute;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.1);
+  filter: blur(8px);
 }
 
-.decoration-circle:nth-child(1) {
-  width: 300px;
-  height: 300px;
-  top: -100px;
-  right: -100px;
+.decoration-circle:nth-of-type(1) {
+  width: 360px;
+  height: 360px;
+  top: -120px;
+  right: -80px;
+  background: rgba(56, 189, 248, 0.12);
 }
 
-.decoration-circle:nth-child(2) {
-  width: 200px;
-  height: 200px;
-  bottom: -50px;
-  left: -50px;
+.decoration-circle:nth-of-type(2) {
+  width: 280px;
+  height: 280px;
+  bottom: -60px;
+  left: -40px;
+  background: rgba(129, 140, 248, 0.14);
 }
 
-.decoration-circle:nth-child(3) {
-  width: 150px;
-  height: 150px;
-  bottom: 100px;
-  right: 10%;
+.decoration-circle:nth-of-type(3) {
+  width: 220px;
+  height: 220px;
+  bottom: 120px;
+  right: 12%;
+  background: rgba(192, 132, 252, 0.12);
+}
+
+.decoration-glow {
+  position: absolute;
+  width: 540px;
+  height: 540px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.18), transparent 68%);
+  filter: blur(18px);
+}
+
+@media (max-width: 1080px) {
+  .login-shell {
+    grid-template-columns: 1fr;
+    max-width: 720px;
+  }
+
+  .login-brand-panel {
+    min-height: auto;
+  }
+
+  .brand-title {
+    max-width: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .login-view {
+    padding: 18px;
+  }
+
+  .login-shell {
+    gap: 18px;
+  }
+
+  .login-brand-panel,
+  .login-card {
+    padding: 24px;
+    border-radius: 22px;
+  }
+
+  .brand-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    align-self: flex-end;
+  }
+
+  .login-title {
+    font-size: 26px;
+  }
+}
+
+@media (max-width: 520px) {
+  .login-brand-panel {
+    display: none;
+  }
+
+  .login-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .login-card {
+    padding: 22px;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary

登录页视觉全面重构：从旧版"居中白卡片"升级为现代 AI 产品风格的双栏布局，左侧承载品牌价值说明，右侧保留登录表单，全量文案接入 i18n 中英文支持。

## What Changed

- **布局**：纯居中单卡片 → 左右双栏（品牌区 + 表单区），三断点响应式适配（1080/768/520）
- **背景**：普通紫蓝渐变 → 深色 AI 风格底色 + 网格 + 光斑 + 辉光装饰
- **表单**：输入框增大圆角 + 定制聚焦态 + 按钮升级为独立渐变 CTA
- **品牌区**：badge / 标题 / 描述 / 指标卡片 / 核心卖点列表
- **国际化**：品牌区 + 表单区所有文案接入 `login.brand.*` / `login.kicker` / `login.welcomeSubtitle` 翻译键

## Verification

- [x] `npm run type-check` 通过
- [x] `npm run build` 通过
- [x] `npm run lint:i18n` 无新增缺失键（97 个缺失均为已有问题）
- [x] 旧版登录逻辑、校验规则、路由跳转均未改动