### PR TITLE
fix: harden MCP header configuration flow

### DIFF
--- a/data/skills/mcp-client/index.js
+++ b/data/skills/mcp-client/index.js
@@ -195,28 +195,59 @@ function parseHeaders(headersStr) {
   }
 }
 
+function resolveCredentialPlaceholder(value, credentials) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const envOverrides = credentials?.env_overrides || credentials || {};
+
+  return value.replace(/\$\{user\.(\w+)\}/g, (match, fieldName) => {
+    const replacement = envOverrides[fieldName];
+    if (replacement === undefined || replacement === null) {
+      log(`Missing credential field for header placeholder: ${fieldName}`);
+      return match;
+    }
+    return String(replacement);
+  });
+}
+
+function getHeaderKeyCaseInsensitive(headers, headerName) {
+  const target = String(headerName || '').toLowerCase();
+  return Object.keys(headers || {}).find(key => key.toLowerCase() === target) || null;
+}
+
+function hasUnresolvedCredentialPlaceholder(value) {
+  return typeof value === 'string' && /\$\{user\.\w+\}/.test(value);
+}
+
 function buildAuthHeaders(headersStr, credentials) {
-  const headers = parseHeaders(headersStr);
+  const headers = Object.fromEntries(
+    Object.entries(parseHeaders(headersStr)).map(([key, value]) => [
+      key,
+      resolveCredentialPlaceholder(value, credentials),
+    ])
+  );
   
   // 凭证可能存储在 credentials.env_overrides 中
   const envOverrides = credentials?.env_overrides || credentials || {};
-  
-  if (envOverrides.api_key) {
-    headers['Authorization'] = `Bearer ${envOverrides.api_key}`;
-  } else if (envOverrides.token) {
-    headers['Authorization'] = `Bearer ${envOverrides.token}`;
-  } else if (envOverrides.API_KEY) {
-    headers['X-API-Key'] = envOverrides.API_KEY;
+
+  const authorizationKey = getHeaderKeyCaseInsensitive(headers, 'Authorization');
+  const apiKeyHeaderKey = getHeaderKeyCaseInsensitive(headers, 'X-API-Key');
+
+  if (!authorizationKey || hasUnresolvedCredentialPlaceholder(headers[authorizationKey])) {
+    if (envOverrides.api_key) {
+      headers[authorizationKey || 'Authorization'] = `Bearer ${envOverrides.api_key}`;
+    } else if (envOverrides.token) {
+      headers[authorizationKey || 'Authorization'] = `Bearer ${envOverrides.token}`;
+    }
+  }
+
+  if ((!apiKeyHeaderKey || hasUnresolvedCredentialPlaceholder(headers[apiKeyHeaderKey])) && envOverrides.API_KEY) {
+    headers[apiKeyHeaderKey || 'X-API-Key'] = envOverrides.API_KEY;
   }
   
   return headers;
-}
-
-function sanitizeHeaders(headers) {
-  const sanitized = { ...headers };
-  if (sanitized.Authorization) sanitized.Authorization = 'Bearer ***';
-  if (sanitized['X-API-Key']) sanitized['X-API-Key'] = '***';
-  return sanitized;
 }
 
 async function createTransport(serverConfig, credentials = null) {
@@ -262,14 +293,14 @@ async function createTransport(serverConfig, credentials = null) {
     
     if (isStateless) {
       log(`Creating StatelessHTTP transport for ${serverConfig.name}: ${serverConfig.url}`);
-      log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}, timeout=${timeoutMs}ms`);
+      log(`Timeout=${timeoutMs}ms`);
       return new StatelessHTTPTransport(new URL(serverConfig.url), { requestInit: { headers }, timeout: timeoutMs });
     }
     
     const useSSE = transportType === 'sse' || serverConfig.url.endsWith('/sse') || serverConfig.use_sse;
     
     log(`Creating ${useSSE ? 'SSE' : 'StreamableHTTP'} transport for ${serverConfig.name}: ${serverConfig.url}`);
-    log(`Headers: ${JSON.stringify(sanitizeHeaders(headers))}, timeout=${timeoutMs}ms`);
+    log(`Timeout=${timeoutMs}ms`);
     
     const TransportClass = useSSE ? SSEClientTransport : StreamableHTTPClientTransport;
     return new TransportClass(new URL(serverConfig.url), { requestInit, fetch: customFetch });

--- a/frontend/src/components/settings/McpTab.vue
+++ b/frontend/src/components/settings/McpTab.vue
@@ -640,6 +640,8 @@ const closeServerDialog = () => {
 // 保存 Server
 const saveServer = async () => {
   try {
+    const normalized_headers = serverForm.headers.trim() ? serverForm.headers : null
+
     // 构建请求数据 - 全量更新：表单里有什么就传什么
     const requestData: any = {
       name: serverForm.name,
@@ -648,7 +650,7 @@ const saveServer = async () => {
       is_enabled: serverForm.is_enabled,
       // HTTP/SSE 字段
       url: serverForm.url || undefined,
-      headers: serverForm.headers || undefined,
+      headers: normalized_headers,
       // STDIO 字段
       command: serverForm.command || undefined,
       args: serverForm.args || undefined,

--- a/lib/mcp-stateless-http.js
+++ b/lib/mcp-stateless-http.js
@@ -64,7 +64,6 @@ export class StatelessHTTPTransport {
     
     transportLog(`Sending to ${this._url}`);
     transportLog(`Message preview: ${msgPreview}`);
-    transportLog(`Headers: ${JSON.stringify(Object.keys(headers))}`);
     transportLog(`Body size: ${body.length} bytes, timeout: ${this._timeout}ms`);
     
     const controller = new AbortController();

--- a/server/routes/mcp.routes.js
+++ b/server/routes/mcp.routes.js
@@ -289,6 +289,7 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         icon,
         category,
       } = ctx.request.body;
+      const normalizedHeaders = typeof headers === 'string' && headers.trim() === '' ? null : headers;
 
       // 验证必要字段
       if (!name) {
@@ -330,7 +331,7 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
         args: args || null,
         env_template: env_template || null,
         url: url || null,
-        headers: headers || null,
+        headers: normalizedHeaders || null,
         is_public: is_public || false,
         is_enabled: true,
         requires_credentials: requires_credentials || false,
@@ -394,6 +395,10 @@ export default function createMcpRoutes(db, authMiddleware, residentSkillManager
 
       for (const field of allowedFields) {
         if (updateData[field] !== undefined) {
+          if (field === 'headers' && typeof updateData[field] === 'string' && updateData[field].trim() === '') {
+            server[field] = null;
+            continue;
+          }
           server[field] = updateData[field];
         }
       }


### PR DESCRIPTION
## Summary
- support user credential placeholders inside custom MCP HTTP headers
- normalize empty header configuration values so clearing headers really removes them
- remove header-level debug logging and harden authorization header fallback behavior

## Details
- resolve `${user.xxx}` placeholders from MCP credential values when building HTTP headers
- treat empty `headers` values as `null` in both the MCP settings UI and server routes
- avoid duplicate or unresolved auth header injection by handling header names case-insensitively
- remove request header logging from the MCP client and stateless HTTP transport

## Validation
- `node --check data/skills/mcp-client/index.js`
- manual code audit of `data/skills/mcp-client/index.js`, `frontend/src/components/settings/McpTab.vue`, `lib/mcp-stateless-http.js`, and `server/routes/mcp.routes.js`

## Notes
- excludes unrelated local untracked directory `apps/els/`