### PR TITLE
fix: stabilize expert chat streaming flow

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -123,7 +123,7 @@ export const messageApi = {
     task_id?: string;
     working_path?: string;  // 当前工作目录路径（任务模式下的浏览路径或技能目录路径）
   }) =>
-    apiRequest<{ message: string; topic_id: string }>(apiClient.post('/chat', data)),
+    apiRequest<{ request_id: string; topic_id: string }>(apiClient.post('/chat', data)),
 
   // 删除消息
   deleteMessage: (topic_id: string, message_id: string) =>
@@ -134,12 +134,18 @@ export const messageApi = {
     apiRequest<{ message: string; deleted_messages_count: number; deleted_topics_count: number }>(apiClient.delete(`/messages/expert/${expert_id}`)),
 
   // 停止生成
-  stopGeneration: (expert_id: string) =>
-    apiRequest<{ success: boolean }>(apiClient.post('/chat/stop', { expert_id })),
+  stopGeneration: (request_id: string) =>
+    apiRequest<{ success: boolean; aborted: boolean; request_id: string }>(apiClient.post('/chat/stop', { request_id })),
 
   // 获取指定消息及其之前的 N 条消息（用于 SSE 完成后获取真实消息，包括 tool 消息）
   getMessagesWithBefore: (expert_id: string, message_id: string, params?: { limit?: number }) =>
     apiRequest<Message[]>(apiClient.get(`/messages/expert/${expert_id}/with-before/${message_id}`, { params })),
+
+  // 增量获取指定游标之后的消息
+  getMessagesSince: (expert_id: string, params?: { after_message_id?: string; limit?: number }) =>
+    apiRequest<{ items: Message[]; latest_message_id: string | null; has_more: boolean }>(
+      apiClient.get(`/messages/expert/${expert_id}/since`, { params })
+    ),
 }
 
 // 模型相关 API

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -24,8 +24,9 @@
       <div
         v-for="message in messages"
         :key="message.id"
+        :data-message-id="message.id"
         class="message"
-        :class="message.role"
+        :class="[message.role, { 'message-highlighted': highlightedMessageId === message.id }]"
       >
         <!-- tool 消息的特殊渲染 - 简洁内敛风格 -->
         <template v-if="message.role === 'tool'">
@@ -121,10 +122,21 @@
                     <div class="tool-section-title">{{ $t('chat.toolArguments') || '参数' }}</div>
                     <pre class="tool-section-content">{{ formatToolCallArguments(toolCall) }}</pre>
                   </div>
+                  <div v-if="toolCall.result_preview && !toolCall.result" class="tool-section">
+                    <div class="tool-section-title">{{ $t('chat.toolResult') || '结果摘要' }}</div>
+                    <pre class="tool-section-content">{{ addLineNumbers(String(toolCall.result_preview)) }}</pre>
+                  </div>
                   <div v-if="toolCall.result" class="tool-section">
                     <div class="tool-section-title">{{ $t('chat.toolResult') || '结果' }}</div>
                     <pre class="tool-section-content">{{ formatToolCallResult(toolCall) }}</pre>
                   </div>
+                  <button
+                    v-if="toolCall.tool_message_id"
+                    class="tool-message-link"
+                    @click.stop="jumpToMessage(String(toolCall.tool_message_id))"
+                  >
+                    定位 tool message: {{ toolCall.tool_message_id }}
+                  </button>
                 </div>
               </div>
             </div>
@@ -184,6 +196,14 @@
         </div>
       </div>
     </div>
+
+    <button
+      v-if="showNewMessagesHint"
+      class="new-messages-hint"
+      @click="handleScrollToBottom"
+    >
+      {{ newMessagesHintText }}
+    </button>
 
     <!-- 滚动到底部按钮 -->
     <button
@@ -280,8 +300,36 @@ const messagesContainer = ref<HTMLElement | null>(null)
 const inputRef = ref<HTMLTextAreaElement | null>(null)
 const isComposing = ref(false) // 中文输入法组合状态
 const showScrollToBottom = ref(false) // 是否显示滚动到底部按钮
+const showNewMessagesHint = ref(false)
+const pendingNewMessageCount = ref(0)
 const expandedTools = ref<Set<string>>(new Set()) // 展开的工具消息ID
 const expandedReasoning = ref<Set<string>>(new Set()) // 展开的思考内容消息ID
