### PR TITLE
fix: 统一未登录页与已登录头部 branding 展示链路 (#832)

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -86,6 +86,7 @@ import { useUserStore } from '@/stores/user'
 import { useSystemSettingsStore } from '@/stores/systemSettings'
 import { useI18n } from 'vue-i18n'
 import type { Locale } from '@/i18n'
+import { getDisplayableLogoIcon, getBrandingAppName, DEFAULT_BRANDING_APP_NAME, DEFAULT_BRANDING_LOGO_ICON } from '@/utils/branding'
 
 const route = useRoute()
 const router = useRouter()
@@ -93,8 +94,8 @@ const userStore = useUserStore()
 const systemSettingsStore = useSystemSettingsStore()
 const { locale } = useI18n()
 
-const appName = computed(() => systemSettingsStore.brandingSettings?.app_name || 'Touwaka Mate')
-const appIcon = computed(() => systemSettingsStore.brandingSettings?.logo_icon || '🤖')
+const appName = computed(() => getBrandingAppName(systemSettingsStore.brandingSettings, DEFAULT_BRANDING_APP_NAME))
+const appIcon = computed(() => getDisplayableLogoIcon(systemSettingsStore.brandingSettings?.logo_icon, DEFAULT_BRANDING_LOGO_ICON))
 
 const showUserMenu = ref(false)
 const menuRef = ref<HTMLElement | null>(null)

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,6 +3,7 @@ import { useUserStore } from '@/stores/user'
 import { useSystemSettingsStore } from '@/stores/systemSettings'
 import { getLocale, i18n } from '@/i18n'
 import { ElMessageBox } from 'element-plus'
+import { getBrandingAppName, DEFAULT_BRANDING_APP_NAME } from '@/utils/branding'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -216,7 +217,7 @@ router.beforeEach(async (to, from) => {
     await systemSettingsStore.loadBranding()
   }
 
-  const appName = systemSettingsStore.brandingSettings?.app_name || 'Touwaka Mate'
+  const appName = getBrandingAppName(systemSettingsStore.brandingSettings, DEFAULT_BRANDING_APP_NAME)
   document.title = to.meta.title ? `${to.meta.title} - ${appName}` : appName
   document.documentElement.setAttribute('lang', getLocale())
 })

--- a/frontend/src/utils/branding.ts
+++ b/frontend/src/utils/branding.ts
@@ -1,16 +1,19 @@
 import type { BrandingSettings } from '@/stores/systemSettings'
 
-export function getDisplayableLogoIcon(icon: string | undefined | null): string {
-  if (!icon) return ''
+export const DEFAULT_BRANDING_APP_NAME = 'Touwaka Mate'
+export const DEFAULT_BRANDING_LOGO_ICON = '🤖'
+
+export function getDisplayableLogoIcon(icon: string | undefined | null, fallback: string = DEFAULT_BRANDING_LOGO_ICON): string {
+  if (!icon) return fallback
   const trimmed = icon.trim()
-  if (/^https?:\/\//.test(trimmed)) return ''
-  if (trimmed.length > 10) return ''
+  if (/^https?:\/\//.test(trimmed)) return fallback
+  if (trimmed.length > 10) return fallback
   return trimmed
 }
 
 export function getBrandingAppName(
   branding: BrandingSettings | undefined | null,
-  fallback: string
+  fallback: string = DEFAULT_BRANDING_APP_NAME
 ): string {
   return branding?.app_name || fallback
 }

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -109,12 +109,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
 import { useSystemSettingsStore } from '@/stores/systemSettings'
-import { getDisplayableLogoIcon, getBrandingAppName } from '@/utils/branding'
+import { getDisplayableLogoIcon, getBrandingAppName, DEFAULT_BRANDING_APP_NAME } from '@/utils/branding'
 import LangSelector from '@/components/common/LangSelector.vue'
 import type { FormInstance, FormRules } from 'element-plus'
 
@@ -124,7 +124,7 @@ const userStore = useUserStore()
 const systemSettingsStore = useSystemSettingsStore()
 const formRef = ref<FormInstance>()
 
-const brandingAppName = computed(() => getBrandingAppName(systemSettingsStore.brandingSettings, t('login.brand.eyebrow')))
+const brandingAppName = computed(() => getBrandingAppName(systemSettingsStore.brandingSettings, DEFAULT_BRANDING_APP_NAME))
 const brandingLogoIcon = computed(() => getDisplayableLogoIcon(systemSettingsStore.brandingSettings?.logo_icon))
 
 const form = reactive({
@@ -139,10 +139,6 @@ const rules = reactive<FormRules>({
 
 const loading = ref(false)
 const error = ref('')
-
-onMounted(() => {
-  systemSettingsStore.loadBranding()
-})
 
 const handleLogin = async () => {
   if (!formRef.value) return

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -111,7 +111,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
 import { useSystemSettingsStore } from '@/stores/systemSettings'
-import { getDisplayableLogoIcon, getBrandingAppName } from '@/utils/branding'
+import { getDisplayableLogoIcon, getBrandingAppName, DEFAULT_BRANDING_APP_NAME } from '@/utils/branding'
 import LangSelector from '@/components/common/LangSelector.vue'
 import { getRegistrationConfig, verifyInvitationCode, register, type VerifyResult } from '@/api/invitation'
 import type { FormInstance, FormRules } from 'element-plus'
@@ -123,7 +123,7 @@ const userStore = useUserStore()
 const systemSettingsStore = useSystemSettingsStore()
 const formRef = ref<FormInstance>()
 
-const brandingAppName = computed(() => getBrandingAppName(systemSettingsStore.brandingSettings, t('app.title')))
+const brandingAppName = computed(() => getBrandingAppName(systemSettingsStore.brandingSettings, DEFAULT_BRANDING_APP_NAME))
 const brandingLogoIcon = computed(() => getDisplayableLogoIcon(systemSettingsStore.brandingSettings?.logo_icon))
 
 const form = reactive({
@@ -175,12 +175,10 @@ const isSubmitDisabled = computed(() => {
 
 // 加载注册配置
 onMounted(async () => {
-  systemSettingsStore.loadBranding()
   try {
     const config = await getRegistrationConfig()
     allowSelfRegistration.value = config.allowSelfRegistration
 
-    // 从 URL 参数获取邀请码
     const codeFromUrl = route.query.code as string
     if (codeFromUrl) {
       form.invitation_code = codeFromUrl


### PR DESCRIPTION
## Summary

- 统一系统名称 fallback 规则：提取 `DEFAULT_BRANDING_APP_NAME` 常量，替代分散的 i18n key
- 统一 Logo 展示策略：使用 `getDisplayableLogoIcon()` 函数，URL 型值统一降级为 `'🤖'`
- 收敛 branding 加载职责：移除 LoginView/RegisterView 中冗余的 `loadBranding()` 调用

## 变更文件

- `frontend/src/utils/branding.ts` - 提取统一 fallback 常量
- `frontend/src/views/LoginView.vue` - 使用统一 fallback，移除冗余加载
- `frontend/src/views/RegisterView.vue` - 使用统一 fallback，移除冗余加载
- `frontend/src/components/AppHeader.vue` - 使用统一 fallback 和 Logo 过滤函数
- `frontend/src/router/index.ts` - 使用统一 fallback 函数

## 验收标准

- `/login`、`/register`、AppHeader、document.title 使用统一 fallback
- Logo URL 型值全站降级为默认图标 `'🤖'`
- 类型检查通过

## 关联 Issue

Closes #832