### PR TITLE
feat: MCP 工具选择器文案优化

### DIFF
--- a/frontend/src/components/docs/DocPipelineConfigDialog.vue
+++ b/frontend/src/components/docs/DocPipelineConfigDialog.vue
@@ -55,6 +55,9 @@
                   :value="t.value"
                 />
               </el-select>
+              <div v-if="form.pending_ocr.mcp.tool && !isToolValueStale(form.pending_ocr.mcp.server, form.pending_ocr.mcp.tool) && getToolDescription(form.pending_ocr.mcp.server, form.pending_ocr.mcp.tool)" class="tool-hint tool-desc">
+                说明：{{ getToolDescription(form.pending_ocr.mcp.server, form.pending_ocr.mcp.tool) }}
+              </div>
               <div v-if="form.pending_ocr.mcp.server && toolCache[form.pending_ocr.mcp.server]?.loaded && getToolOptions(form.pending_ocr.mcp.server).length === 0 && !isToolValueStale(form.pending_ocr.mcp.server, form.pending_ocr.mcp.tool)" class="tool-hint">
                 当前服务暂无工具缓存，请先到 MCP 设置中刷新工具列表
               </div>
@@ -144,6 +147,9 @@
                   :value="t.value"
                 />
               </el-select>
+              <div v-if="form.ocr_processing.mcp.tool && !isToolValueStale(form.ocr_processing.mcp.server, form.ocr_processing.mcp.tool) && getToolDescription(form.ocr_processing.mcp.server, form.ocr_processing.mcp.tool)" class="tool-hint tool-desc">
+                说明：{{ getToolDescription(form.ocr_processing.mcp.server, form.ocr_processing.mcp.tool) }}
+              </div>
               <div v-if="form.ocr_processing.mcp.server && toolCache[form.ocr_processing.mcp.server]?.loaded && getToolOptions(form.ocr_processing.mcp.server).length === 0 && !isToolValueStale(form.ocr_processing.mcp.server, form.ocr_processing.mcp.tool)" class="tool-hint">
                 当前服务暂无工具缓存，请先到 MCP 设置中刷新工具列表
               </div>
@@ -214,6 +220,9 @@
                   :value="t.value"
                 />
               </el-select>
+              <div v-if="form.ocr_finalize.default_deliverable_tool && !isToolValueStale(form.ocr_finalize.mcp.server, form.ocr_finalize.default_deliverable_tool) && getToolDescription(form.ocr_finalize.mcp.server, form.ocr_finalize.default_deliverable_tool)" class="tool-hint tool-desc">
+                说明：{{ getToolDescription(form.ocr_finalize.mcp.server, form.ocr_finalize.default_deliverable_tool) }}
+              </div>
               <div v-if="form.ocr_finalize.mcp.server && toolCache[form.ocr_finalize.mcp.server]?.loaded && getToolOptions(form.ocr_finalize.mcp.server).length === 0 && !isToolValueStale(form.ocr_finalize.mcp.server, form.ocr_finalize.default_deliverable_tool)" class="tool-hint">
                 当前服务暂无工具缓存，请先到 MCP 设置中刷新工具列表
               </div>
@@ -245,6 +254,9 @@
                   :value="t.value"
                 />
               </el-select>
+              <div v-if="form.ocr_finalize.list_deliverables_tool && !isToolValueStale(form.ocr_finalize.mcp.server, form.ocr_finalize.list_deliverables_tool) && getToolDescription(form.ocr_finalize.mcp.server, form.ocr_finalize.list_deliverables_tool)" class="tool-hint tool-desc">
+                说明：{{ getToolDescription(form.ocr_finalize.mcp.server, form.ocr_finalize.list_deliverables_tool) }}
+              </div>
               <div v-if="form.ocr_finalize.mcp.server && toolCache[form.ocr_finalize.mcp.server]?.loaded && getToolOptions(form.ocr_finalize.mcp.server).length === 0 && !isToolValueStale(form.ocr_finalize.mcp.server, form.ocr_finalize.list_deliverables_tool)" class="tool-hint">
                 当前服务暂无工具缓存，请先到 MCP 设置中刷新工具列表
               </div>
