### PR TITLE
refactor: 统一前后端默认值权威来源，消除漂移风险

### DIFF
--- a/frontend/src/components/settings/SystemConfigTab.vue
+++ b/frontend/src/components/settings/SystemConfigTab.vue
@@ -350,51 +350,75 @@ const toast = useToastStore()
 const activeSubTab = ref<'general' | 'registration' | 'connection' | 'token' | 'timeout' | 'tool' | 'app' | 'packages' | 'branding'>('general')
 const saving = ref(false)
 
-const createDefaultForm = () => ({
-  llm: { context_threshold: 0.7, temperature: 0.7, reflective_temperature: 0.3, top_p: 1, frequency_penalty: 0, presence_penalty: 0 },
-  registration: { allow_self_registration: true, default_invitation_quota: 10, default_invitation_max_uses: 5, invitation_expiry_days: 30 },
-  connection: { max_per_user: 5, max_per_expert: 100 },
-  token: { access_expiry: '15m', refresh_expiry: '7d' },
-  timeout: { vm_execution: 30, python_execution: 300, skill_call: 60, skill_http: 180, resident_skill: 300, remote_llm: 120, chat_idle: 300 },
-  tool: { max_rounds: 20 },
-  app: { clock_interval: 30, batch_size: 10, max_concurrency: 5, text_filter_max_length: 50000, attachment_base_path: './data/attachments', max_upload_size: 50 },
-  branding: { app_name: 'Touwaka Mate', logo_icon: '🤖' },
+// 表单基线：记录最近一次成功加载/保存后的状态，用于判断是否有改动
+const baselineSettings = ref<any>(null)
+
+// 空结构占位（仅用于表单初始化，不定义业务默认值）
+// 默认值权威来源在后端 /system-settings 接口
+const createEmptyForm = () => ({
+  llm: { context_threshold: 0, temperature: 0, reflective_temperature: 0, top_p: 0, frequency_penalty: 0, presence_penalty: 0 },
+  registration: { allow_self_registration: false, default_invitation_quota: 0, default_invitation_max_uses: 0, invitation_expiry_days: 0 },
+  connection: { max_per_user: 0, max_per_expert: 0 },
+  token: { access_expiry: '', refresh_expiry: '' },
+  timeout: { vm_execution: 0, python_execution: 0, skill_call: 0, skill_http: 0, resident_skill: 0, remote_llm: 0, chat_idle: 0 },
+  tool: { max_rounds: 0 },
+  app: { clock_interval: 0, batch_size: 0, max_concurrency: 0, text_filter_max_length: 0, attachment_base_path: '', max_upload_size: 0 },
+  branding: { app_name: '', logo_icon: '' },
 })
 
-const form = reactive(createDefaultForm())
-
-const defaults = createDefaultForm()
+const form = reactive(createEmptyForm())
 
 const hasChanges = computed(() => {
-  const settings = systemSettingsStore.settings
-  if (!settings) return false
-  return JSON.stringify(form) !== JSON.stringify({
-    llm: { context_threshold: settings.llm?.context_threshold ?? 0.7, temperature: settings.llm?.temperature ?? 0.7, reflective_temperature: settings.llm?.reflective_temperature ?? 0.3, top_p: settings.llm?.top_p ?? 1, frequency_penalty: settings.llm?.frequency_penalty ?? 0, presence_penalty: settings.llm?.presence_penalty ?? 0 },
-    registration: { allow_self_registration: settings.registration?.allow_self_registration ?? true, default_invitation_quota: settings.registration?.default_invitation_quota ?? 10, default_invitation_max_uses: settings.registration?.default_invitation_max_uses ?? 5, invitation_expiry_days: settings.registration?.invitation_expiry_days ?? 30 },
-    connection: { max_per_user: settings.connection?.max_per_user ?? 5, max_per_expert: settings.connection?.max_per_expert ?? 100 },
-    token: { access_expiry: settings.token?.access_expiry ?? '15m', refresh_expiry: settings.token?.refresh_expiry ?? '7d' },
-    timeout: { vm_execution: settings.timeout?.vm_execution ?? 30, python_execution: settings.timeout?.python_execution ?? 300, skill_call: settings.timeout?.skill_call ?? 60, skill_http: settings.timeout?.skill_http ?? 180, resident_skill: settings.timeout?.resident_skill ?? 300, remote_llm: settings.timeout?.remote_llm ?? 120, chat_idle: settings.timeout?.chat_idle ?? 300 },
-    tool: { max_rounds: settings.tool?.max_rounds ?? 20 },
-    app: { clock_interval: settings.app?.clock_interval ?? 30, batch_size: settings.app?.batch_size ?? 10, max_concurrency: settings.app?.max_concurrency ?? 5, text_filter_max_length: settings.app?.text_filter_max_length ?? 50000, attachment_base_path: settings.app?.attachment_base_path ?? './data/attachments', max_upload_size: settings.app?.max_upload_size ?? 50 },
-    branding: { app_name: settings.branding?.app_name ?? 'Touwaka Mate', logo_icon: settings.branding?.logo_icon ?? '🤖' },
-  })
+  if (!baselineSettings.value) return false
+  return JSON.stringify(form) !== JSON.stringify(baselineSettings.value)
 })
 
-const resetSection = (section: string) => {
-  Object.assign(form[section as keyof typeof form], structuredClone(defaults[section as keyof typeof defaults]))
+const resetSection = async (section: string) => {
+  // 重置需要后端权威默认值，调用 reset 接口
+  try {
+    await systemSettingsStore.resetSettings([section])
+    await systemSettingsStore.loadSettings()
+    const settings = systemSettingsStore.settings
+    if (settings) {
+      Object.assign(form[section as keyof typeof form], settings[section as keyof typeof settings] || {})
+      baselineSettings.value = JSON.parse(JSON.stringify(form))
+    }
+    toast.success(t('settings.resetSuccess'))
+  } catch (error) {
+    console.error('Failed to reset section:', error)
+    toast.error(t('settings.resetFailed'))
+  }
 }
 
-const resetAll = () => {
-  const freshDefaults = createDefaultForm()
-  for (const key of Object.keys(freshDefaults) as Array<keyof typeof freshDefaults>) {
-    Object.assign(form[key], structuredClone(freshDefaults[key]))
+const resetAll = async () => {
+  try {
+    await systemSettingsStore.resetSettings()
+    await systemSettingsStore.loadSettings()
+    const settings = systemSettingsStore.settings
+    if (settings) {
+      for (const key of Object.keys(form) as Array<keyof typeof form>) {
+        Object.assign(form[key], settings[key] || {})
+      }
+      baselineSettings.value = JSON.parse(JSON.stringify(form))
+    }
+    toast.success(t('settings.resetSuccess'))
+  } catch (error) {
+    console.error('Failed to reset all:', error)
+    toast.error(t('settings.resetFailed'))
   }
 }
 
 const saveConfig = async () => {
+  // 检查是否已成功从后端加载，禁止保存占位结构
+  if (!systemSettingsStore.loadedFromBackend) {
+    toast.error(t('settings.cannotSaveNotLoaded'))
+    return
+  }
   saving.value = true
   try {
     await systemSettingsStore.updateSettings(form)
+    // 保存成功后更新基线，用于后续变更判断
+    baselineSettings.value = JSON.parse(JSON.stringify(form))
     toast.success(t('settings.saveSuccess'))
   } catch (error) {
     console.error('Failed to save settings:', error)
@@ -413,38 +437,23 @@ const handleBeforeUnload = (event: BeforeUnloadEvent) => {
 onMounted(async () => {
   window.addEventListener('beforeunload', handleBeforeUnload)
   await systemSettingsStore.loadSettings()
+  // 检查是否成功从后端加载，只有成功加载才填充表单和基线
+  if (!systemSettingsStore.loadedFromBackend) {
+    console.error('[SystemConfigTab] Failed to load settings from backend, cannot initialize form')
+    return
+  }
   const settings = systemSettingsStore.settings
   if (settings) {
-    form.llm.context_threshold = settings.llm?.context_threshold ?? 0.7
-    form.llm.temperature = settings.llm?.temperature ?? 0.7
-    form.llm.reflective_temperature = settings.llm?.reflective_temperature ?? 0.3
-    form.llm.top_p = settings.llm?.top_p ?? 1
-    form.llm.frequency_penalty = settings.llm?.frequency_penalty ?? 0
-    form.llm.presence_penalty = settings.llm?.presence_penalty ?? 0
-    form.registration.allow_self_registration = settings.registration?.allow_self_registration ?? true
-    form.registration.default_invitation_quota = settings.registration?.default_invitation_quota ?? 10
-    form.registration.default_invitation_max_uses = settings.registration?.default_invitation_max_uses ?? 5
-    form.registration.invitation_expiry_days = settings.registration?.invitation_expiry_days ?? 30
-    form.connection.max_per_user = settings.connection?.max_per_user ?? 5
-    form.connection.max_per_expert = settings.connection?.max_per_expert ?? 100
-    form.token.access_expiry = settings.token?.access_expiry ?? '15m'
-    form.token.refresh_expiry = settings.token?.refresh_expiry ?? '7d'
-    form.timeout.vm_execution = settings.timeout?.vm_execution ?? 30
-    form.timeout.python_execution = settings.timeout?.python_execution ?? 300
-    form.timeout.skill_call = settings.timeout?.skill_call ?? 60
-    form.timeout.skill_http = settings.timeout?.skill_http ?? 180
-    form.timeout.resident_skill = settings.timeout?.resident_skill ?? 300
-    form.timeout.remote_llm = settings.timeout?.remote_llm ?? 120
-    form.timeout.chat_idle = settings.timeout?.chat_idle ?? 300
-    form.tool.max_rounds = settings.tool?.max_rounds ?? 20
-    form.app.clock_interval = settings.app?.clock_interval ?? 30
-    form.app.batch_size = settings.app?.batch_size ?? 10
-    form.app.max_concurrency = settings.app?.max_concurrency ?? 5
-    form.app.text_filter_max_length = settings.app?.text_filter_max_length ?? 50000
-    form.app.attachment_base_path = settings.app?.attachment_base_path ?? './data/attachments'
-    form.app.max_upload_size = settings.app?.max_upload_size ?? 50
-    form.branding.app_name = settings.branding?.app_name ?? 'Touwaka Mate'
-    form.branding.logo_icon = settings.branding?.logo_icon ?? '🤖'
+    // 直接使用接口返回值填充表单，不再使用硬编码默认值
+    Object.assign(form.llm, settings.llm || {})
+    Object.assign(form.registration, settings.registration || {})
+    Object.assign(form.connection, settings.connection || {})
+    Object.assign(form.token, settings.token || {})
+    Object.assign(form.timeout, settings.timeout || {})
+    Object.assign(form.tool, settings.tool || {})
+    Object.assign(form.app, settings.app || {})
+    Object.assign(form.branding, settings.branding || {})
+    baselineSettings.value = JSON.parse(JSON.stringify(form))
   }
 })
 
@@ -458,37 +467,19 @@ watch(hasChanges, (val) => {
 })
 
 watch(() => systemSettingsStore.settings, (settings) => {
+  // 只有成功从后端加载才更新表单和基线
+  if (!systemSettingsStore.loadedFromBackend) return
   if (settings) {
-    form.llm.context_threshold = settings.llm?.context_threshold ?? 0.7
-    form.llm.temperature = settings.llm?.temperature ?? 0.7
-    form.llm.reflective_temperature = settings.llm?.reflective_temperature ?? 0.3
-    form.llm.top_p = settings.llm?.top_p ?? 1
-    form.llm.frequency_penalty = settings.llm?.frequency_penalty ?? 0
-    form.llm.presence_penalty = settings.llm?.presence_penalty ?? 0
-    form.registration.allow_self_registration = settings.registration?.allow_self_registration ?? true
-    form.registration.default_invitation_quota = settings.registration?.default_invitation_quota ?? 10
-    form.registration.default_invitation_max_uses = settings.registration?.default_invitation_max_uses ?? 5
-    form.registration.invitation_expiry_days = settings.registration?.invitation_expiry_days ?? 30
-    form.connection.max_per_user = settings.connection?.max_per_user ?? 5
-    form.connection.max_per_expert = settings.connection?.max_per_expert ?? 100
-    form.token.access_expiry = settings.token?.access_expiry ?? '15m'
-    form.token.refresh_expiry = settings.token?.refresh_expiry ?? '7d'
-    form.timeout.vm_execution = settings.timeout?.vm_execution ?? 30
-    form.timeout.python_execution = settings.timeout?.python_execution ?? 300
-    form.timeout.skill_call = settings.timeout?.skill_call ?? 60
-    form.timeout.skill_http = settings.timeout?.skill_http ?? 180
-    form.timeout.resident_skill = settings.timeout?.resident_skill ?? 300
-    form.timeout.remote_llm = settings.timeout?.remote_llm ?? 120
-    form.timeout.chat_idle = settings.timeout?.chat_idle ?? 300
-    form.tool.max_rounds = settings.tool?.max_rounds ?? 20
-    form.app.clock_interval = settings.app?.clock_interval ?? 30
-    form.app.batch_size = settings.app?.batch_size ?? 10
-    form.app.max_concurrency = settings.app?.max_concurrency ?? 5
-    form.app.text_filter_max_length = settings.app?.text_filter_max_length ?? 50000
-    form.app.attachment_base_path = settings.app?.attachment_base_path ?? './data/attachments'
-    form.app.max_upload_size = settings.app?.max_upload_size ?? 50
-    form.branding.app_name = settings.branding?.app_name ?? 'Touwaka Mate'
-    form.branding.logo_icon = settings.branding?.logo_icon ?? '🤖'
+    // 直接使用接口返回值更新表单，不再使用硬编码默认值
+    Object.assign(form.llm, settings.llm || {})
+    Object.assign(form.registration, settings.registration || {})
+    Object.assign(form.connection, settings.connection || {})
+    Object.assign(form.token, settings.token || {})
+    Object.assign(form.timeout, settings.timeout || {})
+    Object.assign(form.tool, settings.tool || {})
+    Object.assign(form.app, settings.app || {})
+    Object.assign(form.branding, settings.branding || {})
+    baselineSettings.value = JSON.parse(JSON.stringify(form))
   }
 }, { deep: true })
 </script>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -213,6 +213,7 @@ export default {
     apiKey: 'API Key',
     notifications: 'Notifications',
     saveSuccess: 'Settings saved',
+    cannotSaveNotLoaded: 'Cannot save: settings not loaded from server',
     save: 'Save',
     modelAndProvider: 'Models & Providers',
     modelSettings: 'Model Settings',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -213,6 +213,7 @@ export default {
     apiKey: 'API 密钥',
     notifications: '通知设置',
     saveSuccess: '设置已保存',
+    cannotSaveNotLoaded: '无法保存：配置未从服务器加载',
     save: '保存',
     modelAndProvider: '模型与提供商',
     modelSettings: '模型设置',

--- a/frontend/src/stores/systemSettings.ts
+++ b/frontend/src/stores/systemSettings.ts
@@ -70,47 +70,59 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   const error = ref<string | null>(null)
   const brandingLoaded = ref(false)
   const unsavedConfigChanges = ref(false)
+  // 标记是否已成功从后端加载真实配置（区别于占位结构）
+  const loadedFromBackend = ref(false)
   let brandingPromise: Promise<BrandingSettings> | null = null
 
-  // 默认配置（用于初始化）
+  // 空结构占位（仅防止 undefined 导致模板报错，不定义业务默认值）
+  // 默认值权威来源在后端，前端通过接口获取
+  // 注意：必须包含所有 section，确保失败态下 reset 能正确展开字段列表
   const defaultSettings: SystemSettings = {
     llm: {
-      context_threshold: 0.70,
-      temperature: 0.70,
-      reflective_temperature: 0.30,
-      top_p: 1.0,
-      frequency_penalty: 0.0,
-      presence_penalty: 0.0,
+      context_threshold: 0,
+      temperature: 0,
+      reflective_temperature: 0,
+      top_p: 0,
+      frequency_penalty: 0,
+      presence_penalty: 0,
     },
     connection: {
-      max_per_user: 5,
-      max_per_expert: 100,
+      max_per_user: 0,
+      max_per_expert: 0,
     },
     token: {
-      access_expiry: '15m',
-      refresh_expiry: '7d',
+      access_expiry: '',
+      refresh_expiry: '',
     },
     timeout: {
-      vm_execution: 30,
-      python_execution: 300,
-      skill_call: 60,
-      skill_http: 180,
-      resident_skill: 300,
-      remote_llm: 120,
-      chat_idle: 300,
+      vm_execution: 0,
+      python_execution: 0,
+      skill_call: 0,
+      skill_http: 0,
+      resident_skill: 0,
+      remote_llm: 0,
+      chat_idle: 0,
     },
     tool: {
-      max_rounds: 20,
+      max_rounds: 0,
     },
     registration: {
-      allow_self_registration: true,
-      default_invitation_quota: 10,
-      default_invitation_max_uses: 5,
-      invitation_expiry_days: 30,
+      allow_self_registration: false,
+      default_invitation_quota: 0,
+      default_invitation_max_uses: 0,
+      invitation_expiry_days: 0,
+    },
+    app: {
+      clock_interval: 0,
+      batch_size: 0,
+      max_concurrency: 0,
+      text_filter_max_length: 0,
+      attachment_base_path: '',
+      max_upload_size: 0,
     },
     branding: {
-      app_name: 'Touwaka Mate',
-      logo_icon: '🤖',
+      app_name: '',
+      logo_icon: '',
     },
   }
 
@@ -131,10 +143,15 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
     try {
       const response = await apiClient.get('/system-settings')
       settings.value = response.data.data
+      loadedFromBackend.value = true  // 标记已成功加载
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load system settings'
-      // 加载失败时使用默认值
-      settings.value = defaultSettings
+      // 加载失败时保持空结构占位，不填充业务默认值
+      // 后端才是默认值权威来源，前端不应自行定义业务默认值
+      loadedFromBackend.value = false  // 标记未成功加载
+      if (!settings.value) {
+        settings.value = defaultSettings
+      }
     } finally {
       isLoading.value = false
     }
@@ -154,15 +171,17 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
         },
       }
     } catch {
-      console.warn('[systemSettings] 运行时配置加载失败，使用默认值')
-      if (!settings.value) {
-        settings.value = defaultSettings
-      }
+      console.warn('[systemSettings] 运行时配置加载失败，保持现有状态')
+      // 不填充业务默认值，避免与后端权威来源冲突
     }
   }
 
   // 更新系统配置
   const updateSettings = async (newSettings: Partial<SystemSettings>) => {
+    // 检查是否已成功加载真实配置，禁止保存占位结构
+    if (!loadedFromBackend.value) {
+      throw new Error('Cannot save settings: configuration not loaded from backend')
+    }
     isLoading.value = true
     error.value = null
     try {
@@ -178,13 +197,34 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   }
 
   // 重置配置为默认值
+  // keys 参数可以是：
+  // 1. 未定义或空数组 -> 重置所有配置
+  // 2. 扁平 key 数组 -> 重置指定字段（如 ['registration.allow_self_registration']）
+  // 3. section 名数组 -> 自动展开为该 section 下所有字段
   const resetSettings = async (keys?: string[]) => {
     isLoading.value = true
     error.value = null
     try {
+      // 如果传入 section 名，展开为完整字段列表
+      let flattenedKeys = keys
+      if (keys && keys.length > 0) {
+        flattenedKeys = keys.flatMap(key => {
+          // 如果 key 包含点号，说明已经是扁平格式，直接使用
+          if (key.includes('.')) {
+            return [key]
+          }
+          // 否则展开为该 section 下所有字段
+          const sectionSettings = settings.value?.[key as keyof SystemSettings]
+          if (sectionSettings && typeof sectionSettings === 'object') {
+            return Object.keys(sectionSettings).map(subKey => `${key}.${subKey}`)
+          }
+          return [key]
+        })
+      }
+      
       const response = await apiClient.post('/system-settings/reset', {
-        keys,
-        all: !keys
+        keys: flattenedKeys,
+        all: !flattenedKeys || flattenedKeys.length === 0
       })
       settings.value = response.data.data
       return true
@@ -261,6 +301,7 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
     registrationSettings,
     brandingSettings,
     brandingLoaded,
+    loadedFromBackend,  // 导出加载状态标记
     unsavedConfigChanges,
     loadSettings,
     loadRuntimeSettings,

--- a/server/controllers/system-setting.controller.js
+++ b/server/controllers/system-setting.controller.js
@@ -5,7 +5,7 @@
  */
 
 import logger from '../../lib/logger.js';
-import { getSystemSettingService } from '../services/system-setting.service.js';
+import { getSystemSettingService, DEFAULT_SETTINGS as SERVICE_DEFAULTS } from '../services/system-setting.service.js';
 import {
   DOC_PIPELINE_KEYS,
   getStageDefault,
@@ -13,55 +13,15 @@ import {
   isOcrStage,
 } from '../../lib/doc-pipeline-defaults.js';
 
-const DEFAULT_SETTINGS = {
-  llm: {
-    context_threshold: 0.70,
-    temperature: 0.70,
-    reflective_temperature: 0.30,
-    top_p: 1.0,
-    frequency_penalty: 0.0,
-    presence_penalty: 0.0,
-    // Note: max_tokens 不在系统设置中管理，由模型表和专家配置决定
-  },
-  connection: {
-    max_per_user: 5,
-    max_per_expert: 100,
-  },
-  token: {
-    access_expiry: '15m',
-    refresh_expiry: '7d',
-  },
-  timeout: {
-    vm_execution: 30,       // VM 执行超时（秒）
-    python_execution: 300,  // Python 执行超时（秒）
-    skill_call: 60,         // 技能调用超时（秒）
-    skill_http: 180,        // 技能 HTTP 调用超时（秒）
-    resident_skill: 300,    // 驻留技能超时（秒）
-    remote_llm: 120,        // 远程 LLM 调用超时（秒）
-    chat_idle: 300,         // 聊天空闲超时（秒）
-  },
-  tool: {
-    max_rounds: 20,         // 最大工具调用轮数
-  },
-  registration: {
-    allow_self_registration: false,    // 是否允许自主注册
-    default_invitation_quota: 1,       // 默认邀请配额
-    default_invitation_max_uses: 5,    // 默认邀请码最大使用次数
-    invitation_expiry_days: 0,         // 邀请码有效期（天）
-  },
-  app: {
-    clock_interval: 30,                // AppClock 轮询间隔（秒）
-    batch_size: 10,                    // 每批处理记录数量
-    max_concurrency: 5,                // 最大并发处理数
-    text_filter_max_length: 50000,     // 文本过滤最大长度（字符）
-    attachment_base_path: './data/attachments', // 附件存储路径
-    max_upload_size: 50,               // 附件上传大小限制（MB）
-  },
-  branding: {
-    app_name: 'Touwaka Mate',
-    logo_icon: '🤖',
-  },
-};
+// 从服务层导出的 DEFAULT_SETTINGS 提取扁平默认值（用于控制器 reset 等场景）
+// 服务层是权威来源，控制器不独立维护默认值定义
+const DEFAULT_SETTINGS = {};
+for (const [section, keys] of Object.entries(SERVICE_DEFAULTS)) {
+  DEFAULT_SETTINGS[section] = {};
+  for (const [key, config] of Object.entries(keys)) {
+    DEFAULT_SETTINGS[section][key] = config.value;
+  }
+}
 
 class SystemSettingController {
   constructor(db) {

--- a/server/services/system-setting.service.js
+++ b/server/services/system-setting.service.js
@@ -324,23 +324,22 @@ class SystemSettingService {
    */
   async getRegistrationConfig() {
     const settings = await this.getAllSettings();
-    return settings.registration || {
-      allow_self_registration: false,
-      default_invitation_quota: 1,
-      default_invitation_max_uses: 5,
-      invitation_expiry_days: 0,
-    };
+    // 统一从 DEFAULT_SETTINGS 派生默认值，避免内联漂移
+    const defaults = {};
+    for (const [key, config] of Object.entries(DEFAULT_SETTINGS.registration)) {
+      defaults[key] = config.value;
+    }
+    return settings.registration || defaults;
   }
 
   async getAppConfig() {
     const settings = await this.getAllSettings();
-    return settings.app || {
-      clock_interval: 30,
-      batch_size: 10,
-      max_concurrency: 5,
-      text_filter_max_length: 50000,
-      attachment_base_path: './data/attachments',
-    };
+    // 统一从 DEFAULT_SETTINGS 派生默认值，避免内联漂移
+    const defaults = {};
+    for (const [key, config] of Object.entries(DEFAULT_SETTINGS.app)) {
+      defaults[key] = config.value;
+    }
+    return settings.app || defaults;
   }
 
   clearCache() {

--- a/server/tests/system-setting-defaults.test.js
+++ b/server/tests/system-setting-defaults.test.js
@@ -1,0 +1,188 @@
+/**
+ * 系统设置默认值一致性测试
+ * 验证后端 DEFAULT_SETTINGS 结构完整性，防止未来新增字段时遗漏定义
+ * 
+ * 根据 issue #835 要求：
+ * - 后端是系统设置默认值的唯一权威来源
+ * - 新增系统设置字段时，必须在 DEFAULT_SETTINGS 中定义默认值
+ */
+
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { DEFAULT_SETTINGS } from '../services/system-setting.service.js'
+
+describe('System Setting Defaults Consistency', () => {
+  it('should have all required sections', () => {
+    const requiredSections = ['llm', 'connection', 'token', 'timeout', 'tool', 'registration', 'app', 'branding']
+    for (const section of requiredSections) {
+      expect(DEFAULT_SETTINGS).to.have.property(section)
+      expect(DEFAULT_SETTINGS[section]).to.be.an('object')
+    }
+  })
+
+  it('should have complete llm defaults', () => {
+    const llmKeys = ['context_threshold', 'temperature', 'reflective_temperature', 'top_p', 'frequency_penalty', 'presence_penalty']
+    for (const key of llmKeys) {
+      expect(DEFAULT_SETTINGS.llm).to.have.property(key)
+      expect(DEFAULT_SETTINGS.llm[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.llm[key]).to.have.property('type')
+      expect(DEFAULT_SETTINGS.llm[key].type).to.equal('number')
+    }
+  })
+
+  it('should have complete registration defaults', () => {
+    const registrationKeys = ['allow_self_registration', 'default_invitation_quota', 'default_invitation_max_uses', 'invitation_expiry_days']
+    for (const key of registrationKeys) {
+      expect(DEFAULT_SETTINGS.registration).to.have.property(key)
+      expect(DEFAULT_SETTINGS.registration[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.registration[key]).to.have.property('type')
+    }
+    // 验证关键字段类型
+    expect(DEFAULT_SETTINGS.registration.allow_self_registration.type).to.equal('boolean')
+    expect(DEFAULT_SETTINGS.registration.default_invitation_quota.type).to.equal('number')
+    expect(DEFAULT_SETTINGS.registration.default_invitation_max_uses.type).to.equal('number')
+    expect(DEFAULT_SETTINGS.registration.invitation_expiry_days.type).to.equal('number')
+  })
+
+  it('should have complete timeout defaults', () => {
+    const timeoutKeys = ['vm_execution', 'python_execution', 'skill_call', 'skill_http', 'resident_skill', 'remote_llm', 'chat_idle']
+    for (const key of timeoutKeys) {
+      expect(DEFAULT_SETTINGS.timeout).to.have.property(key)
+      expect(DEFAULT_SETTINGS.timeout[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.timeout[key].type).to.equal('number')
+      // 所有超时值应该大于 0
+      expect(DEFAULT_SETTINGS.timeout[key].value).to.be.above(0)
+    }
+  })
+
+  it('should have complete connection defaults', () => {
+    const connectionKeys = ['max_per_user', 'max_per_expert']
+    for (const key of connectionKeys) {
+      expect(DEFAULT_SETTINGS.connection).to.have.property(key)
+      expect(DEFAULT_SETTINGS.connection[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.connection[key].type).to.equal('number')
+      expect(DEFAULT_SETTINGS.connection[key].value).to.be.above(0)
+    }
+  })
+
+  it('should have complete token defaults', () => {
+    const tokenKeys = ['access_expiry', 'refresh_expiry']
+    for (const key of tokenKeys) {
+      expect(DEFAULT_SETTINGS.token).to.have.property(key)
+      expect(DEFAULT_SETTINGS.token[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.token[key]).to.have.property('type')
+      expect(DEFAULT_SETTINGS.token[key].type).to.equal('string')
+      expect(DEFAULT_SETTINGS.token[key].value).to.be.a('string')
+      expect(DEFAULT_SETTINGS.token[key].value.length).to.be.above(0)
+    }
+  })
+
+  it('should have complete tool defaults', () => {
+    expect(DEFAULT_SETTINGS.tool).to.have.property('max_rounds')
+    expect(DEFAULT_SETTINGS.tool.max_rounds).to.have.property('value')
+    expect(DEFAULT_SETTINGS.tool.max_rounds.type).to.equal('number')
+    expect(DEFAULT_SETTINGS.tool.max_rounds.value).to.be.above(0)
+  })
+
+  it('should have complete app defaults', () => {
+    const appKeys = ['clock_interval', 'batch_size', 'max_concurrency', 'text_filter_max_length', 'attachment_base_path', 'max_upload_size']
+    for (const key of appKeys) {
+      expect(DEFAULT_SETTINGS.app).to.have.property(key)
+      expect(DEFAULT_SETTINGS.app[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.app[key]).to.have.property('type')
+    }
+  })
+
+  it('should have complete branding defaults', () => {
+    const brandingKeys = ['app_name', 'logo_icon']
+    for (const key of brandingKeys) {
+      expect(DEFAULT_SETTINGS.branding).to.have.property(key)
+      expect(DEFAULT_SETTINGS.branding[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.branding[key]).to.have.property('type')
+      expect(DEFAULT_SETTINGS.branding[key].type).to.equal('string')
+    }
+  })
+
+  it('should prevent future drift: all values must be explicitly defined', () => {
+    // 此测试用于提醒：新增字段时必须在 DEFAULT_SETTINGS 中显式定义
+    // 如果某个字段缺失 value 或 type，说明定义不完整
+    for (const [section, keys] of Object.entries(DEFAULT_SETTINGS)) {
+      for (const [key, config] of Object.entries(keys)) {
+        expect(config).to.have.property('value')
+        expect(config).to.have.property('type')
+        expect(config).to.have.property('description')
+      }
+    }
+  })
+
+  it('should derive registration defaults from DEFAULT_SETTINGS', () => {
+    // 验证 registration 默认值派生逻辑
+    const registrationDefaults = {}
+    for (const [key, config] of Object.entries(DEFAULT_SETTINGS.registration)) {
+      registrationDefaults[key] = config.value
+    }
+    // 关键字段验证：防止未来漂移
+    expect(registrationDefaults.allow_self_registration).to.equal(false)
+    expect(registrationDefaults.default_invitation_quota).to.equal(1)
+    expect(registrationDefaults.default_invitation_max_uses).to.equal(5)
+    expect(registrationDefaults.invitation_expiry_days).to.equal(0)
+  })
+
+  it('should derive app defaults from DEFAULT_SETTINGS', () => {
+    // 验证 app 默认值派生逻辑
+    const appDefaults = {}
+    for (const [key, config] of Object.entries(DEFAULT_SETTINGS.app)) {
+      appDefaults[key] = config.value
+    }
+    expect(appDefaults.clock_interval).to.equal(30)
+    expect(appDefaults.batch_size).to.equal(10)
+    expect(appDefaults.max_concurrency).to.equal(5)
+    expect(appDefaults.text_filter_max_length).to.equal(50000)
+    expect(appDefaults.attachment_base_path).to.equal('./data/attachments')
+  })
+
+  it('should have consistent default value types', () => {
+    // 验证默认值类型一致性：防止类型漂移
+    for (const [section, keys] of Object.entries(DEFAULT_SETTINGS)) {
+      for (const [key, config] of Object.entries(keys)) {
+        const actualType = typeof config.value
+        const declaredType = config.type
+        // 类型必须匹配
+        if (declaredType === 'number') {
+          expect(actualType).to.equal('number')
+        } else if (declaredType === 'boolean') {
+          expect(actualType).to.equal('boolean')
+        } else if (declaredType === 'string') {
+          expect(actualType).to.equal('string')
+        }
+      }
+    }
+  })
+
+  it('should have complete section coverage for reset key expansion', () => {
+    // 验证所有 section 都有完整字段定义，防止前端 reset 时无法展开
+    const requiredSections = ['llm', 'connection', 'token', 'timeout', 'tool', 'registration', 'app', 'branding']
+    for (const section of requiredSections) {
+      expect(DEFAULT_SETTINGS).to.have.property(section)
+      expect(DEFAULT_SETTINGS[section]).to.be.an('object')
+      // 每个 section 至少有一个字段
+      expect(Object.keys(DEFAULT_SETTINGS[section]).length).to.be.above(0)
+    }
+  })
+
+  it('should prevent reset with invalid section name', () => {
+    // 验证 app section 的完整字段列表
+    const appKeys = Object.keys(DEFAULT_SETTINGS.app)
+    expect(appKeys).to.include('clock_interval')
+    expect(appKeys).to.include('batch_size')
+    expect(appKeys).to.include('max_concurrency')
+    expect(appKeys).to.include('text_filter_max_length')
+    expect(appKeys).to.include('attachment_base_path')
+    expect(appKeys).to.include('max_upload_size')
+    // 验证这些字段都有完整的默认值定义
+    for (const key of appKeys) {
+      expect(DEFAULT_SETTINGS.app[key]).to.have.property('value')
+      expect(DEFAULT_SETTINGS.app[key]).to.have.property('type')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

统一前后端默认值权威来源，消除漂移风险。

## 主要变更

### 后端统一
- 控制器从服务层 `DEFAULT_SETTINGS` 提取扁平值，不再独立维护默认值对象
- 服务层 `getRegistrationConfig()` 和 `getAppConfig()` 从 DEFAULT_SETTINGS 派生默认值

### 前端整改
- store 移除硬编码业务默认值，改为空结构占位
- 新增 `loadedFromBackend` 状态标记，防止失败态误保存
- SystemConfigTab 统一表单逻辑，使用 `baselineSettings` 作为基线
- 补齐 `app` section 占位结构，确保失败态下 reset 正确展开

### i18n 补充
- 补充 `settings.cannotSaveNotLoaded` 中英文文案

### 测试保护
- 新增 `server/tests/system-setting-defaults.test.js`
- 验证 DEFAULT_SETTINGS 结构完整性、默认值派生、类型一致性

## 审计情况

经过 3 轮审计迭代：
- 第一轮：发现 4 个问题（2 个阻断项）
- 第二轮：发现 2 个问题（1 个阻断项）
- 第三轮：无阻断性发现，可验收通过

审计报告详见：`docs/tasks/active/task-835-system-setting-default-source-of-truth/audit-round-*.md`

## 验收标准

| 验收标准 | 状态 |
|---------|------|
| 三处漂移字段前后端定义一致 | ✅ |
| 后端单一权威源 | ✅ |
| 前端无硬编码业务默认值 | ✅ |
| 加载失败时不误保存占位值 | ✅ |
| 分区重置功能正确 | ✅ |
| 至少一项自动化测试 | ✅ |

## 文件变更

7 文件修改，1 文件新增，减少 186 行，增加 367 行

Closes #835