### PR TITLE
feat: 文档平台预处理配置中心

### DIFF
--- a/frontend/src/api/doc-pipeline.ts
+++ b/frontend/src/api/doc-pipeline.ts
@@ -1,0 +1,137 @@
+import apiClient, { apiRequest } from './client'
+
+export interface DocPipelineJudge {
+  model_id: string | null
+  temperature: number
+  prompt_template: string
+  output_schema: Record<string, unknown>
+}
+
+export interface DocPipelineMcpStage {
+  enabled: boolean
+  type: string
+  mcp?: {
+    server: string
+    tool: string
+    params_mapping: Record<string, string>
+    params: Record<string, unknown>
+  }
+  judge?: DocPipelineJudge
+  provider_name?: string
+  timeout_ms?: number
+  poll_interval_ms?: number
+}
+
+export interface DocPipelineOcrFinalize {
+  enabled: boolean
+  mcp: {
+    server: string
+  }
+  default_deliverable_tool: string
+  list_deliverables_tool: string
+  image_deliverables_tool: string
+  download_deliverable_tool: string | null
+  persist_raw_result: boolean
+  persist_image_attachments: boolean
+  timeout_ms: number
+  judge: DocPipelineJudge
+}
+
+export interface DocPipelineCleanStage {
+  enabled: boolean
+  type: string
+  model_id: string | null
+  temperature: number
+  chunk_max_length: number
+  prompt_template: string
+  rules: {
+    remove_page_number: boolean
+    remove_watermark: boolean
+    remove_garbled_text: boolean
+    remove_header_footer: boolean
+  }
+  timeout_ms: number
+}
+
+export interface DocPipelineMetadataStage {
+  enabled: boolean
+  type: string
+  model_id: string | null
+  temperature: number
+  schema_json: Record<string, unknown>
+  prompt_template: string
+  timeout_ms: number
+}
+
+export interface DocPipelineChunkStage {
+  enabled: boolean
+  type: string
+  chunk_mode: string
+  max_length: number
+  overlap_length: number
+  keep_heading: boolean
+  merge_small_chunks: boolean
+}
+
+export interface DocPipelineEmbeddingStage {
+  enabled: boolean
+  embedding_model_id: string | null
+  batch_size: number
+  skip_empty_chunks: boolean
+  retry_times: number
+  timeout_ms: number
+}
+
+export interface DocPipelineRelocateStage {
+  enabled: boolean
+  target_strategy: string
+  tag_strategy: string
+  metadata_writeback: boolean
+  auto_publish: boolean
+}
+
+export interface DocPipelineMeta {
+  version: number
+  enabled: boolean
+}
+
+export interface DocPipelineConfig {
+  meta: DocPipelineMeta
+  pending_ocr: DocPipelineMcpStage
+  ocr_processing: DocPipelineMcpStage
+  ocr_finalize: DocPipelineOcrFinalize
+  pending_clean: DocPipelineCleanStage
+  pending_metadata: DocPipelineMetadataStage
+  pending_chunk: DocPipelineChunkStage
+  pending_embedding: DocPipelineEmbeddingStage
+  pending_relocate: DocPipelineRelocateStage
+}
+
+export interface McpServerItem {
+  id: string
+  name: string
+  is_enabled: boolean
+}
+
+export interface ModelItem {
+  id: string
+  model_name: string
+  display_name?: string
+}
+
+export const docPipelineApi = {
+  getConfig: () =>
+    apiRequest<DocPipelineConfig>(apiClient.get('/system-settings/doc-pipeline')),
+
+  saveConfig: (config: DocPipelineConfig) =>
+    apiRequest<DocPipelineConfig>(apiClient.put('/system-settings/doc-pipeline', config)),
+
+  resetConfig: (keys?: string[]) =>
+    apiRequest<DocPipelineConfig>(apiClient.post('/system-settings/doc-pipeline/reset', { keys })),
+
+  getMcpServers: () =>
+    apiRequest<{ servers: McpServerItem[] }>(apiClient.get('/mcp/servers')),
+
+  getModels: () =>
+    apiRequest<ModelItem[]>(apiClient.get('/models')),
+}