@@ -276,6 +288,9 @@
                   :value="t.value"
                 />
               </el-select>
+              <div v-if="form.ocr_finalize.image_deliverables_tool && !isToolValueStale(form.ocr_finalize.mcp.server, form.ocr_finalize.image_deliverables_tool) && getToolDescription(form.ocr_finalize.mcp.server, form.ocr_finalize.image_deliverables_tool)" class="tool-hint tool-desc">
+                说明：{{ getToolDescription(form.ocr_finalize.mcp.server, form.ocr_finalize.image_deliverables_tool) }}
+              </div>
               <div v-if="form.ocr_finalize.mcp.server && toolCache[form.ocr_finalize.mcp.server]?.loaded && getToolOptions(form.ocr_finalize.mcp.server).length === 0 && !isToolValueStale(form.ocr_finalize.mcp.server, form.ocr_finalize.image_deliverables_tool)" class="tool-hint">
                 当前服务暂无工具缓存，请先到 MCP 设置中刷新工具列表
               </div>
@@ -531,10 +546,18 @@ function getToolOptions(serverName: string): { label: string; value: string; des
   const entry = toolCache.value[serverName]
   if (!entry || !entry.tools.length) return []
   return entry.tools.map(t => ({
-    label: t.description ? `${t.tool_name} — ${t.description}` : t.tool_name,
+    label: t.tool_name,
     value: t.tool_name,
     description: t.description,
   }))
+}
+
+function getToolDescription(serverName: string, toolValue: string): string | null {
+  if (!serverName || !toolValue) return null
+  const entry = toolCache.value[serverName]
+  if (!entry || !entry.tools) return null
+  const tool = entry.tools.find(t => t.tool_name === toolValue)
+  return tool?.description || null
 }
 
 function isToolValueStale(serverName: string, toolValue: string): boolean {
@@ -736,6 +759,9 @@ function onClose() {
   font-size: 12px;
   line-height: 1.4;
   margin-top: 4px;
+}
+.tool-hint.tool-desc {
+  color: #606266;
 }
 .tool-hint.tool-stale {
   color: #e6a23c;

--- a/frontend/src/stores/systemSettings.ts
+++ b/frontend/src/stores/systemSettings.ts
@@ -146,11 +146,11 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
       const runtimeSettings = response.data.data as Partial<SystemSettings>
       settings.value = {
         ...defaultSettings,
-        ...(settings.value || {}),
+        ...settings.value,
         timeout: {
           ...defaultSettings.timeout,
-          ...(settings.value?.timeout || {}),
-          ...(runtimeSettings.timeout || {}),
+          ...settings.value?.timeout,
+          ...runtimeSettings.timeout,
         },
       }
     } catch {


### PR DESCRIPTION
## Summary

- MCP 工具选择器下拉列表仅显示 `tool_name`，不再拼接描述
- 已选工具的描述展示在下拉框下方说明区域
- 新增 `getToolDescription()` 辅助方法获取工具描述
- 5 处工具选择字段均添加描述展示（pending_ocr, ocr_processing, ocr_finalize 三个阶段）
- 现有 stale/error/empty 状态提示逻辑保持不变
- 附带清理 `systemSettings.ts` 中冗余的 `|| {}` 展开语法

## 变更文件

- `frontend/src/components/docs/DocPipelineConfigDialog.vue`
- `frontend/src/stores/systemSettings.ts`

## 验证

- TypeScript 类型检查通过
- 下拉项简洁化：`create_task_from_file`（原为 `create_task_from_file — 上传文件并创建 OCR 任务`）
- 描述展示：选择工具后下方显示 `说明：xxx`

## 关联任务

- docs/tasks/active/task-001-mcp-tool-selector-copy