### PR TITLE
feat: 文档平台 OCR 参数来源拆分

### DIFF
--- a/frontend/src/api/doc-pipeline.ts
+++ b/frontend/src/api/doc-pipeline.ts
@@ -1,5 +1,18 @@
 import apiClient, { apiRequest } from './client'
 
+export interface ParamSourceAttachment {
+  group: 'attachment'
+  field: string
+}
+
+export interface ParamSourceSetting {
+  group: 'setting'
+  value: boolean | string | null
+  enabled?: boolean
+}
+
+export type ParamSource = ParamSourceAttachment | ParamSourceSetting
+
 export interface DocPipelineJudge {
   model_id: string | null
   temperature: number
@@ -14,7 +27,8 @@ export interface DocPipelineMcpStage {
     server: string
     tool: string
     params_mapping: Record<string, string>
-    params: Record<string, unknown>
+    param_sources?: Record<string, ParamSource>
+    params?: Record<string, unknown>
   }
   judge: DocPipelineJudge
   provider_name?: string

--- a/frontend/src/components/docs/DocPipelineConfigDialog.vue
+++ b/frontend/src/components/docs/DocPipelineConfigDialog.vue
@@ -74,24 +74,56 @@
             <el-form-item label="超时(ms)">
               <el-input-number v-model="form.pending_ocr.timeout_ms" :min="5000" :step="10000" />
             </el-form-item>
-            <el-divider content-position="left">参数映射</el-divider>
+            <el-divider content-position="left">附件提取参数</el-divider>
             <el-form-item label="file_base64">
-              <el-input v-model="form.pending_ocr.mcp.params_mapping.file_base64" placeholder="file_base64" />
+              <div class="param-row">
+                <el-tag size="small" type="info">附件 Base64</el-tag>
+                <span class="param-arrow">→</span>
+                <el-input v-model="form.pending_ocr.mcp.params_mapping.file_base64" placeholder="file_base64" class="param-mapping-input" />
+              </div>
             </el-form-item>
             <el-form-item label="file_name">
-              <el-input v-model="form.pending_ocr.mcp.params_mapping.file_name" placeholder="file_name" />
+              <div class="param-row">
+                <el-tag size="small" type="info">附件文件名</el-tag>
+                <span class="param-arrow">→</span>
+                <el-input v-model="form.pending_ocr.mcp.params_mapping.file_name" placeholder="file_name" class="param-mapping-input" />
+              </div>
             </el-form-item>
-            <el-form-item label="lang">
-              <el-input v-model="form.pending_ocr.mcp.params_mapping.lang" placeholder="lang" />
+            <el-divider content-position="left">设定值参数</el-divider>
+            <el-form-item label="公式识别">
+              <div class="param-row">
+                <el-switch v-model="getParamSource('formula_enable').value" />
+                <span class="param-arrow">→</span>
+                <el-input v-model="form.pending_ocr.mcp.params_mapping.formula_enable" placeholder="formula_enable" class="param-mapping-input" />
+              </div>
             </el-form-item>
-            <el-form-item label="formula_enable">
-              <el-input v-model="form.pending_ocr.mcp.params_mapping.formula_enable" placeholder="formula_enable" />
+            <el-form-item label="表格识别">
+              <div class="param-row">
+                <el-switch v-model="getParamSource('table_enable').value" />
+                <span class="param-arrow">→</span>
+                <el-input v-model="form.pending_ocr.mcp.params_mapping.table_enable" placeholder="table_enable" class="param-mapping-input" />
+              </div>
             </el-form-item>
-            <el-form-item label="table_enable">
-              <el-input v-model="form.pending_ocr.mcp.params_mapping.table_enable" placeholder="table_enable" />
+            <el-form-item label="图片分析">
+              <div class="param-row">
+                <el-switch v-model="getParamSource('image_analysis').value" />
+                <span class="param-arrow">→</span>
+                <el-input v-model="form.pending_ocr.mcp.params_mapping.image_analysis" placeholder="image_analysis" class="param-mapping-input" />
+              </div>
             </el-form-item>
-            <el-form-item label="image_analysis">
-              <el-input v-model="form.pending_ocr.mcp.params_mapping.image_analysis" placeholder="image_analysis" />
+            <el-form-item label="语言">
+              <div class="param-row lang-param-row">
+                <el-switch v-model="getParamSource('lang').enabled" />
+                <el-input
+                  v-if="getParamSource('lang').enabled"
+                  v-model="getParamSource('lang').value"
+                  placeholder="如: ch, en"
+                  class="lang-value-input"
+                />
+                <span class="param-arrow">→</span>
+                <el-input v-model="form.pending_ocr.mcp.params_mapping.lang" placeholder="lang" class="param-mapping-input" />
+              </div>
+              <div v-if="!getParamSource('lang').enabled" class="param-hint">未启用时不传递 lang 参数</div>
             </el-form-item>
             <el-divider content-position="left">LLM 归一化</el-divider>
             <el-form-item label="归一化模型">
@@ -505,7 +537,19 @@ const defaultForm: DocPipelineConfig = {
   meta: { version: 1, enabled: true },
   pending_ocr: {
     enabled: true, type: 'mcp', provider_name: 'mineru', timeout_ms: 120000,
-    mcp: { server: 'mineru', tool: 'create_task_from_file', params_mapping: { file_base64: 'file_base64', file_name: 'file_name', lang: 'lang', formula_enable: 'formula_enable', table_enable: 'table_enable', image_analysis: 'image_analysis' }, params: {} },
+    mcp: {
+      server: 'mineru',
+      tool: 'create_task_from_file',
+      params_mapping: { file_base64: 'file_base64', file_name: 'file_name', formula_enable: 'formula_enable', table_enable: 'table_enable', image_analysis: 'image_analysis', lang: 'lang' },
+      param_sources: {
+        file_base64: { group: 'attachment', field: 'file_base64' },
+        file_name: { group: 'attachment', field: 'file_name' },
+        formula_enable: { group: 'setting', value: true },
+        table_enable: { group: 'setting', value: true },
+        image_analysis: { group: 'setting', value: true },
+        lang: { group: 'setting', value: null, enabled: false },
+      },
+    },
     judge: { model_id: null, temperature: 0.1, prompt_template: '', output_schema: {} },
   },
   ocr_processing: {
@@ -616,6 +660,34 @@ function onSchemaInput(val: string, stage: 'pending_ocr' | 'ocr_processing' | 'o
   } catch {
     schemaError.value[stage] = 'JSON 格式错误，已保留原值'
   }
+}
+
+function ensureParamSources() {
+  if (!form.pending_ocr.mcp.param_sources) {
+    form.pending_ocr.mcp.param_sources = {
+      file_base64: { group: 'attachment', field: 'file_base64' },
+      file_name: { group: 'attachment', field: 'file_name' },
+      formula_enable: { group: 'setting', value: true },
+      table_enable: { group: 'setting', value: true },
+      image_analysis: { group: 'setting', value: true },
+      lang: { group: 'setting', value: null, enabled: false },
+    }
+  }
+}
+
+function getParamSource(key: string): { group: string; value: boolean | string | null; enabled?: boolean } {
+  ensureParamSources()
+  const sources = form.pending_ocr.mcp.param_sources!
+  if (!sources[key]) {
+    if (key === 'file_base64' || key === 'file_name') {
+      sources[key] = { group: 'attachment', field: key }
+    } else if (key === 'lang') {
+      sources[key] = { group: 'setting', value: null, enabled: false }
+    } else {
+      sources[key] = { group: 'setting', value: true }
+    }
+  }
+  return sources[key] as { group: string; value: boolean | string | null; enabled?: boolean }
 }
 
 
@@ -768,5 +840,29 @@ function onClose() {
 }
 .tool-hint.tool-error {
   color: #f56c6c;
+}
+.param-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+}
+.param-arrow {
+  color: #909399;
+  font-size: 14px;
+}
+.param-mapping-input {
+  width: 180px;
+}
+.lang-param-row {
+  flex-wrap: wrap;
+}
+.lang-value-input {
+  width: 120px;
+}
+.param-hint {
+  color: #909399;
+  font-size: 12px;
+  margin-top: 4px;
 }
 </style>

--- a/frontend/src/stores/collection.ts
+++ b/frontend/src/stores/collection.ts
@@ -195,6 +195,9 @@ export const useCollectionStore = defineStore('collection', () => {
     app_id?: string
     schema_id?: string | null
     lang?: string
+    image_analysis?: boolean
+    formula_enable?: boolean
+    table_enable?: boolean
   }): Promise<{
     attachment: UploadAttachmentResponse
     intake: DocIntakeResult
@@ -218,10 +221,10 @@ export const useCollectionStore = defineStore('collection', () => {
 
       const submit = await submitOcr(intake.document_id, {
         attachment_id: attachment.id,
-        lang: options?.lang || 'ch',
-        image_analysis: true,
-        formula_enable: true,
-        table_enable: true,
+        ...options?.lang !== undefined && { lang: options.lang },
+        ...options?.image_analysis !== undefined && { image_analysis: options.image_analysis },
+        ...options?.formula_enable !== undefined && { formula_enable: options.formula_enable },
+        ...options?.table_enable !== undefined && { table_enable: options.table_enable },
       })
 
       await fetchCollectionDocuments(collectionId)

--- a/lib/doc-pipeline-defaults.js
+++ b/lib/doc-pipeline-defaults.js
@@ -18,16 +18,37 @@ const DOC_PIPELINE_DEFAULTS = {
       params_mapping: {
         file_base64: 'file_base64',
         file_name: 'file_name',
-        lang: 'lang',
         formula_enable: 'formula_enable',
         table_enable: 'table_enable',
         image_analysis: 'image_analysis',
+        lang: 'lang',
       },
-      params: {
-        lang: 'ch',
-        formula_enable: true,
-        table_enable: true,
-        image_analysis: true,
+      param_sources: {
+        file_base64: {
+          group: 'attachment',
+          field: 'file_base64',
+        },
+        file_name: {
+          group: 'attachment',
+          field: 'file_name',
+        },
+        formula_enable: {
+          group: 'setting',
+          value: true,
+        },
+        table_enable: {
+          group: 'setting',
+          value: true,
+        },
+        image_analysis: {
+          group: 'setting',
+          value: true,
+        },
+        lang: {
+          group: 'setting',
+          value: null,
+          enabled: false,
+        },
       },
     },
     judge: {
@@ -197,12 +218,60 @@ function mergeWithDefaults(stored) {
   const result = {};
   for (const key of DOC_PIPELINE_KEYS) {
     if (stored && stored[key] && typeof stored[key] === 'object') {
-      result[key] = stored[key];
+      result[key] = normalizeParamSources(stored[key], key);
     } else {
       result[key] = getStageDefault(key);
     }
   }
   return result;
+}
+
+function normalizeParamSources(stageConfig, stageKey) {
+  if (stageKey !== 'pending_ocr') return stageConfig;
+
+  const defaultPendingOcr = getStageDefault('pending_ocr');
+  if (!stageConfig?.mcp) return stageConfig;
+
+  const mcp = stageConfig.mcp;
+
+  const defaultMapping = defaultPendingOcr.mcp.params_mapping;
+  if (!mcp.params_mapping) {
+    mcp.params_mapping = { ...defaultMapping };
+  } else {
+    for (const [key, target] of Object.entries(defaultMapping)) {
+      if (!(key in mcp.params_mapping)) {
+        mcp.params_mapping[key] = target;
+      }
+    }
+  }
+
+  if (mcp.param_sources && typeof mcp.param_sources === 'object') {
+    const mergedSources = { ...defaultPendingOcr.mcp.param_sources };
+    for (const [key, source] of Object.entries(mcp.param_sources)) {
+      if (source && typeof source === 'object') {
+        mergedSources[key] = source;
+      }
+    }
+    mcp.param_sources = mergedSources;
+    return stageConfig;
+  }
+
+  if (mcp.params && typeof mcp.params === 'object') {
+    const paramSources = {
+      file_base64: { group: 'attachment', field: 'file_base64' },
+      file_name: { group: 'attachment', field: 'file_name' },
+      formula_enable: { group: 'setting', value: mcp.params.formula_enable ?? true },
+      table_enable: { group: 'setting', value: mcp.params.table_enable ?? true },
+      image_analysis: { group: 'setting', value: mcp.params.image_analysis ?? true },
+      lang: { group: 'setting', value: mcp.params.lang ?? null, enabled: mcp.params.lang !== undefined && mcp.params.lang !== null },
+    };
+    mcp.param_sources = paramSources;
+    delete mcp.params;
+  } else {
+    mcp.param_sources = { ...defaultPendingOcr.mcp.param_sources };
+  }
+
+  return stageConfig;
 }
 
 /**
@@ -251,6 +320,7 @@ export {
   getStageDefault,
   getAllDefaults,
   mergeWithDefaults,
+  normalizeParamSources,
   isOcrStage,
   createCallLlmFn,
 };

--- a/lib/document-ocr-service.js
+++ b/lib/document-ocr-service.js
@@ -64,16 +64,72 @@ class DocumentOcrService {
     return stageConfig?.timeout_ms || fallbackMs;
   }
 
-  _buildMcpParams(stageConfig, inputs) {
+  _normalizeParamSources(stageConfig) {
+    const mcp = stageConfig?.mcp;
+    if (!mcp) return null;
+
+    if (mcp.param_sources && typeof mcp.param_sources === 'object') {
+      return mcp.param_sources;
+    }
+
+    if (mcp.params && typeof mcp.params === 'object') {
+      const legacySources = {};
+      for (const [key, value] of Object.entries(mcp.params)) {
+        if (key === 'file_base64' || key === 'file_name') {
+          legacySources[key] = { group: 'attachment', field: key };
+        } else {
+          legacySources[key] = { group: 'setting', value };
+          if (key === 'lang') {
+            legacySources[key].enabled = value !== null && value !== undefined;
+          }
+        }
+      }
+      return legacySources;
+    }
+
+    return null;
+  }
+
+  _buildMcpParams(stageConfig, inputs, attachmentContext = {}) {
     if (!stageConfig?.mcp) return inputs;
+
     const mapping = stageConfig.mcp.params_mapping || {};
-    const staticParams = stageConfig.mcp.params || {};
-    const result = { ...staticParams };
-    for (const [inputKey, paramName] of Object.entries(mapping)) {
-      if (inputs[inputKey] !== undefined) {
-        result[paramName] = inputs[inputKey];
+    const paramSources = this._normalizeParamSources(stageConfig);
+
+    const resolvedParams = {};
+
+    if (paramSources) {
+      for (const [internalKey, source] of Object.entries(paramSources)) {
+        if (source.group === 'attachment') {
+          const field = source.field || internalKey;
+          if (attachmentContext[field] !== undefined) {
+            resolvedParams[internalKey] = attachmentContext[field];
+          }
+        } else if (source.group === 'setting') {
+          if (internalKey === 'lang') {
+            if (source.enabled === true && source.value !== null && source.value !== undefined && source.value !== '') {
+              resolvedParams[internalKey] = source.value;
+            }
+          } else {
+            resolvedParams[internalKey] = source.value;
+          }
+        }
       }
     }
+
+    for (const [inputKey, value] of Object.entries(inputs)) {
+      if (value !== undefined) {
+        resolvedParams[inputKey] = value;
+      }
+    }
+
+    const result = {};
+    for (const [internalKey, paramName] of Object.entries(mapping)) {
+      if (resolvedParams[internalKey] !== undefined) {
+        result[paramName] = resolvedParams[internalKey];
+      }
+    }
+
     return result;
   }
 
@@ -202,14 +258,18 @@ class DocumentOcrService {
     }
 
     const fileBase64 = await this.readAttachmentBase64(attachment);
-    const mcpParams = this._buildMcpParams(config, {
+    const attachmentContext = {
       file_base64: fileBase64,
       file_name: attachment.file_name || `document-${documentId}.bin`,
-      lang: options.lang || 'ch',
-      formula_enable: options.formulaEnable ?? true,
-      table_enable: options.tableEnable ?? true,
-      image_analysis: options.imageAnalysis ?? true,
-    });
+    };
+
+    const runtimeOverrides = {};
+    if (options.lang !== undefined) runtimeOverrides.lang = options.lang;
+    if (options.formulaEnable !== undefined) runtimeOverrides.formula_enable = options.formulaEnable;
+    if (options.tableEnable !== undefined) runtimeOverrides.table_enable = options.tableEnable;
+    if (options.imageAnalysis !== undefined) runtimeOverrides.image_analysis = options.imageAnalysis;
+
+    const mcpParams = this._buildMcpParams(config, runtimeOverrides, attachmentContext);
 
     const submitToolResult = await this.callMcp(
       serverName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,11 +42,13 @@
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
+        "chai": "^6.2.2",
         "concurrently": "^8.2.2",
+        "mocha": "^11.7.6",
         "sequelize-auto": "^0.8.8"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -593,6 +595,109 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@koa/cors": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
@@ -921,6 +1026,17 @@
       "license": "MIT",
       "dependencies": {
         "pako": "^1.0.10"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/debug": {
@@ -1361,6 +1477,13 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1481,6 +1604,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -1530,6 +1676,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "regexp-to-ast": "0.4.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cliui": {
@@ -1822,6 +1984,19 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -1869,6 +2044,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dingbat-to-unicode": {
@@ -1981,6 +2166,13 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2082,6 +2274,19 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -2329,6 +2534,50 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2533,6 +2782,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hono": {
@@ -2744,6 +3003,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2755,6 +3034,19 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -2768,6 +3060,22 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -2776,6 +3084,36 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3117,6 +3455,22 @@
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
       "license": "ISC"
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -3232,6 +3586,23 @@
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -3248,6 +3619,13 @@
         "option": "~0.2.1",
         "underscore": "^1.13.1"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lru.min": {
       "version": "1.1.4",
@@ -3366,6 +3744,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -3377,6 +3765,91 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.7.6",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/moment": {
@@ -3573,6 +4046,45 @@
       "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -3586,6 +4098,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -3604,6 +4126,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3690,6 +4229,13 @@
       "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -3769,6 +4315,16 @@
         "inherits": "~2.0.3"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3835,6 +4391,20 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/regexp-to-ast": {
@@ -4226,6 +4796,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -4407,6 +4987,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/spawn-command": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
@@ -4492,6 +5085,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4503,6 +5112,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -4752,7 +5388,33 @@
         "@types/node": "*"
       }
     },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -4868,6 +5530,35 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -59,10 +59,12 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
+    "chai": "^6.2.2",
     "concurrently": "^8.2.2",
+    "mocha": "^11.7.6",
     "sequelize-auto": "^0.8.8"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   }
 }

--- a/server/tests/doc-pipeline-param-sources.test.js
+++ b/server/tests/doc-pipeline-param-sources.test.js
@@ -1,0 +1,374 @@
+/**
+ * OCR 参数来源拆分测试
+ * 验证 pending_ocr 阶段的 param_sources 配置正确工作
+ */
+
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import {
+  DOC_PIPELINE_DEFAULTS,
+  getStageDefault,
+  mergeWithDefaults,
+  normalizeParamSources,
+} from '../../lib/doc-pipeline-defaults.js'
+
+describe('OCR Parameter Sources', () => {
+  describe('Default Configuration', () => {
+    it('should have param_sources in pending_ocr default', () => {
+      const defaultConfig = getStageDefault('pending_ocr')
+      expect(defaultConfig.mcp).to.have.property('param_sources')
+      expect(defaultConfig.mcp.param_sources).to.be.an('object')
+    })
+
+    it('should have attachment group for file_base64 and file_name', () => {
+      const defaultConfig = getStageDefault('pending_ocr')
+      expect(defaultConfig.mcp.param_sources.file_base64.group).to.equal('attachment')
+      expect(defaultConfig.mcp.param_sources.file_name.group).to.equal('attachment')
+    })
+
+    it('should have setting group for boolean params with true default', () => {
+      const defaultConfig = getStageDefault('pending_ocr')
+      expect(defaultConfig.mcp.param_sources.formula_enable.group).to.equal('setting')
+      expect(defaultConfig.mcp.param_sources.formula_enable.value).to.equal(true)
+      expect(defaultConfig.mcp.param_sources.table_enable.group).to.equal('setting')
+      expect(defaultConfig.mcp.param_sources.table_enable.value).to.equal(true)
+      expect(defaultConfig.mcp.param_sources.image_analysis.group).to.equal('setting')
+      expect(defaultConfig.mcp.param_sources.image_analysis.value).to.equal(true)
+    })
+
+    it('should have lang disabled by default', () => {
+      const defaultConfig = getStageDefault('pending_ocr')
+      expect(defaultConfig.mcp.param_sources.lang.group).to.equal('setting')
+      expect(defaultConfig.mcp.param_sources.lang.enabled).to.equal(false)
+      expect(defaultConfig.mcp.param_sources.lang.value).to.equal(null)
+    })
+
+    it('should not have params with hardcoded lang', () => {
+      const defaultConfig = getStageDefault('pending_ocr')
+      expect(defaultConfig.mcp.params).to.be.undefined
+    })
+  })
+
+  describe('normalizeParamSources', () => {
+    it('should normalize old config with params to param_sources', () => {
+      const oldConfig = {
+        enabled: true,
+        type: 'mcp',
+        mcp: {
+          server: 'mineru',
+          tool: 'create_task_from_file',
+          params_mapping: {
+            file_base64: 'file_base64',
+            file_name: 'file_name',
+            lang: 'lang',
+            formula_enable: 'formula_enable',
+            table_enable: 'table_enable',
+            image_analysis: 'image_analysis',
+          },
+          params: {
+            lang: 'ch',
+            formula_enable: true,
+            table_enable: true,
+            image_analysis: true,
+          },
+        },
+      }
+
+      const normalized = normalizeParamSources(oldConfig, 'pending_ocr')
+      expect(normalized.mcp).to.have.property('param_sources')
+      expect(normalized.mcp).to.not.have.property('params')
+      expect(normalized.mcp.param_sources.lang.enabled).to.equal(true)
+      expect(normalized.mcp.param_sources.lang.value).to.equal('ch')
+    })
+
+    it('should handle old config without params', () => {
+      const oldConfig = {
+        enabled: true,
+        type: 'mcp',
+        mcp: {
+          server: 'mineru',
+          tool: 'create_task_from_file',
+          params_mapping: {
+            file_base64: 'file_base64',
+            file_name: 'file_name',
+          },
+        },
+      }
+
+      const normalized = normalizeParamSources(oldConfig, 'pending_ocr')
+      expect(normalized.mcp).to.have.property('param_sources')
+      expect(normalized.mcp.param_sources.formula_enable.value).to.equal(true)
+      expect(normalized.mcp.param_sources.lang.enabled).to.equal(false)
+    })
+
+    it('should not modify other stages', () => {
+      const otherConfig = {
+        enabled: true,
+        type: 'mcp',
+        mcp: {
+          server: 'mineru',
+          tool: 'get_task_status',
+        },
+      }
+
+      const normalized = normalizeParamSources(otherConfig, 'ocr_processing')
+      expect(normalized).to.deep.equal(otherConfig)
+    })
+  })
+
+  describe('mergeWithDefaults', () => {
+    it('should merge old stored config and normalize param_sources', () => {
+      const stored = {
+        pending_ocr: {
+          enabled: true,
+          type: 'mcp',
+          mcp: {
+            server: 'mineru',
+            tool: 'create_task_from_file',
+            params_mapping: {
+              file_base64: 'file_base64',
+              file_name: 'file_name',
+              lang: 'lang',
+            },
+            params: {
+              lang: 'en',
+              formula_enable: false,
+            },
+          },
+        },
+      }
+
+      const merged = mergeWithDefaults(stored)
+      expect(merged.pending_ocr.mcp).to.have.property('param_sources')
+      expect(merged.pending_ocr.mcp.param_sources.lang.value).to.equal('en')
+      expect(merged.pending_ocr.mcp.param_sources.lang.enabled).to.equal(true)
+      expect(merged.pending_ocr.mcp.param_sources.formula_enable.value).to.equal(false)
+    })
+
+    it('should fill missing stages with defaults', () => {
+      const stored = {}
+      const merged = mergeWithDefaults(stored)
+      expect(merged.pending_ocr.mcp).to.have.property('param_sources')
+      expect(merged.pending_ocr.mcp.param_sources.lang.enabled).to.equal(false)
+    })
+  })
+
+  describe('MCP Payload Building', () => {
+    it('should not include lang when disabled', async () => {
+      const { default: DocumentOcrService } = await import('../../lib/document-ocr-service.js')
+      const service = new DocumentOcrService(null, {
+        callMcp: async () => ({ content: '{}' }),
+        callLlm: null,
+        getDocPipelineConfig: async () => getStageDefault('pending_ocr'),
+      })
+
+      const config = getStageDefault('pending_ocr')
+      const attachmentContext = {
+        file_base64: 'test-base64',
+        file_name: 'test.pdf',
+      }
+
+      const params = service._buildMcpParams(config, {}, attachmentContext)
+      expect(params).to.have.property('file_base64')
+      expect(params).to.have.property('file_name')
+      expect(params).to.have.property('formula_enable')
+      expect(params.formula_enable).to.equal(true)
+      expect(params).to.not.have.property('lang')
+    })
+
+    it('should include lang when enabled', async () => {
+      const { default: DocumentOcrService } = await import('../../lib/document-ocr-service.js')
+      const service = new DocumentOcrService(null, {
+        callMcp: async () => ({ content: '{}' }),
+        callLlm: null,
+        getDocPipelineConfig: async () => getStageDefault('pending_ocr'),
+      })
+
+      const config = getStageDefault('pending_ocr')
+      config.mcp.param_sources.lang.enabled = true
+      config.mcp.param_sources.lang.value = 'en'
+
+      const attachmentContext = {
+        file_base64: 'test-base64',
+        file_name: 'test.pdf',
+      }
+
+      const params = service._buildMcpParams(config, {}, attachmentContext)
+      expect(params).to.have.property('lang')
+      expect(params.lang).to.equal('en')
+    })
+
+    it('should respect false values for boolean params', async () => {
+      const { default: DocumentOcrService } = await import('../../lib/document-ocr-service.js')
+      const service = new DocumentOcrService(null, {
+        callMcp: async () => ({ content: '{}' }),
+        callLlm: null,
+        getDocPipelineConfig: async () => getStageDefault('pending_ocr'),
+      })
+
+      const config = getStageDefault('pending_ocr')
+      config.mcp.param_sources.formula_enable.value = false
+      config.mcp.param_sources.table_enable.value = false
+      config.mcp.param_sources.image_analysis.value = false
+
+      const attachmentContext = {
+        file_base64: 'test-base64',
+        file_name: 'test.pdf',
+      }
+
+      const params = service._buildMcpParams(config, {}, attachmentContext)
+      expect(params.formula_enable).to.equal(false)
+      expect(params.table_enable).to.equal(false)
+      expect(params.image_analysis).to.equal(false)
+    })
+
+    it('should allow runtime overrides', async () => {
+      const { default: DocumentOcrService } = await import('../../lib/document-ocr-service.js')
+      const service = new DocumentOcrService(null, {
+        callMcp: async () => ({ content: '{}' }),
+        callLlm: null,
+        getDocPipelineConfig: async () => getStageDefault('pending_ocr'),
+      })
+
+      const config = getStageDefault('pending_ocr')
+      const attachmentContext = {
+        file_base64: 'test-base64',
+        file_name: 'test.pdf',
+      }
+
+      const runtimeOverrides = {
+        formula_enable: false,
+        lang: 'jp',
+      }
+
+      const params = service._buildMcpParams(config, runtimeOverrides, attachmentContext)
+      expect(params.formula_enable).to.equal(false)
+      expect(params.lang).to.equal('jp')
+    })
+
+    it('should use custom MCP param mapping', async () => {
+      const { default: DocumentOcrService } = await import('../../lib/document-ocr-service.js')
+      const service = new DocumentOcrService(null, {
+        callMcp: async () => ({ content: '{}' }),
+        callLlm: null,
+        getDocPipelineConfig: async () => getStageDefault('pending_ocr'),
+      })
+
+      const config = getStageDefault('pending_ocr')
+      config.mcp.params_mapping.file_base64 = 'file_content'
+      config.mcp.params_mapping.formula_enable = 'enable_formula'
+
+      const attachmentContext = {
+        file_base64: 'test-base64',
+        file_name: 'test.pdf',
+      }
+
+      const params = service._buildMcpParams(config, {}, attachmentContext)
+      expect(params).to.have.property('file_content')
+      expect(params).to.not.have.property('file_base64')
+      expect(params).to.have.property('enable_formula')
+      expect(params).to.not.have.property('formula_enable')
+    })
+  })
+
+  describe('Old Config Compatibility - Payload Behavior', () => {
+    it('should include boolean params in payload after migrating incomplete params_mapping', async () => {
+      const { default: DocumentOcrService } = await import('../../lib/document-ocr-service.js')
+
+      const oldConfig = {
+        enabled: true,
+        type: 'mcp',
+        mcp: {
+          server: 'mineru',
+          tool: 'create_task_from_file',
+          params_mapping: {
+            file_base64: 'file_base64',
+            file_name: 'file_name',
+            lang: 'lang',
+          },
+          params: {
+            formula_enable: false,
+          },
+        },
+      }
+
+      const normalized = normalizeParamSources(oldConfig, 'pending_ocr')
+
+      const service = new DocumentOcrService(null, {
+        callMcp: async () => ({ content: '{}' }),
+        callLlm: null,
+        getDocPipelineConfig: async () => normalized,
+      })
+
+      const attachmentContext = {
+        file_base64: 'test-base64',
+        file_name: 'test.pdf',
+      }
+
+      const params = service._buildMcpParams(normalized, {}, attachmentContext)
+
+      expect(params).to.have.property('file_base64')
+      expect(params).to.have.property('file_name')
+      expect(params).to.have.property('formula_enable')
+      expect(params.formula_enable).to.equal(false)
+      expect(params).to.have.property('table_enable')
+      expect(params.table_enable).to.equal(true)
+      expect(params).to.have.property('image_analysis')
+      expect(params.image_analysis).to.equal(true)
+      expect(params).to.not.have.property('lang')
+    })
+
+    it('should merge missing params_mapping keys with defaults', () => {
+      const oldConfig = {
+        enabled: true,
+        type: 'mcp',
+        mcp: {
+          server: 'mineru',
+          tool: 'create_task_from_file',
+          params_mapping: {
+            file_base64: 'file_base64',
+            file_name: 'file_name',
+          },
+          params: {
+            formula_enable: true,
+            table_enable: false,
+          },
+        },
+      }
+
+      const normalized = normalizeParamSources(oldConfig, 'pending_ocr')
+
+      expect(normalized.mcp.params_mapping).to.have.property('formula_enable')
+      expect(normalized.mcp.params_mapping).to.have.property('table_enable')
+      expect(normalized.mcp.params_mapping).to.have.property('image_analysis')
+      expect(normalized.mcp.params_mapping).to.have.property('lang')
+    })
+
+    it('should preserve existing custom params_mapping during migration', () => {
+      const oldConfig = {
+        enabled: true,
+        type: 'mcp',
+        mcp: {
+          server: 'mineru',
+          tool: 'create_task_from_file',
+          params_mapping: {
+            file_base64: 'file_content',
+            file_name: 'filename',
+            formula_enable: 'enable_formula',
+          },
+          params: {
+            formula_enable: true,
+          },
+        },
+      }
+
+      const normalized = normalizeParamSources(oldConfig, 'pending_ocr')
+
+      expect(normalized.mcp.params_mapping.file_base64).to.equal('file_content')
+      expect(normalized.mcp.params_mapping.file_name).to.equal('filename')
+      expect(normalized.mcp.params_mapping.formula_enable).to.equal('enable_formula')
+      expect(normalized.mcp.params_mapping.table_enable).to.equal('table_enable')
+      expect(normalized.mcp.params_mapping.image_analysis).to.equal('image_analysis')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- 将 `pending_ocr` 参数模型拆分为"附件来源"和"设定值来源"两组
- `lang` 从默认强制传参改为默认关闭
- 前端配置界面拆分为"附件提取参数"和"设定值参数"两块
- 存量配置兼容：自动补齐 `param_sources` 和缺失的 `params_mapping`
- 补充 18 个自动化测试覆盖默认配置、lang 开关、布尔值、旧配置迁移

## Changes

| File | Change |
|------|--------|
| `lib/doc-pipeline-defaults.js` | 新增 `param_sources` 结构，去掉 `lang: 'ch'` 硬编码，新增 `normalizeParamSources` 函数补齐缺失 `params_mapping` |
| `lib/document-ocr-service.js` | `_buildMcpParams` 改为配置驱动，移除硬编码默认值 |
| `frontend/src/api/doc-pipeline.ts` | 新增 `ParamSource` 类型定义 |
| `frontend/src/components/docs/DocPipelineConfigDialog.vue` | 参数区域拆分，布尔参数用开关，`lang` 用启用开关+输入框 |
| `frontend/src/stores/collection.ts` | 清理硬编码传参，补齐类型定义 |
| `server/tests/doc-pipeline-param-sources.test.js` | 新增 18 个测试 |

## Test Results

```
18 passing (44ms)
```

## Audit

- Round 01: 7.6/10 (发现高严重和中严重问题)
- Round 02: 8.9/10 (所有问题已修复，通过验收)

Closes #841