### PR TITLE
fix: 修复后端系统设置布尔值写入类型问题

### DIFF
--- a/scripts/fix-system-setting-boolean-type.js
+++ b/scripts/fix-system-setting-boolean-type.js
@@ -1,0 +1,155 @@
+/**
+ * 系统设置布尔值类型修复脚本
+ * 用于对账和修复 Issue #831 的历史脏数据
+ * 
+ * 运行方式:
+ * - 预览模式: node scripts/fix-system-setting-boolean-type.js
+ * - 修复模式: node scripts/fix-system-setting-boolean-type.js --fix
+ */
+
+import 'dotenv/config';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Database from '../lib/db.js';
+import logger from '../lib/logger.js';
+import { DEFAULT_SETTINGS } from '../server/services/system-setting.service.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const BOOLEAN_CONFIG_KEYS = [];
+
+for (const [section, keys] of Object.entries(DEFAULT_SETTINGS)) {
+  for (const [key, config] of Object.entries(keys)) {
+    if (config.type === 'boolean') {
+      BOOLEAN_CONFIG_KEYS.push(`${section}.${key}`);
+    }
+  }
+}
+
+async function auditBooleanSettings(db) {
+  const SystemSetting = db.getModel('system_setting');
+  
+  logger.info('=== 系统设置布尔配置对账清单 ===');
+  logger.info(`预期布尔配置项数量: ${BOOLEAN_CONFIG_KEYS.length}`);
+  logger.info(`布尔配置项列表: ${BOOLEAN_CONFIG_KEYS.join(', ')}`);
+  
+  const records = await SystemSetting.findAll({
+    where: { setting_key: BOOLEAN_CONFIG_KEYS },
+    raw: true
+  });
+  
+  const auditResult = [];
+  
+  for (const expectedKey of BOOLEAN_CONFIG_KEYS) {
+    const record = records.find(r => r.setting_key === expectedKey);
+    const [section, key] = expectedKey.split('.');
+    const expectedConfig = DEFAULT_SETTINGS[section]?.[key];
+    
+    if (!record) {
+      auditResult.push({
+        setting_key: expectedKey,
+        expected_type: 'boolean',
+        db_value_type: null,
+        db_setting_value: null,
+        expected_value: String(expectedConfig.value),
+        status: 'missing'
+      });
+    } else {
+      const valueTypeMatch = record.value_type === 'boolean';
+      const valueValid = record.setting_value === 'true' || record.setting_value === 'false';
+      
+      let status = 'ok';
+      if (!valueTypeMatch) status = 'mismatch';
+      else if (!valueValid) status = 'invalid_value';
+      
+      auditResult.push({
+        setting_key: expectedKey,
+        expected_type: 'boolean',
+        db_value_type: record.value_type || '(null)',
+        db_setting_value: record.setting_value,
+        expected_value: String(expectedConfig.value),
+        status
+      });
+    }
+  }
+  
+  logger.info('\n对账结果:');
+  console.table(auditResult);
+  
+  const mismatchCount = auditResult.filter(r => r.status !== 'ok').length;
+  logger.info(`\n异常记录数量: ${mismatchCount}`);
+  
+  return auditResult;
+}
+
+async function fixBooleanSettings(db, auditResult, dryRun = true) {
+  const SystemSetting = db.getModel('system_setting');
+  
+  const mismatchRecords = auditResult.filter(r => r.status === 'mismatch' || r.status === 'invalid_value');
+  
+  if (mismatchRecords.length === 0) {
+    logger.info('✅ 无需修复，所有布尔配置项类型一致');
+    return;
+  }
+  
+  logger.info(`\n待修复记录数量: ${mismatchRecords.length}`);
+  
+  for (const record of mismatchRecords) {
+    if (dryRun) {
+      logger.info(`[DRY RUN] 将修复: ${record.setting_key}`);
+      logger.info(`  - 当前: value_type='${record.db_value_type}', setting_value='${record.db_setting_value}'`);
+      logger.info(`  - 目标: value_type='boolean', setting_value='${record.expected_value}'`);
+    } else {
+      await SystemSetting.update(
+        {
+          value_type: 'boolean',
+          setting_value: record.expected_value,
+          updated_at: new Date()
+        },
+        { where: { setting_key: record.setting_key } }
+      );
+      logger.info(`[FIXED] 已修复: ${record.setting_key}`);
+    }
+  }
+  
+  if (dryRun) {
+    logger.info('\n以上为预览模式，未实际修改数据');
+    logger.info('如需执行修复，请运行: node scripts/fix-system-setting-boolean-type.js --fix');
+  } else {
+    logger.info('\n✅ 修复完成，请重启服务以清除缓存');
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = !args.includes('--fix');
+  
+  logger.info(`运行模式: ${dryRun ? '预览模式（不修改数据）' : '修复模式（将修改数据）'}`);
+  
+  const dbConfig = {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '3306'),
+    database: process.env.DB_NAME || 'touwaka',
+    user: process.env.DB_USER || 'root',
+    password: process.env.DB_PASSWORD || '',
+    connectionLimit: 10
+  };
+  
+  const db = new Database(dbConfig);
+  
+  try {
+    await db.connect();
+    const auditResult = await auditBooleanSettings(db);
+    await fixBooleanSettings(db, auditResult, dryRun);
+  } catch (error) {
+    logger.error('脚本执行失败:', error.message);
+    process.exit(1);
+  } finally {
+    if (db.sequelize) {
+      await db.sequelize.close();
+    }
+  }
+}
+
+main();

