### PR TITLE
fix: harden expert access control

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -171,6 +171,10 @@ export const expertApi = {
   getExperts: (params?: { is_active?: boolean }) =>
     apiRequest<Expert[]>(apiClient.get('/experts', { params })),
 
+  // 获取用户可访问的专家列表（聊天侧栏使用）
+  getAccessibleExperts: () =>
+    apiRequest<Expert[]>(apiClient.get('/chat/experts')),
+
   // 获取单个专家
   getExpert: (id: string) =>
     apiRequest<Expert>(apiClient.get(`/experts/${id}`)),

--- a/frontend/src/components/panel/ExpertTab.vue
+++ b/frontend/src/components/panel/ExpertTab.vue
@@ -26,8 +26,9 @@
           <div v-else class="avatar-placeholder">
             <span class="placeholder-text">{{ getInitials(currentExpert.name) }}</span>
           </div>
-          <!-- 悬浮刷新按钮 -->
+          <!-- 悬浮刷新按钮（仅管理员可见） -->
           <button
+            v-if="isAdmin"
             class="refresh-btn-floating"
             :disabled="isRefreshing"
             :title="$t('expert.refreshCache')"
@@ -91,11 +92,15 @@ import { computed, watch, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useExpertStore } from '@/stores/expert'
+import { useUserStore } from '@/stores/user'
 import { expertApi } from '@/api/services'
 
 const { t } = useI18n()
 const route = useRoute()
 const expertStore = useExpertStore()
+const userStore = useUserStore()
+
+const isAdmin = computed(() => userStore.isAdmin)
 
 // 从路由获取当前 expertId
 const currentExpertId = computed(() => route.params.expertId as string)

--- a/frontend/src/stores/expert.ts
+++ b/frontend/src/stores/expert.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { expertApi } from '@/api/services'
+import { useUserStore } from './user'
 import type { Expert } from '@/types'
 
 /**
@@ -31,7 +32,11 @@ export const useExpertStore = defineStore('expert', () => {
     isLoading.value = true
     error.value = null
     try {
-      const data = await expertApi.getExperts(options || {})
+      const userStore = useUserStore()
+      // 管理员使用管理接口，普通用户使用安全接口
+      const data = userStore.isAdmin 
+        ? await expertApi.getExperts(options || {})
+        : await expertApi.getAccessibleExperts()
       experts.value = data
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load experts'

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -207,7 +207,7 @@
     </div>
 
     <!-- 专家设置 -->
-    <div v-if="activeTab === 'expert'" class="settings-section expert-section">
+    <div v-if="activeTab === 'expert' && isAdmin" class="settings-section expert-section">
       <div class="panel-header">
         <h3 class="panel-title">{{ $t('settings.expertManagement') }}</h3>
         <el-button @click="openExpertDialog()">
@@ -278,7 +278,7 @@
     </div>
 
     <!-- 用户管理 -->
-    <div v-if="activeTab === 'user'" class="settings-section user-section">
+    <div v-if="activeTab === 'user' && isAdmin" class="settings-section user-section">
       <div class="panel-header">
         <h3 class="panel-title">{{ $t('settings.userManagement') }}</h3>
         <el-button @click="openUserDialog()" :title="$t('settings.addUser')">
@@ -357,7 +357,7 @@
     </div>
 
     <!-- 角色管理 -->
-    <div v-if="activeTab === 'role'" class="settings-section role-section">
+    <div v-if="activeTab === 'role' && isAdmin" class="settings-section role-section">
       <div class="split-panel">
         <!-- 左侧：角色列表 -->
         <div class="panel role-list-panel">

--- a/server/controllers/stream.controller.js
+++ b/server/controllers/stream.controller.js
@@ -15,6 +15,7 @@
 import logger from '../../lib/logger.js';
 import Utils from '../../lib/utils.js';
 import { getSystemSettingService } from '../services/system-setting.service.js';
+import { getPermissionService } from '../services/permission.service.js';
 
 class StreamController {
   constructor(db, chatService) {
@@ -22,9 +23,45 @@ class StreamController {
     this.chatService = chatService;
     this.Topic = db.getModel('topic');
     this.Message = db.getModel('message');
+    this.Expert = db.getModel('expert');
     this.systemSettingService = getSystemSettingService(db);
+    this.permissionService = getPermissionService(db);
     // 存储活跃的 SSE 连接：Map<expertId, Set<{userId, res}>>
     this.expertConnections = new Map();
+  }
+
+  /**
+   * 校验用户是否有权限访问指定专家
+   * @param {string} userId - 用户ID
+   * @param {string} expertId - 专家ID
+   * @returns {Promise<{ allowed: boolean, reason: string | null }>}
+   */
+  async checkExpertAccess(userId, expertId) {
+    try {
+      const expert = await this.Expert.findOne({
+        where: { id: expertId },
+        attributes: ['id', 'is_active'],
+        raw: true,
+      });
+
+      if (!expert) {
+        return { allowed: false, reason: 'EXPERT_NOT_FOUND' };
+      }
+
+      if (!expert.is_active) {
+        return { allowed: false, reason: 'EXPERT_INACTIVE' };
+      }
+
+      const hasAccess = await this.permissionService.canAccessExpert(userId, expertId);
+      if (!hasAccess) {
+        return { allowed: false, reason: 'NO_ACCESS' };
+      }
+
+      return { allowed: true, reason: null };
+    } catch (error) {
+      logger.error('[StreamController] checkExpertAccess error:', error.message);
+      return { allowed: false, reason: 'CHECK_FAILED' };
+    }
   }
 
   /**
@@ -46,6 +83,14 @@ class StreamController {
       }
 
       const user_id = ctx.state.session.id;
+
+      // 校验用户是否有权限访问该专家
+      const accessCheck = await this.checkExpertAccess(user_id, expert_id);
+      if (!accessCheck.allowed) {
+        // 统一返回 403，避免专家枚举侧信道
+        ctx.error('无权访问该专家', 403);
+        return;
+      }
 
       // 检查 SSE 连接是否存在
       const connections = this.expertConnections.get(expert_id);
@@ -270,6 +315,14 @@ class StreamController {
     }
 
     const user_id = ctx.state.session.id;
+
+    // 校验用户是否有权限访问该专家
+    const accessCheck = await this.checkExpertAccess(user_id, expert_id);
+    if (!accessCheck.allowed) {
+      // 统一返回 403，避免专家枚举侧信道
+      ctx.error('无权访问该专家', 403);
+      return;
+    }
 
     // 从系统配置获取连接数限制
     const connectionLimits = await this.systemSettingService.getConnectionLimits();

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -7,6 +7,7 @@
 import bcrypt from 'bcryptjs';
 import logger from '../../lib/logger.js';
 import Utils from '../../lib/utils.js';
+import { Op } from 'sequelize';
 
 class UserController {
   constructor(db) {
@@ -511,6 +512,7 @@ class UserController {
    * 管理员专用
    */
   async updateUserRoles(ctx) {
+    let transaction = null;
     try {
       // 检查管理员权限
       if (!ctx.state.session.isAdmin) {
@@ -522,7 +524,7 @@ class UserController {
       const { roleIds } = ctx.request.body;
 
       if (!Array.isArray(roleIds)) {
-        ctx.error('roleIds 必须是数组');
+        ctx.error('roleIds 必须是数组', 400);
         return;
       }
 
@@ -533,22 +535,50 @@ class UserController {
         return;
       }
 
-      // 删除现有角色
-      await this.UserRole.destroy({ where: { user_id: id } });
+      // 校验所有 roleIds 是否存在
+      if (roleIds.length > 0) {
+        const existingRoles = await this.Role.findAll({
+          where: { id: { [Op.in]: roleIds } },
+          attributes: ['id'],
+          raw: true,
+        });
+        const existingRoleIds = existingRoles.map(r => r.id);
+        const invalidRoleIds = roleIds.filter(rid => !existingRoleIds.includes(rid));
+        
+        if (invalidRoleIds.length > 0) {
+          ctx.error(`角色不存在: ${invalidRoleIds.join(', ')}`, 400);
+          return;
+        }
+      }
 
-      // 添加新角色
+      transaction = await this.db.sequelize.transaction();
+
+      // 删除现有角色（事务内）
+      await this.UserRole.destroy({ where: { user_id: id }, transaction });
+
+      // 添加新角色（事务内）
       if (roleIds.length > 0) {
         const roleRecords = roleIds.map(roleId => ({
           user_id: id,
           role_id: roleId,
         }));
-        await this.UserRole.bulkCreate(roleRecords);
+        await this.UserRole.bulkCreate(roleRecords, { transaction });
       }
 
+      // 提交事务
+      await transaction.commit();
       ctx.success(null, '角色更新成功');
     } catch (error) {
+      // 回滚事务
+      if (transaction) {
+        try {
+          await transaction.rollback();
+        } catch (rollbackError) {
+          logger.error('Transaction rollback error:', rollbackError.message);
+        }
+      }
       logger.error('Update user roles error:', error);
-      ctx.error('更新角色失败', 500);
+      ctx.error('更新角色失败: ' + error.message, 500);
     }
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -99,6 +99,7 @@ import departmentRoutes from './routes/department.routes.js';
 import positionRoutes from './routes/position.routes.js';
 import systemSettingRoutes, { createBrandingRoutes } from './routes/system-setting.routes.js';
 import { getSystemSettingService } from './services/system-setting.service.js';
+import { getPermissionService } from './services/permission.service.js';
 import packageRoutes from './routes/package.routes.js';
 import assistantRoutes from './routes/assistant.routes.js';
 import internalRoutes from './routes/internal.routes.js';
@@ -375,8 +376,9 @@ class ApiServer {
     this.app.use(streamRoutes(this.controllers.stream).allowedMethods());
     
     // Chat 路由（前端兼容）
-    this.app.use(chatRoutes(this.controllers.stream).routes());
-    this.app.use(chatRoutes(this.controllers.stream).allowedMethods());
+    const permissionService = getPermissionService(this.db);
+    this.app.use(chatRoutes(this.controllers.stream, { permissionService }).routes());
+    this.app.use(chatRoutes(this.controllers.stream, { permissionService }).allowedMethods());
     
     // Provider 路由（需要数据库实例）
     try {

--- a/server/routes/chat.routes.js
+++ b/server/routes/chat.routes.js
@@ -6,8 +6,22 @@ import Router from '@koa/router';
 import { authenticate } from '../middlewares/auth.js';
 import logger from '../../lib/logger.js';
 
-export default (controller) => {
+export default (controller, services = {}) => {
   const router = new Router({ prefix: '/api/chat' });
+
+  // 获取用户可访问的专家列表（用户侧安全接口）
+  router.get('/experts', authenticate(), async (ctx) => {
+    try {
+      const permissionService = services.permissionService;
+      const userId = ctx.state.session.id;
+      
+      const experts = await permissionService.getAccessibleExperts(userId);
+      ctx.success(experts);
+    } catch (error) {
+      logger.error('[ChatRoutes] Get user experts error:', error);
+      ctx.error('获取专家列表失败: ' + error.message, 500);
+    }
+  });
 
   // 发送消息（需要认证）- content 在 body 中，支持流式响应
   router.post('/', authenticate(), controller.sendMessage.bind(controller));

--- a/server/routes/expert.routes.js
+++ b/server/routes/expert.routes.js
@@ -3,34 +3,34 @@
  */
 
 import Router from '@koa/router';
-import { authenticate } from '../middlewares/auth.js';
+import { authenticate, requireAdmin } from '../middlewares/auth.js';
 
 export default (controller) => {
   const router = new Router({ prefix: '/api/experts' });
 
-  // 获取专家列表（需要认证）
-  router.get('/', authenticate(), controller.list.bind(controller));
+  // 获取专家列表（需要管理员权限）
+  router.get('/', authenticate(), requireAdmin(), controller.list.bind(controller));
 
-  // 获取专家详情（需要认证）
-  router.get('/:id', authenticate(), controller.get.bind(controller));
+  // 获取专家详情（需要管理员权限）
+  router.get('/:id', authenticate(), requireAdmin(), controller.get.bind(controller));
 
-  // 创建专家（需要认证）
-  router.post('/', authenticate(), controller.create.bind(controller));
+  // 创建专家（需要管理员权限）
+  router.post('/', authenticate(), requireAdmin(), controller.create.bind(controller));
 
-  // 更新专家（需要认证）
-  router.put('/:id', authenticate(), controller.update.bind(controller));
+  // 更新专家（需要管理员权限）
+  router.put('/:id', authenticate(), requireAdmin(), controller.update.bind(controller));
 
-  // 删除专家（需要认证）
-  router.delete('/:id', authenticate(), controller.delete.bind(controller));
+  // 删除专家（需要管理员权限）
+  router.delete('/:id', authenticate(), requireAdmin(), controller.delete.bind(controller));
 
-  // 获取专家技能列表（需要认证）
-  router.get('/:id/skills', authenticate(), controller.getSkills.bind(controller));
+  // 获取专家技能列表（需要管理员权限）
+  router.get('/:id/skills', authenticate(), requireAdmin(), controller.getSkills.bind(controller));
 
-  // 更新专家技能（需要认证）
-  router.post('/:id/skills', authenticate(), controller.updateSkills.bind(controller));
+  // 更新专家技能（需要管理员权限）
+  router.post('/:id/skills', authenticate(), requireAdmin(), controller.updateSkills.bind(controller));
 
-  // 刷新专家缓存（需要认证）
-  router.post('/:id/refresh', authenticate(), controller.refresh.bind(controller));
+  // 刷新专家缓存（需要管理员权限）
+  router.post('/:id/refresh', authenticate(), requireAdmin(), controller.refresh.bind(controller));
 
   return router;
 };

--- a/server/services/permission.service.js
+++ b/server/services/permission.service.js
@@ -1,0 +1,184 @@
+/**
+ * Permission Service - 权限服务
+ *
+ * 提供统一的专家访问权限校验方法
+ */
+
+import logger from '../../lib/logger.js';
+import { Op } from 'sequelize';
+
+let permissionServiceInstance = null;
+
+class PermissionService {
+  constructor(db) {
+    this.db = db;
+    this.User = db.getModel('user');
+    this.Role = db.getModel('role');
+    this.UserRole = db.getModel('user_role');
+    this.RoleExpert = db.getModel('role_expert');
+    this.Expert = db.getModel('expert');
+  }
+
+  /**
+   * 检查用户是否为管理员
+   * @param {string} userId - 用户ID
+   * @returns {Promise<boolean>}
+   */
+  async isAdmin(userId) {
+    try {
+      const roles = await this.getUserRoles(userId);
+      return roles.includes('admin');
+    } catch (error) {
+      logger.error('[PermissionService] isAdmin error:', error.message);
+      return false;
+    }
+  }
+
+  /**
+   * 获取用户的所有角色标识
+   * @param {string} userId - 用户ID
+   * @returns {Promise<string[]>}
+   */
+  async getUserRoles(userId) {
+    try {
+      const userRoles = await this.UserRole.findAll({
+        where: { user_id: userId },
+        include: [{
+          model: this.Role,
+          as: 'role',
+          attributes: ['mark'],
+        }],
+        raw: true,
+        nest: true,
+      });
+      return userRoles.map(r => r.role?.mark).filter(Boolean);
+    } catch (error) {
+      logger.error('[PermissionService] getUserRoles error:', error.message);
+      return [];
+    }
+  }
+
+  /**
+   * 获取用户可访问的专家ID列表
+   * - 管理员可访问所有激活专家
+   * - 普通用户只能访问其角色绑定的专家
+   * @param {string} userId - 用户ID
+   * @returns {Promise<string[]>}
+   */
+  async getAccessibleExpertIds(userId) {
+    try {
+      const isAdmin = await this.isAdmin(userId);
+      
+      if (isAdmin) {
+        const experts = await this.Expert.findAll({
+          where: { is_active: true },
+          attributes: ['id'],
+          raw: true,
+        });
+        return experts.map(e => e.id);
+      }
+
+      const userRoles = await this.UserRole.findAll({
+        where: { user_id: userId },
+        attributes: ['role_id'],
+        raw: true,
+      });
+      const roleIds = userRoles.map(r => r.role_id).filter(Boolean);
+
+      if (roleIds.length === 0) {
+        return [];
+      }
+
+      const roleExperts = await this.RoleExpert.findAll({
+        where: { role_id: { [Op.in]: roleIds } },
+        attributes: ['expert_id'],
+        raw: true,
+      });
+      const expertIds = [...new Set(roleExperts.map(r => r.expert_id).filter(Boolean))];
+
+      const activeExperts = await this.Expert.findAll({
+        where: { id: { [Op.in]: expertIds }, is_active: true },
+        attributes: ['id'],
+        raw: true,
+      });
+
+      return activeExperts.map(e => e.id);
+    } catch (error) {
+      logger.error('[PermissionService] getAccessibleExpertIds error:', error.message);
+      return [];
+    }
+  }
+
+  /**
+   * 检查用户是否可以访问指定专家
+   * @param {string} userId - 用户ID
+   * @param {string} expertId - 专家ID
+   * @returns {Promise<boolean>}
+   */
+  async canAccessExpert(userId, expertId) {
+    try {
+      const accessibleIds = await this.getAccessibleExpertIds(userId);
+      return accessibleIds.includes(expertId);
+    } catch (error) {
+      logger.error('[PermissionService] canAccessExpert error:', error.message);
+      return false;
+    }
+  }
+
+  /**
+   * 获取用户可访问的专家列表（安全版本，仅返回必要字段）
+   * @param {string} userId - 用户ID
+   * @returns {Promise<object[]>}
+   */
+  async getAccessibleExperts(userId) {
+    try {
+      const isAdmin = await this.isAdmin(userId);
+      
+      const where = { is_active: true };
+      
+      if (!isAdmin) {
+        const expertIds = await this.getAccessibleExpertIds(userId);
+        if (expertIds.length === 0) {
+          return [];
+        }
+        where.id = { [Op.in]: expertIds };
+      }
+
+      const experts = await this.Expert.findAll({
+        where,
+        attributes: [
+          'id',
+          'name',
+          'introduction',
+          'is_active',
+          'avatar_base64',
+          'avatar_large_base64',
+        ],
+        order: [['created_at', 'DESC']],
+        raw: true,
+      });
+
+      return experts.map(e => ({
+        ...e,
+        is_active: !!e.is_active,
+      }));
+    } catch (error) {
+      logger.error('[PermissionService] getAccessibleExperts error:', error.message);
+      return [];
+    }
+  }
+}
+
+/**
+ * 获取权限服务实例（单例）
+ * @param {object} db - 数据库实例
+ * @returns {PermissionService}
+ */
+export function getPermissionService(db) {
+  if (!permissionServiceInstance) {
+    permissionServiceInstance = new PermissionService(db);
+  }
+  return permissionServiceInstance;
+}
+
+export default PermissionService;


### PR DESCRIPTION
## Summary
- harden expert management APIs so only admins can manage expert configuration, skills, and cache refresh
- add a safe user-facing expert list plus runtime access checks for chat and SSE based on `role_experts`
- strengthen user role updates with existence validation and transactional writes, and align frontend visibility with the new permission boundary

## Validation
- `node --check server/controllers/user.controller.js`
- `node --check server/controllers/stream.controller.js`
- `node --check server/routes/expert.routes.js`

## Notes
- excludes unrelated untracked workspace content under `apps/els/`