+
+const newMessagesHintText = computed(() => {
+  return pendingNewMessageCount.value > 1 ? `有 ${pendingNewMessageCount.value} 条新消息` : '有新消息'
+})
+
+const highlightedMessageId = ref<string | null>(null)
+let highlightTimer: ReturnType<typeof setTimeout> | null = null
+
+const jumpToMessage = (messageId: string) => {
+  if (!messagesContainer.value) return
+
+  const target = messagesContainer.value.querySelector(`[data-message-id="${messageId}"]`) as HTMLElement | null
+  if (!target) return
+
+  target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  highlightedMessageId.value = messageId
+
+  if (highlightTimer) {
+    clearTimeout(highlightTimer)
+  }
+
+  highlightTimer = setTimeout(() => {
+    highlightedMessageId.value = null
+    highlightTimer = null
+  }, 2000)
+}
 
 // 切换工具展开状态
 const toggleToolExpand = (messageId: string) => {
@@ -380,6 +428,11 @@ const handleScroll = () => {
   
   // 更新滚动到底部按钮状态
   showScrollToBottom.value = !isUserAtBottom.value
+
+  if (isUserAtBottom.value) {
+    showNewMessagesHint.value = false
+    pendingNewMessageCount.value = 0
+  }
   
   // 检测是否需要加载更多
   if (!props.hasMoreMessages || props.isLoadingMore) return
@@ -399,6 +452,8 @@ const handleScrollToBottom = () => {
   isUserAtBottom.value = true
   scrollToBottom()
   showScrollToBottom.value = false
+  showNewMessagesHint.value = false
+  pendingNewMessageCount.value = 0
 }
 
 // 手动点击加载更多
@@ -432,10 +487,17 @@ watch(
         if (oldLength === 0 || oldLength === undefined) {
           scrollToBottom()
           isUserAtBottom.value = true
+          showNewMessagesHint.value = false
+          pendingNewMessageCount.value = 0
         } else {
           // 非初始加载：只有用户在底部时才滚动
           if (isUserAtBottom.value) {
             scrollToBottom()
+            showNewMessagesHint.value = false
+            pendingNewMessageCount.value = 0
+          } else {
+            pendingNewMessageCount.value += Math.max(newLength - (oldLength || 0), 1)
+            showNewMessagesHint.value = true
           }
         }
         showScrollToBottom.value = !checkIsAtBottom()
@@ -719,6 +781,7 @@ onUnmounted(() => {
 
 interface ToolCallData {
   tool_call_id?: string
+  tool_message_id?: string
   name?: string
   tool_name?: string
   content?: string
@@ -727,6 +790,7 @@ interface ToolCallData {
   timestamp?: string
   arguments?: Record<string, unknown>
   result?: unknown
+  result_preview?: string
   context?: string  // 工具调用前的状态文本上下文
 }
 
@@ -1629,6 +1693,26 @@ defineExpose({
   z-index: 10;
 }
 
+.new-messages-hint {
+  position: absolute;
+  bottom: 144px;
+  right: 24px;
+  z-index: 10;
+  padding: 8px 14px;
+  border: 1px solid var(--border-color, #dbe4ee);
+  border-radius: 999px;
+  background: var(--bg-primary, #fff);
+  color: var(--primary-color, #2196f3);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.new-messages-hint:hover {
+  background: var(--hover-bg, #f5faff);
+}
+
 .scroll-to-bottom-btn:hover {
   background: var(--primary-color, #2196f3);
   border-color: var(--primary-color, #2196f3);
@@ -1834,6 +1918,36 @@ defineExpose({
 /* ==================== 嵌入式工具调用卡片样式 ==================== */
 .tool-calls-section {
   margin-bottom: 12px;
+}
+
+.tool-message-link {
+  margin-top: 8px;
+  color: var(--text-secondary, #666);
+  font-size: 12px;
+  font-family: 'Consolas', 'Monaco', monospace;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.tool-message-link:hover {
+  color: var(--primary-color, #2196f3);
+  text-decoration: underline;
+}
+
+.message-highlighted {
+  animation: message-highlight-fade 2s ease;
+}
+
+@keyframes message-highlight-fade {
+  0% {
+    background: rgba(37, 99, 235, 0.16);
+  }
+  100% {
+    background: transparent;
+  }
 }
 
 .tool-message-card.embedded {

--- a/frontend/src/components/TopicList.vue
+++ b/frontend/src/components/TopicList.vue
@@ -82,7 +82,6 @@ const filteredTopics = computed(() => {
 
 const selectTopic = (id: string) => {
   chatStore.setCurrentTopic(id)
-  router.push({ name: 'chat', params: { topicId: id } })
 }
 
 const logout = async () => {
@@ -176,6 +175,17 @@ onMounted(() => {
   border-radius: 8px;
   cursor: pointer;
   transition: background 0.2s;
+}
+
+.topic-item::after {
+  content: '阶段摘要';
+  display: inline-block;
+  margin-top: 6px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--secondary-bg, #eef3f8);
+  color: var(--text-secondary, #666);
+  font-size: 11px;
 }
 
 .topic-item:hover {

--- a/frontend/src/components/panel/TopicsTab.vue
+++ b/frontend/src/components/panel/TopicsTab.vue
@@ -21,6 +21,10 @@
         <span class="btn-text">{{ $t('topics.compress') }}</span>
       </button>
     </div>
+
+    <div class="topics-hint">
+      {{ $t('topics.title') }}{{ ' · 阶段摘要，仅用于辅助定位，不切换主会话入口' }}
+    </div>
     
     <!-- 搜索框 -->
     <div class="search-box">
@@ -236,6 +240,16 @@ const emit = defineEmits<{
   gap: 8px;
   margin-bottom: 8px;
   flex-shrink: 0;
+}
+
+.topics-hint {
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--secondary-bg, #f5f7fa);
+  color: var(--text-secondary, #666);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .action-btn {

--- a/frontend/src/composables/useMessageSending.ts
+++ b/frontend/src/composables/useMessageSending.ts
@@ -37,11 +37,15 @@ export function useMessageSending(options: UseMessageSendingOptions) {
   const streamingContent = ref('')
   // 流式思考内容累积器 - 用于 reasoning_delta 事件
   const streamingReasoningContent = ref('')
+  const activeRequestId = ref<string | null>(null)
 
   // 当前正在流式输出的助手消息 - 从 store 自动推导
-  const currentAssistantMessage = computed<Message | null>(() =>
-    chatStore.messages.find(m => m.role === 'assistant' && m.status === 'streaming') || null
-  )
+  const currentAssistantMessage = computed<Message | null>(() => {
+    if (activeRequestId.value) {
+      return chatStore.findStreamingAssistantByRequestId(activeRequestId.value) || null
+    }
+    return chatStore.messages.find(m => m.role === 'assistant' && m.status === 'streaming') || null
+  })
 
   // 当前用户消息ID - 从当前助手消息自动推导
   const currentUserMessageId = computed<string | null>(() => {
@@ -67,6 +71,11 @@ export function useMessageSending(options: UseMessageSendingOptions) {
   const resetStreamingContent = () => {
     streamingContent.value = ''
     streamingReasoningContent.value = ''
+    activeRequestId.value = null
+  }
+
+  const setActiveRequestId = (requestId: string | null) => {
+    activeRequestId.value = requestId
   }
 
   // 追加流式内容
@@ -116,7 +125,7 @@ export function useMessageSending(options: UseMessageSendingOptions) {
     }
 
     // 添加用户消息到本地
-    chatStore.addLocalMessage({
+    const userPlaceholder = chatStore.addLocalMessage({
       expert_id,
       role: 'user',
       content,
@@ -124,7 +133,7 @@ export function useMessageSending(options: UseMessageSendingOptions) {
     })
 
     // 添加助手消息占位（流式）
-    chatStore.addLocalMessage({
+    const assistantPlaceholder = chatStore.addLocalMessage({
       expert_id,
       role: 'assistant',
       content: '',
@@ -136,8 +145,6 @@ export function useMessageSending(options: UseMessageSendingOptions) {
 
     try {
       // 获取最后一条用户消息（刚添加的）
-      const lastUserMessage = chatStore.messages[chatStore.messages.length - 1]
-
       // 构建消息参数
       const messageParams: {
         content: string
@@ -146,7 +153,7 @@ export function useMessageSending(options: UseMessageSendingOptions) {
         task_id?: string
         working_path?: string
       } = {
-        content: lastUserMessage?.content || content,
+        content: userPlaceholder?.content || content,
         expert_id,
         model_id: getModelId(),
       }
@@ -168,11 +175,16 @@ export function useMessageSending(options: UseMessageSendingOptions) {
 
       // 发送消息
       const result = await messageApi.sendMessage(messageParams)
+      if (result.request_id) {
+        activeRequestId.value = result.request_id
+        chatStore.updateMessageRequestId(assistantPlaceholder.id, result.request_id)
+      }
       console.log('[useMessageSending] Message sent:', result)
       return true
 
     } catch (error) {
       console.error('[useMessageSending] Send message error:', error)
+      activeRequestId.value = null
       
       // 更新助手消息为错误状态
       const assistant = currentAssistantMessage.value
@@ -232,11 +244,13 @@ export function useMessageSending(options: UseMessageSendingOptions) {
     currentUserMessageId,
     streamingContent,
     streamingReasoningContent,
+    activeRequestId,
     
     // 方法
     sendMessage,
     retryMessage,
     resetStreamingContent,
+    setActiveRequestId,
     appendStreamingContent,
     appendReasoningContent,
     getStreamingContent,

--- a/frontend/src/composables/useSSEHandler.ts
+++ b/frontend/src/composables/useSSEHandler.ts
@@ -13,6 +13,8 @@ export interface UseSSEHandlerOptions {
   expertId: string | (() => string)
   currentAssistantMessage: () => Message | null
   currentUserMessageId: () => string | null
+  activeRequestId: () => string | null
+  setActiveRequestId: (requestId: string | null) => void
   getStreamingContent: () => string
   getReasoningContent: () => string
   setStreamingContent: (content: string) => void
@@ -24,11 +26,8 @@ export interface UseSSEHandlerOptions {
 }
 
 export interface CompleteEventData {
-  message_id?: string
-  content?: string
-  reasoning_content?: string
-  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number }
-  model?: string
+  request_id?: string
+  message?: Message
 }
 
 /**
@@ -51,6 +50,35 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
   // 记录上一次收到的最新消息 ID，用于避免重复拉取
   const lastKnownMessageId = ref<string | null>(null)
+  const lastKnownSequence = ref<number>(0)
+
+  const getAssistantByRequestId = (requestId?: string | null): Message | null => {
+    if (!requestId) {
+      return options.currentAssistantMessage()
+    }
+    return chatStore.findStreamingAssistantByRequestId(requestId) || null
+  }
+
+  const bindPendingAssistantToRequest = (requestId?: string | null) => {
+    if (!requestId) return null
+
+    const matched = chatStore.findStreamingAssistantByRequestId(requestId)
+    if (matched) return matched
+
+    const pendingAssistant = chatStore.messages.find(
+      m => m.role === 'assistant' && m.status === 'streaming' && !m.request_id
+    )
+
+    if (pendingAssistant) {
+      chatStore.updateMessageRequestId(pendingAssistant.id, requestId)
+      if (!options.activeRequestId()) {
+        options.setActiveRequestId(requestId)
+      }
+      return chatStore.findStreamingAssistantByRequestId(requestId)
+    }
+
+    return null
+  }
 
   // 批量缓冲相关
   let contentBuffer = ''
@@ -71,7 +99,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
   // 强制刷新缓冲区到UI
   const flushBuffers = () => {
-    const assistant = options.currentAssistantMessage()
+    const assistant = getAssistantByRequestId(options.activeRequestId())
     if (!assistant) {
       flushTimer = null
       return
@@ -121,36 +149,25 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
    * 使用服务端返回的内容更新临时消息（fallback 方案）
    */
   const updateTempMessageWithServerData = (data: CompleteEventData) => {
-    const assistant = options.currentAssistantMessage()
+    const assistant = getAssistantByRequestId(data.request_id)
     if (!assistant) return
 
-    const finalContent = data.content || options.getStreamingContent()
-    chatStore.updateMessageContent(assistant.id, finalContent, 'completed')
+    const message = data.message
+    if (!message) return
 
-    if (data.reasoning_content || options.getReasoningContent()) {
-      chatStore.updateMessageReasoningContent(
-        assistant.id,
-        data.reasoning_content || options.getReasoningContent()
-      )
-    }
-
-    if (data.usage && data.usage.prompt_tokens !== undefined && data.usage.completion_tokens !== undefined && data.usage.total_tokens !== undefined) {
-      chatStore.updateMessageMetadata(assistant.id, {
-        tokens: {
-          prompt_tokens: data.usage.prompt_tokens,
-          completion_tokens: data.usage.completion_tokens,
-          total_tokens: data.usage.total_tokens,
-        },
-        model: data.model,
-      })
-    }
+    chatStore.replaceMessage(assistant.id, {
+      ...message,
+      request_id: data.request_id || message.request_id,
+      status: 'completed',
+      updated_at: message.updated_at || message.created_at,
+    })
   }
 
   /**
    * 从数据库获取消息并替换临时消息
    */
-  const replaceTempMessagesWithDb = async (messageId: string): Promise<boolean> => {
-    const assistant = options.currentAssistantMessage()
+  const replaceTempMessagesWithDb = async (messageId: string, requestId?: string): Promise<boolean> => {
+    const assistant = getAssistantByRequestId(requestId)
     const expertId = getExpertId()
     if (!expertId || !assistant) return false
 
@@ -256,38 +273,36 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
    * 处理 SSE complete 事件
    */
   const handleCompleteEvent = async (data: CompleteEventData) => {
-    const assistant = options.currentAssistantMessage()
+    const assistant = getAssistantByRequestId(data.request_id)
     if (!assistant) {
       console.log('[useSSEHandler] Setting isSending to false on complete event (no current message)')
       clearSendingTimeout()
+      options.setActiveRequestId(null)
       return
     }
 
     // 更新已知的消息 ID，避免心跳检测误判导致刷新
-    if (data.message_id) {
-      lastKnownMessageId.value = data.message_id
+    if (data.message?.id) {
+      lastKnownMessageId.value = data.message.id
     }
 
-    // 尝试从数据库获取消息
-    if (data.message_id && options.expertId) {
-      const success = await replaceTempMessagesWithDb(data.message_id)
-      if (!success) {
-        // 数据库获取失败，使用服务端返回的内容
-        console.log('[useSSEHandler] Failed to get DB messages, using server data')
-        updateTempMessageWithServerData(data)
-      }
-    } else {
-      // 没有 message_id，使用服务端返回的内容
+    if (data.message) {
       updateTempMessageWithServerData(data)
+    } else if (data.request_id && assistant.request_id === data.request_id) {
+      const success = await replaceTempMessagesWithDb(assistant.id, data.request_id)
+      if (!success) {
+        console.log('[useSSEHandler] Failed to get DB messages, using server data')
+      }
     }
 
     // 检测技能相关操作
-    const finalContent = data.content || options.getStreamingContent()
+    const finalContent = data.message?.content || options.getStreamingContent()
     detectAndEmitSkillEvents(finalContent)
     options.onSkillEvent?.(finalContent)
 
     console.log('[useSSEHandler] Setting isSending to false on complete event')
     clearSendingTimeout()
+    options.setActiveRequestId(null)
     options.onComplete?.()
   }
 
@@ -300,6 +315,11 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
       try {
         const data = JSON.parse(event.data)
         const serverLatestMessageId = data.latest_message_id
+        const serverLatestSequence = Number(data.latest_sequence || 0)
+
+        if (serverLatestSequence > lastKnownSequence.value) {
+          lastKnownSequence.value = serverLatestSequence
+        }
 
         // 如果正在发送消息，跳过心跳检测触发的刷新
         const isSending = chatStore.messages.some(m => m.status === 'streaming')
@@ -311,28 +331,38 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
           return
         }
 
-        // 如果服务端有消息 ID，且与本地已知的不同
+        // 如果服务端有消息 ID，且与本地已知的不同，只更新游标
+        // 不再通过 heartbeat 触发第一页整页重载，避免聊天视图被打断
         if (serverLatestMessageId && serverLatestMessageId !== lastKnownMessageId.value) {
-          // 获取本地最新消息 ID
-          const localMessages = chatStore.sortedMessages
-          const lastMessage = localMessages.length > 0 ? localMessages[localMessages.length - 1] : undefined
-          const localLatestId = lastMessage?.id ?? null
+          console.log('[useSSEHandler] heartbeat detected newer server message id, cursor updated only:', {
+            serverLatest: serverLatestMessageId,
+            localKnown: lastKnownMessageId.value,
+          })
 
-          // 如果服务端消息 ID 与本地最新消息 ID 不同，说明有新消息
-          if (serverLatestMessageId !== localLatestId) {
-            console.log('[useSSEHandler] 检测到新消息，主动拉取:', {
-              serverLatest: serverLatestMessageId,
-              localLatest: localLatestId,
-            })
+          const expertId = getExpertId()
+          if (expertId) {
+            try {
+              const result = await messageApi.getMessagesSince(expertId, {
+                after_message_id: lastKnownMessageId.value || undefined,
+                limit: 50,
+              })
 
-            // 刷新消息列表（只拉取第一页最新消息）
-            const expertId = getExpertId()
-            if (expertId) {
-              await chatStore.loadMessagesByExpert(expertId, 1)
+              if (result.items?.length) {
+                chatStore.mergeMessages(result.items.map(message => ({
+                  ...message,
+                  status: 'completed',
+                })))
+              }
+
+              if (result.latest_message_id) {
+                lastKnownMessageId.value = result.latest_message_id
+                return
+              }
+            } catch (error) {
+              console.warn('[useSSEHandler] incremental sync failed:', error)
             }
           }
 
-          // 更新已知的消息 ID
           lastKnownMessageId.value = serverLatestMessageId
         }
       } catch (e) {
@@ -343,6 +373,13 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
     try {
       const data = JSON.parse(event.data)
+      const eventSequence = Number(data.sequence || event.id || 0)
+      if (eventSequence && eventSequence <= lastKnownSequence.value && event.event !== 'connected') {
+        return
+      }
+      if (eventSequence > lastKnownSequence.value) {
+        lastKnownSequence.value = eventSequence
+      }
 
       switch (event.event) {
         case 'connected':
@@ -351,6 +388,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
         case 'start':
           console.log('[useSSEHandler] SSE start:', data)
+          bindPendingAssistantToRequest(data.request_id)
           // 如果检测到新话题，刷新话题列表
           if (data.is_new_topic) {
             console.log('[useSSEHandler] 检测到新话题，刷新话题列表')
@@ -360,7 +398,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
           break
 
         case 'delta':
-          if (options.currentAssistantMessage()) {
+          if (getAssistantByRequestId(data.request_id)) {
             // 使用批量缓冲机制，减少UI更新频率
             contentBuffer += data.content
             
@@ -379,7 +417,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
         case 'reasoning_delta':
           // 处理思考内容增量事件（DeepSeek R1、GLM-Z1、Qwen3 等支持）
-          if (options.currentAssistantMessage()) {
+          if (getAssistantByRequestId(data.request_id)) {
             // 使用批量缓冲机制
             reasoningBuffer += data.content
             
@@ -399,7 +437,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
         case 'tool_call':
           // 工具调用开始 - 只显示简单的进度提示
           console.log('[useSSEHandler] Tool call:', data)
-          if (options.currentAssistantMessage() && data.toolCalls) {
+          if (getAssistantByRequestId(data.request_id) && data.toolCalls) {
             const toolNames = data.toolCalls.map((tc: { displayName?: string; function?: { name?: string }; name?: string }) => {
               return tc.displayName || tc.function?.name || tc.name || 'unknown'
             }).join(', ')
@@ -410,7 +448,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
             options.setStreamingContent(newContent)
             // 更新 store 中的消息内容
             chatStore.updateMessageContent(
-              options.currentAssistantMessage()!.id,
+              getAssistantByRequestId(data.request_id)!.id,
               newContent
             )
           }
@@ -442,7 +480,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
           // 工具调用即将达到上限（80%阈值），显示警告提示
           console.log('[useSSEHandler] Tool limit warning:', data)
           if (data.message) {
-            const assistant = options.currentAssistantMessage()
+            const assistant = getAssistantByRequestId(data.request_id)
             if (assistant) {
               const currentContent = options.getStreamingContent() || ''
               const warningText = `\n\n⚠️ ${data.message}\n`
@@ -456,7 +494,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
           // 工具调用已达到上限（100%），显示总结
           console.log('[useSSEHandler] Tool limit reached:', data)
           if (data.summary) {
-            const assistant = options.currentAssistantMessage()
+            const assistant = getAssistantByRequestId(data.request_id)
             if (assistant) {
               const currentContent = options.getStreamingContent() || ''
               const summaryText = `\n\n📊 ${data.summary}\n\n${data.message || ''}`
@@ -464,6 +502,27 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
               chatStore.updateMessageContent(assistant.id, currentContent + summaryText)
             }
           }
+          break
+
+        case 'stopped':
+          console.log('[useSSEHandler] SSE stopped event received:', data)
+          if (flushTimer) {
+            clearTimeout(flushTimer)
+            flushTimer = null
+          }
+          flushBuffers()
+          {
+            const assistant = getAssistantByRequestId(data.request_id)
+            if (assistant) {
+              chatStore.updateMessageContent(
+                assistant.id,
+                options.getStreamingContent() || assistant.content || '',
+                'stopped'
+              )
+            }
+          }
+          clearSendingTimeout()
+          options.setActiveRequestId(null)
           break
 
         case 'error':
@@ -475,7 +534,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
           }
           flushBuffers()
           
-          const assistant = options.currentAssistantMessage()
+          const assistant = getAssistantByRequestId(data.request_id)
           if (assistant) {
             chatStore.updateMessageContent(
               assistant.id,
@@ -485,6 +544,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
           }
           console.log('[useSSEHandler] Setting isSending to false on error event')
           clearSendingTimeout()
+          options.setActiveRequestId(null)
           options.onError?.(new Error(data.message || t('error.unknownError')))
           break
 

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -151,6 +151,7 @@ export const useChatStore = defineStore('chat', () => {
 
     const newMessage: Message = {
       id: messageId,
+      request_id: message.request_id,
       expert_id: message.expert_id || currentExpertId.value || '',
       user_id: message.user_id || '',
       topic_id: message.topic_id,
@@ -192,6 +193,72 @@ export const useChatStore = defineStore('chat', () => {
     const message = messages.value.find(m => m.id === messageId)
     if (message) {
       message.metadata = { ...message.metadata, ...metadata }
+    }
+  }
+
+  /**
+   * 绑定服务端 request_id 到本地占位消息
+   */
+  const updateMessageRequestId = (messageId: string, requestId: string) => {
+    const index = messages.value.findIndex(m => m.id === messageId)
+    if (index !== -1) {
+      const message = messages.value[index]
+      if (message) {
+        messages.value.splice(index, 1, {
+          ...message,
+          request_id: requestId,
+          updated_at: new Date().toISOString(),
+        })
+      }
+    }
+  }
+
+  /**
+   * 根据 request_id 查找正在流式中的助手占位消息
+   */
+  const findStreamingAssistantByRequestId = (requestId: string) => {
+    return messages.value.find(
+      m => m.role === 'assistant' && m.status === 'streaming' && m.request_id === requestId
+    ) || null
+  }
+
+  /**
+   * 使用服务端最终快照替换本地占位消息
+   */
+  const replaceMessage = (messageId: string, nextMessage: Message) => {
+    const index = messages.value.findIndex(m => m.id === messageId)
+    if (index === -1) return
+
+    const duplicateIndex = messages.value.findIndex((m, i) => i !== index && m.id === nextMessage.id)
+    if (duplicateIndex !== -1) {
+      messages.value.splice(duplicateIndex, 1)
+    }
+
+    messages.value.splice(index, 1, nextMessage)
+  }
+
+  /**
+   * 增量合并消息到尾部，按 id 去重
+   */
+  const mergeMessages = (incomingMessages: Message[]) => {
+    for (const incoming of incomingMessages) {
+      const index = messages.value.findIndex(m => m.id === incoming.id)
+      if (index !== -1) {
+        const current = messages.value[index]
+        if (current) {
+          messages.value.splice(index, 1, {
+            ...current,
+            ...incoming,
+            updated_at: incoming.updated_at || current.updated_at,
+          })
+        }
+        continue
+      }
+
+      messages.value.push({
+        ...incoming,
+        status: incoming.status || 'completed',
+      })
     }
   }
 
@@ -358,7 +425,11 @@ export const useChatStore = defineStore('chat', () => {
     addLocalMessage,
     updateMessageContent,
     updateMessageMetadata,
+    updateMessageRequestId,
     updateMessageReasoningContent,
+    findStreamingAssistantByRequestId,
+    replaceMessage,
+    mergeMessages,
     removeMessage,
     clearChat,
     clearError,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,6 +53,7 @@ export type MessageStatus = 'pending' | 'streaming' | 'completed' | 'error' | 'c
 // 核心设计：消息按 expert + user 组织，topic_id 只是对话历史的阶段性总结标记
 export interface Message {
   id: string
+  request_id?: string
   expert_id: string      // 所属专家
   user_id?: string       // 所属用户
   topic_id?: string      // 可选，阶段总结标记
@@ -85,6 +86,7 @@ export interface MessageMetadata {
 export interface ToolCallData {
   [key: string]: unknown
   tool_call_id?: string
+  tool_message_id?: string
   name?: string
   tool_name?: string
   content?: string
@@ -93,6 +95,7 @@ export interface ToolCallData {
   timestamp?: string
   arguments?: Record<string, unknown>
   result?: unknown
+  result_preview?: string
 }
 
 // Token 使用情况

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -189,6 +189,8 @@ const sseHandler = useSSEHandler({
   get expertId() { return currentExpertId.value },
   currentAssistantMessage: () => messageSending.currentAssistantMessage.value,
   currentUserMessageId: () => messageSending.currentUserMessageId.value,
+  activeRequestId: () => messageSending.activeRequestId.value,
+  setActiveRequestId: messageSending.setActiveRequestId,
   getStreamingContent: messageSending.getStreamingContent,
   getReasoningContent: messageSending.getReasoningContent,
   setStreamingContent: messageSending.setStreamingContent,
@@ -264,8 +266,8 @@ const handlePanelResize = (panes: { size: number }[]) => {
 
 // 处理 Topic 选择
 const handleTopicSelect = (topic: Topic) => {
-  console.log('Selected topic:', topic)
-  // TODO: 加载该 topic 的消息
+  console.log('Selected topic summary:', topic)
+  chatStore.setCurrentTopic(topic.id)
 }
 
 // 处理 Doc 选择
@@ -375,7 +377,9 @@ const handleStopGenerate = async () => {
 
   // 调用后端停止 API
   try {
-    await messageApi.stopGeneration(currentExpertId.value!)
+    const requestId = messageSending.activeRequestId.value
+    if (!requestId) return
+    await messageApi.stopGeneration(requestId)
   } catch (error) {
     console.warn('Stop generation API not available:', error)
   }

--- a/frontend/src/views/TopicsView.vue
+++ b/frontend/src/views/TopicsView.vue
@@ -33,9 +33,6 @@
           <span v-if="topic.message_count">{{ topic.message_count }} {{ $t('topics.messages') }}</span>
         </div>
         <div class="topic-actions">
-          <el-button type="primary" size="small" @click="openTopic(topic.id)">
-            {{ $t('topics.continue') }}
-          </el-button>
           <el-button
             v-if="topic.status === 'active'"
             size="small"
@@ -75,11 +72,9 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useChatStore } from '@/stores/chat'
 
-const router = useRouter()
 const { t } = useI18n()
 const chatStore = useChatStore()
 
@@ -100,10 +95,6 @@ const filteredTopics = computed(() => {
 
   return topics
 })
-
-const openTopic = (topicId: string) => {
-  router.push({ name: 'chat', params: { topicId } })
-}
 
 const archiveTopic = async (topicId: string) => {
   await chatStore.updateTopic(topicId, { status: 'archived' })

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -195,7 +195,7 @@ class ChatService {
    * 支持流式响应和多轮工具调用
    * @returns {Promise<object>} LLM 调用结果
    */
-  async _executeLLMRounds(expertService, { modelConfig, thinkingConfig, tools, currentMessages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, onDelta }) {
+  async _executeLLMRounds(expertService, { modelConfig, thinkingConfig, tools, currentMessages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, request_id, onDelta }) {
     const systemSettingService = getSystemSettingService(this.db);
     const MAX_TOOL_ROUNDS = expertService.expertConfig?.expert?.max_tool_rounds
       || await systemSettingService.getMaxToolRounds();
@@ -236,6 +236,7 @@ class ChatService {
         thinking: thinkingConfig.thinking,
         reasoning: thinkingConfig.reasoning,
         user_id,  // 添加 user_id 用于 abort 机制
+        request_id,
         onDelta: (delta) => {
           roundContent += delta;
           fullContent += delta;
@@ -316,6 +317,7 @@ class ChatService {
           ...call,
           result: result ? { success: result.success, data: result.data, error: result.error } : null,
           duration: result?.duration || 0,
+          tool_message_id: result?.toolMessageId || null,
           timestamp: new Date().toISOString(),
         };
       });
@@ -408,6 +410,48 @@ class ChatService {
   }
 
   /**
+   * 构建 assistant 完成态使用的工具调用快照
+   * 返回前端可直接渲染的摘要结构，而不是完整工具结果真相源。
+   * 完整结果仍以独立 tool message 为准。
+   * @param {Array} toolCallsWithResults - 工具调用及结果数组
+   * @returns {Array}
+   */
+  buildToolCallSnapshot(toolCallsWithResults = []) {
+    if (!Array.isArray(toolCallsWithResults) || toolCallsWithResults.length === 0) {
+      return [];
+    }
+
+    return toolCallsWithResults.map(call => {
+      const rawResult = call.result?.data;
+      let resultPreview = null;
+
+      if (typeof rawResult === 'string') {
+        resultPreview = rawResult.slice(0, 200);
+      } else if (rawResult !== undefined) {
+        try {
+          resultPreview = JSON.stringify(rawResult).slice(0, 200);
+        } catch (error) {
+          resultPreview = '[unserializable result]';
+        }
+      } else if (call.result?.error) {
+        resultPreview = String(call.result.error).slice(0, 200);
+      }
+
+      return {
+        tool_call_id: call.id || call.tool_call_id || null,
+        name: call.function?.name || call.name || 'unknown',
+        display_name: call.displayName || call.function?.name || call.name || 'unknown',
+        arguments: call.function?.arguments || call.arguments || null,
+        success: call.result?.success !== false,
+        duration: call.duration || 0,
+        result_preview: resultPreview,
+        tool_message_id: call.tool_message_id || null,
+        timestamp: call.timestamp || new Date().toISOString(),
+      };
+    });
+  }
+
+  /**
    * 执行工具调用（私有方法）
    * @returns {Promise<Array>} 工具执行结果数组
    */
@@ -452,7 +496,7 @@ class ChatService {
    * @param {Function} onError - 错误回调 (error: Error) => void
    */
   async streamChat(params, onDelta, onComplete, onError) {
-    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, session } = params;
+    const { topic_id: providedTopicId, user_id, expert_id, content, model_id, task_id, working_path, session, request_id } = params;
 
     try {
       logger.info('[ChatService] 开始流式聊天:', { expert_id, user_id, topic_id: providedTopicId, task_id, working_path });
@@ -481,7 +525,7 @@ class ChatService {
       logger.debug('[ChatService] Topic ID:', topic_id, isNewTopic ? '(新话题)' : '(继续当前话题)');
 
       // 4. 发送开始事件
-      onDelta?.({ type: 'start', message_id: `msg_${Utils.newID(10)}`, topic_id, is_new_topic: isNewTopic });
+      onDelta?.({ type: 'start', request_id, message_id: `msg_${Utils.newID(10)}`, topic_id, is_new_topic: isNewTopic });
 
       // 5. 保存用户消息
       const userMessageId = await this.saveUserMessage(topic_id, user_id, content, expert_id, task_id);
@@ -536,7 +580,7 @@ class ChatService {
       this.saveLLMPayload(user_id, expert_id, llmPayload);
 
       // 9. 执行多轮 LLM 调用
-      const llmResult = await this._executeLLMRounds(expertService, { modelConfig, thinkingConfig, tools, currentMessages: context.messages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, onDelta });
+      const llmResult = await this._executeLLMRounds(expertService, { modelConfig, thinkingConfig, tools, currentMessages: context.messages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, request_id, onDelta });
       const { fullContent, fullReasoningContent, tokenUsage } = llmResult;
       let finalContent = fullContent;
       const latency = Date.now() - startTime;
@@ -572,6 +616,7 @@ class ChatService {
       }
 
       // 10. 保存助手消息
+      const assistantCreatedAt = new Date().toISOString();
       const assistantMessageId = await this.saveAssistantMessage(topic_id, user_id, finalContent, {
         prompt_tokens: tokenUsage?.prompt_tokens || 0,
         completion_tokens: tokenUsage?.completion_tokens || 0,
@@ -581,6 +626,7 @@ class ChatService {
         expert_id,
         reasoning_content: fullReasoningContent || null,
         task_id,
+        created_at: assistantCreatedAt,
       });
 
       // 11. 异步反思和历史归档
@@ -588,8 +634,33 @@ class ChatService {
       expertService.processHistoryIfNeeded(user_id, topic_id).catch(err => logger.error('[ChatService] 历史归档失败:', err.message));
       await this.updateTopicTimestamp(topic_id);
 
+      const toolCallSnapshot = this.buildToolCallSnapshot(llmResult.allToolCalls || []);
+
       // 12. 发送完成事件
-      onComplete?.({ type: 'complete', message_id: assistantMessageId, content: finalContent, reasoning_content: fullReasoningContent || null, usage: tokenUsage, latency, model: modelConfig.model_name });
+      onComplete?.({
+        type: 'complete',
+        request_id,
+        message: {
+          id: assistantMessageId,
+          request_id,
+          topic_id,
+          role: 'assistant',
+          content: finalContent,
+          reasoning_content: fullReasoningContent || null,
+          tool_calls: toolCallSnapshot,
+          metadata: {
+            tokens: tokenUsage ? {
+              prompt_tokens: tokenUsage.prompt_tokens || 0,
+              completion_tokens: tokenUsage.completion_tokens || 0,
+              total_tokens: tokenUsage.total_tokens || 0,
+            } : null,
+            latency,
+            model: modelConfig.model_name,
+            provider: modelConfig.provider_name,
+          },
+          created_at: assistantCreatedAt,
+        },
+      });
 
     } catch (error) {
       logger.error('[ChatService] 流式聊天失败:', error.message);
@@ -843,6 +914,7 @@ class ChatService {
       expert_id = null,
       reasoning_content = null,  // 思考过程内容（DeepSeek）
       task_id = null,  // 任务ID
+      created_at = new Date().toISOString(),
     } = options;
 
     await this.Message.create({
@@ -859,6 +931,7 @@ class ChatService {
       model_name,
       provider_name,
       tool_calls,
+      created_at,
     });
 
     // 如果有关联的任务，更新任务的 last_executed_at
@@ -1511,6 +1584,17 @@ class ChatService {
     const expertService = await this.getExpertService(expertId);
     return expertService.abortUserRequest(userId);
   }
+
+  /**
+   * 中止指定 request_id 的请求
+   * @param {string} expertId - 专家ID
+   * @param {string} requestId - 请求ID
+   * @returns {boolean} 是否成功中止
+   */
+  async abortRequest(expertId, requestId) {
+    const expertService = await this.getExpertService(expertId);
+    return expertService.abortRequest(requestId);
+  }
 }
 
 // ============================================================
@@ -2072,6 +2156,21 @@ class ExpertChatService {
     }
     const aborted = this.llmClient.abortUserRequest(userId);
     logger.info(`[ExpertChatService] abortUserRequest: user=${userId}, expert=${this.expertId}, aborted=${aborted}`);
+    return aborted;
+  }
+
+  /**
+   * 中止指定 request_id 的请求
+   * @param {string} requestId - 请求ID
+   * @returns {boolean} 是否成功中止
+   */
+  abortRequest(requestId) {
+    if (!this.llmClient) {
+      logger.warn(`[ExpertChatService] abortRequest: LLMClient not initialized`);
+      return false;
+    }
+    const aborted = this.llmClient.abortRequest(requestId);
+    logger.info(`[ExpertChatService] abortRequest: request_id=${requestId}, expert=${this.expertId}, aborted=${aborted}`);
     return aborted;
   }
 

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -73,6 +73,23 @@ class LLMClient {
   }
 
   /**
+   * 中止指定 request_id 的请求
+   * @param {string} requestId - 请求ID
+   * @returns {boolean} 是否成功中止
+   */
+  abortRequest(requestId) {
+    const req = this.activeRequests.get(requestId);
+    if (!req) {
+      return false;
+    }
+
+    logger.info(`[LLMClient] Aborting request by request_id: ${requestId}`);
+    req.destroy(new Error('Request aborted by user'));
+    this.activeRequests.delete(requestId);
+    return true;
+  }
+
+  /**
    * 获取当前活跃请求数
    * @returns {number}
    */
@@ -195,7 +212,7 @@ class LLMClient {
    */
   async call(model, messages, options = {}) {
     const userId = options.user_id || 'anonymous';
-    const requestId = this._generateRequestId(userId);
+    const requestId = options.request_id || this._generateRequestId(userId);
     const processedMessages = this.processMultimodalMessages(messages, model);
 
     const callType = options._reflective ? '反思' : '非流式';
@@ -223,7 +240,7 @@ class LLMClient {
    */
   async callWithRetry(model, messages, options = {}) {
     const userId = options.user_id || 'anonymous';
-    const requestId = this._generateRequestId(userId);
+    const requestId = options.request_id || this._generateRequestId(userId);
     const processedMessages = this.processMultimodalMessages(messages, model);
     return baseCallWithRetry(model, processedMessages, {
       ...options,
@@ -454,7 +471,7 @@ class LLMClient {
    */
   async callStream(model, messages, options = {}) {
     const userId = options.user_id || 'anonymous';
-    const requestId = this._generateRequestId(userId);
+    const requestId = options.request_id || this._generateRequestId(userId);
     const processedMessages = this.processMultimodalMessages(messages, model);
     const { tools } = options;
 

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -20,6 +20,33 @@ class MessageController {
     this.Message = db.getModel('message');
   }
 
+  safeParseJSON(value) {
+    if (!value) return null;
+    try {
+      return typeof value === 'string' ? JSON.parse(value) : value;
+    } catch (e) {
+      logger.warn('JSON parse failed:', value);
+      return null;
+    }
+  }
+
+  formatMessage(m) {
+    return {
+      ...m,
+      inner_voice: this.safeParseJSON(m.inner_voice),
+      tool_calls: this.safeParseJSON(m.tool_calls),
+      error_info: this.safeParseJSON(m.error_info),
+      metadata: {
+        tokens: (m.prompt_tokens || m.completion_tokens) ? {
+          total_tokens: (m.prompt_tokens || 0) + (m.completion_tokens || 0),
+          prompt_tokens: m.prompt_tokens || 0,
+          completion_tokens: m.completion_tokens || 0,
+        } : null,
+        latency: m.latency_ms || null,
+      },
+    };
+  }
+
   /**
    * 按 expert + user 获取消息列表（主要入口）
    * 这是新的核心 API，用于加载某个 expert 与当前用户的对话历史
@@ -63,39 +90,13 @@ class MessageController {
         raw: true,
       });
 
-      // 安全解析 JSON
-      const safeParseJSON = (value) => {
-        if (!value) return null;
-        try {
-          const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-          return parsed;
-        } catch (e) {
-          logger.warn('JSON parse failed:', value);
-          return null;
-        }
-      };
-
       // 反转数组，使消息按时间正序返回（最早的在前，便于聊天界面显示）
       const sortedRows = rows.reverse();
 
       const pages = Math.ceil(count / size);
 
       ctx.success({
-        items: sortedRows.map(m => ({
-          ...m,
-          inner_voice: safeParseJSON(m.inner_voice),
-          tool_calls: safeParseJSON(m.tool_calls),
-          error_info: safeParseJSON(m.error_info),
-          // 将数据库字段转换为前端期望的 metadata 格式
-          metadata: {
-            tokens: (m.prompt_tokens || m.completion_tokens) ? {
-              total_tokens: (m.prompt_tokens || 0) + (m.completion_tokens || 0),
-              prompt_tokens: m.prompt_tokens || 0,
-              completion_tokens: m.completion_tokens || 0,
-            } : null,
-            latency: m.latency_ms || null,
-          },
-        })),
+        items: sortedRows.map(m => this.formatMessage(m)),
         pagination: {
           page,
           size,
@@ -123,13 +124,19 @@ class MessageController {
         return;
       }
 
+      const userId = ctx.state.session.id;
+
+      if (!userId) {
+        ctx.error('未登录', 401);
+        return;
+      }
+
       const page = parseInt(pageNumber);
       const size = parseInt(pageSize);
       const offset = (page - 1) * size;
 
-      // 获取消息
       const { count, rows } = await this.Message.findAndCountAll({
-        where: { topic_id },
+        where: { topic_id, user_id: userId },
         attributes: [
           'id', 'topic_id', 'role', 'content', 'tokens', 'inner_voice', 'tool_calls',
           'error_info', 'created_at', 'latency_ms'
@@ -177,13 +184,19 @@ class MessageController {
         return;
       }
 
+      const userId = ctx.state.session.id;
+
+      if (!userId) {
+        ctx.error('未登录', 401);
+        return;
+      }
+
       const page = parseInt(pageNumber);
       const size = parseInt(pageSize);
       const offset = (page - 1) * size;
 
-      // 获取消息
       const { count, rows } = await this.Message.findAndCountAll({
-        where: { topic_id: topicId },
+        where: { topic_id: topicId, user_id: userId },
         attributes: [
           'id', 'topic_id', 'role', 'content', 'tokens', 'inner_voice', 'tool_calls',
           'error_info', 'created_at', 'latency_ms'
@@ -224,9 +237,15 @@ class MessageController {
   async get(ctx) {
     try {
       const { id } = ctx.params;
+      const userId = ctx.state.session.id;
+
+      if (!userId) {
+        ctx.error('未登录', 401);
+        return;
+      }
 
       const message = await this.Message.findOne({
-        where: { id },
+        where: { id, user_id: userId },
         attributes: [
           'id', 'topic_id', 'role', 'content', 'tokens', 'inner_voice', 'tool_calls',
           'error_info', 'created_at', 'latency_ms'
@@ -309,38 +328,93 @@ class MessageController {
 
       logger.info('[listWithBefore] Found messages:', messages.length);
 
-      // 安全解析 JSON
-      const safeParseJSON = (value) => {
-        if (!value) return null;
-        try {
-          const parsed = typeof value === 'string' ? JSON.parse(value) : value;
-          return parsed;
-        } catch (e) {
-          logger.warn('JSON parse failed:', value);
-          return null;
-        }
-      };
-
       // 反转为正序（最早的在前）
       const sortedMessages = messages.reverse();
 
-      ctx.success(sortedMessages.map(m => ({
-        ...m,
-        inner_voice: safeParseJSON(m.inner_voice),
-        tool_calls: safeParseJSON(m.tool_calls),
-        error_info: safeParseJSON(m.error_info),
-        metadata: {
-          tokens: (m.prompt_tokens || m.completion_tokens) ? {
-            total_tokens: (m.prompt_tokens || 0) + (m.completion_tokens || 0),
-            prompt_tokens: m.prompt_tokens || 0,
-            completion_tokens: m.completion_tokens || 0,
-          } : null,
-          latency: m.latency_ms || null,
-        },
-      })));
+      ctx.success(sortedMessages.map(m => this.formatMessage(m)));
     } catch (error) {
       console.error('Get messages with before error:', error.stack || error);
       ctx.error('获取消息失败', 500);
+    }
+  }
+
+  /**
+   * 按最新消息游标增量获取消息
+   */
+  async listSince(ctx) {
+    try {
+      const { expertId } = ctx.params;
+      const { after_message_id, limit: limitValue = 50 } = ctx.query;
+      const userId = ctx.state.session.id;
+
+      if (!expertId) {
+        ctx.error('缺少 expertId 参数');
+        return;
+      }
+
+      if (!userId) {
+        ctx.error('未登录', 401);
+        return;
+      }
+
+      const limit = Math.min(parseInt(limitValue, 10) || 50, 100);
+      let anchorCreatedAt = null;
+      let anchorId = null;
+
+      if (after_message_id) {
+        const anchor = await this.Message.findOne({
+          where: {
+            id: after_message_id,
+            expert_id: expertId,
+            user_id: userId,
+          },
+          attributes: ['id', 'created_at'],
+          raw: true,
+        });
+
+        if (anchor) {
+          anchorCreatedAt = anchor.created_at;
+          anchorId = anchor.id;
+        }
+      }
+
+      const where = {
+        expert_id: expertId,
+        user_id: userId,
+      };
+
+      if (anchorCreatedAt && anchorId) {
+        where[Op.or] = [
+          { created_at: { [Op.gt]: anchorCreatedAt } },
+          {
+            created_at: anchorCreatedAt,
+            id: { [Op.gt]: anchorId },
+          },
+        ];
+      }
+
+      const rows = await this.Message.findAll({
+        where,
+        attributes: [
+          'id', 'expert_id', 'user_id', 'topic_id', 'role', 'content', 'reasoning_content',
+          'prompt_tokens', 'completion_tokens',
+          'inner_voice', 'tool_calls', 'error_info', 'created_at', 'latency_ms'
+        ],
+        order: [['created_at', 'ASC'], ['id', 'ASC']],
+        limit,
+        raw: true,
+      });
+
+      const latestMessageId = rows.length > 0 ? rows[rows.length - 1]?.id || null : after_message_id || null;
+
+      ctx.success({
+        items: rows.map(m => this.formatMessage(m)),
+        latest_message_id: latestMessageId,
+        has_more: rows.length === limit,
+      });
+    } catch (error) {
+      logger.error('Get messages since error:', error);
+      ctx.error('获取增量消息失败', 500);
     }
   }
 

--- a/server/controllers/stream.controller.js
+++ b/server/controllers/stream.controller.js
@@ -28,6 +28,37 @@ class StreamController {
     this.permissionService = getPermissionService(db);
     // 存储活跃的 SSE 连接：Map<expertId, Set<{userId, res}>>
     this.expertConnections = new Map();
+    // 存储活跃请求：Map<requestId, {expertId, userId, stopped}>
+    this.activeRequests = new Map();
+    // 事件序号：Map<expertId:userId, number>
+    this.eventSequences = new Map();
+    // 最新游标：Map<expertId:userId, { latest_message_id: string | null }>
+    this.latestCursors = new Map();
+  }
+
+  _getSequenceKey(expert_id, user_id) {
+    return `${expert_id}:${user_id}`;
+  }
+
+  _nextSequence(expert_id, user_id) {
+    const key = this._getSequenceKey(expert_id, user_id);
+    const next = (this.eventSequences.get(key) || 0) + 1;
+    this.eventSequences.set(key, next);
+    return next;
+  }
+
+  _getCurrentSequence(expert_id, user_id) {
+    return this.eventSequences.get(this._getSequenceKey(expert_id, user_id)) || 0;
+  }
+
+  _updateLatestCursor(expert_id, user_id, latest_message_id) {
+    this.latestCursors.set(this._getSequenceKey(expert_id, user_id), {
+      latest_message_id: latest_message_id || null,
+    });
+  }
+
+  _getLatestCursor(expert_id, user_id) {
+    return this.latestCursors.get(this._getSequenceKey(expert_id, user_id)) || { latest_message_id: null };
   }
 
   /**
@@ -106,21 +137,25 @@ class StreamController {
       // 获取或创建该用户与 Expert 的活跃 Topic（支持 task_id 关联）
       const topic_id = await this.getOrCreateActiveTopic(user_id, expert_id, task_id);
 
+      // 创建 request_id（一次流式生成请求的唯一标识）
+      const request_id = `req_${Utils.newID(16)}`;
+
       // 异步处理消息，不等待完成
       this.processMessageAsync({
+        request_id,
         topic_id,
         user_id,
         expert_id,
         content,
         model_id,
         task_id,
-        working_path,  // 传递当前工作目录路径
-        session: ctx.state.session,  // 直接传递 session 对象
+        working_path,
+        session: ctx.state.session,
       });
 
       // 立即返回成功，消息将通过 SSE 推送
       ctx.success({
-        message: '消息已发送',
+        request_id,
         topic_id,
       });
 
@@ -158,8 +193,10 @@ class StreamController {
    * @param {string} event - 事件名称
    * @param {object} data - 事件数据
    */
-  _broadcastToConnections(connections, event, data) {
-    const eventData = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  _broadcastToConnections(expert_id, user_id, connections, event, data) {
+    const sequence = this._nextSequence(expert_id, user_id);
+    const payload = { sequence, ...data };
+    const eventData = `id: ${sequence}\nevent: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
     for (const conn of connections) {
       if (!conn.res.writableEnded) {
         try {
@@ -175,7 +212,7 @@ class StreamController {
    * 异步处理消息并通过 SSE 推送响应
    * 支持多标签页：向该用户的所有连接广播消息
    */
-  async processMessageAsync({ topic_id, user_id, expert_id, content, model_id, task_id, working_path, session }) {
+  async processMessageAsync({ request_id, topic_id, user_id, expert_id, content, model_id, task_id, working_path, session }) {
     // 获取该用户在该 Expert 下的所有活跃连接
     const userConnections = this._getUserConnections(expert_id, user_id);
 
@@ -185,11 +222,13 @@ class StreamController {
     }
 
     logger.info(`Broadcasting to ${userConnections.length} connection(s) for user: ${user_id}`);
+    this.activeRequests.set(request_id, { expert_id, user_id, stopped: false });
 
     try {
       // 使用 ChatService 处理流式对话
       await this.chatService.streamChat(
         {
+          request_id,
           topic_id,
           user_id,
           expert_id,
@@ -202,58 +241,116 @@ class StreamController {
         // onDelta - 流式数据回调（广播到所有连接）
         (delta) => {
           if (delta.type === 'start') {
-            this._broadcastToConnections(userConnections, 'start', {
+            this._broadcastToConnections(expert_id, user_id, userConnections, 'start', {
+              request_id,
               topic_id: delta.topic_id,
               is_new_topic: delta.is_new_topic || false
             });
           } else if (delta.type === 'delta') {
-            this._broadcastToConnections(userConnections, 'delta', {
+            this._broadcastToConnections(expert_id, user_id, userConnections, 'delta', {
+              request_id,
               content: delta.content
             });
           } else if (delta.type === 'reasoning_delta') {
             // 思考内容增量事件（DeepSeek R1、GLM-Z1、Qwen3 等支持）
-            this._broadcastToConnections(userConnections, 'reasoning_delta', {
+            this._broadcastToConnections(expert_id, user_id, userConnections, 'reasoning_delta', {
+              request_id,
               content: delta.content
             });
           } else if (delta.type === 'tool_call') {
-            this._broadcastToConnections(userConnections, 'tool_call', delta);
+            this._broadcastToConnections(expert_id, user_id, userConnections, 'tool_call', {
+              request_id,
+              ...delta,
+            });
           } else if (delta.type === 'tool_result') {
             // 单个工具执行完成，实时推送结果
-            this._broadcastToConnections(userConnections, 'tool_result', {
+            this._broadcastToConnections(expert_id, user_id, userConnections, 'tool_result', {
+              request_id,
               result: delta.result
             });
           } else if (delta.type === 'topic_updated') {
             // 上下文压缩创建了新 Topic，通知前端刷新
-            this._broadcastToConnections(userConnections, 'topic_updated', {
+            this._broadcastToConnections(expert_id, user_id, userConnections, 'topic_updated', {
+              request_id,
               topicsCreated: delta.topicsCreated
+            });
+          } else if (delta.type === 'tool_limit_warning' || delta.type === 'tool_limit_reached') {
+            this._broadcastToConnections(expert_id, user_id, userConnections, delta.type, {
+              request_id,
+              ...delta,
             });
           }
         },
         // onComplete - 完成回调（广播到所有连接）
         (result) => {
-          this._broadcastToConnections(userConnections, 'complete', {
-            message_id: result.message_id,  // 传递真实消息 ID，避免心跳检测误判
-            content: result.content,
-            reasoning_content: result.reasoning_content,  // 传递思考内容
-            // 注意：不再传递 tool_calls，工具调用信息已通过 tool_result 事件传递
-            usage: result.usage,
-            model: result.model,
+          const activeRequest = this.activeRequests.get(request_id);
+          if (activeRequest?.stopped) {
+            this.activeRequests.delete(request_id);
+            return;
+          }
+
+          if (result.message?.id) {
+            this._updateLatestCursor(expert_id, user_id, result.message.id);
+          }
+          this._broadcastToConnections(expert_id, user_id, userConnections, 'complete', {
+            request_id,
+            ...result,
           });
+          this.activeRequests.delete(request_id);
         },
         // onError - 错误回调（广播到所有连接）
         (error) => {
           logger.error('Stream chat error:', error);
-          this._broadcastToConnections(userConnections, 'error', {
+          const activeRequest = this.activeRequests.get(request_id);
+          if (activeRequest?.stopped || error.message === 'Request aborted by user') {
+            this.activeRequests.delete(request_id);
+            return;
+          }
+          this._broadcastToConnections(expert_id, user_id, userConnections, 'error', {
+            request_id,
             message: error.message || '流式处理失败'
           });
+          this.activeRequests.delete(request_id);
         }
       );
     } catch (error) {
       logger.error('Process message error:', error);
-      this._broadcastToConnections(userConnections, 'error', {
+      this._broadcastToConnections(expert_id, user_id, userConnections, 'error', {
+        request_id,
         message: error.message || '处理失败'
       });
+      this.activeRequests.delete(request_id);
     }
+  }
+
+  async stopRequest(request_id, user_id) {
+    const activeRequest = this.activeRequests.get(request_id);
+    if (!activeRequest || activeRequest.user_id !== user_id) {
+      return { success: false, aborted: false, expert_id: null };
+    }
+
+    activeRequest.stopped = true;
+    const aborted = await this.chatService.abortRequest(activeRequest.expert_id, request_id);
+
+    if (!aborted) {
+      activeRequest.stopped = false;
+      return {
+        success: false,
+        aborted: false,
+        expert_id: activeRequest.expert_id,
+      };
+    }
+
+    const userConnections = this._getUserConnections(activeRequest.expert_id, user_id);
+    this._broadcastToConnections(activeRequest.expert_id, user_id, userConnections, 'stopped', { request_id });
+
+    this.activeRequests.delete(request_id);
+
+    return {
+      success: true,
+      aborted: true,
+      expert_id: activeRequest.expert_id,
+    };
   }
 
   /**
@@ -363,8 +460,9 @@ class StreamController {
     ctx.status = 200;
 
     // 发送连接成功事件
-    ctx.res.write(`event: connected\n`);
-    ctx.res.write(`data: ${JSON.stringify({ status: 'connected', expert_id })}\n\n`);
+    const connectedSequence = this._nextSequence(expert_id, user_id);
+    ctx.res.write(`id: ${connectedSequence}\nevent: connected\n`);
+    ctx.res.write(`data: ${JSON.stringify({ status: 'connected', expert_id, sequence: connectedSequence })}\n\n`);
 
     // 存储连接到 Expert 的连接池
     if (!this.expertConnections.has(expert_id)) {
@@ -385,26 +483,34 @@ class StreamController {
       }
       
       try {
-        // 查询当前专家与当前用户的最新一条消息ID
-        const latestMessage = await this.Message.findOne({
-          where: {
-            expert_id,
-            user_id,
-          },
-          order: [['created_at', 'DESC']],
-          attributes: ['id'],
-          raw: true,
-        });
+        let latestMessageId = this._getLatestCursor(expert_id, user_id).latest_message_id;
+
+        if (!latestMessageId) {
+          const latestMessage = await this.Message.findOne({
+            where: {
+              expert_id,
+              user_id,
+            },
+            order: [['created_at', 'DESC']],
+            attributes: ['id'],
+            raw: true,
+          });
+          latestMessageId = latestMessage?.id || null;
+          this._updateLatestCursor(expert_id, user_id, latestMessageId);
+        }
         
         const heartbeatData = {
-          latest_message_id: latestMessage?.id || null,
+          latest_message_id: latestMessageId,
+          latest_sequence: this._getCurrentSequence(expert_id, user_id),
         };
         
-        ctx.res.write(`event: heartbeat\ndata: ${JSON.stringify(heartbeatData)}\n\n`);
+        const heartbeatSequence = this._nextSequence(expert_id, user_id);
+        ctx.res.write(`id: ${heartbeatSequence}\nevent: heartbeat\ndata: ${JSON.stringify({ sequence: heartbeatSequence, ...heartbeatData })}\n\n`);
       } catch (err) {
         logger.error('Heartbeat error:', err);
         // 即使查询失败也发送心跳，保持连接
-        ctx.res.write(`event: heartbeat\ndata: ${JSON.stringify({ latest_message_id: null })}\n\n`);
+        const heartbeatSequence = this._nextSequence(expert_id, user_id);
+        ctx.res.write(`id: ${heartbeatSequence}\nevent: heartbeat\ndata: ${JSON.stringify({ sequence: heartbeatSequence, latest_message_id: null, latest_sequence: this._getCurrentSequence(expert_id, user_id) })}\n\n`);
       }
     };
     

--- a/server/controllers/topic.controller.js
+++ b/server/controllers/topic.controller.js
@@ -201,14 +201,15 @@ class TopicController {
   async get(ctx) {
     try {
       const { id } = ctx.params;
+      const userId = ctx.state.session.id;
 
       const topic = await this.Topic.findOne({
-        where: { id },
+        where: { id, user_id: userId },
         raw: true,
       });
 
       if (!topic) {
-        ctx.error('话题不存在', 404);
+        ctx.error('话题不存在或无权限', 404);
         return;
       }
 
@@ -263,7 +264,7 @@ class TopicController {
       const { id } = ctx.params;
 
       // 先删除关联的消息
-      await this.Message.destroy({ where: { topic_id: id } });
+      await this.Message.destroy({ where: { topic_id: id, user_id: ctx.state.session.id } });
 
       // 删除话题
       const result = await this.Topic.destroy({

--- a/server/routes/chat.routes.js
+++ b/server/routes/chat.routes.js
@@ -31,17 +31,43 @@ export default (controller, services = {}) => {
 
   // 停止生成（需要认证）
   router.post('/stop', authenticate(), async (ctx) => {
-    const { expert_id } = ctx.request.body || {};
+    const { request_id } = ctx.request.body || {};
     const user_id = ctx.state.session.id;
 
     try {
-      // 真正中止 LLM 请求
-      const aborted = await controller.chatService.abortUserRequest(user_id, expert_id);
+      if (!request_id) {
+        ctx.error('缺少 request_id 参数');
+        return;
+      }
+
+      const result = await controller.stopRequest(request_id, user_id);
+
+      if (!result.success) {
+        ctx.status = 409;
+        ctx.body = {
+          code: 409,
+          message: 'stop failed',
+          data: {
+            success: false,
+            aborted: false,
+            request_id,
+            expert_id: result.expert_id,
+            user_id,
+          },
+        };
+        return;
+      }
       
       ctx.body = {
         code: 0,
         message: 'success',
-        data: { success: true, aborted, expert_id, user_id },
+        data: {
+          success: result.success,
+          aborted: result.aborted,
+          request_id,
+          expert_id: result.expert_id,
+          user_id,
+        },
       };
     } catch (error) {
       logger.error('[ChatRoutes] Stop generation error:', error);

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -7,7 +7,7 @@
  */
 
 import Router from '@koa/router';
-import { authenticate, optionalAuth, requireAdmin } from '../middlewares/auth.js';
+import { authenticate, requireAdmin } from '../middlewares/auth.js';
 
 export default (controller) => {
   const router = new Router({ prefix: '/api/messages' });
@@ -18,8 +18,11 @@ export default (controller) => {
   // 获取指定消息及其之前的 N 条消息（需要认证）- 用于 SSE 完成后获取真实消息
   router.get('/expert/:expertId/with-before/:messageId', authenticate(), controller.listWithBefore.bind(controller));
 
+  // 按游标增量获取消息（需要认证）
+  router.get('/expert/:expertId/since', authenticate(), controller.listSince.bind(controller));
+
   // 获取消息列表（旧 API，按 topic，保留兼容）
-  router.get('/', optionalAuth(), controller.list.bind(controller));
+  router.get('/', authenticate(), controller.list.bind(controller));
 
   // 获取单条消息详情（需要认证）
   router.get('/:id', authenticate(), controller.get.bind(controller));

--- a/server/routes/topic.routes.js
+++ b/server/routes/topic.routes.js
@@ -3,7 +3,7 @@
  */
 
 import Router from '@koa/router';
-import { authenticate, optionalAuth } from '../middlewares/auth.js';
+import { authenticate } from '../middlewares/auth.js';
 
 export default (controller, messageController) => {
   const router = new Router({ prefix: '/api/topics' });
@@ -21,7 +21,7 @@ export default (controller, messageController) => {
   router.post('/', authenticate(), controller.create.bind(controller));
 
   // 获取话题详情（公开访问）
-  router.get('/:id', optionalAuth(), controller.get.bind(controller));
+  router.get('/:id', authenticate(), controller.get.bind(controller));
 
   // 更新话题（需要认证）
   router.put('/:id', authenticate(), controller.update.bind(controller));


### PR DESCRIPTION
## Summary
- harden expert chat ownership checks and remove topic-as-session-entry behavior
- add request-scoped streaming flow with request_id, precise stop semantics, complete snapshots, and tool call summaries
- replace heartbeat page reloads with incremental sync, sequence tracking, and improved multi-tab message reconciliation

## Validation
- `npm run type-check`
- `git diff --check`

## Related
- Closes #807