--- a/frontend/src/components/docs/DocPipelineConfigDialog.vue
+++ b/frontend/src/components/docs/DocPipelineConfigDialog.vue
@@ -1,0 +1,500 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    title="文档预处理配置"
+    width="960px"
+    :close-on-click-modal="false"
+    @open="onOpen"
+    @close="onClose"
+  >
+    <div class="pipeline-config">
+      <div class="pipeline-nav">
+        <div
+          v-for="stage in stages"
+          :key="stage.key"
+          class="nav-item"
+          :class="{ active: activeStage === stage.key }"
+          @click="activeStage = stage.key"
+        >
+          <span class="nav-label">{{ stage.label }}</span>
+          <span class="nav-key">{{ stage.key }}</span>
+        </div>
+      </div>
+
+      <div class="pipeline-form">
+        <el-form :model="form" label-width="130px" size="small">
+          <!-- pending_ocr -->
+          <template v-if="activeStage === 'pending_ocr'">
+            <el-form-item label="启用"><el-switch v-model="form.pending_ocr.enabled" disabled /></el-form-item>
+            <el-form-item label="执行方式"><el-tag size="small" type="info">mcp（固定）</el-tag></el-form-item>
+            <el-divider content-position="left">MCP 配置</el-divider>
+            <el-form-item label="MCP 服务">
+              <el-select v-model="form.pending_ocr.mcp.server" placeholder="选择 MCP 服务" clearable filterable>
+                <el-option v-for="s in mcpServers" :key="s.id" :label="s.name" :value="s.name" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="提交工具名">
+              <el-input v-model="form.pending_ocr.mcp.tool" placeholder="create_task_from_file" />
+            </el-form-item>
+            <el-form-item label="Provider 标识">
+              <el-input v-model="form.pending_ocr.provider_name" placeholder="mineru" />
+            </el-form-item>
+            <el-form-item label="超时(ms)">
+              <el-input-number v-model="form.pending_ocr.timeout_ms" :min="5000" :step="10000" />
+            </el-form-item>
+            <el-divider content-position="left">参数映射</el-divider>
+            <el-form-item label="file_base64">
+              <el-input v-model="form.pending_ocr.mcp.params_mapping.file_base64" placeholder="file_base64" />
+            </el-form-item>
+            <el-form-item label="file_name">
+              <el-input v-model="form.pending_ocr.mcp.params_mapping.file_name" placeholder="file_name" />
+            </el-form-item>
+            <el-form-item label="lang">
+              <el-input v-model="form.pending_ocr.mcp.params_mapping.lang" placeholder="lang" />
+            </el-form-item>
+            <el-form-item label="formula_enable">
+              <el-input v-model="form.pending_ocr.mcp.params_mapping.formula_enable" placeholder="formula_enable" />
+            </el-form-item>
+            <el-form-item label="table_enable">
+              <el-input v-model="form.pending_ocr.mcp.params_mapping.table_enable" placeholder="table_enable" />
+            </el-form-item>
+            <el-form-item label="image_analysis">
+              <el-input v-model="form.pending_ocr.mcp.params_mapping.image_analysis" placeholder="image_analysis" />
+            </el-form-item>
+            <el-divider content-position="left">LLM 归一化</el-divider>
+            <el-form-item label="归一化模型">
+              <el-select v-model="form.pending_ocr.judge.model_id" placeholder="默认模型" clearable filterable>
+                <el-option v-for="m in models" :key="m.id" :label="m.model_name" :value="m.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="温度">
+              <el-input-number v-model="form.pending_ocr.judge.temperature" :min="0" :max="2" :step="0.1" />
+            </el-form-item>
+            <el-form-item label="归一化提示词">
+              <el-input v-model="form.pending_ocr.judge.prompt_template" type="textarea" :rows="4" />
+            </el-form-item>
+            <el-form-item label="输出 Schema (JSON)">
+              <el-input
+                :model-value="schemaJson(form.pending_ocr.judge.output_schema)"
+                type="textarea" :rows="4"
+                @update:model-value="onSchemaInput($event, 'pending_ocr')"
+                placeholder='{"task_id":"string","provider":"string","is_success":true,"message":"string"}'
+              />
+              <span v-if="schemaError['pending_ocr']" class="schema-error">{{ schemaError['pending_ocr'] }}</span>
+            </el-form-item>
+          </template>
+
+          <!-- ocr_processing -->
+          <template v-if="activeStage === 'ocr_processing'">
+            <el-form-item label="启用"><el-switch v-model="form.ocr_processing.enabled" disabled /></el-form-item>
+            <el-form-item label="执行方式"><el-tag size="small" type="info">mcp（固定）</el-tag></el-form-item>
+            <el-divider content-position="left">MCP 配置</el-divider>
+            <el-form-item label="MCP 服务">
+              <el-select v-model="form.ocr_processing.mcp.server" placeholder="选择 MCP 服务" clearable filterable>
+                <el-option v-for="s in mcpServers" :key="s.id" :label="s.name" :value="s.name" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="查询工具名">
+              <el-input v-model="form.ocr_processing.mcp.tool" placeholder="get_task_status" />
+            </el-form-item>
+            <el-form-item label="轮询间隔(ms)">
+              <el-input-number v-model="form.ocr_processing.poll_interval_ms" :min="1000" :step="1000" />
+            </el-form-item>
+            <el-form-item label="超时(ms)">
+              <el-input-number v-model="form.ocr_processing.timeout_ms" :min="5000" :step="10000" />
+            </el-form-item>
+            <el-divider content-position="left">LLM 归一化</el-divider>
+            <el-form-item label="归一化模型">
+              <el-select v-model="form.ocr_processing.judge.model_id" placeholder="默认模型" clearable filterable>
+                <el-option v-for="m in models" :key="m.id" :label="m.model_name" :value="m.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="温度">
+              <el-input-number v-model="form.ocr_processing.judge.temperature" :min="0" :max="2" :step="0.1" />
+            </el-form-item>
+            <el-form-item label="归一化提示词">
+              <el-input v-model="form.ocr_processing.judge.prompt_template" type="textarea" :rows="4" />
+            </el-form-item>
+            <el-form-item label="输出 Schema (JSON)">
+              <el-input
+                :model-value="schemaJson(form.ocr_processing.judge.output_schema)"
+                type="textarea" :rows="4"
+                @update:model-value="onSchemaInput($event, 'ocr_processing')"
+                placeholder='{"status":"pending|processing|completed|failed","progress":0,"is_completed":false,"error_message":"string"}'
+              />
+              <span v-if="schemaError['ocr_processing']" class="schema-error">{{ schemaError['ocr_processing'] }}</span>
+            </el-form-item>
+          </template>
+
+          <!-- ocr_finalize -->
+          <template v-if="activeStage === 'ocr_finalize'">
+            <el-form-item label="启用"><el-switch v-model="form.ocr_finalize.enabled" disabled /></el-form-item>
+            <el-divider content-position="left">MCP 配置</el-divider>
+            <el-form-item label="MCP 服务">
+              <el-select v-model="form.ocr_finalize.mcp.server" placeholder="选择 MCP 服务" clearable filterable>
+                <el-option v-for="s in mcpServers" :key="s.id" :label="s.name" :value="s.name" />
+              </el-select>
+            </el-form-item>
+            <el-divider content-position="left">产物工具</el-divider>
+            <el-form-item label="默认主产物工具">
+              <el-input v-model="form.ocr_finalize.default_deliverable_tool" placeholder="get_default_deliverable" />
+            </el-form-item>
+            <el-form-item label="交付物列表工具">
+              <el-input v-model="form.ocr_finalize.list_deliverables_tool" placeholder="list_deliverables" />
+            </el-form-item>
+            <el-form-item label="图片产物工具">
+              <el-input v-model="form.ocr_finalize.image_deliverables_tool" placeholder="get_image_deliverables" />
+            </el-form-item>
+            <el-form-item label="超时(ms)">
+              <el-input-number v-model="form.ocr_finalize.timeout_ms" :min="5000" :step="10000" />
+            </el-form-item>
+            <el-form-item label="持久化原始结果">
+              <el-switch v-model="form.ocr_finalize.persist_raw_result" />
+            </el-form-item>
+            <el-form-item label="持久化图片附件">
+              <el-switch v-model="form.ocr_finalize.persist_image_attachments" />
+            </el-form-item>
+            <el-divider content-position="left">LLM 归一化</el-divider>
+            <el-form-item label="归一化模型">
+              <el-select v-model="form.ocr_finalize.judge.model_id" placeholder="默认模型" clearable filterable>
+                <el-option v-for="m in models" :key="m.id" :label="m.model_name" :value="m.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="温度">
+              <el-input-number v-model="form.ocr_finalize.judge.temperature" :min="0" :max="2" :step="0.1" />
+            </el-form-item>
+            <el-form-item label="归一化提示词">
+              <el-input v-model="form.ocr_finalize.judge.prompt_template" type="textarea" :rows="4" />
+            </el-form-item>
+            <el-form-item label="输出 Schema (JSON)">
+              <el-input
+                :model-value="schemaJson(form.ocr_finalize.judge.output_schema)"
+                type="textarea" :rows="4"
+                @update:model-value="onSchemaInput($event, 'ocr_finalize')"
+                placeholder='{"main_markdown":"string","deliverables":[],"is_success":true,"error_message":"string"}'
+              />
+              <span v-if="schemaError['ocr_finalize']" class="schema-error">{{ schemaError['ocr_finalize'] }}</span>
+            </el-form-item>
+          </template>
+
+          <!-- pending_clean -->
+          <template v-if="activeStage === 'pending_clean'">
+            <el-form-item label="启用"><el-switch v-model="form.pending_clean.enabled" /></el-form-item>
+            <el-form-item label="执行方式">
+              <el-select v-model="form.pending_clean.type">
+                <el-option label="内置 LLM" value="internal_llm" />
+                <el-option label="脚本" value="script" />
+                <el-option label="禁用" value="disabled" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="模型">
+              <el-select v-model="form.pending_clean.model_id" placeholder="默认模型" clearable filterable>
+                <el-option v-for="m in models" :key="m.id" :label="m.model_name" :value="m.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="温度">
+              <el-input-number v-model="form.pending_clean.temperature" :min="0" :max="2" :step="0.1" />
+            </el-form-item>
+            <el-form-item label="分块最大长度">
+              <el-input-number v-model="form.pending_clean.chunk_max_length" :min="500" :step="500" />
+            </el-form-item>
+            <el-form-item label="清洗提示词">
+              <el-input v-model="form.pending_clean.prompt_template" type="textarea" :rows="4" />
+            </el-form-item>
+            <el-divider content-position="left">清洗规则</el-divider>
+            <el-form-item label="移除页码"><el-switch v-model="form.pending_clean.rules.remove_page_number" /></el-form-item>
+            <el-form-item label="移水印"><el-switch v-model="form.pending_clean.rules.remove_watermark" /></el-form-item>
+            <el-form-item label="移除乱码"><el-switch v-model="form.pending_clean.rules.remove_garbled_text" /></el-form-item>
+            <el-form-item label="移除页眉页脚"><el-switch v-model="form.pending_clean.rules.remove_header_footer" /></el-form-item>
+            <el-form-item label="超时(ms)">
+              <el-input-number v-model="form.pending_clean.timeout_ms" :min="5000" :step="10000" />
+            </el-form-item>
+          </template>
+
+          <!-- pending_metadata -->
+          <template v-if="activeStage === 'pending_metadata'">
+            <el-form-item label="启用"><el-switch v-model="form.pending_metadata.enabled" /></el-form-item>
+            <el-form-item label="执行方式">
+              <el-select v-model="form.pending_metadata.type">
+                <el-option label="内置 LLM" value="internal_llm" />
+                <el-option label="禁用" value="disabled" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="模型">
+              <el-select v-model="form.pending_metadata.model_id" placeholder="默认模型" clearable filterable>
+                <el-option v-for="m in models" :key="m.id" :label="m.model_name" :value="m.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="温度">
+              <el-input-number v-model="form.pending_metadata.temperature" :min="0" :max="2" :step="0.1" />
+            </el-form-item>
+            <el-form-item label="元数据提示词">
+              <el-input v-model="form.pending_metadata.prompt_template" type="textarea" :rows="4" />
+            </el-form-item>
+            <el-form-item label="超时(ms)">
+              <el-input-number v-model="form.pending_metadata.timeout_ms" :min="5000" :step="10000" />
+            </el-form-item>
+          </template>
+
+          <!-- pending_chunk -->
+          <template v-if="activeStage === 'pending_chunk'">
+            <el-form-item label="启用"><el-switch v-model="form.pending_chunk.enabled" /></el-form-item>
+            <el-form-item label="分块模式">
+              <el-select v-model="form.pending_chunk.chunk_mode">
+                <el-option label="按标题" value="heading" />
+                <el-option label="按段落" value="paragraph" />
+                <el-option label="固定长度" value="fixed" />
+                <el-option label="混合策略" value="mixed" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="最大长度">
+              <el-input-number v-model="form.pending_chunk.max_length" :min="100" :step="100" />
+            </el-form-item>
+            <el-form-item label="重叠长度">
+              <el-input-number v-model="form.pending_chunk.overlap_length" :min="0" :step="50" />
+            </el-form-item>
+            <el-form-item label="保留标题"><el-switch v-model="form.pending_chunk.keep_heading" /></el-form-item>
+            <el-form-item label="合并小块"><el-switch v-model="form.pending_chunk.merge_small_chunks" /></el-form-item>
+          </template>
+
+          <!-- pending_embedding -->
+          <template v-if="activeStage === 'pending_embedding'">
+            <el-form-item label="启用"><el-switch v-model="form.pending_embedding.enabled" /></el-form-item>
+            <el-form-item label="嵌入模型">
+              <el-select v-model="form.pending_embedding.embedding_model_id" placeholder="默认模型" clearable filterable>
+                <el-option v-for="m in models" :key="m.id" :label="m.model_name" :value="m.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="批处理大小">
+              <el-input-number v-model="form.pending_embedding.batch_size" :min="1" :step="5" />
+            </el-form-item>
+            <el-form-item label="跳过空块"><el-switch v-model="form.pending_embedding.skip_empty_chunks" /></el-form-item>
+            <el-form-item label="重试次数">
+              <el-input-number v-model="form.pending_embedding.retry_times" :min="0" :max="10" :step="1" />
+            </el-form-item>
+            <el-form-item label="超时(ms)">
+              <el-input-number v-model="form.pending_embedding.timeout_ms" :min="5000" :step="10000" />
+            </el-form-item>
+          </template>
+
+          <!-- pending_relocate -->
+          <template v-if="activeStage === 'pending_relocate'">
+            <el-form-item label="启用"><el-switch v-model="form.pending_relocate.enabled" /></el-form-item>
+            <el-form-item label="入库策略">
+              <el-select v-model="form.pending_relocate.target_strategy">
+                <el-option label="当前集合" value="current_collection" />
+                <el-option label="指定集合" value="specified_collection" />
+                <el-option label="自动路由" value="auto_route" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="标签策略">
+              <el-select v-model="form.pending_relocate.tag_strategy">
+                <el-option label="不写入" value="none" />
+                <el-option label="自动标签" value="auto" />
+                <el-option label="手动标签" value="manual" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="元数据回写"><el-switch v-model="form.pending_relocate.metadata_writeback" /></el-form-item>
+            <el-form-item label="自动发布"><el-switch v-model="form.pending_relocate.auto_publish" /></el-form-item>
+          </template>
+        </el-form>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="dialog-footer">
+        <el-button @click="resetStage">恢复默认</el-button>
+        <el-button @click="visible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="save">保存</el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, watch } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { docPipelineApi, type DocPipelineConfig } from '@/api/doc-pipeline'
+
+const props = defineProps<{
+  modelValue: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', val: boolean): void
+}>()
+
+const visible = ref(props.modelValue)
+watch(() => props.modelValue, (v) => { visible.value = v })
+watch(visible, (v) => { emit('update:modelValue', v) })
+
+const stages = [
+  { key: 'pending_ocr', label: 'OCR提交' },
+  { key: 'ocr_processing', label: 'OCR轮询' },
+  { key: 'ocr_finalize', label: 'OCR产物提取' },
+  { key: 'pending_clean', label: '文本清洗' },
+  { key: 'pending_metadata', label: '元数据提取' },
+  { key: 'pending_chunk', label: '文本分块' },
+  { key: 'pending_embedding', label: '向量化' },
+  { key: 'pending_relocate', label: '入库收尾' },
+]
+
+const activeStage = ref('pending_ocr')
+const saving = ref(false)
+const loading = ref(false)
+const schemaError = ref<Record<string, string>>({})
+
+const defaultForm: DocPipelineConfig = {
+  meta: { version: 1, enabled: true },
+  pending_ocr: {
+    enabled: true, type: 'mcp', provider_name: 'mineru', timeout_ms: 120000,
+    mcp: { server: 'mineru', tool: 'create_task_from_file', params_mapping: { file_base64: 'file_base64', file_name: 'file_name', lang: 'lang', formula_enable: 'formula_enable', table_enable: 'table_enable', image_analysis: 'image_analysis' }, params: {} },
+    judge: { model_id: null, temperature: 0.1, prompt_template: '', output_schema: {} },
+  },
+  ocr_processing: {
+    enabled: true, type: 'mcp', timeout_ms: 120000, poll_interval_ms: 5000,
+    mcp: { server: 'mineru', tool: 'get_task_status', params_mapping: { task_id: 'task_id' }, params: {} },
+    judge: { model_id: null, temperature: 0.1, prompt_template: '', output_schema: {} },
+  },
+  ocr_finalize: {
+    enabled: true, mcp: { server: 'mineru' },
+    default_deliverable_tool: 'get_default_deliverable', list_deliverables_tool: 'list_deliverables', image_deliverables_tool: 'get_image_deliverables',
+    download_deliverable_tool: null, persist_raw_result: true, persist_image_attachments: true, timeout_ms: 120000,
+    judge: { model_id: null, temperature: 0.1, prompt_template: '', output_schema: {} },
+  },
+  pending_clean: {
+    enabled: true, type: 'internal_llm', model_id: null, temperature: 0.3, chunk_max_length: 8000, prompt_template: '', timeout_ms: 120000,
+    rules: { remove_page_number: true, remove_watermark: true, remove_garbled_text: true, remove_header_footer: true },
+  },
+  pending_metadata: { enabled: true, type: 'internal_llm', model_id: null, temperature: 0.3, schema_json: {}, prompt_template: '', timeout_ms: 120000 },
+  pending_chunk: { enabled: true, type: 'builtin', chunk_mode: 'heading', max_length: 1000, overlap_length: 100, keep_heading: true, merge_small_chunks: false },
+  pending_embedding: { enabled: true, embedding_model_id: null, batch_size: 20, skip_empty_chunks: true, retry_times: 3, timeout_ms: 120000 },
+  pending_relocate: { enabled: true, target_strategy: 'current_collection', tag_strategy: 'none', metadata_writeback: false, auto_publish: false },
+}
+
+const form = reactive<DocPipelineConfig>(JSON.parse(JSON.stringify(defaultForm)))
+
+const mcpServers = ref<{ id: string; name: string; is_enabled: boolean }[]>([])
+const models = ref<{ id: string; model_name: string }[]>([])
+
+let initialForm = ''
+
+function schemaJson(obj: Record<string, unknown>) {
+  try { return JSON.stringify(obj, null, 2) } catch { return '{}' }
+}
+
+function onSchemaInput(val: string, stage: 'pending_ocr' | 'ocr_processing' | 'ocr_finalize') {
+  try {
+    form[stage].judge.output_schema = JSON.parse(val)
+    delete schemaError.value[stage]
+  } catch {
+    schemaError.value[stage] = 'JSON 格式错误，已保留原值'
+  }
+}
+
+async function loadConfig() {
+  loading.value = true
+  try {
+    const config = await docPipelineApi.getConfig()
+    Object.assign(form, JSON.parse(JSON.stringify(config)))
+    initialForm = JSON.stringify(form)
+  } catch {
+    ElMessage.error('加载配置失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadMcpServers() {
+  try {
+    const res = await docPipelineApi.getMcpServers()
+    mcpServers.value = res.servers || []
+  } catch { /* ignore */ }
+}
+
+async function loadModels() {
+  try {
+    models.value = await docPipelineApi.getModels()
+  } catch { /* ignore */ }
+}
+
+function onOpen() {
+  schemaError.value = {}
+  loadConfig()
+  loadMcpServers()
+  loadModels()
+}
+
+async function save() {
+  if (Object.keys(schemaError.value).length > 0) {
+    ElMessage.warning('请先修正所有阶段中格式错误的输出 Schema')
+    return
+  }
+  saving.value = true
+  try {
+    const result = await docPipelineApi.saveConfig(JSON.parse(JSON.stringify(form)))
+    Object.assign(form, result)
+    initialForm = JSON.stringify(form)
+    ElMessage.success('配置已保存')
+  } catch {
+    ElMessage.error('保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function resetStage() {
+  try {
+    await ElMessageBox.confirm(`确定恢复「${stages.find(s => s.key === activeStage.value)?.label}」阶段为默认配置吗？`, '恢复默认', { type: 'warning' })
+    await docPipelineApi.resetConfig([activeStage.value])
+    await loadConfig()
+    ElMessage.success('已恢复默认')
+  } catch { /* cancelled */ }
+}
+
+function onClose() {
+  if (JSON.stringify(form) !== initialForm) {
+    ElMessage.warning('未保存的配置已丢弃')
+  }
+}
+</script>
+
+<style scoped>
+.pipeline-config {
+  display: flex;
+  gap: 0;
+  height: 520px;
+}
+.pipeline-nav {
+  width: 170px;
+  border-right: 1px solid #ebeef5;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+.nav-item {
+  padding: 12px 16px;
+  cursor: pointer;
+  border-bottom: 1px solid #f0f0f0;
+  transition: background 0.15s;
+}
+.nav-item:hover { background: #f5f7fa; }
+.nav-item.active { background: #ecf5ff; border-right: 3px solid #409eff; }
+.nav-label { display: block; font-size: 14px; font-weight: 500; }
+.nav-key { display: block; font-size: 11px; color: #999; margin-top: 2px; }
+.pipeline-form {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 24px;
+}
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.schema-error {
+  color: #f56c6c;
+  font-size: 12px;
+  line-height: 1.4;
+  margin-top: 4px;
+}
+</style>

--- a/frontend/src/views/CollectionListView.vue
+++ b/frontend/src/views/CollectionListView.vue
@@ -14,6 +14,9 @@
         </el-button>
       </template>
       <template #actions>
+        <el-button v-if="isAdmin" size="small" @click="showConfigDialog = true">
+          <el-icon style="margin-right:4px"><Setting /></el-icon>配置
+        </el-button>
         <el-button v-if="activeView === 'collections'" type="primary" @click="showCreateDialog = true">
           新建集合
         </el-button>
@@ -153,28 +156,37 @@
       v-model:visible="showCreateDialog"
       @created="onCreated"
     />
+
+    <DocPipelineConfigDialog v-model="showConfigDialog" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { Setting } from '@element-plus/icons-vue'
 import { useCollectionStore } from '@/stores/collection'
 import { useDocStore } from '@/stores/doc'
+import { useUserStore } from '@/stores/user'
 import ContextHeader from '@/components/docs/ContextHeader.vue'
 import DocSearchBar from '@/components/docs/DocSearchBar.vue'
 import DocStatusBadge from '@/components/docs/DocStatusBadge.vue'
 import CollectionCard from '@/components/docs/CollectionCard.vue'
 import CreateCollectionModal from '@/components/doc-collections/CreateCollectionModal.vue'
+import DocPipelineConfigDialog from '@/components/docs/DocPipelineConfigDialog.vue'
 
 const router = useRouter()
 const collStore = useCollectionStore()
 const docStore = useDocStore()
+const userStore = useUserStore()
+
+const isAdmin = computed(() => userStore.isAdmin)
 
 const activeView = ref<'documents' | 'collections'>('documents')
 const collectionSearch = ref('')
 const showCreateDialog = ref(false)
+const showConfigDialog = ref(false)
 
 const filterDocType = ref('')
 const recallQuery = ref('')

--- a/lib/app-clock.js
+++ b/lib/app-clock.js
@@ -7,6 +7,7 @@ import jwt from 'jsonwebtoken';
 import ExtensionTableService from '../server/services/extension-table.service.js';
 import InternalLLMService from './internal-llm-service.js';
 import DocumentOcrService from './document-ocr-service.js';
+import { DOC_PIPELINE_KEYS, mergeWithDefaults, createCallLlmFn } from './doc-pipeline-defaults.js';
 
 const MAX_TICK_OUTPUT_STRING_LENGTH = parseInt(process.env.APP_CLOCK_MAX_OUTPUT_LENGTH || '4096', 10);
 const MAX_TICK_OUTPUT_ARRAY_ITEMS = parseInt(process.env.APP_CLOCK_MAX_OUTPUT_ARRAY_ITEMS || '10', 10);
@@ -237,6 +238,25 @@ class AppClock {
       callMcp: async (server, tool, params, timeoutMs) => {
         return await this.callMcp(server, tool, params, timeoutMs);
       },
+      getDocPipelineConfig: async () => {
+        const SystemSetting = this.db.getModel('system_setting');
+        if (!SystemSetting) return null;
+        const records = await SystemSetting.findAll({
+          where: { setting_key: DOC_PIPELINE_KEYS.map(k => `doc_pipeline.${k}`) },
+          raw: true,
+        });
+        const stored = {};
+        for (const record of records) {
+          const stageKey = record.setting_key.replace('doc_pipeline.', '');
+          try {
+            stored[stageKey] = JSON.parse(record.setting_value);
+          } catch {
+            stored[stageKey] = null;
+          }
+        }
+        return mergeWithDefaults(stored);
+      },
+      callLlm: createCallLlmFn(this.db),
     });
 
     return {

--- a/lib/doc-pipeline-defaults.js
+++ b/lib/doc-pipeline-defaults.js
@@ -1,0 +1,256 @@
+/**
+ * 文档预处理流水线默认配置
+ * 保存位置：system_settings 表 doc_pipeline.* 命名空间
+ */
+
+const DOC_PIPELINE_DEFAULTS = {
+  meta: {
+    version: 1,
+    enabled: true,
+  },
+
+  pending_ocr: {
+    enabled: true,
+    type: 'mcp',
+    mcp: {
+      server: 'mineru',
+      tool: 'create_task_from_file',
+      params_mapping: {
+        file_base64: 'file_base64',
+        file_name: 'file_name',
+        lang: 'lang',
+        formula_enable: 'formula_enable',
+        table_enable: 'table_enable',
+        image_analysis: 'image_analysis',
+      },
+      params: {
+        lang: 'ch',
+        formula_enable: true,
+        table_enable: true,
+        image_analysis: true,
+      },
+    },
+    judge: {
+      model_id: null,
+      temperature: 0.1,
+      prompt_template: '将以下 MCP 返回结果归一化为提交结果 JSON，必须返回 task_id、provider、is_success、message。',
+      output_schema: {
+        task_id: 'string',
+        provider: 'string',
+        is_success: true,
+        message: 'string',
+      },
+    },
+    provider_name: 'mineru',
+    timeout_ms: 120000,
+  },
+
+  ocr_processing: {
+    enabled: true,
+    type: 'mcp',
+    mcp: {
+      server: 'mineru',
+      tool: 'get_task_status',
+      params_mapping: {
+        task_id: 'task_id',
+      },
+      params: {},
+    },
+    poll_interval_ms: 5000,
+    timeout_ms: 120000,
+    judge: {
+      model_id: null,
+      temperature: 0.1,
+      prompt_template: '将以下 MCP 返回的状态信息归一化为标准状态对象，必须返回 status、progress、is_completed、error_message。',
+      output_schema: {
+        status: 'pending|processing|completed|failed',
+        progress: 0,
+        is_completed: false,
+        error_message: 'string',
+      },
+    },
+  },
+
+  ocr_finalize: {
+    enabled: true,
+    mcp: {
+      server: 'mineru',
+    },
+    default_deliverable_tool: 'get_default_deliverable',
+    list_deliverables_tool: 'list_deliverables',
+    image_deliverables_tool: 'get_image_deliverables',
+    download_deliverable_tool: null,
+    persist_raw_result: true,
+    persist_image_attachments: true,
+    timeout_ms: 120000,
+    judge: {
+      model_id: null,
+      temperature: 0.1,
+      prompt_template: '从 MCP 返回结果中提取主 Markdown、交付物清单、下载方式、图片列表。',
+      output_schema: {
+        main_markdown: 'string',
+        deliverables: [
+          {
+            name: 'string',
+            type: 'markdown|json|image|other',
+            download_method: 'inline|url|tool',
+            download_payload: {},
+          },
+        ],
+        raw_payload: {},
+        image_items: [],
+        is_success: true,
+        error_message: 'string',
+      },
+    },
+  },
+
+  pending_clean: {
+    enabled: true,
+    type: 'internal_llm',
+    model_id: null,
+    temperature: 0.3,
+    chunk_max_length: 8000,
+    prompt_template: '',
+    rules: {
+      remove_page_number: true,
+      remove_watermark: true,
+      remove_garbled_text: true,
+      remove_header_footer: true,
+    },
+    timeout_ms: 120000,
+  },
+
+  pending_metadata: {
+    enabled: true,
+    type: 'internal_llm',
+    model_id: null,
+    temperature: 0.3,
+    schema_json: {},
+    prompt_template: '',
+    timeout_ms: 120000,
+  },
+
+  pending_chunk: {
+    enabled: true,
+    type: 'builtin',
+    chunk_mode: 'heading',
+    max_length: 1000,
+    overlap_length: 100,
+    keep_heading: true,
+    merge_small_chunks: false,
+  },
+
+  pending_embedding: {
+    enabled: true,
+    embedding_model_id: null,
+    batch_size: 20,
+    skip_empty_chunks: true,
+    retry_times: 3,
+    timeout_ms: 120000,
+  },
+
+  pending_relocate: {
+    enabled: true,
+    target_strategy: 'current_collection',
+    tag_strategy: 'none',
+    metadata_writeback: false,
+    auto_publish: false,
+  },
+};
+
+const PIPELINE_STAGE_KEYS = [
+  'pending_ocr',
+  'ocr_processing',
+  'ocr_finalize',
+  'pending_clean',
+  'pending_metadata',
+  'pending_chunk',
+  'pending_embedding',
+  'pending_relocate',
+];
+
+const DOC_PIPELINE_KEYS = ['meta', ...PIPELINE_STAGE_KEYS];
+
+/**
+ * 获取单个阶段的默认配置（深拷贝）
+ */
+function getStageDefault(stageKey) {
+  const source = DOC_PIPELINE_DEFAULTS[stageKey];
+  if (!source) return null;
+  return JSON.parse(JSON.stringify(source));
+}
+
+/**
+ * 获取完整 doc_pipeline 默认配置（深拷贝）
+ */
+function getAllDefaults() {
+  return JSON.parse(JSON.stringify(DOC_PIPELINE_DEFAULTS));
+}
+
+/**
+ * 补齐缺失的阶段配置
+ * @param {Object} stored - 数据库中读取的已解析配置
+ * @returns {Object} 补齐默认值后的完整配置
+ */
+function mergeWithDefaults(stored) {
+  const result = {};
+  for (const key of DOC_PIPELINE_KEYS) {
+    if (stored && stored[key] && typeof stored[key] === 'object') {
+      result[key] = stored[key];
+    } else {
+      result[key] = getStageDefault(key);
+    }
+  }
+  return result;
+}
+
+/**
+ * 判断是否为 MCP 阶段
+ */
+function isOcrStage(stageKey) {
+  return stageKey === 'pending_ocr' || stageKey === 'ocr_processing' || stageKey === 'ocr_finalize';
+}
+
+/**
+ * 创建 LLM 调用函数
+ * 用于 DocumentOcrService 的 callLlm 选项，消除 app-clock / doc-controller 中的重复代码
+ * @param {Object} db - 数据库实例
+ * @returns {Function} callLlm(opts) - opts: { model_id, temperature, messages }
+ */
+function createCallLlmFn(db) {
+  return async (opts) => {
+    const ModelRegistry = db.getModel('ai_model');
+    const modelRow = opts.model_id
+      ? await ModelRegistry.findByPk(opts.model_id, { raw: true })
+      : await ModelRegistry.findOne({ where: { is_default: true }, raw: true });
+    if (!modelRow) throw new Error('No LLM model available for judge normalization');
+    const { call } = await import('./chat/base-llm.js');
+    const callOptions = { temperature: opts.temperature ?? 0.1 };
+    if (opts.output_schema && typeof opts.output_schema === 'object' && Object.keys(opts.output_schema).length > 0) {
+      callOptions.response_format = { type: 'json_object' };
+    }
+    const response = await call(
+      { model_name: modelRow.model_name, base_url: modelRow.base_url, api_key: modelRow.api_key },
+      opts.messages || [],
+      callOptions,
+    );
+    const content = response?.choices?.[0]?.message?.content || '';
+    try {
+      return JSON.parse(content);
+    } catch {
+      return { _raw: content };
+    }
+  };
+}
+
+export {
+  DOC_PIPELINE_DEFAULTS,
+  DOC_PIPELINE_KEYS,
+  PIPELINE_STAGE_KEYS,
+  getStageDefault,
+  getAllDefaults,
+  mergeWithDefaults,
+  isOcrStage,
+  createCallLlmFn,
+};

--- a/lib/document-ocr-service.js
+++ b/lib/document-ocr-service.js
@@ -4,6 +4,7 @@ import path from 'path';
 import Utils from './utils.js';
 import logger from './logger.js';
 import DocPipelineAdvancer from './doc-pipeline-advancer.js';
+import { getStageDefault } from './doc-pipeline-defaults.js';
 
 const DEFAULT_PROVIDER = 'mineru';
 const DEFAULT_SERVER_NAME = 'mineru';
@@ -30,13 +31,156 @@ class DocumentOcrService {
   constructor(db, options = {}) {
     this.db = db;
     this.callMcp = options.callMcp;
+    this.callLlm = options.callLlm || null;
+    this.getDocPipelineConfig = options.getDocPipelineConfig || null;
     this.provider = options.provider || DEFAULT_PROVIDER;
     this.serverName = options.serverName || DEFAULT_SERVER_NAME;
     this.advancer = new DocPipelineAdvancer(db);
   }
 
+  async _loadStageConfig(stageKey) {
+    if (typeof this.getDocPipelineConfig === 'function') {
+      try {
+        const fullConfig = await this.getDocPipelineConfig();
+        if (fullConfig && fullConfig[stageKey]) {
+          return fullConfig[stageKey];
+        }
+      } catch (err) {
+        logger.warn(`[DocumentOcrService] Failed to load ${stageKey} config, using defaults:`, err.message);
+      }
+    }
+    return getStageDefault(stageKey);
+  }
+
+  _resolveMcpServer(stageConfig) {
+    return stageConfig?.mcp?.server || DEFAULT_SERVER_NAME;
+  }
+
+  _resolveMcpTool(stageConfig, fallbackTool) {
+    return stageConfig?.mcp?.tool || fallbackTool;
+  }
+
+  _resolveTimeout(stageConfig, fallbackMs) {
+    return stageConfig?.timeout_ms || fallbackMs;
+  }
+
+  _buildMcpParams(stageConfig, inputs) {
+    if (!stageConfig?.mcp) return inputs;
+    const mapping = stageConfig.mcp.params_mapping || {};
+    const staticParams = stageConfig.mcp.params || {};
+    const result = { ...staticParams };
+    for (const [inputKey, paramName] of Object.entries(mapping)) {
+      if (inputs[inputKey] !== undefined) {
+        result[paramName] = inputs[inputKey];
+      }
+    }
+    return result;
+  }
+
+  _validateJudgeResult(judgeResult, stageKey, outputSchema) {
+    if (!judgeResult || typeof judgeResult !== 'object') {
+      return { valid: false, reason: 'result_not_object' };
+    }
+
+    const missing = [];
+
+    if (stageKey === 'pending_ocr') {
+      if (!judgeResult.task_id) missing.push('task_id');
+      if (judgeResult.provider === undefined || judgeResult.provider === null) missing.push('provider');
+      if (judgeResult.is_success === undefined || judgeResult.is_success === null) missing.push('is_success');
+    } else if (stageKey === 'ocr_processing') {
+      if (!judgeResult.status) missing.push('status');
+      if (typeof judgeResult.progress !== 'number') missing.push('progress');
+      if (judgeResult.is_completed === undefined || judgeResult.is_completed === null) missing.push('is_completed');
+    } else if (stageKey === 'ocr_finalize') {
+      if (judgeResult.is_success === undefined || judgeResult.is_success === null) missing.push('is_success');
+      if (judgeResult.is_success === false) {
+        logger.warn(`[DocumentOcrService] Judge reported failure for ocr_finalize: ${judgeResult.error_message || 'unknown'}`);
+        return { valid: true, failed: true };
+      }
+    }
+
+    if (outputSchema && typeof outputSchema === 'object') {
+      const schemaKeys = Object.keys(outputSchema);
+      const schemaMissing = [];
+      for (const key of schemaKeys) {
+        if (!(key in judgeResult)) schemaMissing.push(key);
+      }
+      if (schemaMissing.length > 0) {
+        const isOcrCore = stageKey === 'pending_ocr' || stageKey === 'ocr_processing' || stageKey === 'ocr_finalize';
+        if (isOcrCore) {
+          logger.warn(`[DocumentOcrService] Judge result missing schema keys for ${stageKey}: [${schemaMissing.join(', ')}]`);
+          missing.push(...schemaMissing);
+        } else {
+          logger.warn(`[DocumentOcrService] Judge result missing suggested schema keys for ${stageKey}: [${schemaMissing.join(', ')}]`);
+        }
+      }
+    }
+
+    if (missing.length > 0) {
+      logger.warn(`[DocumentOcrService] Judge validation failed for ${stageKey}: missing keys [${missing.join(', ')}]`);
+      return { valid: false, reason: `missing_keys: ${missing.join(',')}` };
+    }
+
+    return { valid: true };
+  }
+
+  _buildJudgePrompt(judge, mcpText) {
+    let prompt = judge.prompt_template || '';
+    const schema = judge.output_schema;
+    if (schema && typeof schema === 'object' && Object.keys(schema).length > 0) {
+      const schemaDesc = JSON.stringify(schema, null, 2);
+      prompt = `${prompt}\n\n必须严格按以下 JSON Schema 输出，只返回 JSON 对象，不要包含任何额外解释文字：\n${schemaDesc}`;
+    }
+    return `${prompt}\n\nMCP返回结果：\n${mcpText}`;
+  }
+
+  async _runJudge(stageConfig, mcpResult, stageContext = {}) {
+    const judge = stageConfig?.judge;
+    if (!judge || !judge.prompt_template) return mcpResult;
+    if (typeof this.callLlm !== 'function') {
+      logger.warn('[DocumentOcrService] callLlm not available, skipping judge normalization');
+      return mcpResult;
+    }
+
+    try {
+      const mcpText = JSON.stringify(mcpResult, null, 2);
+      const prompt = this._buildJudgePrompt(judge, mcpText);
+      const judgeResult = await this.callLlm({
+        model_id: judge.model_id || null,
+        temperature: judge.temperature ?? 0.1,
+        messages: [{ role: 'user', content: prompt }],
+        output_schema: judge.output_schema || {},
+      });
+
+      if (judgeResult && typeof judgeResult === 'object') {
+        const stageKey = stageContext?.stage || 'unknown';
+        const validation = this._validateJudgeResult(judgeResult, stageKey, judge.output_schema);
+        if (!validation.valid) {
+          logger.warn(`[DocumentOcrService] Judge validation failed for ${stageKey}: ${validation.reason}`);
+          return { ...mcpResult, _normalized: { _judge_error: validation.reason, ...judgeResult } };
+        }
+        if (validation.failed) {
+          logger.warn(`[DocumentOcrService] Judge reported failure for ${stageKey}`);
+          return { ...mcpResult, _normalized: { ...judgeResult } };
+        }
+        return { ...mcpResult, _normalized: judgeResult };
+      }
+      return mcpResult;
+    } catch (err) {
+      logger.warn(`[DocumentOcrService] Judge normalization failed: ${err.message}`);
+      return mcpResult;
+    }
+  }
+
   async submit(documentId, options = {}) {
     this.ensureCallMcp();
+    const config = await this._loadStageConfig('pending_ocr');
+    const serverName = this._resolveMcpServer(config);
+    const toolName = this._resolveMcpTool(config, 'create_task_from_file');
+    const timeoutMs = this._resolveTimeout(config, 120000);
+    const provider = config.provider_name || this.provider;
+
     const ctx = await this.loadDocumentContext(documentId);
     const existingOcrResult = await this.getLatestOcrResult(ctx.revision.id);
     if (existingOcrResult?.task_id && ['pending', 'processing', 'completed'].includes(existingOcrResult.status)) {
@@ -58,40 +202,50 @@ class DocumentOcrService {
     }
 
     const fileBase64 = await this.readAttachmentBase64(attachment);
+    const mcpParams = this._buildMcpParams(config, {
+      file_base64: fileBase64,
+      file_name: attachment.file_name || `document-${documentId}.bin`,
+      lang: options.lang || 'ch',
+      formula_enable: options.formulaEnable ?? true,
+      table_enable: options.tableEnable ?? true,
+      image_analysis: options.imageAnalysis ?? true,
+    });
+
     const submitToolResult = await this.callMcp(
-      this.serverName,
-      'create_task_from_file',
-      {
-        file_base64: fileBase64,
-        file_name: attachment.file_name || `document-${documentId}.bin`,
-        backend: options.backend,
-        lang: options.lang || 'ch',
-        formula_enable: options.formulaEnable ?? true,
-        table_enable: options.tableEnable ?? true,
-        image_analysis: options.imageAnalysis ?? true,
-      },
-      options.timeoutMs || 120000,
+      serverName,
+      toolName,
+      mcpParams,
+      timeoutMs,
     );
     const result = this.extractStructuredToolResult(submitToolResult);
 
-    const normalizedStatus = this.normalizeStatus(result?.status || 'pending');
+    const judged = await this._runJudge(config, result, { stage: 'pending_ocr' });
+    const normalized = judged?._normalized || {};
+
+    const taskId = normalized.task_id || result?.task_id || null;
+    const resolvedProvider = normalized.provider || provider;
+    const isSuccess = normalized.is_success !== false;
+    const normalizedStatus = isSuccess ? this.normalizeStatus(result?.status || 'pending') : 'failed';
+    const failMessage = !isSuccess ? (normalized.message || 'OCR submit failed') : null;
+
     await ocrResult.update({
-      provider: this.provider,
-      task_id: result?.task_id || null,
+      provider: resolvedProvider,
+      task_id: taskId,
       status: normalizedStatus,
       progress: normalizedStatus === 'failed' ? -1 : 0,
       started_at: new Date(),
       error_code: normalizedStatus === 'failed' ? 'submit_failed' : null,
-      error_message: normalizedStatus === 'failed' ? (result?.error || result?.message || 'OCR submit failed') : null,
+      error_message: normalizedStatus === 'failed' ? failMessage : null,
       metadata: {
         ...(ocrResult.metadata || {}),
         submit_tool_result: this.buildToolResultSummary(submitToolResult),
         submit_result: this.buildResultSummary(result),
+        judge_result: judged?._normalized || null,
       },
     });
 
     if (normalizedStatus === 'failed') {
-      await this.advancer.fail(documentId, 'ocr_submit_failed', result?.error || result?.message || 'OCR submit failed');
+      await this.advancer.fail(documentId, 'ocr_submit_failed', failMessage || 'OCR submit failed');
       return ocrResult;
     }
 
@@ -100,6 +254,11 @@ class DocumentOcrService {
 
   async syncTaskStatus(documentId, options = {}) {
     this.ensureCallMcp();
+    const config = await this._loadStageConfig('ocr_processing');
+    const serverName = this._resolveMcpServer(config);
+    const toolName = this._resolveMcpTool(config, 'get_task_status');
+    const timeoutMs = this._resolveTimeout(config, 120000);
+
     const ctx = await this.loadDocumentContext(documentId);
     this.ensureDocumentWritableForOcr(ctx.document);
     const ocrResult = await this.ensureOcrResult(ctx);
@@ -116,34 +275,41 @@ class DocumentOcrService {
     }
 
     const statusToolResult = await this.callMcp(
-      this.serverName,
-      'get_task_status',
+      serverName,
+      toolName,
       { task_id: ocrResult.task_id },
-      options.timeoutMs || 120000,
+      timeoutMs,
     );
     await this.assertDocumentNotDeleted(documentId);
     const statusResult = this.extractStructuredToolResult(statusToolResult);
+    const judged = await this._runJudge(config, statusResult, { stage: 'ocr_processing' });
+    const normalized = judged?._normalized || {};
 
-    const normalizedStatus = this.normalizeStatus(statusResult?.status);
+    const normalizedStatus = normalized.status ? this.normalizeStatus(normalized.status) : this.normalizeStatus(statusResult?.status);
+    const progress = typeof normalized.progress === 'number' ? normalized.progress : (typeof statusResult?.progress === 'number' ? statusResult.progress : ocrResult.progress);
+    const isCompleted = normalizedStatus === 'completed' || normalized.is_completed === true;
+    const finalStatus = isCompleted ? 'completed' : normalizedStatus;
+
     await ocrResult.update({
-      status: normalizedStatus,
-      progress: typeof statusResult?.progress === 'number' ? statusResult.progress : ocrResult.progress,
-      error_code: normalizedStatus === 'failed' ? 'task_failed' : null,
-      error_message: normalizedStatus === 'failed' ? (statusResult?.error || statusResult?.message || 'OCR task failed') : null,
-      completed_at: normalizedStatus === 'completed' || normalizedStatus === 'failed' ? new Date() : null,
+      status: finalStatus,
+      progress: isCompleted ? 100 : progress,
+      error_code: finalStatus === 'failed' ? 'task_failed' : null,
+      error_message: finalStatus === 'failed' ? (normalized.error_message || statusResult?.error || statusResult?.message || 'OCR task failed') : null,
+      completed_at: finalStatus === 'completed' || finalStatus === 'failed' ? new Date() : null,
       metadata: {
         ...(ocrResult.metadata || {}),
         last_status_tool_result: this.buildToolResultSummary(statusToolResult),
         last_status_result: this.buildResultSummary(statusResult),
+        judge_result: judged?._normalized || null,
       },
     });
 
-    if (normalizedStatus === 'failed') {
-      await this.advancer.fail(documentId, 'ocr_task_failed', statusResult?.error || statusResult?.message || 'OCR task failed');
+    if (finalStatus === 'failed') {
+      await this.advancer.fail(documentId, 'ocr_task_failed', normalized.error_message || statusResult?.error || statusResult?.message || 'OCR task failed');
       return { ocrResult, statusResult, completed: false };
     }
 
-    if (normalizedStatus !== 'completed') {
+    if (!isCompleted) {
       return { ocrResult, statusResult, completed: false };
     }
 
@@ -155,6 +321,9 @@ class DocumentOcrService {
 
   async cancelTask(documentId, options = {}) {
     this.ensureCallMcp();
+    const config = await this._loadStageConfig('ocr_processing');
+    const serverName = this._resolveMcpServer(config);
+
     const ctx = await this.loadDocumentContext(documentId);
     const ocrResult = await this.getLatestOcrResult(ctx.revision.id);
 
@@ -184,7 +353,7 @@ class DocumentOcrService {
     try {
       result.remoteCancelAttempted = true;
       const cancelToolResult = await this.callMcp(
-        this.serverName,
+        serverName,
         'cancel_task',
         { task_id: ocrResult.task_id },
         options.timeoutMs || 120000,
@@ -226,39 +395,89 @@ class DocumentOcrService {
 
   async finalizeCompletedTask(ctx, ocrResult, options = {}) {
     this.ensureDocumentWritableForOcr(ctx.document);
+    const config = await this._loadStageConfig('ocr_finalize');
+    const serverName = this._resolveMcpServer(config);
+    const timeoutMs = this._resolveTimeout(config, 120000);
+
+    const defaultDeliverableTool = config?.default_deliverable_tool || 'get_default_deliverable';
+    const listDeliverablesTool = config?.list_deliverables_tool || 'list_deliverables';
+    const imageDeliverablesTool = config?.image_deliverables_tool || 'get_image_deliverables';
+
     const taskId = ocrResult.task_id;
     const defaultDeliverable = this.extractStructuredToolResult(
-      await this.callMcp(this.serverName, 'get_default_deliverable', { task_id: taskId }, options.timeoutMs || 120000)
+      await this.callMcp(serverName, defaultDeliverableTool, { task_id: taskId }, timeoutMs)
     );
     await this.assertDocumentNotDeleted(ctx.document.id);
     const deliverables = this.extractStructuredToolResult(
-      await this.callMcp(this.serverName, 'list_deliverables', { task_id: taskId }, options.timeoutMs || 120000)
+      await this.callMcp(serverName, listDeliverablesTool, { task_id: taskId }, timeoutMs)
     );
     await this.assertDocumentNotDeleted(ctx.document.id);
     const imageDeliverables = this.extractStructuredToolResult(
-      await this.callMcp(this.serverName, 'get_image_deliverables', { task_id: taskId }, options.timeoutMs || 120000)
+      await this.callMcp(serverName, imageDeliverablesTool, { task_id: taskId }, timeoutMs)
     );
     await this.assertDocumentNotDeleted(ctx.document.id);
 
-    const mainMarkdown = this.extractDefaultMarkdown(defaultDeliverable);
-    const imageItems = Array.isArray(imageDeliverables?.items) ? imageDeliverables.items : [];
+    const judged = await this._runJudge(config, {
+      default_deliverable: defaultDeliverable,
+      deliverables,
+      image_deliverables: this.summarizeImageDeliverables(imageDeliverables),
+    }, { stage: 'ocr_finalize' });
+    const normalized = judged?._normalized || {};
+
+    const judgeExplicitFailed = normalized.is_success === false;
+    const judgeMissingMain = normalized.error_message && !normalized.main_markdown;
+    const mainMarkdown = normalized.main_markdown || this.extractDefaultMarkdown(defaultDeliverable);
+    const normalizedImageItems = Array.isArray(normalized.image_items) ? normalized.image_items : [];
+    const fallbackImageItems = Array.isArray(imageDeliverables?.items) ? imageDeliverables.items : [];
+    const imageItems = normalizedImageItems.length > 0 ? normalizedImageItems : fallbackImageItems;
+
+    const normalizedDeliverables = Array.isArray(normalized.deliverables) ? normalized.deliverables : [];
+    const hasNormalizedDeliverables = normalizedDeliverables.length > 0;
+
+    // Phase 2 预留: 按 normalized.deliverables[].download_method (inline|url|tool)
+    // 执行实际下载/分发逻辑。当前阶段归一化结果仅用于结构化描述与 metadata 存储，
+    // 实际二进制提取仍通过 config 中的 MCP 工具名调用原始 MCP 服务完成。
+
+    const hasContent = mainMarkdown.trim().length > 0;
+    if (judgeExplicitFailed && !hasContent) {
+      logger.error(`[DocumentOcrService] Finalize judge failed and no fallback content: ${normalized.error_message || 'unknown'}`);
+      await ocrResult.update({
+        status: 'failed',
+        progress: -1,
+        error_code: 'judge_normalization_failed',
+        error_message: normalized.error_message || 'Judge normalization failed with no fallback content',
+        completed_at: new Date(),
+        metadata: {
+          ...this.toPlainObject(ocrResult.metadata),
+          judge_result: judged?._normalized || null,
+        },
+      });
+      await this.advancer.fail(ctx.document.id, 'judge_normalization_failed', normalized.error_message || 'Judge normalization failed');
+      return ocrResult;
+    }
+
+    if (judgeExplicitFailed || judgeMissingMain) {
+      logger.warn(`[DocumentOcrService] Judge reported issue for finalize, using fallback extraction: ${normalized.error_message || 'no main_markdown'}`);
+    }
+
     const imageUrlMap = {};
     const imageRecords = [];
 
     for (let i = 0; i < imageItems.length; i++) {
       await this.assertDocumentNotDeleted(ctx.document.id);
       const item = imageItems[i];
-      const imageDataUrl = imageDeliverables?.images?.[item.filename];
+      const normalizedDataUrl = typeof item?.data_url === 'string' ? item.data_url : null;
+      const imageDataUrl = normalizedDataUrl || imageDeliverables?.images?.[item.filename] || imageDeliverables?.images?.[item.relative_path || item.filename];
       if (!imageDataUrl) continue;
       const attachment = await this.createAttachmentFromDataUrl(
         ctx.revision.id,
         ctx.revision.created_by || null,
-        item.filename,
+        item.filename || 'image.png',
         imageDataUrl,
         this.truncateText(item.alt_text || '', MAX_ATTACHMENT_ALT_TEXT_LENGTH),
         this.truncateText(item.description || null, MAX_ATTACHMENT_DESCRIPTION_LENGTH)
       );
-      imageUrlMap[item.relative_path] = `/api/attachments/${attachment.id}`;
+      imageUrlMap[item.relative_path || item.filename] = `/api/attachments/${attachment.id}`;
       imageRecords.push({ item, attachment, sortOrder: i });
     }
 
@@ -290,6 +509,9 @@ class DocumentOcrService {
         },
         deliverables_summary: this.buildResultSummary(deliverables),
         image_deliverables_summary: this.buildImageDeliverablesSummary(imageDeliverables),
+        judge_result: judged?._normalized || null,
+        normalized_deliverables: hasNormalizedDeliverables ? normalizedDeliverables : null,
+        normalized_raw_payload: normalized.raw_payload || null,
       },
     });
 

--- a/server/controllers/doc.controller.js
+++ b/server/controllers/doc.controller.js
@@ -21,6 +21,8 @@ import DocCompareExecutor from '../../lib/doc-compare-executor.js';
 import DocAccessService from '../../lib/doc-access-service.js';
 import CollectionAccessService from '../../lib/collection-access-service.js';
 import DocumentOcrService from '../../lib/document-ocr-service.js';
+import { getSystemSettingService } from '../services/system-setting.service.js';
+import { DOC_PIPELINE_KEYS, mergeWithDefaults, createCallLlmFn } from '../../lib/doc-pipeline-defaults.js';
 
 class DocController {
   constructor(db) {
@@ -88,6 +90,7 @@ class DocController {
 
   ensureDocumentOcrService(ctx) {
     if (!this.documentOcrService) {
+      const systemSettingService = getSystemSettingService(this.db);
       this.documentOcrService = new DocumentOcrService(this.db, {
         callMcp: async (server, tool, params, timeoutMs) => {
           const appClock = ctx?.app?.context?.appClock;
@@ -96,6 +99,23 @@ class DocController {
           }
           return await appClock.callMcp(server, tool, params, timeoutMs);
         },
+        getDocPipelineConfig: async () => {
+          const records = await systemSettingService.SystemSetting.findAll({
+            where: { setting_key: DOC_PIPELINE_KEYS.map(k => `doc_pipeline.${k}`) },
+            raw: true,
+          });
+          const stored = {};
+          for (const record of records) {
+            const stageKey = record.setting_key.replace('doc_pipeline.', '');
+            try {
+              stored[stageKey] = JSON.parse(record.setting_value);
+            } catch {
+              stored[stageKey] = null;
+            }
+          }
+          return mergeWithDefaults(stored);
+        },
+        callLlm: createCallLlmFn(this.db),
       });
     }
   }

--- a/server/controllers/system-setting.controller.js
+++ b/server/controllers/system-setting.controller.js
@@ -6,6 +6,12 @@
 
 import logger from '../../lib/logger.js';
 import { getSystemSettingService } from '../services/system-setting.service.js';
+import {
+  DOC_PIPELINE_KEYS,
+  getStageDefault,
+  mergeWithDefaults,
+  isOcrStage,
+} from '../../lib/doc-pipeline-defaults.js';
 
 const DEFAULT_SETTINGS = {
   llm: {
@@ -158,6 +164,121 @@ class SystemSettingController {
     } catch (error) {
       logger.error('Update system settings error:', error);
       ctx.app.emit('error', error, ctx);
+    }
+  }
+
+  async getDocPipeline(ctx) {
+    if (!this._checkAdmin(ctx)) return;
+    try {
+      const records = await this.SystemSetting.findAll({
+        where: { setting_key: DOC_PIPELINE_KEYS.map(k => `doc_pipeline.${k}`) },
+        raw: true,
+      });
+      const stored = {};
+      for (const record of records) {
+        const stageKey = record.setting_key.replace('doc_pipeline.', '');
+        try {
+          stored[stageKey] = JSON.parse(record.setting_value);
+        } catch {
+          stored[stageKey] = null;
+        }
+      }
+      const result = mergeWithDefaults(stored);
+      ctx.success(result);
+    } catch (error) {
+      logger.error('Get doc pipeline config error:', error);
+      ctx.error('获取文档预处理配置失败', 500);
+    }
+  }
+
+  async updateDocPipeline(ctx) {
+    if (!this._checkAdmin(ctx)) return;
+    try {
+      const body = ctx.request.body || {};
+      const config = mergeWithDefaults(body);
+
+      for (const key of DOC_PIPELINE_KEYS) {
+        if (isOcrStage(key)) {
+          const stage = config[key];
+          if (stage.type && stage.type !== 'mcp') {
+            ctx.error(`阶段 ${key} 执行方式必须为 mcp`, 400);
+            return;
+          }
+          if (stage.enabled === false) {
+            ctx.error(`阶段 ${key} 必须启用`, 400);
+            return;
+          }
+        }
+      }
+
+      for (const key of DOC_PIPELINE_KEYS) {
+        const settingKey = `doc_pipeline.${key}`;
+        const value = config[key] || getStageDefault(key);
+        await this.SystemSetting.upsert({
+          setting_key: settingKey,
+          setting_value: JSON.stringify(value),
+          value_type: 'json',
+          description: `文档预处理流水线配置 - ${key}`,
+          updated_at: new Date(),
+        });
+      }
+
+      if (this.systemSettingService) {
+        this.systemSettingService.clearCache();
+      }
+
+      ctx.success(config);
+    } catch (error) {
+      logger.error('Update doc pipeline config error:', error);
+      ctx.error('保存文档预处理配置失败', 500);
+    }
+  }
+
+  async resetDocPipeline(ctx) {
+    if (!this._checkAdmin(ctx)) return;
+    try {
+      const { keys } = ctx.request.body || {};
+      const stageKeys = (keys && Array.isArray(keys) && keys.length > 0)
+        ? keys.filter(k => DOC_PIPELINE_KEYS.includes(k))
+        : DOC_PIPELINE_KEYS;
+
+      const config = {};
+      for (const key of stageKeys) {
+        const settingKey = `doc_pipeline.${key}`;
+        const defaultValue = getStageDefault(key);
+        if (defaultValue !== null) {
+          await this.SystemSetting.upsert({
+            setting_key: settingKey,
+            setting_value: JSON.stringify(defaultValue),
+            value_type: 'json',
+            description: `文档预处理流水线配置 - ${key}`,
+            updated_at: new Date(),
+          });
+        }
+        config[key] = defaultValue;
+      }
+
+      if (this.systemSettingService) {
+        this.systemSettingService.clearCache();
+      }
+
+      const records = await this.SystemSetting.findAll({
+        where: { setting_key: DOC_PIPELINE_KEYS.map(k => `doc_pipeline.${k}`) },
+        raw: true,
+      });
+      const stored = {};
+      for (const record of records) {
+        const stageKey = record.setting_key.replace('doc_pipeline.', '');
+        try {
+          stored[stageKey] = JSON.parse(record.setting_value);
+        } catch {
+          stored[stageKey] = null;
+        }
+      }
+      ctx.success(mergeWithDefaults(stored));
+    } catch (error) {
+      logger.error('Reset doc pipeline config error:', error);
+      ctx.error('重置文档预处理配置失败', 500);
     }
   }
 

--- a/server/routes/system-setting.routes.js
+++ b/server/routes/system-setting.routes.js
@@ -16,6 +16,10 @@ export default (db) => {
   router.put('/', authenticate(), (ctx) => controller.update(ctx));
   router.post('/reset', authenticate(), (ctx) => controller.reset(ctx));
 
+  router.get('/doc-pipeline', authenticate(), (ctx) => controller.getDocPipeline(ctx));
+  router.put('/doc-pipeline', authenticate(), (ctx) => controller.updateDocPipeline(ctx));
+  router.post('/doc-pipeline/reset', authenticate(), (ctx) => controller.resetDocPipeline(ctx));
+
   return router;
 };
 


### PR DESCRIPTION
## Summary

为文档平台增加管理员级"预处理配置中心"，实现 OCR 全链路配置化与 LLM 归一化。

### Phase 1 交付

- 文档平台主界面管理员"配置"按钮 + `DocPipelineConfigDialog` 弹窗（8 阶段）
- `GET/PUT /api/system-settings/doc-pipeline` + `POST /reset` 配置接口
- `pending_ocr`/`ocr_processing`/`ocr_finalize` 三阶段运行时接入配置读取
- MCP 返回统一走 `_runJudge()` LLM 归一化（prompt 注入 + `response_format: json_object` + 服务端键完整性校验）
- 前端 3 阶段 `output_schema` JSON 编辑器 + 非法 JSON 阻断保存
- 6 轮外包审计通过（评分 8.9/10）

### Phase 2 预留

- `ocr_finalize` 中 `download_method` 驱动实际下载/分发执行
- `pending_clean` ~ `pending_relocate` 五阶段运行时接入

## Changes

**新增 (3)**:
- `lib/doc-pipeline-defaults.js`
- `frontend/src/api/doc-pipeline.ts`
- `frontend/src/components/docs/DocPipelineConfigDialog.vue`

**修改 (6)**:
- `lib/document-ocr-service.js`
- `lib/app-clock.js`
- `server/controllers/system-setting.controller.js`
- `server/controllers/doc.controller.js`
- `server/routes/system-setting.routes.js`
- `frontend/src/views/CollectionListView.vue`

Closes #826