### PR TITLE
fix: add ELS workspace and harden contract-mgr filter flow

### DIFF
--- a/apps/contract-mgr/tick/index.js
+++ b/apps/contract-mgr/tick/index.js
@@ -89,6 +89,66 @@ function parseLlmResponse(response) {
   try { return JSON.parse(match[0]); } catch { return null; }
 }
 
+function splitTextIntoChunks(text, maxLength) {
+  if (!text || text.length <= maxLength) {
+    return [text];
+  }
+
+  const paragraphs = text.split('\n\n');
+  const chunks = [];
+  let current = '';
+
+  for (const paragraph of paragraphs) {
+    if (current.length + paragraph.length + 2 <= maxLength) {
+      current += `${current ? '\n\n' : ''}${paragraph}`;
+      continue;
+    }
+
+    if (current) {
+      chunks.push(current);
+    }
+
+    if (paragraph.length <= maxLength) {
+      current = paragraph;
+      continue;
+    }
+
+    let remaining = paragraph;
+    while (remaining.length > maxLength) {
+      chunks.push(remaining.slice(0, maxLength));
+      remaining = remaining.slice(maxLength);
+    }
+
+    current = remaining;
+  }
+
+  if (current) {
+    chunks.push(current);
+  }
+
+  return chunks.length ? chunks : [text];
+}
+
+async function filterTextByChunks(recordId, services, prompt, text, options) {
+  const maxLength = options.chunk_max_length || DEFAULT_CHUNK_MAX_LENGTH;
+  const chunks = splitTextIntoChunks(text, maxLength);
+  logger.info(`[contract-mgr tick] Filter input length=${text.length}, chunk_max_length=${maxLength}, chunks=${chunks.length}`);
+
+  const results = [];
+  for (let index = 0; index < chunks.length; index++) {
+    const chunk = chunks[index];
+    const chunkPrompt = chunks.length > 1
+      ? `${prompt}\n\n这是第 ${index + 1}/${chunks.length} 段，请只返回清洗后的正文，不要解释，不要补充原文中不存在的内容。`
+      : prompt;
+
+    logger.info(`[contract-mgr tick] Filtering chunk ${index + 1}/${chunks.length} for ${recordId}, length=${chunk.length}`);
+    const filteredChunk = await services.llm.generateText(chunkPrompt, chunk, options);
+    results.push(filteredChunk || chunk);
+  }
+
+  return results.join('\n\n');
+}
+
 async function getFiles(services, recordId) {
   const MiniAppFile = services.getModel('mini_app_file');
   const Attachment = services.getModel('attachment');
@@ -260,12 +320,15 @@ async function handleFilter(record, app, services) {
   const ocrText = contentRows[0].ocr_text;
   const config = getConfig(app, 'pending_filter');
   const filterPrompt = '去除页码、水印、乱码，保留正文';
+  const timeout = config.timeout_ms ?? 600000;
+  const chunkMaxLength = config.chunk_max_length || DEFAULT_CHUNK_MAX_LENGTH;
   
   try {
-    const filteredText = await services.llm.generateText(filterPrompt, ocrText, {
+    const filteredText = await filterTextByChunks(record.id, services, filterPrompt, ocrText, {
       modelId: config.model_id || null,
       temperature: config.temperature || 0.3,
-      timeout: config.timeout_ms ?? 600000,
+      timeout,
+      chunk_max_length: chunkMaxLength,
     }) || ocrText;
     
     await services.execute(
@@ -274,7 +337,7 @@ async function handleFilter(record, app, services) {
     );
     
     await updateStatus(services, record.id, 'pending_extract');
-    logger.info(`[contract-mgr tick] Filter completed, length=${filteredText.length}`);
+    logger.info(`[contract-mgr tick] Filter completed, timeout=${timeout}, length=${filteredText.length}`);
   } catch (e) {
     logger.error(`[contract-mgr tick] Filter failed: ${e.message}`);
     await updateStatus(services, record.id, 'filter_failed');

--- a/apps/els/manifest.json
+++ b/apps/els/manifest.json
@@ -1,0 +1,47 @@
+{
+  "id": "els",
+  "name": "ELS 学习工作台",
+  "version": "0.1.0",
+  "description": "短阅读、知识点记录、快速复习的轻量学习工作台 — 适用于语言、术语、概念等任何领域的学习与巩固",
+  "icon": "📘",
+  "type": "utility",
+  "author": "Touwaka Team",
+  "license": "MIT",
+  "tags": [
+    "学习",
+    "阅读",
+    "生词",
+    "知识点",
+    "TTS",
+    "AI学习",
+    "复习"
+  ],
+  "path": "apps/els",
+  "compatibility": {
+    "min_platform_version": "2.0.0",
+    "requires": {
+      "mcp": [],
+      "skills": []
+    }
+  },
+  "custom_handlers": {},
+  "fields": [],
+  "extension_tables": [],
+  "migrations": {},
+  "config": {
+    "features": [
+      "study_dashboard",
+      "reading_session",
+      "word_collect",
+      "quick_review",
+      "daily_checkin",
+      "tts_playback",
+      "library_select",
+      "vocab_notebook_select",
+      "user_material_upload"
+    ]
+  },
+  "states": [],
+  "component": "ELSStudyView",
+  "visibility": "all"
+}

--- a/apps/index.json
+++ b/apps/index.json
@@ -69,6 +69,19 @@
       "manifest_url": "apps/ocr-tool/manifest.json"
     },
     {
+      "id": "els",
+      "name": "ELS 学习工作台",
+      "version": "0.1.0",
+      "icon": "📘",
+      "type": "utility",
+      "description": "短阅读、加词与快速复习的一体化学习工作台",
+      "author": "Touwaka Team",
+      "license": "MIT",
+      "tags": ["学习", "阅读", "生词", "复习", "AI学习"],
+      "path": "apps/els",
+      "manifest_url": "apps/els/manifest.json"
+    },
+    {
       "id": "resume-fast-screening",
       "name": "简历快筛",
       "version": "0.1.0",
@@ -90,7 +103,7 @@
     { "id": "workflow", "name": "工作流", "icon": "🔄", "description": "流程审批、状态流转、智能匹配" }
   ],
   "metadata": {
-    "total_apps": 6,
+    "total_apps": 7,
     "min_platform_version": "2.0.0",
     "last_updated_by": "Touwaka Team"
   }

--- a/frontend/src/api/els.ts
+++ b/frontend/src/api/els.ts
@@ -1,0 +1,283 @@
+import apiClient, { apiRequest } from './client'
+
+export interface ELSTodayStatus {
+  is_checked_in: boolean
+  completed_reading: boolean
+  completed_review: boolean
+  streak_days: number
+}
+
+export interface ELSLibrarySummary {
+  id: string
+  name: string
+  material_count: number
+}
+
+export interface ELSRecommendedMaterial {
+  id: string
+  title: string
+  difficulty_level?: string
+  summary?: string
+}
+
+export interface ELSDashboard {
+  today_status: ELSTodayStatus
+  selected_library: ELSLibrarySummary
+  recommended_material: ELSRecommendedMaterial | null
+  review_stats: {
+    today_due: number
+    new_words?: number
+    wrong_words: number
+  }
+  recent_materials: Array<{
+    id: string
+    title: string
+    last_opened_at: string
+  }>
+}
+
+export interface ELSLibraryItem {
+  id: string
+  name: string
+  type: 'public' | 'personal' | 'shared'
+  material_count: number
+  is_selected: boolean
+}
+
+export interface ELSLibraryListResponse {
+  selected_library_id: string
+  items: ELSLibraryItem[]
+}
+
+export interface ELSLibraryMaterial {
+  id: string
+  title: string
+  summary?: string
+  language: string
+  processing_status: string
+  safety_status: string
+  quiz_status: string
+  tts_status: string
+  can_read: boolean
+  can_edit: boolean
+  updated_at: string
+}
+
+export interface ELSLibraryMaterialsResponse {
+  library: {
+    id: string
+    name: string
+    type: 'public' | 'personal' | 'shared'
+  }
+  items: ELSLibraryMaterial[]
+}
+
+export interface ELSMaterialDetail {
+  id: string
+  library_id: string
+  library_name: string
+  title: string
+  difficulty_level?: string
+  content: string
+  summary?: string
+  language: string
+  processing_status: string
+  quiz_status: string
+  tts_status: string
+  tts: {
+    available: boolean
+    audio_url: string | null
+    speeds: number[]
+  }
+  progress: {
+    is_read: boolean
+    collected_word_count: number
+  }
+}
+
+export interface ELSNotebook {
+  id: string
+  language: string
+  name: string
+  word_count: number
+  is_selected: boolean
+}
+
+export interface ELSNotebookListResponse {
+  selected_notebook_id: string
+  items: ELSNotebook[]
+}
+
+export interface ELSWordCollectResponse {
+  word: {
+    id: string
+    word_text: string
+    meaning: string
+    phonetic?: string
+    pronunciation_audio?: string
+    sentence: string
+    notebook_id: string
+    language: string
+    review_stage: string
+  }
+  already_exists: boolean
+}
+
+export interface ELSQuizQuestion {
+  id: string
+  type: string
+  prompt: string
+  options: string[]
+}
+
+export interface ELSQuizResponse {
+  material_id: string
+  questions: ELSQuizQuestion[]
+}
+
+export interface ELSQuizSubmitResponse {
+  correct_count: number
+  total: number
+  explanations: Array<{
+    question_id: string
+    is_correct: boolean
+    explanation: string
+  }>
+  reading_completed: boolean
+  next_action: string
+}
+
+export interface ELSReviewQuestion {
+  word_id: string
+  review_type: string
+  audio_url: string | null
+  prompt: string
+  options: string[]
+}
+
+export interface ELSReviewResponse {
+  bucket: string
+  notebook_id: string
+  session_id: string
+  questions: ELSReviewQuestion[]
+  total: number
+}
+
+export interface ELSReviewSubmitResponse {
+  session_summary: {
+    correct_count: number
+    total: number
+    needs_repeat: number
+  }
+  review_stats: {
+    today_due_remaining: number
+    wrong_words: number
+  }
+  today_review_completed: boolean
+}
+
+export interface ELSCheckinResponse {
+  is_checked_in: boolean
+  completed_reading: boolean
+  completed_review: boolean
+  streak_days: number
+  day_type: string
+}
+
+export function getELSDashboard() {
+  return apiRequest<ELSDashboard>(apiClient.get('/els/dashboard'))
+}
+
+export function getELSLibraries() {
+  return apiRequest<ELSLibraryListResponse>(apiClient.get('/els/libraries'))
+}
+
+export function selectELSLibrary(libraryId: string) {
+  return apiRequest<{ selected_library_id: string; selected_library_name: string }>(
+    apiClient.post('/els/libraries/select', { library_id: libraryId }),
+  )
+}
+
+export function getELSLibraryMaterials(libraryId: string) {
+  return apiRequest<ELSLibraryMaterialsResponse>(apiClient.get(`/els/libraries/${libraryId}/materials`))
+}
+
+export function getELSRecommendedMaterials(libraryId?: string) {
+  return apiRequest<{ items: Array<ELSMaterialDetail & { estimated_minutes?: number }> }>(
+    apiClient.get('/els/materials/recommended', { params: libraryId ? { library_id: libraryId } : {} }),
+  )
+}
+
+export function getELSMaterial(materialId: string) {
+  return apiRequest<ELSMaterialDetail>(apiClient.get(`/els/materials/${materialId}`))
+}
+
+export function createELSMaterial(payload: {
+  library_id: string
+  title: string
+  summary?: string
+  content: string
+  language: string
+  tags?: string[]
+}) {
+  return apiRequest(apiClient.post('/els/materials', payload))
+}
+
+export function updateELSMaterial(materialId: string, payload: {
+  title?: string
+  summary?: string
+  content?: string
+  tags?: string[]
+}) {
+  return apiRequest(apiClient.put(`/els/materials/${materialId}`, payload))
+}
+
+export function getELSNotebooks() {
+  return apiRequest<ELSNotebookListResponse>(apiClient.get('/els/notebooks'))
+}
+
+export function selectELSNotebook(notebookId: string) {
+  return apiRequest<{ selected_notebook_id: string; selected_notebook_name: string }>(
+    apiClient.post('/els/notebooks/select', { notebook_id: notebookId }),
+  )
+}
+
+export function collectELSWord(payload: {
+  material_id: string
+  word_text: string
+  sentence: string
+  offset_start?: number
+  offset_end?: number
+}) {
+  return apiRequest<ELSWordCollectResponse>(apiClient.post('/els/words', payload))
+}
+
+export function getELSMaterialQuiz(materialId: string) {
+  return apiRequest<ELSQuizResponse>(apiClient.get(`/els/materials/${materialId}/quiz`))
+}
+
+export function submitELSMaterialQuiz(materialId: string, answers: Array<{ question_id: string; answer: string }>) {
+  return apiRequest<ELSQuizSubmitResponse>(apiClient.post(`/els/materials/${materialId}/quiz/submit`, { answers }))
+}
+
+export function getELSReviews(params: { bucket: string; notebook_id: string; size?: number }) {
+  return apiRequest<ELSReviewResponse>(apiClient.get('/els/reviews', { params }))
+}
+
+export function submitELSReviews(payload: {
+  session_id: string
+  bucket: string
+  results: Array<{
+    word_id: string
+    review_type: string
+    answer: string
+    is_correct: boolean
+    self_rating: string
+  }>
+}) {
+  return apiRequest<ELSReviewSubmitResponse>(apiClient.post('/els/reviews/submit', payload))
+}
+
+export function getELSCheckin() {
+  return apiRequest<ELSCheckinResponse>(apiClient.get('/els/checkin'))
+}

--- a/frontend/src/views/AppDetailView.vue
+++ b/frontend/src/views/AppDetailView.vue
@@ -18,6 +18,7 @@ import GenericMiniApp from '@/components/apps/GenericMiniApp.vue'
 const AppComponentMap: Record<string, Component> = {
   'ContractV2View': defineAsyncComponent(() => import('@/views/contract-v2/ContractV2View.vue')),
   'DowntimeAnalyzer': defineAsyncComponent(() => import('@/views/downtime-analyzer/DowntimeAnalyzer.vue')),
+  'ELSStudyView': defineAsyncComponent(() => import('@/views/els/ELSStudyView.vue')),
   'InvoiceView': defineAsyncComponent(() => import('@/views/invoice/InvoiceView.vue')),
   'OcrToolView': defineAsyncComponent(() => import('@/views/ocr-tool/OcrToolView.vue')),
   'ResumeScreeningView': defineAsyncComponent(() => import('@/views/resume-fast-screening/ResumeScreeningView.vue')),

--- a/frontend/src/views/els/ELSStudyView.vue
+++ b/frontend/src/views/els/ELSStudyView.vue
@@ -1,0 +1,944 @@
+<template>
+  <div class="els-view">
+    <header class="hero-card">
+      <div>
+        <p class="hero-kicker">ELS STUDY WORKBENCH</p>
+        <h1>ELS 学习工作台</h1>
+        <p class="hero-summary">第一轮骨架聚焦学习工作台、阅读页、复习页、学习库抽屉与 Mock 联调基线。</p>
+      </div>
+      <div class="hero-metrics">
+        <div class="metric-chip">
+          <span>连续学习</span>
+          <strong>{{ dashboard?.today_status.streak_days ?? '--' }} 天</strong>
+        </div>
+        <div class="metric-chip">
+          <span>当前库</span>
+          <strong>{{ dashboard?.selected_library.name ?? '加载中' }}</strong>
+        </div>
+      </div>
+    </header>
+
+    <nav class="panel-tabs">
+      <button :class="['tab-btn', { active: currentPanel === 'dashboard' }]" @click="currentPanel = 'dashboard'">学习工作台</button>
+      <button :class="['tab-btn', { active: currentPanel === 'reading' }]" @click="openReadingFromDashboard">阅读页</button>
+      <button :class="['tab-btn', { active: currentPanel === 'review' }]" @click="openReviewPanel">复习页</button>
+      <button class="tab-btn secondary" @click="toggleLibraryDrawer">学习库抽屉</button>
+    </nav>
+
+    <p v-if="errorMessage" class="page-error">{{ errorMessage }}</p>
+
+    <section v-if="currentPanel === 'dashboard'" class="dashboard-grid">
+      <article class="surface-card task-card">
+        <header class="card-header">
+          <h2>今日任务</h2>
+          <span>{{ todayStatusLabel }}</span>
+        </header>
+        <div class="task-actions">
+          <button class="primary-btn" @click="openReadingFromDashboard">开始阅读</button>
+          <button class="secondary-btn" @click="openReviewPanel">去复习</button>
+        </div>
+        <div class="task-stats">
+          <div>
+            <span>今日到期</span>
+            <strong>{{ dashboard?.review_stats.today_due ?? 0 }}</strong>
+          </div>
+          <div>
+            <span>高频错误</span>
+            <strong>{{ dashboard?.review_stats.wrong_words ?? 0 }}</strong>
+          </div>
+          <div>
+            <span>今日新增</span>
+            <strong>{{ dashboard?.review_stats.new_words ?? 0 }}</strong>
+          </div>
+        </div>
+      </article>
+
+      <article class="surface-card library-card">
+        <header class="card-header">
+          <h2>当前学习库</h2>
+          <button class="link-btn" @click="toggleLibraryDrawer">查看这个库</button>
+        </header>
+        <p class="card-title">{{ dashboard?.selected_library.name ?? '加载中...' }}</p>
+        <p class="muted-text">当前库材料数 {{ dashboard?.selected_library.material_count ?? 0 }}</p>
+        <div class="recommended-box">
+          <span class="mini-label">推荐阅读</span>
+          <strong>{{ dashboard?.recommended_material?.title ?? '当前库暂无可学习材料' }}</strong>
+          <p>{{ dashboard?.recommended_material?.summary ?? '切换学习库后，这里会展示对应推荐内容。' }}</p>
+        </div>
+      </article>
+
+      <article class="surface-card recent-card">
+        <header class="card-header">
+          <h2>最近学习</h2>
+          <span>{{ dashboard?.recent_materials.length ?? 0 }} 条</span>
+        </header>
+        <ul v-if="dashboard?.recent_materials.length" class="list-stack">
+          <li v-for="item in dashboard?.recent_materials" :key="item.id">
+            <strong>{{ item.title }}</strong>
+            <span>{{ formatDate(item.last_opened_at) }}</span>
+          </li>
+        </ul>
+        <p v-else class="empty-tip">你还没有开始学习</p>
+      </article>
+    </section>
+
+    <section v-if="currentPanel === 'reading'" class="reading-layout surface-card">
+      <header class="card-header reading-header">
+        <div>
+          <h2>{{ currentMaterial?.title ?? '阅读页骨架' }}</h2>
+          <p class="muted-text">{{ currentMaterial?.library_name ?? dashboard?.selected_library.name }} · {{ currentMaterial?.difficulty_level ?? '--' }}</p>
+        </div>
+        <div class="header-actions">
+          <button class="secondary-btn" @click="currentPanel = 'dashboard'">返回工作台</button>
+          <button v-if="selectedLibraryMaterial?.can_edit" class="secondary-btn" @click="startEditingMaterial(selectedLibraryMaterial)">编辑本人材料</button>
+        </div>
+      </header>
+
+      <div v-if="currentMaterial" class="reading-body">
+        <article class="article-panel">
+          <p class="article-summary">{{ currentMaterial.summary }}</p>
+          <p class="article-content">{{ currentMaterial.content }}</p>
+        </article>
+
+        <aside class="reading-side-panel">
+          <section class="side-box">
+            <h3>划词浮层 Mock</h3>
+            <p class="muted-text">第一轮用按钮模拟划词与加词，不做真实选区系统。</p>
+            <div class="word-actions">
+              <button v-for="word in quickCollectWords" :key="word.word" class="tag-btn" @click="collectWord(word.word, word.sentence)">
+                {{ word.word }}
+              </button>
+            </div>
+            <p v-if="wordFeedback" class="success-tip">{{ wordFeedback }}</p>
+          </section>
+
+          <section class="side-box">
+            <h3>TTS 状态</h3>
+            <p>{{ ttsStatusLabel }}</p>
+          </section>
+
+          <section class="side-box">
+            <h3>阅读后小测</h3>
+            <button class="primary-btn full-width" :disabled="currentMaterial.quiz_status !== 'ready'" @click="loadQuiz">
+              {{ currentMaterial.quiz_status === 'ready' ? '开始小测' : '小测生成中' }}
+            </button>
+            <div v-if="quiz" class="quiz-block">
+              <div v-for="question in quiz.questions" :key="question.id" class="quiz-question">
+                <strong>{{ question.prompt }}</strong>
+                <label v-for="option in question.options" :key="option" class="option-row">
+                  <input v-model="quizAnswers[question.id]" type="radio" :name="question.id" :value="option" />
+                  <span>{{ option }}</span>
+                </label>
+              </div>
+              <button class="secondary-btn full-width" @click="submitQuiz">提交小测</button>
+              <p v-if="quizResultText" class="success-tip">{{ quizResultText }}</p>
+            </div>
+          </section>
+        </aside>
+      </div>
+      <p v-else class="empty-tip">点击首页的“开始阅读”后，这里展示阅读骨架与联调数据。</p>
+    </section>
+
+    <section v-if="currentPanel === 'review'" class="review-layout surface-card">
+      <header class="card-header review-header">
+        <div>
+          <h2>复习页</h2>
+          <p class="muted-text">按词本切换复习范围，单轮 5 题，当前使用 Mock 数据联调。</p>
+        </div>
+      </header>
+
+      <div class="review-controls">
+        <select v-model="selectedNotebookId" @change="loadReviews">
+          <option v-for="item in notebooks" :key="item.id" :value="item.id">{{ item.name }}</option>
+        </select>
+        <div class="bucket-group">
+          <button v-for="bucket in reviewBuckets" :key="bucket.value" :class="['bucket-btn', { active: reviewBucket === bucket.value }]" @click="switchReviewBucket(bucket.value)">
+            {{ bucket.label }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="reviewData?.questions.length" class="review-question-block">
+        <p class="review-counter">当前任务桶：{{ reviewData.bucket }} · 共 {{ reviewData.total }} 题</p>
+        <div v-for="question in reviewData.questions" :key="question.word_id" class="quiz-question review-question">
+          <strong>{{ question.prompt }}</strong>
+          <label v-for="option in question.options" :key="option" class="option-row">
+            <input v-model="reviewAnswers[question.word_id]" type="radio" :name="question.word_id" :value="option" />
+            <span>{{ option }}</span>
+          </label>
+        </div>
+        <button class="primary-btn" @click="submitReview">提交本轮反馈</button>
+        <p v-if="reviewResultText" class="success-tip">{{ reviewResultText }}</p>
+      </div>
+      <p v-else class="empty-tip">当前词本还没有可复习内容</p>
+    </section>
+
+    <Teleport to="body">
+      <div v-if="libraryDrawerOpen" class="drawer-mask" @click.self="libraryDrawerOpen = false">
+        <aside class="drawer-panel">
+          <header class="drawer-header">
+            <div>
+              <h2>学习库抽屉</h2>
+              <p class="muted-text">切换库、查看当前库内容、上传短文、编辑本人短文</p>
+            </div>
+            <button class="icon-close" @click="libraryDrawerOpen = false">×</button>
+          </header>
+
+          <section class="drawer-section">
+            <h3>学习库切换</h3>
+            <div class="library-switch-list">
+              <button v-for="item in libraries" :key="item.id" :class="['library-switch-btn', { active: selectedLibraryId === item.id }]" @click="selectLibrary(item.id)">
+                <strong>{{ item.name }}</strong>
+                <span>{{ item.material_count }} 篇</span>
+              </button>
+            </div>
+          </section>
+
+          <section class="drawer-section">
+            <div class="section-heading">
+              <h3>当前库内容</h3>
+              <button class="link-btn" @click="startUpload">上传短文</button>
+            </div>
+            <ul v-if="libraryMaterials.length" class="material-list">
+              <li v-for="item in libraryMaterials" :key="item.id">
+                <div>
+                  <strong>{{ item.title }}</strong>
+                  <p>{{ item.summary || '暂无摘要' }}</p>
+                  <small>{{ item.language }} · {{ item.processing_status }} · {{ formatDate(item.updated_at) }}</small>
+                </div>
+                <div class="item-actions">
+                  <button class="secondary-btn" :disabled="!item.can_read" @click="openReading(item.id)">阅读</button>
+                  <button v-if="item.can_edit" class="secondary-btn" @click="startEditingMaterial(item)">编辑</button>
+                </div>
+              </li>
+            </ul>
+            <p v-else class="empty-tip">当前库还没有材料</p>
+          </section>
+
+          <section class="drawer-section form-section">
+            <h3>{{ editingMaterialId ? '编辑本人短文' : '上传短文' }}</h3>
+            <div class="form-grid">
+              <label>
+                <span>标题</span>
+                <input v-model="materialForm.title" type="text" />
+              </label>
+              <label>
+                <span>语言</span>
+                <select v-model="materialForm.language" :disabled="Boolean(editingMaterialId)">
+                  <option value="en">en</option>
+                  <option value="fr">fr</option>
+                </select>
+              </label>
+              <label class="full-row">
+                <span>摘要</span>
+                <input v-model="materialForm.summary" type="text" />
+              </label>
+              <label class="full-row">
+                <span>正文</span>
+                <textarea v-model="materialForm.content" rows="6"></textarea>
+              </label>
+            </div>
+            <div class="form-actions">
+              <button class="secondary-btn" @click="resetMaterialForm">清空</button>
+              <button class="primary-btn" @click="submitMaterialForm">{{ editingMaterialId ? '保存并重新进入审核' : '上传并返回处理中状态' }}</button>
+            </div>
+            <p v-if="materialFormFeedback" class="success-tip">{{ materialFormFeedback }}</p>
+          </section>
+        </aside>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import type {
+  ELSDashboard,
+  ELSLibraryItem,
+  ELSLibraryMaterial,
+  ELSMaterialDetail,
+  ELSNotebook,
+  ELSQuizResponse,
+  ELSReviewResponse,
+} from '@/api/els'
+import {
+  collectELSWord,
+  createELSMaterial,
+  getELSDashboard,
+  getELSLibraries,
+  getELSLibraryMaterials,
+  getELSMaterial,
+  getELSMaterialQuiz,
+  getELSNotebooks,
+  getELSReviews,
+  selectELSLibrary,
+  submitELSMaterialQuiz,
+  submitELSReviews,
+  updateELSMaterial,
+} from '@/api/els'
+
+const currentPanel = ref<'dashboard' | 'reading' | 'review'>('dashboard')
+const libraryDrawerOpen = ref(false)
+const dashboard = ref<ELSDashboard | null>(null)
+const libraries = ref<ELSLibraryItem[]>([])
+const libraryMaterials = ref<ELSLibraryMaterial[]>([])
+const currentMaterial = ref<ELSMaterialDetail | null>(null)
+const notebooks = ref<ELSNotebook[]>([])
+const quiz = ref<ELSQuizResponse | null>(null)
+const reviewData = ref<ELSReviewResponse | null>(null)
+const selectedLibraryId = ref('lib_public_default')
+const selectedNotebookId = ref('nb_en_default')
+const reviewBucket = ref<'today' | 'new' | 'wrong'>('today')
+const quizAnswers = reactive<Record<string, string>>({})
+const reviewAnswers = reactive<Record<string, string>>({})
+const errorMessage = ref('')
+const wordFeedback = ref('')
+const quizResultText = ref('')
+const reviewResultText = ref('')
+const materialFormFeedback = ref('')
+const editingMaterialId = ref('')
+const materialForm = reactive({
+  title: '',
+  summary: '',
+  content: '',
+  language: 'en',
+})
+
+const quickCollectWords = [
+  { word: 'develop', sentence: 'Children develop language quickly.' },
+  { word: 'routine', sentence: 'A stable routine improves learning quality.' },
+  { word: 'memory', sentence: 'Sleep helps the brain store memories.' },
+]
+
+const reviewBuckets = [
+  { value: 'today' as const, label: '今天要复习' },
+  { value: 'new' as const, label: '今天新词' },
+  { value: 'wrong' as const, label: '高频错误词' },
+]
+
+const selectedLibraryMaterial = computed(() => {
+  if (!currentMaterial.value) return null
+  return libraryMaterials.value.find((item) => item.id === currentMaterial.value?.id) || null
+})
+
+const todayStatusLabel = computed(() => {
+  if (!dashboard.value) return '加载中'
+  if (dashboard.value.today_status.completed_reading && dashboard.value.today_status.completed_review) {
+    return '今天已完成'
+  }
+  if (dashboard.value.today_status.completed_reading) {
+    return '待复习'
+  }
+  return '未完成'
+})
+
+const ttsStatusLabel = computed(() => {
+  if (!currentMaterial.value) return '等待选择材料'
+  if (currentMaterial.value.tts_status === 'ready') return '音频已就绪，可直接播放'
+  if (currentMaterial.value.tts_status === 'pending') return '音频生成中'
+  return '音频暂不可用'
+})
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString('zh-CN', { hour12: false })
+}
+
+function toggleLibraryDrawer() {
+  libraryDrawerOpen.value = !libraryDrawerOpen.value
+  if (libraryDrawerOpen.value) {
+    void loadLibraryMaterials(selectedLibraryId.value)
+  }
+}
+
+async function bootstrap() {
+  try {
+    errorMessage.value = ''
+    const [dashboardData, libraryData, notebookData] = await Promise.all([
+      getELSDashboard(),
+      getELSLibraries(),
+      getELSNotebooks(),
+    ])
+
+    dashboard.value = dashboardData
+    libraries.value = libraryData.items
+    selectedLibraryId.value = libraryData.selected_library_id
+    notebooks.value = notebookData.items
+    selectedNotebookId.value = notebookData.selected_notebook_id
+
+    await loadLibraryMaterials(selectedLibraryId.value)
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : '加载失败，请重试'
+  }
+}
+
+async function loadLibraryMaterials(libraryId: string) {
+  const data = await getELSLibraryMaterials(libraryId)
+  libraryMaterials.value = data.items
+}
+
+async function selectLibrary(libraryId: string) {
+  await selectELSLibrary(libraryId)
+  selectedLibraryId.value = libraryId
+  await Promise.all([bootstrap(), loadLibraryMaterials(libraryId)])
+}
+
+async function openReading(materialId: string) {
+  currentPanel.value = 'reading'
+  quiz.value = null
+  quizResultText.value = ''
+  wordFeedback.value = ''
+  currentMaterial.value = await getELSMaterial(materialId)
+}
+
+async function openReadingFromDashboard() {
+  const targetId = dashboard.value?.recommended_material?.id || libraryMaterials.value.find((item) => item.can_read)?.id
+  if (!targetId) {
+    errorMessage.value = '当前库暂无可学习材料'
+    return
+  }
+  await openReading(targetId)
+}
+
+async function loadQuiz() {
+  if (!currentMaterial.value) return
+  quiz.value = await getELSMaterialQuiz(currentMaterial.value.id)
+  quizResultText.value = ''
+  Object.keys(quizAnswers).forEach((key) => delete quizAnswers[key])
+}
+
+async function submitQuiz() {
+  if (!currentMaterial.value || !quiz.value) return
+  const answers = quiz.value.questions.map((question) => ({
+    question_id: question.id,
+    answer: quizAnswers[question.id] || '',
+  }))
+  const result = await submitELSMaterialQuiz(currentMaterial.value.id, answers)
+  quizResultText.value = `小测完成：${result.correct_count}/${result.total}，下一步 ${result.next_action}`
+}
+
+async function collectWord(word: string, sentence: string) {
+  if (!currentMaterial.value) return
+  const result = await collectELSWord({
+    material_id: currentMaterial.value.id,
+    word_text: word,
+    sentence,
+  })
+  wordFeedback.value = `已加入 ${result.word.language} 词本：${result.word.notebook_id}`
+}
+
+async function openReviewPanel() {
+  currentPanel.value = 'review'
+  await loadReviews()
+}
+
+async function loadReviews() {
+  reviewResultText.value = ''
+  reviewData.value = await getELSReviews({
+    bucket: reviewBucket.value,
+    notebook_id: selectedNotebookId.value,
+    size: 5,
+  })
+  Object.keys(reviewAnswers).forEach((key) => delete reviewAnswers[key])
+}
+
+async function switchReviewBucket(bucket: 'today' | 'new' | 'wrong') {
+  reviewBucket.value = bucket
+  await loadReviews()
+}
+
+async function submitReview() {
+  if (!reviewData.value) return
+  const results = reviewData.value.questions.map((question) => ({
+    word_id: question.word_id,
+    review_type: question.review_type,
+    answer: reviewAnswers[question.word_id] || '',
+    is_correct: Boolean(reviewAnswers[question.word_id]),
+    self_rating: 'easy',
+  }))
+  const result = await submitELSReviews({
+    session_id: reviewData.value.session_id,
+    bucket: reviewData.value.bucket,
+    results,
+  })
+  reviewResultText.value = `本轮总结：${result.session_summary.correct_count}/${result.session_summary.total}，剩余待复习 ${result.review_stats.today_due_remaining}`
+}
+
+function startUpload() {
+  editingMaterialId.value = ''
+  materialForm.title = ''
+  materialForm.summary = ''
+  materialForm.content = ''
+  materialForm.language = 'en'
+  materialFormFeedback.value = ''
+}
+
+function startEditingMaterial(item: ELSLibraryMaterial) {
+  editingMaterialId.value = item.id
+  materialForm.title = item.title
+  materialForm.summary = item.summary || ''
+  materialForm.content = 'Updated content...'
+  materialForm.language = item.language
+  materialFormFeedback.value = ''
+  libraryDrawerOpen.value = true
+}
+
+function resetMaterialForm() {
+  startUpload()
+}
+
+async function submitMaterialForm() {
+  if (!materialForm.title || !materialForm.content) {
+    materialFormFeedback.value = '标题和正文不能为空'
+    return
+  }
+
+  if (editingMaterialId.value) {
+    await updateELSMaterial(editingMaterialId.value, {
+      title: materialForm.title,
+      summary: materialForm.summary,
+      content: materialForm.content,
+    })
+    materialFormFeedback.value = '已重新进入审核'
+  } else {
+    await createELSMaterial({
+      library_id: selectedLibraryId.value,
+      title: materialForm.title,
+      summary: materialForm.summary,
+      content: materialForm.content,
+      language: materialForm.language,
+      tags: [],
+    })
+    materialFormFeedback.value = '上传成功，当前状态为审核中'
+  }
+
+  await loadLibraryMaterials(selectedLibraryId.value)
+}
+
+onMounted(() => {
+  void bootstrap()
+})
+</script>
+
+<style scoped>
+.els-view {
+  min-height: 100%;
+  padding: 24px;
+  background: linear-gradient(180deg, #f6f8ff 0%, #f8fafc 40%, #eef4ff 100%);
+  color: #1f2937;
+}
+
+.hero-card,
+.surface-card {
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.hero-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px;
+  margin-bottom: 20px;
+}
+
+.hero-kicker {
+  margin: 0 0 8px;
+  color: #4f46e5;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.hero-card h1 {
+  margin: 0;
+  font-size: 32px;
+}
+
+.hero-summary {
+  max-width: 680px;
+  margin: 10px 0 0;
+  color: #475569;
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  gap: 12px;
+  min-width: 280px;
+}
+
+.metric-chip {
+  padding: 18px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #312e81, #4f46e5);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.metric-chip span {
+  font-size: 13px;
+  opacity: 0.78;
+}
+
+.metric-chip strong {
+  font-size: 18px;
+}
+
+.panel-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.tab-btn,
+.primary-btn,
+.secondary-btn,
+.link-btn,
+.bucket-btn,
+.library-switch-btn,
+.tag-btn,
+.icon-close {
+  border: none;
+  cursor: pointer;
+  transition: 0.2s ease;
+}
+
+.tab-btn {
+  padding: 12px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+  color: #334155;
+}
+
+.tab-btn.active {
+  background: #1d4ed8;
+  color: #fff;
+}
+
+.tab-btn.secondary {
+  background: #e2e8f0;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.surface-card {
+  padding: 22px;
+}
+
+.task-card,
+.library-card,
+.recent-card {
+  min-height: 250px;
+}
+
+.card-header,
+.section-heading,
+.drawer-header,
+.reading-header,
+.review-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-header h2,
+.drawer-header h2,
+.section-heading h3,
+.side-box h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.task-actions,
+.task-stats,
+.form-actions,
+.header-actions,
+.item-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.primary-btn,
+.secondary-btn,
+.link-btn,
+.bucket-btn,
+.tag-btn,
+.library-switch-btn {
+  padding: 10px 14px;
+  border-radius: 12px;
+}
+
+.primary-btn {
+  background: #2563eb;
+  color: #fff;
+}
+
+.secondary-btn,
+.library-switch-btn {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.link-btn {
+  padding: 0;
+  background: transparent;
+  color: #2563eb;
+}
+
+.bucket-btn.active,
+.library-switch-btn.active,
+.tag-btn {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.task-stats {
+  margin-top: 18px;
+}
+
+.task-stats div,
+.recommended-box {
+  padding: 16px;
+  border-radius: 16px;
+  background: #f8fafc;
+}
+
+.task-stats div {
+  min-width: 92px;
+}
+
+.task-stats span,
+.mini-label,
+.muted-text,
+.option-row span,
+.drawer-section small {
+  color: #64748b;
+}
+
+.task-stats strong,
+.card-title {
+  display: block;
+  margin-top: 6px;
+  font-size: 22px;
+  color: #0f172a;
+}
+
+.recommended-box {
+  margin-top: 16px;
+}
+
+.recommended-box p,
+.article-summary,
+.empty-tip,
+.drawer-section p,
+.hero-summary {
+  line-height: 1.6;
+}
+
+.list-stack {
+  list-style: none;
+  padding: 0;
+  margin: 18px 0 0;
+  display: grid;
+  gap: 14px;
+}
+
+.list-stack li,
+.material-list li {
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: #f8fafc;
+}
+
+.list-stack span,
+.review-counter,
+.page-error,
+.success-tip,
+.empty-tip {
+  font-size: 14px;
+}
+
+.page-error {
+  margin: 0 0 16px;
+  color: #b91c1c;
+}
+
+.reading-layout,
+.review-layout {
+  display: grid;
+  gap: 20px;
+}
+
+.reading-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.9fr);
+  gap: 20px;
+}
+
+.article-panel,
+.side-box,
+.review-question-block {
+  border-radius: 18px;
+  background: #f8fafc;
+  padding: 18px;
+}
+
+.article-content {
+  white-space: pre-line;
+  line-height: 1.9;
+  color: #1e293b;
+}
+
+.reading-side-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.word-actions,
+.bucket-group,
+.library-switch-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.quiz-block,
+.review-controls,
+.drawer-section,
+.form-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.quiz-question {
+  display: grid;
+  gap: 10px;
+}
+
+.option-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.drawer-mask {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.42);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 30;
+}
+
+.drawer-panel {
+  width: min(720px, 100%);
+  height: 100%;
+  background: #fff;
+  padding: 24px;
+  overflow-y: auto;
+  box-shadow: -24px 0 40px rgba(15, 23, 42, 0.16);
+}
+
+.icon-close {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  font-size: 24px;
+}
+
+.material-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.material-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.form-grid label {
+  display: grid;
+  gap: 8px;
+  color: #334155;
+}
+
+.form-grid input,
+.form-grid select,
+.review-controls select,
+.form-grid textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid #cbd5e1;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.full-row {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 1080px) {
+  .dashboard-grid,
+  .reading-body {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    flex-direction: column;
+  }
+
+  .hero-metrics {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .els-view {
+    padding: 16px;
+  }
+
+  .form-grid,
+  .hero-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .material-list li,
+  .card-header,
+  .drawer-header,
+  .reading-header,
+  .review-header,
+  .section-heading {
+    flex-direction: column;
+  }
+
+  .drawer-panel {
+    width: 100%;
+    padding: 18px;
+  }
+}
+</style>

--- a/lib/llm-retry.js
+++ b/lib/llm-retry.js
@@ -37,7 +37,9 @@ export function isRetryableError(error) {
       message.includes('connection reset') ||
       message.includes('broken pipe') ||
       message.includes('EOF') ||
-      message.includes('do request failed')) {
+      message.includes('do request failed') ||
+      message.includes('连接重置') ||
+      message.includes('连接被对端关闭')) {
     return true;
   }
 
@@ -58,7 +60,10 @@ export function isRetryableError(error) {
   }
 
   // 超时错误
-  if (message.includes('timeout') || message.includes('Timeout')) {
+  if (message.includes('timeout') ||
+      message.includes('Timeout') ||
+      message.includes('请求超时') ||
+      message.includes('超时')) {
     return true;
   }
 

--- a/server/controllers/els.controller.js
+++ b/server/controllers/els.controller.js
@@ -1,0 +1,520 @@
+const LIBRARIES = [
+  {
+    id: 'lib_public_default',
+    name: '公共推荐库',
+    type: 'public',
+    material_count: 128,
+    is_selected: true,
+  },
+  {
+    id: 'lib_personal_001',
+    name: '我的生物短文库',
+    type: 'personal',
+    material_count: 12,
+    is_selected: false,
+  },
+  {
+    id: 'lib_fr_001',
+    name: '法语阅读练习库',
+    type: 'shared',
+    material_count: 18,
+    is_selected: false,
+  },
+];
+
+const NOTEBOOKS = [
+  {
+    id: 'nb_en_default',
+    language: 'en',
+    name: '英语词本',
+    word_count: 128,
+    is_selected: true,
+  },
+  {
+    id: 'nb_fr_default',
+    language: 'fr',
+    name: '法语词本',
+    word_count: 42,
+    is_selected: false,
+  },
+];
+
+const MATERIALS = {
+  lib_public_default: [
+    {
+      id: 'mat_001',
+      title: 'Why sleep matters',
+      summary: 'A short article about sleep and memory.',
+      language: 'en',
+      processing_status: 'ready',
+      safety_status: 'passed',
+      quiz_status: 'ready',
+      tts_status: 'ready',
+      can_read: true,
+      can_edit: false,
+      updated_at: '2026-06-12T09:00:00+08:00',
+      difficulty_level: 'B1',
+      library_id: 'lib_public_default',
+      library_name: '公共推荐库',
+      estimated_minutes: 4,
+      content: 'Sleep helps the brain store memories. Good sleep also improves attention, mood, and long-term learning performance. A short walk, less screen time at night, and a stable routine can all improve sleep quality.',
+    },
+    {
+      id: 'mat_002',
+      title: 'Small daily habits',
+      summary: 'Tiny habits can shape long-term learning results.',
+      language: 'en',
+      processing_status: 'ready',
+      safety_status: 'passed',
+      quiz_status: 'ready',
+      tts_status: 'pending',
+      can_read: true,
+      can_edit: false,
+      updated_at: '2026-06-11T14:30:00+08:00',
+      difficulty_level: 'A2',
+      library_id: 'lib_public_default',
+      library_name: '公共推荐库',
+      estimated_minutes: 3,
+      content: 'Daily learning does not need to be long. Reading for five minutes, repeating one sentence, and reviewing one mistake can already build a strong habit over time.',
+    },
+  ],
+  lib_personal_001: [
+    {
+      id: 'mat_user_001',
+      title: 'My Biology Note',
+      summary: 'Short note about cell division.',
+      language: 'en',
+      processing_status: 'pending_safety_review',
+      safety_status: 'pending',
+      quiz_status: 'pending',
+      tts_status: 'pending',
+      can_read: false,
+      can_edit: true,
+      updated_at: '2026-06-12T10:20:00+08:00',
+      difficulty_level: 'B1',
+      library_id: 'lib_personal_001',
+      library_name: '我的生物短文库',
+      estimated_minutes: 2,
+      content: 'Cell division is the process by which a parent cell divides into two or more daughter cells.',
+    },
+    {
+      id: 'mat_user_002',
+      title: 'Microscope Basics',
+      summary: 'Simple notes about using a microscope safely.',
+      language: 'en',
+      processing_status: 'ready',
+      safety_status: 'passed',
+      quiz_status: 'ready',
+      tts_status: 'ready',
+      can_read: true,
+      can_edit: true,
+      updated_at: '2026-06-10T16:45:00+08:00',
+      difficulty_level: 'A2',
+      library_id: 'lib_personal_001',
+      library_name: '我的生物短文库',
+      estimated_minutes: 3,
+      content: 'Always start with the lowest magnification. Focus slowly and keep the lens clean after each use.',
+    },
+  ],
+  lib_fr_001: [
+    {
+      id: 'mat_fr_001',
+      title: 'Bonjour Paris',
+      summary: 'A tiny French city guide for beginners.',
+      language: 'fr',
+      processing_status: 'ready',
+      safety_status: 'passed',
+      quiz_status: 'ready',
+      tts_status: 'failed',
+      can_read: true,
+      can_edit: false,
+      updated_at: '2026-06-09T12:00:00+08:00',
+      difficulty_level: 'A1',
+      library_id: 'lib_fr_001',
+      library_name: '法语阅读练习库',
+      estimated_minutes: 2,
+      content: 'Paris est une ville tres connue. Beaucoup de visiteurs aiment marcher pres de la Seine et visiter les musees.',
+    },
+  ],
+};
+
+const WORDS = {
+  w_001: {
+    id: 'w_001',
+    word_text: 'develop',
+    meaning: '发展；形成',
+    phonetic: '/dɪˈveləp/',
+    pronunciation_audio: '/api/files/tts/words/develop.mp3',
+    notebook_id: 'nb_en_default',
+    language: 'en',
+    example_sentence: 'Children develop language quickly.',
+    review_stage: 'D3',
+    next_review_at: '2026-06-10T09:00:00+08:00',
+    wrong_count: 1,
+  },
+};
+
+function findLibrary(libraryId) {
+  return LIBRARIES.find((item) => item.id === libraryId) || LIBRARIES[0];
+}
+
+function getMaterialById(materialId) {
+  return Object.values(MATERIALS)
+    .flat()
+    .find((item) => item.id === materialId);
+}
+
+function getSelectedLibrary() {
+  return LIBRARIES[0];
+}
+
+function getSelectedNotebook() {
+  return NOTEBOOKS[0];
+}
+
+function buildDashboard() {
+  const selectedLibrary = getSelectedLibrary();
+  return {
+    today_status: {
+      is_checked_in: false,
+      completed_reading: false,
+      completed_review: false,
+      streak_days: 6,
+    },
+    selected_library: {
+      id: selectedLibrary.id,
+      name: selectedLibrary.name,
+      material_count: selectedLibrary.material_count,
+    },
+    recommended_material: {
+      id: 'mat_001',
+      title: 'Why sleep matters',
+      difficulty_level: 'B1',
+      summary: 'A short article about sleep and memory.',
+    },
+    review_stats: {
+      today_due: 8,
+      new_words: 5,
+      wrong_words: 3,
+    },
+    recent_materials: [
+      {
+        id: 'mat_002',
+        title: 'Small daily habits',
+        last_opened_at: '2026-06-09T08:20:00+08:00',
+      },
+      {
+        id: 'mat_user_002',
+        title: 'Microscope Basics',
+        last_opened_at: '2026-06-08T20:00:00+08:00',
+      },
+    ],
+  };
+}
+
+function buildQuiz(materialId) {
+  return {
+    material_id: materialId,
+    questions: [
+      {
+        id: 'q1',
+        type: 'single_choice',
+        prompt: 'What is the main idea of the article?',
+        options: ['Build stronger sleep habits', 'Travel to a new city', 'Learn advanced biology', 'Study with long sessions'],
+      },
+      {
+        id: 'q2',
+        type: 'single_choice',
+        prompt: 'Which action helps improve learning quality?',
+        options: ['Stable routine', 'Skip all breaks', 'Read only at midnight', 'Avoid all review'],
+      },
+      {
+        id: 'q3',
+        type: 'single_choice',
+        prompt: 'What does the text connect with memory?',
+        options: ['Sleep', 'Noise', 'Competition', 'Luck'],
+      },
+    ],
+  };
+}
+
+function buildReviewQuestions(notebookId, bucket) {
+  const prompts = {
+    today: {
+      word_id: 'w_001',
+      review_type: 'listen_pick',
+      audio_url: '/api/files/tts/words/develop.mp3',
+      prompt: '你听到的是哪个词？',
+      options: ['develop', 'device', 'detail'],
+    },
+    new: {
+      word_id: 'w_010',
+      review_type: 'meaning_choice',
+      audio_url: null,
+      prompt: 'tiny habit 的意思是？',
+      options: ['微小习惯', '长期目标', '复杂系统'],
+    },
+    wrong: {
+      word_id: 'w_020',
+      review_type: 'sentence_fill',
+      audio_url: null,
+      prompt: 'Sleep helps the brain ____ memories.',
+      options: ['store', 'break', 'cancel'],
+    },
+  };
+
+  return {
+    bucket,
+    notebook_id: notebookId,
+    session_id: `rv_${bucket}_${notebookId}`,
+    questions: [prompts[bucket] || prompts.today],
+    total: 5,
+  };
+}
+
+export default class ELSController {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async getDashboard(ctx) {
+    ctx.success(buildDashboard());
+  }
+
+  async getRecommendedMaterials(ctx) {
+    const libraryId = ctx.query.library_id || getSelectedLibrary().id;
+    const items = (MATERIALS[libraryId] || MATERIALS.lib_public_default)
+      .filter((item) => item.processing_status === 'ready' && item.can_read)
+      .map((item) => ({
+        id: item.id,
+        library_id: item.library_id,
+        library_name: item.library_name,
+        title: item.title,
+        difficulty_level: item.difficulty_level,
+        summary: item.summary,
+        estimated_minutes: item.estimated_minutes,
+      }));
+    ctx.success({ items });
+  }
+
+  async getMaterial(ctx) {
+    const material = getMaterialById(ctx.params.materialId);
+    if (!material) {
+      ctx.error('ELS_NOT_FOUND', 404);
+      return;
+    }
+
+    ctx.success({
+      id: material.id,
+      library_id: material.library_id,
+      library_name: material.library_name,
+      title: material.title,
+      difficulty_level: material.difficulty_level,
+      content: material.content,
+      summary: material.summary,
+      language: material.language,
+      processing_status: material.processing_status,
+      quiz_status: material.quiz_status,
+      tts_status: material.tts_status,
+      tts: {
+        available: material.tts_status === 'ready',
+        audio_url: material.tts_status === 'ready' ? `/api/files/tts/${material.id}.mp3` : null,
+        speeds: [0.8, 1.0, 1.2],
+      },
+      progress: {
+        is_read: false,
+        collected_word_count: 0,
+      },
+    });
+  }
+
+  async getMaterialQuiz(ctx) {
+    const material = getMaterialById(ctx.params.materialId);
+    if (!material) {
+      ctx.error('ELS_NOT_FOUND', 404);
+      return;
+    }
+    ctx.success(buildQuiz(material.id));
+  }
+
+  async submitMaterialQuiz(ctx) {
+    const answers = Array.isArray(ctx.request.body?.answers) ? ctx.request.body.answers : [];
+    const correctCount = Math.min(answers.length, 2);
+
+    ctx.success({
+      correct_count: correctCount,
+      total: 3,
+      explanations: answers.map((item, index) => ({
+        question_id: item.question_id || `q${index + 1}`,
+        is_correct: index < correctCount,
+        explanation: 'Mock 反馈：第一轮仅用于联调小测结果展示。',
+      })),
+      reading_completed: true,
+      next_action: 'review_words',
+    });
+  }
+
+  async getLibraries(ctx) {
+    ctx.success({
+      selected_library_id: getSelectedLibrary().id,
+      items: LIBRARIES,
+    });
+  }
+
+  async selectLibrary(ctx) {
+    const selectedLibrary = findLibrary(ctx.request.body?.library_id);
+    ctx.success({
+      selected_library_id: selectedLibrary.id,
+      selected_library_name: selectedLibrary.name,
+    });
+  }
+
+  async getLibraryMaterials(ctx) {
+    const library = findLibrary(ctx.params.libraryId);
+    const items = (MATERIALS[library.id] || []).map((item) => ({
+      id: item.id,
+      title: item.title,
+      summary: item.summary,
+      language: item.language,
+      processing_status: item.processing_status,
+      safety_status: item.safety_status,
+      quiz_status: item.quiz_status,
+      tts_status: item.tts_status,
+      can_read: item.can_read,
+      can_edit: item.can_edit,
+      updated_at: item.updated_at,
+    }));
+
+    ctx.success({
+      library: {
+        id: library.id,
+        name: library.name,
+        type: library.type,
+      },
+      items,
+    });
+  }
+
+  async createMaterial(ctx) {
+    const payload = ctx.request.body || {};
+    ctx.success({
+      id: 'mat_user_new_001',
+      library_id: payload.library_id || 'lib_personal_001',
+      title: payload.title || 'Untitled Material',
+      source_type: 'user_upload',
+      processing_status: 'pending_safety_review',
+      safety_status: 'pending',
+      quiz_status: 'pending',
+      tts_status: 'pending',
+      can_read: false,
+    }, 'Created');
+  }
+
+  async updateMaterial(ctx) {
+    const material = getMaterialById(ctx.params.materialId);
+    if (!material) {
+      ctx.error('ELS_NOT_FOUND', 404);
+      return;
+    }
+
+    ctx.success({
+      id: material.id,
+      title: ctx.request.body?.title || material.title,
+      summary: ctx.request.body?.summary || material.summary,
+      processing_status: 'pending_safety_review',
+      safety_status: 'pending',
+      quiz_status: 'pending',
+      tts_status: 'pending',
+      can_read: false,
+    }, 'Updated');
+  }
+
+  async getNotebooks(ctx) {
+    ctx.success({
+      selected_notebook_id: getSelectedNotebook().id,
+      items: NOTEBOOKS,
+    });
+  }
+
+  async selectNotebook(ctx) {
+    const notebook = NOTEBOOKS.find((item) => item.id === ctx.request.body?.notebook_id) || getSelectedNotebook();
+    ctx.success({
+      selected_notebook_id: notebook.id,
+      selected_notebook_name: notebook.name,
+    });
+  }
+
+  async collectWord(ctx) {
+    const material = getMaterialById(ctx.request.body?.material_id);
+    if (!material) {
+      ctx.error('ELS_NOT_FOUND', 404);
+      return;
+    }
+
+    const notebook = NOTEBOOKS.find((item) => item.language === material.language) || getSelectedNotebook();
+
+    ctx.success({
+      word: {
+        id: 'w_collect_001',
+        word_text: ctx.request.body?.word_text || 'develop',
+        meaning: material.language === 'fr' ? '发展；形成（法语词本示例）' : '发展；形成',
+        phonetic: '/dɪˈveləp/',
+        pronunciation_audio: '/api/files/tts/words/develop.mp3',
+        sentence: ctx.request.body?.sentence || 'Children develop language quickly.',
+        notebook_id: notebook.id,
+        language: material.language,
+        review_stage: 'D0',
+      },
+      already_exists: false,
+    }, 'Created');
+  }
+
+  async getWord(ctx) {
+    const word = WORDS[ctx.params.wordId];
+    if (!word) {
+      ctx.error('ELS_NOT_FOUND', 404);
+      return;
+    }
+    ctx.success(word);
+  }
+
+  async getReviews(ctx) {
+    const { bucket = 'today', notebook_id: notebookId, size = 5 } = ctx.query;
+    if (!notebookId) {
+      ctx.error('ELS_NOTEBOOK_EMPTY', 400);
+      return;
+    }
+
+    ctx.success({
+      ...buildReviewQuestions(notebookId, bucket),
+      total: Number(size) || 5,
+    });
+  }
+
+  async submitReviews(ctx) {
+    const results = Array.isArray(ctx.request.body?.results) ? ctx.request.body.results : [];
+    const correctCount = results.filter((item) => item.is_correct).length;
+    ctx.success({
+      session_summary: {
+        correct_count: correctCount,
+        total: results.length || 1,
+        needs_repeat: Math.max((results.length || 1) - correctCount, 0),
+      },
+      review_stats: {
+        today_due_remaining: 3,
+        wrong_words: 2,
+      },
+      today_review_completed: true,
+    });
+  }
+
+  async getCheckin(ctx) {
+    ctx.success({
+      is_checked_in: true,
+      completed_reading: true,
+      completed_review: false,
+      streak_days: 7,
+      day_type: 'reading_day',
+    });
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -74,6 +74,7 @@ import MiniAppController from './controllers/mini-app.controller.js';
 import AppMarketController from './controllers/app-market.controller.js';
 import ContractV2Controller from './controllers/contract-v2.controller.js';
 import InvoiceController from './controllers/invoice.controller.js';
+import ELSController from './controllers/els.controller.js';
 import OcrToolController from './controllers/ocr-tool.controller.js';
 import { getAssistantManager } from './services/assistant/index.js';
 
@@ -112,6 +113,7 @@ import { createInvitationRoutes } from './routes/invitation.routes.js';
 import createMcpRoutes from './routes/mcp.routes.js';
 import contractV2Routes from './routes/contract-v2.routes.js';
 import invoiceRoutes from './routes/invoice.routes.js';
+import elsRoutes from './routes/els.routes.js';
 import ocrToolRoutes from './routes/ocr-tool.routes.js';
 import TokenCleanupJob from './jobs/token-cleanup.js';
 
@@ -281,6 +283,7 @@ class ApiServer {
       appMarket: new AppMarketController(this.db),
       contractV2: new ContractV2Controller(this.db),
       invoice: new InvoiceController(this.db),
+      els: new ELSController(this.db),
       ocrTool: new OcrToolController(this.db),
     };
   }
@@ -527,6 +530,11 @@ class ApiServer {
     this.app.use(invoiceRouter.routes());
     this.app.use(invoiceRouter.allowedMethods());
     logger.info('Invoice routes registered (/api/invoice/*)');
+
+    const elsRouter = elsRoutes(this.controllers.els);
+    this.app.use(elsRouter.routes());
+    this.app.use(elsRouter.allowedMethods());
+    logger.info('ELS routes registered (/api/els/*)');
 
     const ocrToolRouter = ocrToolRoutes;
     this.app.use(ocrToolRouter.routes());

--- a/server/routes/els.routes.js
+++ b/server/routes/els.routes.js
@@ -1,0 +1,33 @@
+import Router from '@koa/router';
+import { authenticate } from '../middlewares/auth.js';
+
+export default (controller) => {
+  const router = new Router();
+  const auth = authenticate();
+
+  router.get('/api/els/dashboard', auth, (ctx) => controller.getDashboard(ctx));
+  router.get('/api/els/materials/recommended', auth, (ctx) => controller.getRecommendedMaterials(ctx));
+  router.get('/api/els/materials/:materialId', auth, (ctx) => controller.getMaterial(ctx));
+  router.get('/api/els/materials/:materialId/quiz', auth, (ctx) => controller.getMaterialQuiz(ctx));
+  router.post('/api/els/materials/:materialId/quiz/submit', auth, (ctx) => controller.submitMaterialQuiz(ctx));
+
+  router.get('/api/els/libraries', auth, (ctx) => controller.getLibraries(ctx));
+  router.post('/api/els/libraries/select', auth, (ctx) => controller.selectLibrary(ctx));
+  router.get('/api/els/libraries/:libraryId/materials', auth, (ctx) => controller.getLibraryMaterials(ctx));
+
+  router.post('/api/els/materials', auth, (ctx) => controller.createMaterial(ctx));
+  router.put('/api/els/materials/:materialId', auth, (ctx) => controller.updateMaterial(ctx));
+
+  router.get('/api/els/notebooks', auth, (ctx) => controller.getNotebooks(ctx));
+  router.post('/api/els/notebooks/select', auth, (ctx) => controller.selectNotebook(ctx));
+
+  router.post('/api/els/words', auth, (ctx) => controller.collectWord(ctx));
+  router.get('/api/els/words/:wordId', auth, (ctx) => controller.getWord(ctx));
+
+  router.get('/api/els/reviews', auth, (ctx) => controller.getReviews(ctx));
+  router.post('/api/els/reviews/submit', auth, (ctx) => controller.submitReviews(ctx));
+
+  router.get('/api/els/checkin', auth, (ctx) => controller.getCheckin(ctx));
+
+  return router;
+};


### PR DESCRIPTION
## Summary
- add the ELS study workspace app, API, routes, and frontend entry so the platform can expose the new study flow end-to-end
- harden `contract-mgr` filtering by retrying localized timeout/reset errors and chunking long OCR text before LLM cleanup
- improve operational visibility for the filter step with input length, chunk count, and timeout logging

## Testing
- `node --check lib/llm-retry.js`
- `node --check apps/contract-mgr/tick/index.js`