--- a/server/controllers/system-setting.controller.js
+++ b/server/controllers/system-setting.controller.js
@@ -85,7 +85,13 @@ class SystemSettingController {
       if (parts.length === 2) {
         const [section, key] = parts;
         if (result[section] && key in result[section]) {
-          result[section][key] = this._parseValue(record.setting_value, record.value_type);
+          const defaultType = typeof DEFAULT_SETTINGS[section][key];
+          let effectiveType = record.value_type;
+          if (defaultType === 'boolean' && record.value_type === 'string' &&
+              (record.setting_value === 'true' || record.setting_value === 'false')) {
+            effectiveType = 'boolean';
+          }
+          result[section][key] = this._parseValue(record.setting_value, effectiveType);
         }
       }
     }
@@ -96,6 +102,12 @@ class SystemSettingController {
     if (type === 'number') return parseFloat(value);
     if (type === 'boolean') return value === 'true';
     return value;
+  }
+
+  _getValueType(value) {
+    if (typeof value === 'number') return 'number';
+    if (typeof value === 'boolean') return 'boolean';
+    return 'string';
   }
 
   _flattenSettings(obj, prefix = '') {
@@ -147,7 +159,7 @@ class SystemSettingController {
       const updates = ctx.request.body;
       const flatUpdates = this._flattenSettings(updates);
       for (const [key, value] of Object.entries(flatUpdates)) {
-        const valueType = typeof value === 'number' ? 'number' : 'string';
+        const valueType = this._getValueType(value);
         await this.SystemSetting.upsert({
           setting_key: key,
           setting_value: String(value),
@@ -288,7 +300,7 @@ class SystemSettingController {
       const { keys, all } = ctx.request.body;
       if (all) {
         for (const [key, value] of Object.entries(this._flattenSettings(DEFAULT_SETTINGS))) {
-          const valueType = typeof value === 'number' ? 'number' : 'string';
+          const valueType = this._getValueType(value);
           await this.SystemSetting.upsert({
             setting_key: key,
             setting_value: String(value),
@@ -300,7 +312,7 @@ class SystemSettingController {
         for (const key of keys) {
           const defaultValue = this._getNestedValue(DEFAULT_SETTINGS, key);
           if (defaultValue !== undefined) {
-            const valueType = typeof defaultValue === 'number' ? 'number' : 'string';
+            const valueType = this._getValueType(defaultValue);
             await this.SystemSetting.upsert({
               setting_key: key,
               setting_value: String(defaultValue),

--- a/server/services/system-setting.service.js
+++ b/server/services/system-setting.service.js
@@ -144,7 +144,14 @@ class SystemSettingService {
           
           if (record) {
             // 数据库有记录，使用数据库的值
-            const parsedValue = this._parseValue(record.setting_value, record.value_type);
+            // 兼容历史脏数据：如果元数据表明是布尔类型，但存储为 string 且值为 'true'/'false'，则强制使用布尔解析
+            let effectiveType = record.value_type;
+            if (config.type === 'boolean' && record.value_type === 'string' && 
+                (record.setting_value === 'true' || record.setting_value === 'false')) {
+              effectiveType = 'boolean';
+              logger.warn(`[SystemSettingService] 检测到脏数据: ${settingKey} 应为 boolean 类型但存储为 string，已自动修正解析`);
+            }
+            const parsedValue = this._parseValue(record.setting_value, effectiveType);
             result[section][key] = this._validateValue(settingKey, parsedValue);
           } else {
             // 数据库没有记录，准备创建默认值


### PR DESCRIPTION
Closes #831

## Summary

- 修复后端控制器写入布尔型配置时的类型推断逻辑，新增 _getValueType() 方法正确识别 oolean 类型
- 服务层和控制器层增加历史脏数据兼容处理，确保接口返回真实布尔值而非字符串
- 提供数据修复脚本 scripts/fix-system-setting-boolean-type.js 用于清理历史脏数据

## 问题根因

后端在更新/重置系统设置时，使用 	ypeof value === 'number' ? 'number' : 'string' 进行类型推断，导致布尔值被错误写入为 alue_type='string'。这会导致 Boolean('false') === true，使注册开关逻辑失效。

## 修复内容

1. **写入修复**: server/controllers/system-setting.controller.js 新增 _getValueType() 方法，正确识别 number/boolean/string 类型
2. **读取兼容**: server/services/system-setting.service.js 增加历史脏数据兼容逻辑
3. **接口返回兼容**: server/controllers/system-setting.controller.js 的 _parseSettings() 增加兼容逻辑
4. **数据修复脚本**: scripts/fix-system-setting-boolean-type.js 提供对账和修复功能

## 验证结果

数据修复脚本已执行，egistration.allow_self_registration 的 alue_type 已从 'string' 修正为 'boolean'。

## Files Changed

- server/controllers/system-setting.controller.js
- server/services/system-setting.service.js
- scripts/fix-system-setting-boolean-type.js (新增)