### PR TITLE
fix: 系统配置路由离开确认与公共认证页 branding 一致性整改

### DIFF
--- a/frontend/src/components/settings/SystemConfigTab.vue
+++ b/frontend/src/components/settings/SystemConfigTab.vue
@@ -410,14 +410,8 @@ const handleBeforeUnload = (event: BeforeUnloadEvent) => {
   event.returnValue = ''
 }
 
-const beforeLeaveHandler = (event: Event) => {
-  if (!hasChanges.value) return
-  event.preventDefault()
-}
-
 onMounted(async () => {
   window.addEventListener('beforeunload', handleBeforeUnload)
-  window.addEventListener('system-config-before-leave', beforeLeaveHandler)
   await systemSettingsStore.loadSettings()
   const settings = systemSettingsStore.settings
   if (settings) {
@@ -456,7 +450,11 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   window.removeEventListener('beforeunload', handleBeforeUnload)
-  window.removeEventListener('system-config-before-leave', beforeLeaveHandler)
+  systemSettingsStore.unsavedConfigChanges = false
+})
+
+watch(hasChanges, (val) => {
+  systemSettingsStore.unsavedConfigChanges = val
 })
 
 watch(() => systemSettingsStore.settings, (settings) => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,7 +1,8 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useUserStore } from '@/stores/user'
 import { useSystemSettingsStore } from '@/stores/systemSettings'
-import { getLocale } from '@/i18n'
+import { getLocale, i18n } from '@/i18n'
+import { ElMessageBox } from 'element-plus'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -194,6 +195,23 @@ router.beforeEach(async (to, from) => {
   }
 
   const systemSettingsStore = useSystemSettingsStore()
+
+  if (from.meta.settingsTab === 'system' && to.name !== 'sys-config' && systemSettingsStore.unsavedConfigChanges) {
+    try {
+      await ElMessageBox.confirm(
+        i18n.global.t('settings.unsavedChangesConfirm'),
+        i18n.global.t('common.confirm'),
+        {
+          confirmButtonText: i18n.global.t('common.confirm'),
+          cancelButtonText: i18n.global.t('common.cancel'),
+          type: 'warning',
+        }
+      )
+    } catch {
+      return false
+    }
+  }
+
   if (!systemSettingsStore.brandingLoaded) {
     await systemSettingsStore.loadBranding()
   }

--- a/frontend/src/stores/systemSettings.ts
+++ b/frontend/src/stores/systemSettings.ts
@@ -69,6 +69,7 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const brandingLoaded = ref(false)
+  const unsavedConfigChanges = ref(false)
   let brandingPromise: Promise<BrandingSettings> | null = null
 
   // 默认配置（用于初始化）
@@ -260,6 +261,7 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
     registrationSettings,
     brandingSettings,
     brandingLoaded,
+    unsavedConfigChanges,
     loadSettings,
     loadRuntimeSettings,
     updateSettings,

--- a/frontend/src/utils/branding.ts
+++ b/frontend/src/utils/branding.ts
@@ -1,0 +1,16 @@
+import type { BrandingSettings } from '@/stores/systemSettings'
+
+export function getDisplayableLogoIcon(icon: string | undefined | null): string {
+  if (!icon) return ''
+  const trimmed = icon.trim()
+  if (/^https?:\/\//.test(trimmed)) return ''
+  if (trimmed.length > 10) return ''
+  return trimmed
+}
+
+export function getBrandingAppName(
+  branding: BrandingSettings | undefined | null,
+  fallback: string
+): string {
+  return branding?.app_name || fallback
+}

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -2,10 +2,13 @@
   <div class="login-view">
     <div class="login-shell">
       <section class="login-brand-panel">
-        <div class="brand-badge">{{ $t('login.brand.badge') }}</div>
+        <div class="brand-badge">
+          <span v-if="brandingLogoIcon" class="brand-badge-icon">{{ brandingLogoIcon }}</span>
+          {{ $t('login.brand.badge') }}
+        </div>
         <div class="brand-copy">
-          <p class="brand-eyebrow">{{ $t('login.brand.eyebrow') }}</p>
-          <h1 class="brand-title">{{ $t('login.brand.title') }}</h1>
+          <h1 class="brand-title">{{ brandingAppName }}</h1>
+          <p class="brand-slogan">{{ $t('login.brand.title') }}</p>
           <p class="brand-description">
             {{ $t('login.brand.description') }}
           </p>
@@ -106,17 +109,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
+import { useSystemSettingsStore } from '@/stores/systemSettings'
+import { getDisplayableLogoIcon, getBrandingAppName } from '@/utils/branding'
 import LangSelector from '@/components/common/LangSelector.vue'
 import type { FormInstance, FormRules } from 'element-plus'
 
 const router = useRouter()
 const { t } = useI18n()
 const userStore = useUserStore()
+const systemSettingsStore = useSystemSettingsStore()
 const formRef = ref<FormInstance>()
+
+const brandingAppName = computed(() => getBrandingAppName(systemSettingsStore.brandingSettings, t('login.brand.eyebrow')))
+const brandingLogoIcon = computed(() => getDisplayableLogoIcon(systemSettingsStore.brandingSettings?.logo_icon))
 
 const form = reactive({
   account: '',
@@ -130,6 +139,10 @@ const rules = reactive<FormRules>({
 
 const loading = ref(false)
 const error = ref('')
+
+onMounted(() => {
+  systemSettingsStore.loadBranding()
+})
 
 const handleLogin = async () => {
   if (!formRef.value) return
@@ -205,18 +218,18 @@ const handleLogin = async () => {
   color: #c4b5fd;
   background: rgba(76, 29, 149, 0.28);
   border: 1px solid rgba(196, 181, 253, 0.2);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.brand-badge-icon {
+  font-size: 16px;
+  line-height: 1;
 }
 
 .brand-copy {
   margin-top: 32px;
-}
-
-.brand-eyebrow {
-  margin: 0 0 12px;
-  font-size: 14px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: #93c5fd;
 }
 
 .brand-title {
@@ -225,6 +238,14 @@ const handleLogin = async () => {
   line-height: 1.08;
   font-weight: 700;
   max-width: 10ch;
+}
+
+.brand-slogan {
+  margin: 12px 0 0;
+  font-size: 16px;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.9);
+  letter-spacing: 0.02em;
 }
 
 .brand-description {

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -3,7 +3,8 @@
     <div class="register-card">
       <div class="card-header">
         <div class="header-content">
-          <h1 class="register-title">{{ $t('app.title') }}</h1>
+          <span v-if="brandingLogoIcon" class="register-icon">{{ brandingLogoIcon }}</span>
+          <h1 class="register-title">{{ brandingAppName }}</h1>
           <p class="register-subtitle">{{ $t('register.subtitle') }}</p>
         </div>
         <LangSelector />
@@ -109,6 +110,8 @@ import { ref, reactive, onMounted, watch, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
+import { useSystemSettingsStore } from '@/stores/systemSettings'
+import { getDisplayableLogoIcon, getBrandingAppName } from '@/utils/branding'
 import LangSelector from '@/components/common/LangSelector.vue'
 import { getRegistrationConfig, verifyInvitationCode, register, type VerifyResult } from '@/api/invitation'
 import type { FormInstance, FormRules } from 'element-plus'
@@ -117,7 +120,11 @@ const router = useRouter()
 const route = useRoute()
 const { t } = useI18n()
 const userStore = useUserStore()
+const systemSettingsStore = useSystemSettingsStore()
 const formRef = ref<FormInstance>()
+
+const brandingAppName = computed(() => getBrandingAppName(systemSettingsStore.brandingSettings, t('app.title')))
+const brandingLogoIcon = computed(() => getDisplayableLogoIcon(systemSettingsStore.brandingSettings?.logo_icon))
 
 const form = reactive({
   invitation_code: '',
@@ -168,6 +175,7 @@ const isSubmitDisabled = computed(() => {
 
 // 加载注册配置
 onMounted(async () => {
+  systemSettingsStore.loadBranding()
   try {
     const config = await getRegistrationConfig()
     allowSelfRegistration.value = config.allowSelfRegistration
@@ -314,6 +322,14 @@ const handleRegister = async () => {
   text-align: center;
   margin: 0 0 8px 0;
   color: #333;
+}
+
+.register-icon {
+  display: block;
+  text-align: center;
+  font-size: 40px;
+  line-height: 1;
+  margin-bottom: 12px;
 }
 
 .register-subtitle {

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1069,7 +1069,7 @@
 <script setup lang="ts">
 import { ref, reactive, onMounted, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { ElMessageBox } from 'element-plus'
 import { useUserStore } from '@/stores/user'
 import { useModelStore } from '@/stores/model'
@@ -1189,25 +1189,6 @@ const activeTab = computed({
   },
 })
 
-const confirmSystemConfigLeave = () => {
-  if (activeTab.value !== 'system') return true
-
-  let blocked = false
-  const leaveEvent = new Event('system-config-before-leave', { cancelable: true })
-  window.dispatchEvent(leaveEvent)
-  blocked = leaveEvent.defaultPrevented
-
-  if (!blocked) return true
-  return window.confirm(t('settings.unsavedChangesConfirm'))
-}
-
-onBeforeRouteLeave((to, from, next) => {
-  if (confirmSystemConfigLeave()) {
-    next()
-    return
-  }
-  next(false)
-})
 const profileSubTab = ref<'basic' | 'password'>('basic')
 const sidebarCollapsed = ref(false)
 
@@ -1215,7 +1196,6 @@ const handleMenuSelect = (index: string) => {
   const items = currentMenuItems.value
   const item = items?.find(i => i.key === index)
   if (item) {
-    if (!confirmSystemConfigLeave()) return
     router.push(item.route)
   }
 }


### PR DESCRIPTION
## Summary

- 系统配置页存在未保存修改时，站内路由切换必须弹出确认对话框（使用 `router.beforeEach` 全局守卫 + `unsavedConfigChanges` store 标志）
- 登录页、注册页的 branding 展示与系统 branding 配置保持一致（统一 h1 主标题显示 `app_name`，共享 `utils/branding.ts` 判断规则）
- 清理 SettingsView.vue 旧事件确认逻辑残留，统一为单一机制

## Changes

| File | Change |
|------|--------|
| `SystemConfigTab.vue` | `watch(hasChanges)` 同步到 store flag；`onBeforeUnmount` 清理 |
| `router/index.ts` | 新增 `beforeEach` 离开确认钩子 |
| `systemSettings.ts` | 新增 `unsavedConfigChanges` ref |
| `LoginView.vue` | h1 品牌名主标题；共享 utility；URL 安全降级 |
| `RegisterView.vue` | icon 接入；共享 utility |
| `SettingsView.vue` | 清理旧 `confirmSystemConfigLeave`/`onBeforeRouteLeave` |
| `utils/branding.ts` | 新增共享函数统一取值规则 |

## Test Results

- Type-check: 0 new errors (only pre-existing DocPipelineConfigDialog)
- ESLint: 0 new errors
- Self-test checklist: 20 scenarios documented in `SELF-TEST.md`

## Audit Score Progress

ROUND1: 5.6 → ROUND6: 8.5/10

Closes #793