### PR TITLE
feat: Attachment 访问级别与统一接入改造

### DIFF
--- a/frontend/src/api/attachment.ts
+++ b/frontend/src/api/attachment.ts
@@ -1,8 +1,7 @@
 import apiClient from './client'
 
-/**
- * 附件信息
- */
+export type AccessLevel = 'public' | 'private'
+
 export interface Attachment {
   id: string
   filename: string
@@ -12,13 +11,13 @@ export interface Attachment {
   source_id: string
   uploader_id: string
   uploader_name?: string
+  access_level: AccessLevel
+  preview_url: string | null
+  download_url: string | null
+  expires_at?: string | null
   created_at: string
-  token_expires_at?: string
 }
 
-/**
- * 附件列表响应
- */
 export interface AttachmentListResponse {
   items: Attachment[]
   total: number
@@ -27,9 +26,6 @@ export interface AttachmentListResponse {
   pages: number
 }
 
-/**
- * 附件列表查询参数
- */
 export interface AttachmentListParams {
   page?: number
   size?: number
@@ -41,33 +37,25 @@ export interface AttachmentListParams {
   end_date?: string
 }
 
-/**
- * 获取附件列表（管理员）
- */
 export const getAttachments = async (params: AttachmentListParams = {}): Promise<AttachmentListResponse> => {
   const response = await apiClient.get('/attachments/admin', { params })
   return response.data.data
 }
 
-/**
- * 获取附件元数据
- */
 export const getAttachmentMeta = async (id: string): Promise<Attachment> => {
-  const response = await apiClient.get(`/attachments/${id}/meta`)
+  const response = await apiClient.get(`/attachments/${id}`)
   return response.data.data
 }
 
-/**
- * 删除附件（管理员）
- */
+export const getAttachmentContentUrl = (id: string): string => {
+  return `/api/attachments/${id}/content`
+}
+
 export const deleteAttachment = async (id: string): Promise<void> => {
   await apiClient.delete(`/attachments/${id}`)
 }
 
-/**
- * 生成附件访问 Token
- */
-export const generateAttachmentToken = async (sourceTag: string, sourceId: string): Promise<{ token: string; expires_at: string }> => {
+export const generateAttachmentToken = async (sourceTag: string, sourceId: string): Promise<{ token: string; url: string; expires_at: string }> => {
   const response = await apiClient.post('/attachments/token', {
     source_tag: sourceTag,
     source_id: sourceId,
@@ -75,28 +63,22 @@ export const generateAttachmentToken = async (sourceTag: string, sourceId: strin
   return response.data.data
 }
 
-/**
- * 获取附件访问 URL
- */
 export const getAttachmentUrl = (id: string, token: string): string => {
   return `/attach/t/${token}/${id}`
 }
 
-/**
- * 上传附件参数
- */
-export interface UploadAttachmentParams {
-  source_tag: string
-  source_id: string
-  file_name: string
-  mime_type: string
-  base64_data: string
-  alt_text?: string
+export const getPublicAttachmentUrl = (id: string): string => {
+  return `/attach/public/${id}`
 }
 
-/**
- * 上传附件响应
- */
+export interface UploadAttachmentFormDataParams {
+  source_tag: string
+  source_id: string
+  file: File
+  alt_text?: string
+  access_level?: AccessLevel
+}
+
 export interface UploadAttachmentResponse {
   id: string
   source_tag: string
@@ -106,28 +88,12 @@ export interface UploadAttachmentResponse {
   file_size: number
   width: number | null
   height: number | null
-  file_path: string
-  data_url: string
+  access_level: AccessLevel
+  preview_url: string | null
+  download_url: string | null
+  expires_at?: string | null
   ref: string
   created_at: string
-}
-
-/**
- * 上传附件
- */
-export const uploadAttachment = async (params: UploadAttachmentParams): Promise<UploadAttachmentResponse> => {
-  const response = await apiClient.post('/attachments', params)
-  return response.data.data
-}
-
-/**
- * 上传附件 (FormData)
- */
-export interface UploadAttachmentFormDataParams {
-  source_tag: string
-  source_id: string
-  file: File
-  alt_text?: string
 }
 
 export const uploadAttachmentFormData = async (params: UploadAttachmentFormDataParams): Promise<UploadAttachmentResponse> => {
@@ -138,10 +104,27 @@ export const uploadAttachmentFormData = async (params: UploadAttachmentFormDataP
   if (params.alt_text) {
     formData.append('alt_text', params.alt_text)
   }
+  if (params.access_level) {
+    formData.append('access_level', params.access_level)
+  }
   const response = await apiClient.post('/attachments/upload', formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
     },
   })
   return response.data.data
+}
+
+export const getAttachmentContent = async (id: string): Promise<Blob> => {
+  const response = await apiClient.get(`/attachments/${id}/content`, {
+    responseType: 'blob',
+  })
+  return response.data
+}
+
+export const resolveAttachmentDisplayUrl = (attachment: Attachment): string | null => {
+  if (attachment.access_level === 'public') {
+    return `/attach/public/${attachment.id}`
+  }
+  return attachment.preview_url || attachment.download_url || null
 }

--- a/frontend/src/api/docs.ts
+++ b/frontend/src/api/docs.ts
@@ -124,8 +124,11 @@ export interface DocAttachmentInfo {
   file_name: string | null
   mime_type: string
   file_size: number
+  access_level: string
   created_at: string
-  download_url: string
+  download_url: string | null
+  preview_url: string | null
+  requires_auth?: boolean
 }
 
 export interface DocResultImageAttachment {

--- a/frontend/src/components/apps/FileUploader.vue
+++ b/frontend/src/components/apps/FileUploader.vue
@@ -21,7 +21,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { MiniApp } from '@/api/mini-apps'
-import { uploadAttachment } from '@/api/attachment'
+import { uploadAttachmentFormData } from '@/api/attachment'
 
 const props = defineProps<{
   app: MiniApp
@@ -29,7 +29,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   uploaded: [attachmentIds: string[]]
-}>()
+}>>()
 
 const dragging = ref(false)
 const uploadingFiles = ref<{ name: string; status: string; error?: string }[]>([])
@@ -58,13 +58,10 @@ async function processFiles(files: File[]) {
   for (let i = 0; i < files.length; i++) {
     try {
       const file = files[i]!
-      const base64Data = await fileToBase64(file)
-      const att = await uploadAttachment({
+      const att = await uploadAttachmentFormData({
         source_tag: 'mini_app_file',
         source_id: props.app.id,
-        file_name: file.name,
-        mime_type: file.type,
-        base64_data: base64Data,
+        file,
       })
       attachmentIds.push(att.id)
       items[i]!.status = 'done'
@@ -77,19 +74,6 @@ async function processFiles(files: File[]) {
   if (attachmentIds.length > 0) {
     emit('uploaded', attachmentIds)
   }
-}
-
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      const base64 = result.split(',')[1]!
-      resolve(base64)
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
 }
 </script>
 

--- a/frontend/src/components/contract-v2/ContractDetail.vue
+++ b/frontend/src/components/contract-v2/ContractDetail.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { ElMessageBox } from 'element-plus'
 import { useContractV2Store } from '@/stores/contract-v2'
 import type { ContractVersion } from '@/api/contract-v2'
-import { uploadAttachment } from '@/api/attachment'
+import { uploadAttachmentFormData } from '@/api/attachment'
 import { createRecord, newID, getDocumentContent, type DocumentContent } from '@/api/mini-apps'
 import { getRevisions, getDocumentPermissions, type DocRevision, type DocPermissions } from '@/api/docs'
 import DocumentContentViewer from '@/components/apps/DocumentContentViewer.vue'
@@ -203,13 +203,10 @@ async function handleFileUpload(event: Event) {
 
   uploading.value = true
   try {
-    const base64Data = await fileToBase64(file)
-    const att = await uploadAttachment({
+    const att = await uploadAttachmentFormData({
       source_tag: 'mini_app_file',
       source_id: APP_ID,
-      file_name: file.name,
-      mime_type: file.type,
-      base64_data: base64Data,
+      file,
     })
 
     const clientId = await newID(20)
@@ -232,18 +229,6 @@ async function handleFileUpload(event: Event) {
   }
 }
 
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      const base64 = result.split(',')[1]!
-      resolve(base64)
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
-}
 </script>
 
 <template>

--- a/frontend/src/components/contract-v2/ContractList.vue
+++ b/frontend/src/components/contract-v2/ContractList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useContractV2Store } from '@/stores/contract-v2'
-import { uploadAttachment } from '@/api/attachment'
+import { uploadAttachmentFormData } from '@/api/attachment'
 import { createRecord, newID } from '@/api/mini-apps'
 import type { OrgNode } from '@/api/contract-v2'
 import Pagination from '@/components/Pagination.vue'
@@ -129,19 +129,6 @@ function clearFile() {
   selectedFile.value = null
 }
 
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      const base64 = result.split(',')[1]!
-      resolve(base64)
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
-}
-
 async function handleCreate() {
   if (!createForm.value.contract_name.trim()) return
   creating.value = true
@@ -154,13 +141,10 @@ async function handleCreate() {
 
     if (newContract?.id && selectedFile.value) {
       const file = selectedFile.value
-      const base64Data = await fileToBase64(file)
-      const att = await uploadAttachment({
+      const att = await uploadAttachmentFormData({
         source_tag: 'mini_app_file',
         source_id: APP_ID,
-        file_name: file.name,
-        mime_type: file.type,
-        base64_data: base64Data,
+        file,
       })
 
       const clientId = await newID(20)

--- a/frontend/src/components/invoice/InvoiceList.vue
+++ b/frontend/src/components/invoice/InvoiceList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { listInvoices, exportInvoices, type InvoiceRow, type InvoiceListParams } from '@/api/invoice'
-import { uploadAttachment } from '@/api/attachment'
+import { uploadAttachmentFormData } from '@/api/attachment'
 import { createRecord, newID } from '@/api/mini-apps'
 import { ElMessage } from 'element-plus'
 import { ArrowDown } from '@element-plus/icons-vue'
@@ -159,19 +159,6 @@ function clearFile() {
   selectedFile.value = null
 }
 
-function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => {
-      const result = reader.result as string
-      const base64 = result.split(',')[1]!
-      resolve(base64)
-    }
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
-}
-
 async function handleCreate() {
   if (!selectedFile.value) {
     ElMessage.warning('请先选择发票文件')
@@ -180,13 +167,10 @@ async function handleCreate() {
   creating.value = true
   try {
     const file = selectedFile.value
-    const base64Data = await fileToBase64(file)
-    const att = await uploadAttachment({
+    const att = await uploadAttachmentFormData({
       source_tag: 'mini_app_file',
       source_id: APP_ID,
-      file_name: file.name,
-      mime_type: file.type,
-      base64_data: base64Data,
+      file,
     })
 
     const clientId = await newID(20)

--- a/frontend/src/components/settings/AttachmentTab.vue
+++ b/frontend/src/components/settings/AttachmentTab.vue
@@ -293,7 +293,8 @@ import {
   deleteAttachment,
   generateAttachmentToken,
   getAttachmentUrl,
-  uploadAttachment,
+  uploadAttachmentFormData,
+  getPublicAttachmentUrl,
   type Attachment,
   type AttachmentListParams,
 } from '@/api/attachment'
@@ -371,12 +372,12 @@ const loadAttachments = async () => {
 
 // 批量加载附件 Tokens
 const loadAttachmentTokensBatch = async (items: Attachment[]) => {
-  // 只获取图片类型的附件 token
-  const imageAttachments = items.filter(item => isImage(item.mime_type))
+  const privateImageAttachments = items.filter(
+    item => isImage(item.mime_type) && item.access_level !== 'public'
+  )
   
-  // 按 source_tag + source_id 分组，避免重复请求相同资源的 token
   const groupedBySource = new Map<string, Attachment[]>()
-  imageAttachments.forEach(attachment => {
+  privateImageAttachments.forEach(attachment => {
     const key = `${attachment.source_tag}:${attachment.source_id}`
     if (!groupedBySource.has(key)) {
       groupedBySource.set(key, [])
@@ -384,14 +385,12 @@ const loadAttachmentTokensBatch = async (items: Attachment[]) => {
     groupedBySource.get(key)!.push(attachment)
   })
   
-  // 并发获取每个资源组的 token
   const promises = Array.from(groupedBySource.entries()).map(async ([key, attachmentsGroup]) => {
     const firstAttachment = attachmentsGroup[0]
     if (!firstAttachment) return
     
     try {
       const result = await generateAttachmentToken(firstAttachment.source_tag, firstAttachment.source_id)
-      // 为同一资源组的所有附件设置相同的 token
       attachmentsGroup.forEach(attachment => {
         attachmentTokens.value[attachment.id] = result.token
       })
@@ -495,11 +494,16 @@ const formatDate = (dateStr: string): string => {
 // 获取预览 URL
 const getPreviewUrl = (attachment?: Attachment | null): string => {
   if (!attachment) return ''
+  
+  if (attachment.access_level === 'public') {
+    return getPublicAttachmentUrl(attachment.id)
+  }
+  
   const token = attachmentTokens.value[attachment.id]
   if (token) {
     return getAttachmentUrl(attachment.id, token)
   }
-  return ''  // 没有 token 时返回空，显示占位符
+  return ''
 }
 
 // 单个附件 Token 加载（用于预览弹窗）
@@ -605,39 +609,18 @@ const confirmUpload = async () => {
 
   uploading.value = true
   try {
-    // 读取文件并转换为 Base64
-    const reader = new FileReader()
-    reader.onload = async (e) => {
-      const base64Data = e.target?.result as string
-      // 移除 data URL 前缀
-      const base64Content = base64Data.split(',')[1] || ''
-
-      try {
-        await uploadAttachment({
-          source_tag: 'admin_upload',
-          source_id: 'admin_upload', // 管理员上传使用固定 source_id
-          file_name: selectedFile.value!.name,
-          mime_type: selectedFile.value!.type || 'application/octet-stream',
-          base64_data: base64Content,
-        })
-        toast.success(t('attachment.uploadSuccess'))
-        closeUploadModal()
-        loadAttachments()
-      } catch (uploadErr) {
-        console.error('Failed to upload attachment:', uploadErr)
-        toast.error(t('attachment.uploadError'))
-      } finally {
-        uploading.value = false
-      }
-    }
-    reader.onerror = () => {
-      toast.error(t('attachment.readFileError'))
-      uploading.value = false
-    }
-    reader.readAsDataURL(selectedFile.value)
-  } catch (err) {
-    console.error('Failed to read file:', err)
-    toast.error(t('attachment.readFileError'))
+    await uploadAttachmentFormData({
+      source_tag: 'admin_upload',
+      source_id: 'admin_upload',
+      file: selectedFile.value,
+    })
+    toast.success(t('attachment.uploadSuccess'))
+    closeUploadModal()
+    loadAttachments()
+  } catch (uploadErr) {
+    console.error('Failed to upload attachment:', uploadErr)
+    toast.error(t('attachment.uploadError'))
+  } finally {
     uploading.value = false
   }
 }

--- a/frontend/src/views/DocDetailView.vue
+++ b/frontend/src/views/DocDetailView.vue
@@ -110,13 +110,13 @@
           <div class="sidebar-section">
             <h4 class="sidebar-title">下载</h4>
             <div class="sidebar-actions">
-              <el-button v-if="docStore.currentResult.source_attachment" size="small" @click="downloadAttachment(docStore.currentResult.source_attachment.download_url)">
+              <el-button v-if="docStore.currentResult.source_attachment?.download_url" size="small" @click="downloadAttachment(docStore.currentResult.source_attachment?.download_url)">
                 原始文件
               </el-button>
-              <el-button v-if="docStore.currentResult.ocr_result?.main_markdown_attachment" size="small" type="primary" @click="downloadAttachment(docStore.currentResult.ocr_result.main_markdown_attachment.download_url)">
+              <el-button v-if="docStore.currentResult.ocr_result?.main_markdown_attachment?.download_url" size="small" type="primary" @click="downloadAttachment(docStore.currentResult.ocr_result?.main_markdown_attachment?.download_url)">
                 Markdown
               </el-button>
-              <el-button v-if="docStore.currentResult.ocr_result?.raw_result_attachment" size="small" @click="downloadAttachment(docStore.currentResult.ocr_result.raw_result_attachment.download_url)">
+              <el-button v-if="docStore.currentResult.ocr_result?.raw_result_attachment?.download_url" size="small" @click="downloadAttachment(docStore.currentResult.ocr_result?.raw_result_attachment?.download_url)">
                 原始结果
               </el-button>
             </div>
@@ -129,7 +129,7 @@
               <div v-for="item in docStore.currentResult.image_attachments" :key="item.id" class="attachment-item">
                 <div class="attachment-name">{{ item.attachment?.file_name || item.filename || '未命名图片' }}</div>
                 <div class="attachment-meta">{{ item.attachment?.mime_type || item.media_type || '-' }} · {{ formatFileSize(item.attachment?.file_size) }}</div>
-                <el-button size="small" text type="primary" @click="downloadAttachment(item.attachment?.download_url)">下载</el-button>
+                <el-button v-if="item.attachment?.download_url" size="small" text type="primary" @click="downloadAttachment(item.attachment?.download_url)">下载</el-button>
               </div>
             </div>
           </div>
@@ -238,22 +238,18 @@ async function onDeleteDocument() {
 }
 
 async function loadMarkdownPreview() {
-  const url = docStore.currentResult?.ocr_result?.main_markdown_attachment?.download_url
-  if (!url) {
+  const attachment = docStore.currentResult?.ocr_result?.main_markdown_attachment
+  if (!attachment?.id) {
     markdownPreview.value = ''
     return
   }
 
   markdownLoading.value = true
   try {
-    const response = await apiClient.get(url.replace(/^\/api/, ''))
-    const dataUrl = response.data?.data?.data_url as string | undefined
-    if (!dataUrl || !dataUrl.startsWith('data:')) {
-      markdownPreview.value = ''
-      return
-    }
-    const base64 = dataUrl.split(',')[1] || ''
-    markdownPreview.value = atob(base64)
+    const response = await apiClient.get(`/attachments/${attachment.id}/content`, {
+      responseType: 'text',
+    })
+    markdownPreview.value = response.data || ''
   } catch {
     markdownPreview.value = ''
   } finally {

--- a/lib/document-ocr-service.js
+++ b/lib/document-ocr-service.js
@@ -5,6 +5,7 @@ import Utils from './utils.js';
 import logger from './logger.js';
 import DocPipelineAdvancer from './doc-pipeline-advancer.js';
 import { getStageDefault } from './doc-pipeline-defaults.js';
+import AttachmentService from '../server/services/attachment.service.js';
 
 const DEFAULT_PROVIDER = 'mineru';
 const DEFAULT_SERVER_NAME = 'mineru';
@@ -36,6 +37,7 @@ class DocumentOcrService {
     this.provider = options.provider || DEFAULT_PROVIDER;
     this.serverName = options.serverName || DEFAULT_SERVER_NAME;
     this.advancer = new DocPipelineAdvancer(db);
+    this.attachmentService = new AttachmentService(db);
   }
 
   async _loadStageConfig(stageKey) {
@@ -469,25 +471,54 @@ class DocumentOcrService {
       const normalizedDataUrl = typeof item?.data_url === 'string' ? item.data_url : null;
       const imageDataUrl = normalizedDataUrl || imageDeliverables?.images?.[item.filename] || imageDeliverables?.images?.[item.relative_path || item.filename];
       if (!imageDataUrl) continue;
-      const attachment = await this.createAttachmentFromDataUrl(
-        ctx.revision.id,
-        ctx.revision.created_by || null,
-        item.filename || 'image.png',
-        imageDataUrl,
-        this.truncateText(item.alt_text || '', MAX_ATTACHMENT_ALT_TEXT_LENGTH),
-        this.truncateText(item.description || null, MAX_ATTACHMENT_DESCRIPTION_LENGTH)
-      );
-      imageUrlMap[item.relative_path || item.filename] = `/api/attachments/${attachment.id}`;
+      const attachment = await this.attachmentService.createFromDataUrl({
+        sourceTag: 'doc-platform',
+        sourceId: revisionId,
+        createdBy: ctx.revision.created_by || null,
+        fileName: item.filename || 'image.png',
+        dataUrl: imageDataUrl,
+        altText: this.truncateText(item.alt_text || '', MAX_ATTACHMENT_ALT_TEXT_LENGTH),
+        description: this.truncateText(item.description || null, MAX_ATTACHMENT_DESCRIPTION_LENGTH),
+      });
+      imageUrlMap[item.relative_path || item.filename] = `/api/attachments/${attachment.id}/content`;
       imageRecords.push({ item, attachment, sortOrder: i });
     }
 
     const rewrittenMarkdown = this.rewriteMarkdownImageLinks(mainMarkdown, imageUrlMap);
 
     await this.assertDocumentNotDeleted(ctx.document.id);
-    const rawResultAttachment = await this.createTextAttachment(ctx.revision.id, ctx.revision.created_by || null, 'ocr-raw-result.json', this.safeJsonForAttachment(defaultDeliverable), 'application/json');
-    const deliverablesManifestAttachment = await this.createTextAttachment(ctx.revision.id, ctx.revision.created_by || null, 'ocr-deliverables.json', this.safeJsonForAttachment(deliverables), 'application/json');
-    const imageManifestAttachment = await this.createTextAttachment(ctx.revision.id, ctx.revision.created_by || null, 'ocr-images.json', this.safeJsonForAttachment(this.summarizeImageDeliverables(imageDeliverables)), 'application/json');
-    const mainMarkdownAttachment = await this.createTextAttachment(ctx.revision.id, ctx.revision.created_by || null, 'ocr-main.md', rewrittenMarkdown, 'text/markdown');
+    const rawResultAttachment = await this.attachmentService.createTextAttachment({
+      sourceTag: 'doc-platform',
+      sourceId: ctx.revision.id,
+      createdBy: ctx.revision.created_by || null,
+      fileName: 'ocr-raw-result.json',
+      content: this.safeJsonForAttachment(defaultDeliverable),
+      mimeType: 'application/json',
+    });
+    const deliverablesManifestAttachment = await this.attachmentService.createTextAttachment({
+      sourceTag: 'doc-platform',
+      sourceId: ctx.revision.id,
+      createdBy: ctx.revision.created_by || null,
+      fileName: 'ocr-deliverables.json',
+      content: this.safeJsonForAttachment(deliverables),
+      mimeType: 'application/json',
+    });
+    const imageManifestAttachment = await this.attachmentService.createTextAttachment({
+      sourceTag: 'doc-platform',
+      sourceId: ctx.revision.id,
+      createdBy: ctx.revision.created_by || null,
+      fileName: 'ocr-images.json',
+      content: this.safeJsonForAttachment(this.summarizeImageDeliverables(imageDeliverables)),
+      mimeType: 'application/json',
+    });
+    const mainMarkdownAttachment = await this.attachmentService.createTextAttachment({
+      sourceTag: 'doc-platform',
+      sourceId: ctx.revision.id,
+      createdBy: ctx.revision.created_by || null,
+      fileName: 'ocr-main.md',
+      content: rewrittenMarkdown,
+      mimeType: 'text/markdown',
+    });
 
     await ocrResult.update({
       status: 'completed',
@@ -679,22 +710,32 @@ class DocumentOcrService {
   }
 
   async createTextAttachment(revisionId, createdBy, fileName, content, mimeType = 'text/plain') {
-    return await this.createAttachmentRecord({
-      revisionId,
+    return await this.attachmentService.createTextAttachment({
+      sourceTag: 'doc-platform',
+      sourceId: revisionId,
       createdBy,
       fileName,
+      content,
       mimeType,
-      buffer: Buffer.from(content || '', 'utf8'),
     });
   }
 
   async createAttachmentFromDataUrl(revisionId, createdBy, fileName, dataUrl, altText = '', description = null) {
-    const match = /^data:([^;]+);base64,(.+)$/i.exec(dataUrl || '');
-    if (!match) throw new Error(`Invalid data URL for ${fileName}`);
-    const mimeType = match[1];
-    const buffer = Buffer.from(match[2], 'base64');
-    return await this.createAttachmentRecord({
-      revisionId,
+    return await this.attachmentService.createFromDataUrl({
+      sourceTag: 'doc-platform',
+      sourceId: revisionId,
+      createdBy,
+      fileName,
+      dataUrl,
+      altText,
+      description,
+    });
+  }
+
+  async createAttachmentRecord({ revisionId, createdBy = null, fileName, mimeType, buffer, altText = null, description = null }) {
+    return await this.attachmentService.createFromBuffer({
+      sourceTag: 'doc-platform',
+      sourceId: revisionId,
       createdBy,
       fileName,
       mimeType,
@@ -702,32 +743,6 @@ class DocumentOcrService {
       altText,
       description,
     });
-  }
-
-  async createAttachmentRecord({ revisionId, createdBy = null, fileName, mimeType, buffer, altText = null, description = null }) {
-    const Attachment = this.db.getModel('attachment');
-    const id = Utils.newID(20);
-    const extName = path.extname(fileName || '').slice(1) || this.mimeToExt(mimeType);
-    const relativePath = this.buildAttachmentRelativePath(id, extName);
-    const fullPath = path.join(this.getAttachmentBasePath(), relativePath);
-    await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    await fs.writeFile(fullPath, buffer);
-
-    await Attachment.create({
-      id,
-      source_tag: 'doc-platform',
-      source_id: revisionId,
-      file_name: fileName || null,
-      ext_name: extName || null,
-      mime_type: mimeType,
-      file_size: buffer.length,
-      file_path: relativePath,
-      alt_text: altText || null,
-      description: description || null,
-      created_by: createdBy,
-    });
-
-    return await Attachment.findByPk(id, { raw: true });
   }
 
   async readAttachmentBase64(attachment) {

--- a/models/attachment.js
+++ b/models/attachment.js
@@ -66,6 +66,12 @@ export default class attachment extends Model {
       allowNull: true,
       comment: "文件描述（VL模型生成）"
     },
+    access_level: {
+      type: DataTypes.ENUM('public', 'private'),
+      allowNull: false,
+      defaultValue: 'private',
+      comment: "访问级别：public=公开访问，private=私有受控访问"
+    },
     created_by: {
       type: DataTypes.STRING(20),
       allowNull: true,
@@ -119,6 +125,13 @@ export default class attachment extends Model {
         using: "BTREE",
         fields: [
           { name: "created_by" },
+        ]
+      },
+      {
+        name: "idx_access_level",
+        using: "BTREE",
+        fields: [
+          { name: "access_level" },
         ]
       },
     ]

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -2035,6 +2035,65 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== attachments 表添加 access_level 字段 ====================
+  // Issue #001: Attachment 访问级别与统一接入改造
+  // NOTE: For production with large tables, consider using online schema migration tools
+  // like pt-online-schema-change or gh-ost to avoid blocking reads/writes.
+  {
+    name: 'attachments.access_level column add',
+    check: async (conn) => await hasColumn(conn, 'attachments', 'access_level'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE attachments
+        ADD COLUMN access_level ENUM('public', 'private') NOT NULL DEFAULT 'private'
+          COMMENT '访问级别：public=公开访问，private=私有受控访问'
+          AFTER description
+      `);
+      console.log('  ✓ Added access_level column to attachments table');
+
+      await safeExecute(conn, `
+        CREATE INDEX idx_access_level ON attachments(access_level)
+      `);
+      console.log('  ✓ Added idx_access_level index');
+    }
+  },
+
+  // ==================== attachments 表 access_level 老数据回填 ====================
+  // Issue #001: 根据 source_tag 回填历史数据的 access_level
+  // NOTE: Batches by source_tag to limit lock scope. For very large tables,
+  // consider further batching by id ranges: WHERE source_tag=? AND id BETWEEN ? AND ?
+  {
+    name: 'attachments.access_level backfill by source_tag',
+    check: async (conn) => {
+      const [rows] = await conn.execute(`
+        SELECT COUNT(*) AS cnt FROM attachments WHERE access_level = 'public'
+      `);
+      return rows[0].cnt > 0;
+    },
+    migrate: async (conn) => {
+      const publicTags = ['user_avatar', 'expert_avatar', 'site_logo', 'site_background'];
+      for (const tag of publicTags) {
+        await conn.execute(`
+          UPDATE attachments SET access_level = 'public' WHERE source_tag = ?
+        `, [tag]);
+        console.log(`  ✓ Backfilled public for ${tag}`);
+      }
+      
+      const privateTags = ['doc-platform', 'task_export', 'admin_upload', 'mini_app', 'mini_app_file'];
+      for (const tag of privateTags) {
+        await conn.execute(`
+          UPDATE attachments SET access_level = 'private' WHERE source_tag = ? AND access_level = 'public'
+        `, [tag]);
+        console.log(`  ✓ Ensured private for ${tag}`);
+      }
+      
+      const [result] = await conn.execute(`
+        SELECT COUNT(*) AS cnt FROM attachments WHERE access_level = 'public'
+      `);
+      console.log(`  ✓ Total ${result[0].cnt} attachments now marked as public`);
+    }
+  },
+
 ];
 
 /**

--- a/server/controllers/attachment.controller.js
+++ b/server/controllers/attachment.controller.js
@@ -13,9 +13,27 @@ import Utils from '../../lib/utils.js';
 import { Op } from 'sequelize';
 import path from 'path';
 import fs from 'fs/promises';
+import { createReadStream } from 'fs';
 import crypto from 'crypto';
 import SystemSettingService from '../services/system-setting.service.js';
+import AttachmentService from '../services/attachment.service.js';
 import multer from '@koa/multer';
+
+const CONTENT_TYPES = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.zip': 'application/zip',
+};
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 // Token 配置
 const TOKEN_CONFIG = {
@@ -82,12 +100,14 @@ class AttachmentController {
     this.Attachment = null;
     this.AttachmentToken = null;
     this.systemSettingService = new SystemSettingService(db);
+    this.attachmentService = new AttachmentService(db);
   }
 
   ensureModels() {
     if (!this.Attachment) {
       this.Attachment = this.db.getModel('attachment');
       this.AttachmentToken = this.db.getModel('attachment_token');
+      this.attachmentService.ensureModels();
     }
   }
 
@@ -332,7 +352,6 @@ class AttachmentController {
       const data = ctx.request.body;
       const userId = ctx.state.session.id;
 
-      // 参数验证
       if (!data.source_tag || !data.source_id) {
         ctx.throw(400, 'source_tag and source_id are required');
       }
@@ -340,66 +359,37 @@ class AttachmentController {
         ctx.throw(400, 'mime_type and base64_data are required');
       }
 
-      // 验证 MIME 类型白名单
       this.validateMimeTypeWhitelist(data.mime_type);
-
-      // 验证文件魔数
       await this.validateMimeType(data.base64_data, data.mime_type);
 
-      // 检查文件大小
       const maxFileSize = await this.getMaxFileSize();
       const fileSize = Buffer.from(data.base64_data, 'base64').length;
       if (fileSize > maxFileSize) {
         ctx.throw(413, `File size exceeds limit of ${maxFileSize} bytes`);
       }
 
-      // 权限检查
       const hasPermission = await this.checkAttachmentPermission(ctx, data.source_tag, data.source_id);
       if (!hasPermission) {
         ctx.throw(403, '无权访问此资源');
       }
 
-      // 生成附件 ID
-      const id = Utils.newID(20);
-      
-      // 提取扩展名
-      const extName = data.file_name 
-        ? path.extname(data.file_name).slice(1) 
-        : data.mime_type.split('/')[1];
-
-      // 生成文件路径
-      const filePath = this.generateFilePath(id, extName);
-      const fullPath = path.join(this.getAttachmentBasePath(), filePath);
-
-      // 确保目录存在
-      await fs.mkdir(path.dirname(fullPath), { recursive: true });
-
-      // 写入文件
       const buffer = Buffer.from(data.base64_data, 'base64');
-      await fs.writeFile(fullPath, buffer);
-
-      // 获取图片尺寸
       const { width, height } = await this.getImageDimensions(data.base64_data, data.mime_type);
 
-      // 创建数据库记录
-      const attachment = await this.Attachment.create({
-        id,
-        source_tag: data.source_tag,
-        source_id: data.source_id,
-        file_name: data.file_name || null,
-        ext_name: extName,
-        mime_type: data.mime_type,
-        file_size: fileSize,
-        file_path: filePath,
+      const attachment = await this.attachmentService.createFromBuffer({
+        sourceTag: data.source_tag,
+        sourceId: data.source_id,
+        createdBy: userId,
+        fileName: data.file_name || null,
+        mimeType: data.mime_type,
+        buffer,
+        altText: data.alt_text || null,
+        accessLevel: data.access_level || null,
         width,
         height,
-        alt_text: data.alt_text || null,
-        description: null,
-        created_by: userId,
       });
 
-      // 生成 data_url
-      const dataUrl = `data:${data.mime_type};base64,${data.base64_data}`;
+      const accessDescriptor = await this.attachmentService.buildAccessDescriptor(attachment, { userId });
 
       ctx.success({
         id: attachment.id,
@@ -410,14 +400,16 @@ class AttachmentController {
         file_size: attachment.file_size,
         width: attachment.width,
         height: attachment.height,
-        file_path: attachment.file_path,
-        data_url: dataUrl,
+        access_level: attachment.access_level,
+        preview_url: accessDescriptor.preview_url,
+        download_url: accessDescriptor.download_url,
+        expires_at: accessDescriptor.expires_at || null,
         ref: `attach:${attachment.id}`,
         created_at: attachment.created_at,
       });
       ctx.status = 201;
-      
-      logger.info(`[Attachment] upload: ${id} - ${data.file_name || 'unnamed'}`);
+
+      logger.info(`[Attachment] upload: ${attachment.id} - ${data.file_name || 'unnamed'} (${attachment.access_level})`);
     } catch (error) {
       logger.error('[Attachment] upload error:', error);
       ctx.throw(error.status || 500, error.message);
@@ -435,7 +427,6 @@ class AttachmentController {
       const file = ctx.file;
       const body = ctx.request.body;
 
-      // 参数验证
       if (!file) {
         ctx.throw(400, 'file is required');
       }
@@ -443,68 +434,38 @@ class AttachmentController {
         ctx.throw(400, 'source_tag and source_id are required');
       }
 
-      // 验证文件大小
       const maxFileSize = await this.getMaxFileSize();
       if (file.size > maxFileSize) {
         ctx.throw(413, `File size exceeds limit of ${maxFileSize} bytes`);
       }
 
-      // 权限检查
       const hasPermission = await this.checkAttachmentPermission(ctx, body.source_tag, body.source_id);
       if (!hasPermission) {
         ctx.throw(403, '无权访问此资源');
       }
 
-      // 读取文件内容并转为 base64（用于统一存储逻辑）
       const buffer = file.buffer;
       const base64Data = buffer.toString('base64');
 
-      // 验证 MIME 类型白名单
       this.validateMimeTypeWhitelist(file.mimetype);
-
-      // 验证文件魔数（防止客户端伪造 mimetype）
       await this.validateMimeTypeFromBuffer(buffer, file.mimetype);
 
-      // 生成附件 ID
-      const id = Utils.newID(20);
-
-      // 提取扩展名
-      const extName = file.originalname
-        ? path.extname(file.originalname).slice(1)
-        : file.mimetype.split('/')[1];
-
-      // 生成文件路径
-      const filePath = this.generateFilePath(id, extName);
-      const fullPath = path.join(this.getAttachmentBasePath(), filePath);
-
-      // 确保目录存在
-      await fs.mkdir(path.dirname(fullPath), { recursive: true });
-
-      // 写入文件
-      await fs.writeFile(fullPath, buffer);
-
-      // 获取图片尺寸
       const { width, height } = await this.getImageDimensions(base64Data, file.mimetype);
 
-      // 创建数据库记录
-      const attachment = await this.Attachment.create({
-        id,
-        source_tag: body.source_tag,
-        source_id: body.source_id,
-        file_name: file.originalname || null,
-        ext_name: extName,
-        mime_type: file.mimetype,
-        file_size: file.size,
-        file_path: filePath,
+      const attachment = await this.attachmentService.createFromBuffer({
+        sourceTag: body.source_tag,
+        sourceId: body.source_id,
+        createdBy: userId,
+        fileName: file.originalname || null,
+        mimeType: file.mimetype,
+        buffer,
+        altText: body.alt_text || null,
+        accessLevel: body.access_level || null,
         width,
         height,
-        alt_text: body.alt_text || null,
-        description: null,
-        created_by: userId,
       });
 
-      // 生成 data_url
-      const dataUrl = `data:${file.mimetype};base64,${base64Data}`;
+      const accessDescriptor = await this.attachmentService.buildAccessDescriptor(attachment, { userId });
 
       ctx.success({
         id: attachment.id,
@@ -515,14 +476,16 @@ class AttachmentController {
         file_size: attachment.file_size,
         width: attachment.width,
         height: attachment.height,
-        file_path: attachment.file_path,
-        data_url: dataUrl,
+        access_level: attachment.access_level,
+        preview_url: accessDescriptor.preview_url,
+        download_url: accessDescriptor.download_url,
+        expires_at: accessDescriptor.expires_at || null,
         ref: `attach:${attachment.id}`,
         created_at: attachment.created_at,
       });
       ctx.status = 201;
 
-      logger.info(`[Attachment] uploadFormData: ${id} - ${file.originalname || 'unnamed'}`);
+      logger.info(`[Attachment] uploadFormData: ${attachment.id} - ${file.originalname || 'unnamed'} (${attachment.access_level})`);
     } catch (error) {
       logger.error('[Attachment] uploadFormData error:', error);
       ctx.throw(error.status || 500, error.message);
@@ -539,7 +502,6 @@ class AttachmentController {
       const data = ctx.request.body;
       const userId = ctx.state.session.id;
 
-      // 参数验证
       if (!data.source_tag || !data.source_id) {
         ctx.throw(400, 'source_tag and source_id are required');
       }
@@ -550,7 +512,6 @@ class AttachmentController {
         ctx.throw(400, `Maximum ${MAX_BATCH_SIZE} files allowed per batch`);
       }
 
-      // 权限检查
       const hasPermission = await this.checkAttachmentPermission(ctx, data.source_tag, data.source_id);
       if (!hasPermission) {
         ctx.throw(403, '无权访问此资源');
@@ -562,65 +523,39 @@ class AttachmentController {
 
       for (const file of data.files) {
         try {
-          // 验证 MIME 类型白名单
           this.validateMimeTypeWhitelist(file.mime_type);
-
-          // 验证文件魔数
           await this.validateMimeType(file.base64_data, file.mime_type);
 
-          // 检查文件大小
           const fileSize = Buffer.from(file.base64_data, 'base64').length;
           if (fileSize > maxFileSize) {
             throw new Error(`File size exceeds limit of ${maxFileSize} bytes`);
           }
 
-          // 生成附件 ID
-          const id = Utils.newID(20);
-          
-          // 提取扩展名
-          const extName = file.file_name 
-            ? path.extname(file.file_name).slice(1) 
-            : file.mime_type.split('/')[1];
-
-          // 生成文件路径
-          const filePath = this.generateFilePath(id, extName);
-          const fullPath = path.join(this.getAttachmentBasePath(), filePath);
-
-          // 确保目录存在
-          await fs.mkdir(path.dirname(fullPath), { recursive: true });
-
-          // 写入文件
           const buffer = Buffer.from(file.base64_data, 'base64');
-          await fs.writeFile(fullPath, buffer);
-
-          // 获取图片尺寸
           const { width, height } = await this.getImageDimensions(file.base64_data, file.mime_type);
 
-          // 创建数据库记录
-          const attachment = await this.Attachment.create({
-            id,
-            source_tag: data.source_tag,
-            source_id: data.source_id,
-            file_name: file.file_name || null,
-            ext_name: extName,
-            mime_type: file.mime_type,
-            file_size: fileSize,
-            file_path: filePath,
+          const attachment = await this.attachmentService.createFromBuffer({
+            sourceTag: data.source_tag,
+            sourceId: data.source_id,
+            createdBy: userId,
+            fileName: file.file_name || null,
+            mimeType: file.mime_type,
+            buffer,
+            altText: file.alt_text || null,
+            accessLevel: data.access_level || null,
             width,
             height,
-            alt_text: file.alt_text || null,
-            description: null,
-            created_by: userId,
           });
 
-          // 生成 data_url
-          const dataUrl = `data:${file.mime_type};base64,${file.base64_data}`;
+          const accessDescriptor = await this.attachmentService.buildAccessDescriptor(attachment, { userId });
 
           results.push({
             id: attachment.id,
             file_name: attachment.file_name,
             file_size: attachment.file_size,
-            data_url: dataUrl,
+            access_level: attachment.access_level,
+            preview_url: accessDescriptor.preview_url,
+            download_url: accessDescriptor.download_url,
             ref: `attach:${attachment.id}`,
           });
         } catch (error) {
@@ -637,7 +572,7 @@ class AttachmentController {
         errors: errors.length > 0 ? errors : undefined,
       });
       ctx.status = 201;
-      
+
       logger.info(`[Attachment] uploadBatch: ${results.length} success, ${errors.length} failed`);
     } catch (error) {
       logger.error('[Attachment] uploadBatch error:', error);
@@ -660,22 +595,12 @@ class AttachmentController {
         ctx.throw(404, 'Attachment not found');
       }
 
-      // 权限检查
       const hasPermission = await this.checkAttachmentPermission(ctx, attachment.source_tag, attachment.source_id);
       if (!hasPermission) {
         ctx.throw(403, '无权访问此附件');
       }
 
-      // 读取文件并生成 data_url
-      const fullPath = path.join(this.getAttachmentBasePath(), attachment.file_path);
-      let dataUrl = null;
-      try {
-        const buffer = await fs.readFile(fullPath);
-        dataUrl = `data:${attachment.mime_type};base64,${buffer.toString('base64')}`;
-      } catch (fileError) {
-        logger.error(`[Attachment] Failed to read file: ${fullPath}`, fileError.message);
-        ctx.throw(500, 'Failed to read attachment file');
-      }
+      const accessDescriptor = await this.attachmentService.buildAccessDescriptor(attachment, { userId });
 
       ctx.success({
         id: attachment.id,
@@ -688,11 +613,62 @@ class AttachmentController {
         height: attachment.height,
         alt_text: attachment.alt_text,
         description: attachment.description,
-        data_url: dataUrl,
+        access_level: attachment.access_level,
+        preview_url: accessDescriptor.preview_url,
+        download_url: accessDescriptor.download_url,
+        expires_at: accessDescriptor.expires_at || null,
         created_at: attachment.created_at,
       });
     } catch (error) {
       logger.error('[Attachment] get error:', error);
+      ctx.throw(error.status || 500, error.message);
+    }
+  }
+
+  async getContent(ctx) {
+    try {
+      this.ensureModels();
+      const { id } = ctx.params;
+      const userId = ctx.state.session.id;
+
+      const attachment = await this.Attachment.findByPk(id);
+      if (!attachment) {
+        ctx.throw(404, 'Attachment not found');
+      }
+
+      const hasPermission = await this.checkAttachmentPermission(ctx, attachment.source_tag, attachment.source_id);
+      if (!hasPermission) {
+        ctx.throw(403, '无权访问此附件');
+      }
+
+      const fullPath = path.join(this.getAttachmentBasePath(), attachment.file_path);
+      try {
+        const stats = await fs.stat(fullPath);
+        if (!stats.isFile()) {
+          ctx.throw(404, 'Not a file');
+        }
+        if (stats.size > MAX_FILE_SIZE) {
+          ctx.throw(413, 'File too large (max 50MB)');
+        }
+      } catch (fileError) {
+        ctx.throw(404, 'File not found');
+      }
+
+      const ext = path.extname(fullPath).toLowerCase();
+      ctx.type = CONTENT_TYPES[ext] || attachment.mime_type || 'application/octet-stream';
+      ctx.set('Cache-Control', 'private, max-age=3600');
+
+      const stream = createReadStream(fullPath);
+      stream.on('error', (err) => {
+        logger.error('[Attachment] stream read error:', err);
+        if (!ctx.headersSent) {
+          ctx.status = 500;
+          ctx.body = 'File read error';
+        }
+      });
+      ctx.body = stream;
+    } catch (error) {
+      logger.error('[Attachment] getContent error:', error);
       ctx.throw(error.status || 500, error.message);
     }
   }
@@ -757,7 +733,6 @@ class AttachmentController {
         ctx.throw(400, 'source_tag and source_id query parameters are required');
       }
 
-      // 权限检查
       const hasPermission = await this.checkAttachmentPermission(ctx, source_tag, source_id);
       if (!hasPermission) {
         ctx.throw(403, '无权访问此资源');
@@ -768,18 +743,26 @@ class AttachmentController {
         order: [['created_at', 'DESC']],
       });
 
-      ctx.success({
-        items: attachments.map(a => ({
+      const items = await Promise.all(attachments.map(async (a) => {
+        const accessDescriptor = await this.attachmentService.buildAccessDescriptor(a, { userId });
+        return {
           id: a.id,
           file_name: a.file_name,
           mime_type: a.mime_type,
           file_size: a.file_size,
           width: a.width,
           height: a.height,
-          alt_text: a.alt_text,
+          access_level: a.access_level,
+          preview_url: accessDescriptor.preview_url,
+          download_url: accessDescriptor.download_url,
+          expires_at: accessDescriptor.expires_at || null,
           ref: `attach:${a.id}`,
           created_at: a.created_at,
-        })),
+        };
+      }));
+
+      ctx.success({
+        items,
         total: attachments.length,
       });
     } catch (error) {
@@ -944,50 +927,16 @@ class AttachmentController {
         ctx.throw(400, 'source_tag and source_id are required');
       }
 
-      // 权限检查
       const hasPermission = await this.checkAttachmentPermission(ctx, source_tag, source_id);
       if (!hasPermission) {
         ctx.throw(403, '无权访问此资源');
       }
 
-      // 查找现有未过期的 Token
-      const existingToken = await this.AttachmentToken.findOne({
-        where: {
-          source_tag,
-          source_id,
-          user_id: userId,
-          expires_at: { [Op.gt]: new Date() },
-        },
-      });
+      const tokenResult = await this.attachmentService.generateToken(source_tag, source_id, userId);
 
-      if (existingToken) {
-        ctx.success({
-          token: existingToken.token,
-          url: `/attach/t/${existingToken.token}`,
-          expires_at: existingToken.expires_at,
-        });
-        return;
-      }
-
-      // 生成新 Token
-      const token = crypto.randomBytes(32).toString('hex');
-      const expiresAt = new Date(Date.now() + TOKEN_CONFIG.EXPIRES_IN * 1000);
-
-      const attachmentToken = await this.AttachmentToken.create({
-        token,
-        source_tag,
-        source_id,
-        user_id: userId,
-        expires_at: expiresAt,
-      });
-
-      ctx.success({
-        token: attachmentToken.token,
-        url: `/attach/t/${attachmentToken.token}`,
-        expires_at: attachmentToken.expires_at,
-      });
+      ctx.success(tokenResult);
       
-      logger.info(`[Attachment] generateToken: ${token} for ${source_tag}:${source_id}`);
+      logger.info(`[Attachment] generateToken: ${tokenResult.token} for ${source_tag}:${source_id}`);
     } catch (error) {
       logger.error('[Attachment] generateToken error:', error);
       ctx.throw(error.status || 500, error.message);

--- a/server/controllers/doc.controller.js
+++ b/server/controllers/doc.controller.js
@@ -21,6 +21,7 @@ import DocCompareExecutor from '../../lib/doc-compare-executor.js';
 import DocAccessService from '../../lib/doc-access-service.js';
 import CollectionAccessService from '../../lib/collection-access-service.js';
 import DocumentOcrService from '../../lib/document-ocr-service.js';
+import AttachmentService from '../services/attachment.service.js';
 import { getSystemSettingService } from '../services/system-setting.service.js';
 import { DOC_PIPELINE_KEYS, mergeWithDefaults, createCallLlmFn } from '../../lib/doc-pipeline-defaults.js';
 
@@ -32,6 +33,7 @@ class DocController {
     this.compareExecutor = null;
     this.docAccessService = null;
     this.collectionAccessService = null;
+    this.attachmentService = new AttachmentService(db);
   }
 
   // ==================== 版本状态机 ====================
@@ -305,7 +307,7 @@ class DocController {
       const sourceAttachment = revision?.id
         ? await Attachment.findOne({
           where: { source_tag: 'doc-platform', source_id: revision.id },
-          attributes: ['id', 'file_name', 'mime_type', 'file_size', 'created_by', 'created_at'],
+          attributes: ['id', 'file_name', 'mime_type', 'file_size', 'access_level', 'source_tag', 'source_id', 'created_by', 'created_at'],
           order: [['created_at', 'ASC']],
           raw: true,
         })
@@ -327,12 +329,10 @@ class DocController {
       const resultAttachments = attachmentIds.length > 0
         ? await Attachment.findAll({
           where: { id: { [Op.in]: attachmentIds } },
-          attributes: ['id', 'file_name', 'mime_type', 'file_size', 'created_at'],
+          attributes: ['id', 'file_name', 'mime_type', 'file_size', 'access_level', 'source_tag', 'source_id', 'created_at'],
           raw: true,
         })
         : [];
-
-      const resultAttachmentMap = new Map(resultAttachments.map(item => [item.id, item]));
 
       const ocrImages = latestOcrResult?.id
         ? await DocOcrImage.findAll({
@@ -347,11 +347,76 @@ class DocController {
       const imageAttachments = imageAttachmentIds.length > 0
         ? await Attachment.findAll({
           where: { id: { [Op.in]: imageAttachmentIds } },
-          attributes: ['id', 'file_name', 'mime_type', 'file_size', 'created_at'],
+          attributes: ['id', 'file_name', 'mime_type', 'file_size', 'access_level', 'source_tag', 'source_id', 'created_at'],
           raw: true,
         })
         : [];
+
+      const resultAttachmentMap = new Map(resultAttachments.map(item => [item.id, item]));
       const imageAttachmentMap = new Map(imageAttachments.map(item => [item.id, item]));
+      const allAttachmentMap = new Map([
+        ...(sourceAttachment ? [[sourceAttachment.id, sourceAttachment]] : []),
+        ...resultAttachments.map(item => [item.id, item]),
+        ...imageAttachments.map(item => [item.id, item]),
+      ]);
+
+      const userId = ctx.state.session.id;
+
+      const allAttachments = [
+        sourceAttachment,
+        ...(attachmentIds.map(id => resultAttachmentMap.get(id)).filter(Boolean)),
+        ...(imageAttachments),
+      ].filter(Boolean);
+
+      const sourceGroups = new Map();
+      for (const att of allAttachments) {
+        if (att.access_level !== 'public') {
+          const key = `${att.source_tag}:${att.source_id}`;
+          if (!sourceGroups.has(key)) {
+            sourceGroups.set(key, { sourceTag: att.source_tag, sourceId: att.source_id, attachments: [] });
+          }
+          sourceGroups.get(key).attachments.push(att);
+        }
+      }
+
+      const tokenCache = new Map();
+      for (const [key, group] of sourceGroups) {
+        try {
+          const tokenResult = await this.attachmentService.generateToken(group.sourceTag, group.sourceId, userId);
+          tokenCache.set(key, tokenResult);
+        } catch (err) {
+          logger.warn(`[Doc] Failed to generate token for ${key}:`, err.message);
+        }
+      }
+
+      const buildAttachmentResponse = (attachmentId) => {
+        const attachment = attachmentId ? allAttachmentMap.get(attachmentId) : null;
+        if (!attachment) return null;
+
+        const accessLevel = attachment.access_level || 'private';
+        let previewUrl = null;
+        let downloadUrl = null;
+
+        if (accessLevel === 'public') {
+          previewUrl = `/attach/public/${attachment.id}`;
+          downloadUrl = `/attach/public/${attachment.id}`;
+        } else {
+          const key = `${attachment.source_tag}:${attachment.source_id}`;
+          const tokenResult = tokenCache.get(key);
+          if (tokenResult) {
+            previewUrl = `/attach/t/${tokenResult.token}/${attachment.id}`;
+            downloadUrl = `/attach/t/${tokenResult.token}/${attachment.id}`;
+          }
+        }
+
+        return {
+          ...attachment,
+          access_level: accessLevel,
+          preview_url: previewUrl,
+          download_url: downloadUrl,
+          requires_auth: !previewUrl,
+        };
+      };
 
       ctx.success({
         document: {
@@ -365,10 +430,7 @@ class DocController {
             username: uploader.username,
           } : null,
         } : null,
-        source_attachment: sourceAttachment ? {
-          ...sourceAttachment,
-          download_url: `/api/attachments/${sourceAttachment.id}`,
-        } : null,
+        source_attachment: buildAttachmentResponse(sourceAttachment?.id),
         processing: {
           status: document.processing_status,
           error_code: document.processing_error_code,
@@ -385,29 +447,14 @@ class DocController {
           completed_at: latestOcrResult.completed_at,
           error_code: latestOcrResult.error_code,
           error_message: latestOcrResult.error_message,
-          main_markdown_attachment: latestOcrResult.main_markdown_attachment_id ? {
-            ...resultAttachmentMap.get(latestOcrResult.main_markdown_attachment_id),
-            download_url: `/api/attachments/${latestOcrResult.main_markdown_attachment_id}`,
-          } : null,
-          raw_result_attachment: latestOcrResult.raw_result_attachment_id ? {
-            ...resultAttachmentMap.get(latestOcrResult.raw_result_attachment_id),
-            download_url: `/api/attachments/${latestOcrResult.raw_result_attachment_id}`,
-          } : null,
-          deliverables_manifest_attachment: latestOcrResult.deliverables_manifest_attachment_id ? {
-            ...resultAttachmentMap.get(latestOcrResult.deliverables_manifest_attachment_id),
-            download_url: `/api/attachments/${latestOcrResult.deliverables_manifest_attachment_id}`,
-          } : null,
-          image_manifest_attachment: latestOcrResult.image_manifest_attachment_id ? {
-            ...resultAttachmentMap.get(latestOcrResult.image_manifest_attachment_id),
-            download_url: `/api/attachments/${latestOcrResult.image_manifest_attachment_id}`,
-          } : null,
+          main_markdown_attachment: buildAttachmentResponse(latestOcrResult.main_markdown_attachment_id),
+          raw_result_attachment: buildAttachmentResponse(latestOcrResult.raw_result_attachment_id),
+          deliverables_manifest_attachment: buildAttachmentResponse(latestOcrResult.deliverables_manifest_attachment_id),
+          image_manifest_attachment: buildAttachmentResponse(latestOcrResult.image_manifest_attachment_id),
         } : null,
         image_attachments: ocrImages.map((item) => ({
           ...item,
-          attachment: item.attachment_id ? {
-            ...imageAttachmentMap.get(item.attachment_id),
-            download_url: `/api/attachments/${item.attachment_id}`,
-          } : null,
+          attachment: buildAttachmentResponse(item.attachment_id),
         })),
       });
     } catch (error) {
@@ -689,7 +736,9 @@ class DocController {
       });
 
       for (const attachment of attachmentRows) {
-        const fullPath = attachment.file_path ? path.resolve(attachment.file_path) : null;
+        const fullPath = attachment.file_path
+          ? path.join(this.attachmentService.getAttachmentBasePath(), attachment.file_path)
+          : null;
         if (!fullPath) continue;
         try {
           await fs.unlink(fullPath);

--- a/server/routes/attachment-static.routes.js
+++ b/server/routes/attachment-static.routes.js
@@ -1,9 +1,12 @@
 /**
- * Attachment Static Routes - 附件 Token 访问路由
+ * Attachment Static Routes - 附件静态访问路由
  *
  * Issue #557: 实现通用附件服务
+ * Issue #001: Attachment 访问级别与统一接入改造
  * 通过 Token 认证提供附件访问，支持 <img> / <video> 等媒体元素
- * URL 格式: /attach/t/:token/:attachment_id
+ * URL 格式:
+ *   - /attach/public/:attachment_id - 公开附件直接访问
+ *   - /attach/t/:token/:attachment_id - 私有附件 Token 访问
  *
  * 参考：task-static.routes.js (Issue #140)
  */
@@ -14,7 +17,6 @@ import fs from 'fs/promises';
 import path from 'path';
 import logger from '../../lib/logger.js';
 
-// Content-Type 映射
 const CONTENT_TYPES = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -29,55 +31,21 @@ const CONTENT_TYPES = {
   '.zip': 'application/zip',
 };
 
-// 最大文件大小：50MB
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
-/**
- * 创建附件静态文件服务路由
- * @param {Object} db - 数据库实例
- */
 export default (db) => {
   const router = new Router({ prefix: '/attach' });
 
-  /**
-   * 附件 Token 访问路由
-   * 匹配: /attach/t/:token/:attachment_id
-   */
-  router.get('/t/:token/:attachment_id', async (ctx) => {
-    const { token, attachment_id } = ctx.params;
-    const ipAddress = ctx.ip;
-    const userAgent = ctx.get('User-Agent') || '';
+  router.get('/public/:attachment_id', async (ctx) => {
+    const { attachment_id } = ctx.params;
 
-    // 1. 验证参数存在
-    if (!token || !attachment_id) {
+    if (!attachment_id) {
       ctx.status = 400;
-      ctx.body = 'Bad Request: Missing token or attachment_id';
+      ctx.body = 'Bad Request: Missing attachment_id';
       return;
     }
 
     try {
-      // 2. 查询数据库验证 token
-      const tokenRows = await db.query(
-        `SELECT * FROM attachment_token WHERE token = ?`,
-        [token]
-      );
-
-      if (!tokenRows || tokenRows.length === 0) {
-        ctx.status = 401;
-        ctx.body = 'Unauthorized: Invalid token';
-        return;
-      }
-
-      const tokenRecord = tokenRows[0];
-
-      // 3. 检查 token 是否过期
-      if (new Date() > new Date(tokenRecord.expires_at)) {
-        ctx.status = 401;
-        ctx.body = 'Unauthorized: Token expired';
-        return;
-      }
-
-      // 4. 查询附件信息
       const attachmentRows = await db.query(
         `SELECT * FROM attachments WHERE id = ?`,
         [attachment_id]
@@ -91,19 +59,15 @@ export default (db) => {
 
       const attachment = attachmentRows[0];
 
-      // 5. 验证 source_tag 和 source_id 匹配
-      if (attachment.source_tag !== tokenRecord.source_tag ||
-          attachment.source_id !== tokenRecord.source_id) {
+      if (attachment.access_level !== 'public') {
         ctx.status = 403;
-        ctx.body = 'Forbidden: Token does not match attachment resource';
+        ctx.body = 'Forbidden: Attachment is not public';
         return;
       }
 
-      // 6. 获取附件基础路径
       const attachmentBasePath = process.env.ATTACHMENT_BASE_PATH || './data/attachments';
       const fullPath = path.join(attachmentBasePath, attachment.file_path);
 
-      // 7. 检查文件是否存在及大小限制
       let stats;
       try {
         stats = await fs.stat(fullPath);
@@ -123,21 +87,124 @@ export default (db) => {
         return;
       }
 
-      // 8. 更新最后访问时间（异步，不阻塞响应）
+      const ext = path.extname(fullPath).toLowerCase();
+      ctx.type = CONTENT_TYPES[ext] || attachment.mime_type || 'application/octet-stream';
+      ctx.set('Cache-Control', 'public, max-age=86400');
+
+      const stream = createReadStream(fullPath);
+      stream.on('error', (err) => {
+        logger.error('[AttachmentStatic] public stream error:', err);
+        if (!ctx.headersSent) {
+          ctx.status = 500;
+          ctx.body = 'File read error';
+        }
+      });
+      ctx.body = stream;
+
+    } catch (error) {
+      logger.error('[AttachmentStatic] public access error:', error);
+      ctx.status = 500;
+      ctx.body = 'Internal server error';
+    }
+  });
+
+  router.get('/t/:token/:attachment_id', async (ctx) => {
+    const { token, attachment_id } = ctx.params;
+    const ipAddress = ctx.ip;
+    const userAgent = ctx.get('User-Agent') || '';
+
+    if (!token || !attachment_id) {
+      ctx.status = 400;
+      ctx.body = 'Bad Request: Missing token or attachment_id';
+      return;
+    }
+
+    try {
+      const tokenRows = await db.query(
+        `SELECT * FROM attachment_token WHERE token = ?`,
+        [token]
+      );
+
+      if (!tokenRows || tokenRows.length === 0) {
+        ctx.status = 401;
+        ctx.body = 'Unauthorized: Invalid token';
+        return;
+      }
+
+      const tokenRecord = tokenRows[0];
+
+      if (new Date() > new Date(tokenRecord.expires_at)) {
+        ctx.status = 401;
+        ctx.body = 'Unauthorized: Token expired';
+        return;
+      }
+
+      const attachmentRows = await db.query(
+        `SELECT * FROM attachments WHERE id = ?`,
+        [attachment_id]
+      );
+
+      if (!attachmentRows || attachmentRows.length === 0) {
+        ctx.status = 404;
+        ctx.body = 'Attachment not found';
+        return;
+      }
+
+      const attachment = attachmentRows[0];
+
+      if (attachment.access_level === 'public') {
+        ctx.status = 400;
+        ctx.body = 'Bad Request: Public attachment should use /attach/public/:id';
+        return;
+      }
+
+      if (attachment.source_tag !== tokenRecord.source_tag ||
+          attachment.source_id !== tokenRecord.source_id) {
+        ctx.status = 403;
+        ctx.body = 'Forbidden: Token does not match attachment resource';
+        return;
+      }
+
+      const attachmentBasePath = process.env.ATTACHMENT_BASE_PATH || './data/attachments';
+      const fullPath = path.join(attachmentBasePath, attachment.file_path);
+
+      let stats;
+      try {
+        stats = await fs.stat(fullPath);
+        if (!stats.isFile()) {
+          ctx.status = 404;
+          ctx.body = 'Not a file';
+          return;
+        }
+        if (stats.size > MAX_FILE_SIZE) {
+          ctx.status = 413;
+          ctx.body = 'File too large (max 50MB)';
+          return;
+        }
+      } catch (fileError) {
+        ctx.status = 404;
+        ctx.body = 'File not found';
+        return;
+      }
+
       db.query(
         `UPDATE attachment_token SET last_access_at = NOW() WHERE id = ?`,
         [tokenRecord.id]
       ).catch(err => logger.error('Failed to update last_access_at:', err.message));
 
-      // 9. 设置 Content-Type
       const ext = path.extname(fullPath).toLowerCase();
       ctx.type = CONTENT_TYPES[ext] || attachment.mime_type || 'application/octet-stream';
+      ctx.set('Cache-Control', 'private, max-age=3600');
 
-      // 10. 设置缓存控制（附件可以缓存，因为 Token 有过期时间）
-      ctx.set('Cache-Control', 'public, max-age=3600');
-
-      // 11. 返回文件内容
-      ctx.body = createReadStream(fullPath);
+      const stream = createReadStream(fullPath);
+      stream.on('error', (err) => {
+        logger.error('[AttachmentStatic] token stream error:', err);
+        if (!ctx.headersSent) {
+          ctx.status = 500;
+          ctx.body = 'File read error';
+        }
+      });
+      ctx.body = stream;
 
     } catch (error) {
       console.error('Attachment static file error:', error);
@@ -146,9 +213,6 @@ export default (db) => {
     }
   });
 
-  /**
-   * 健康检查端点
-   */
   router.get('/health', async (ctx) => {
     ctx.body = { status: 'ok', service: 'attachment-static' };
   });

--- a/server/routes/attachment.routes.js
+++ b/server/routes/attachment.routes.js
@@ -2,15 +2,17 @@
  * Attachment Routes - 附件服务路由
  *
  * Issue #557: 实现通用附件服务
+ * Issue #001: Attachment 访问级别与统一接入改造
  * API 设计：
  * POST   /api/attachments           - 上传附件 (base64)
  * POST   /api/attachments/upload    - 上传附件 (FormData)
  * POST   /api/attachments/batch     - 批量上传
- * GET    /api/attachments/:id      - 获取附件（返回 data_url）
+ * GET    /api/attachments/:id       - 获取附件元数据（不再返回 data_url）
+ * GET    /api/attachments/:id/content - 获取附件文件流（需认证）
  * POST   /api/attachments/meta      - 批量获取元信息
- * GET    /api/attachments            - 列出资源附件（query: source_tag, source_id）
+ * GET    /api/attachments           - 列出资源附件（query: source_tag, source_id）
  * GET    /api/attachments/admin     - 管理员列表（支持分页和筛选）
- * DELETE /api/attachments/:id        - 删除附件
+ * DELETE /api/attachments/:id       - 删除附件
  * POST   /api/attachments/token     - 生成资源级 Token
  */
 
@@ -22,7 +24,7 @@ const createUploadMiddleware = () => {
   const upload = multer({
     storage: multer.memoryStorage(),
     limits: {
-      fileSize: 50 * 1024 * 1024, // 50MB
+      fileSize: 50 * 1024 * 1024,
     },
   });
   return upload.single('file');
@@ -31,31 +33,24 @@ const createUploadMiddleware = () => {
 export default (controller) => {
   const router = new Router({ prefix: '/api/attachments' });
 
-  // 上传附件 (base64)
   router.post('/', authenticate(), (ctx) => controller.upload(ctx));
 
-  // 上传附件 (FormData)
   router.post('/upload', authenticate(), createUploadMiddleware(), (ctx) => controller.uploadFormData(ctx));
 
-  // 批量上传
   router.post('/batch', authenticate(), (ctx) => controller.uploadBatch(ctx));
 
-  // 批量获取元信息（轻量级）
   router.post('/meta', authenticate(), (ctx) => controller.getMeta(ctx));
 
-  // 生成资源级 Token
   router.post('/token', authenticate(), (ctx) => controller.generateToken(ctx));
 
-  // 管理员列表（支持分页和筛选）- 静态路由，必须在 /:id 之前
   router.get('/admin', authenticate(), (ctx) => controller.listAdmin(ctx));
 
-  // 列出资源附件（query: source_tag, source_id）
   router.get('/', authenticate(), (ctx) => controller.list(ctx));
 
-  // 获取附件详情（返回 data_url）
   router.get('/:id', authenticate(), (ctx) => controller.get(ctx));
 
-  // 删除附件
+  router.get('/:id/content', authenticate(), (ctx) => controller.getContent(ctx));
+
   router.delete('/:id', authenticate(), (ctx) => controller.delete(ctx));
 
   return router;

--- a/server/services/attachment.service.js
+++ b/server/services/attachment.service.js
@@ -1,0 +1,334 @@
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import Utils from '../../lib/utils.js';
+import logger from '../../lib/logger.js';
+
+const TOKEN_EXPIRES_IN = 3600;
+
+const SOURCE_TAG_ACCESS_LEVEL_MAP = {
+  user_avatar: 'public',
+  expert_avatar: 'public',
+  site_logo: 'public',
+  site_background: 'public',
+  kb_article_image: 'private',
+  kb_article_cover: 'private',
+  'doc-platform': 'private',
+  task_export: 'private',
+  admin_upload: 'private',
+  mini_app: 'private',
+  mini_app_file: 'private',
+};
+
+const PUBLIC_ONLY_SOURCE_TAGS = ['user_avatar', 'expert_avatar', 'site_logo', 'site_background'];
+
+class AttachmentService {
+  constructor(db) {
+    this.db = db;
+    this.Attachment = null;
+    this.AttachmentToken = null;
+  }
+
+  ensureModels() {
+    if (!this.Attachment) {
+      this.Attachment = this.db.getModel('attachment');
+      this.AttachmentToken = this.db.getModel('attachment_token');
+    }
+  }
+
+  getAttachmentBasePath() {
+    return process.env.ATTACHMENT_BASE_PATH || './data/attachments';
+  }
+
+  resolveDefaultAccessLevel(sourceTag) {
+    return SOURCE_TAG_ACCESS_LEVEL_MAP[sourceTag] || 'private';
+  }
+
+  generateFilePath(attachmentId, extName) {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return path.join(String(year), month, day, `${attachmentId}.${extName}`);
+  }
+
+  async createFromBuffer(options) {
+    this.ensureModels();
+    const {
+      sourceTag,
+      sourceId,
+      createdBy = null,
+      fileName,
+      mimeType,
+      buffer,
+      altText = null,
+      description = null,
+      width = null,
+      height = null,
+      accessLevel = null,
+    } = options;
+
+    if (!sourceTag || !sourceId) {
+      throw new Error('sourceTag and sourceId are required');
+    }
+    if (!mimeType || !buffer) {
+      throw new Error('mimeType and buffer are required');
+    }
+
+    const id = Utils.newID(20);
+    const extName = fileName ? path.extname(fileName).slice(1) : mimeType.split('/')[1];
+    const filePath = this.generateFilePath(id, extName);
+    const fullPath = path.join(this.getAttachmentBasePath(), filePath);
+
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, buffer);
+
+    const resolvedAccessLevel = (accessLevel === 'public' && PUBLIC_ONLY_SOURCE_TAGS.includes(sourceTag))
+      ? 'public'
+      : this.resolveDefaultAccessLevel(sourceTag);
+
+    const attachment = await this.Attachment.create({
+      id,
+      source_tag: sourceTag,
+      source_id: sourceId,
+      file_name: fileName || null,
+      ext_name: extName,
+      mime_type: mimeType,
+      file_size: buffer.length,
+      file_path: filePath,
+      width,
+      height,
+      alt_text: altText || null,
+      description: description || null,
+      access_level: resolvedAccessLevel,
+      created_by: createdBy,
+    });
+
+    logger.info(`[AttachmentService] createFromBuffer: ${id} - ${fileName || 'unnamed'} (${resolvedAccessLevel})`);
+    return attachment;
+  }
+
+  async createFromDataUrl(options) {
+    const { fileName, dataUrl, altText = null, description = null } = options;
+    
+    const match = /^data:([^;]+);base64,(.+)$/i.exec(dataUrl || '');
+    if (!match) {
+      throw new Error(`Invalid data URL for ${fileName}`);
+    }
+    
+    const mimeType = match[1];
+    const buffer = Buffer.from(match[2], 'base64');
+    
+    return await this.createFromBuffer({
+      ...options,
+      mimeType,
+      buffer,
+      altText,
+      description,
+    });
+  }
+
+  async createTextAttachment(options) {
+    const { fileName, content, mimeType = 'text/plain' } = options;
+    const buffer = Buffer.from(content || '', 'utf8');
+    
+    return await this.createFromBuffer({
+      ...options,
+      mimeType,
+      buffer,
+    });
+  }
+
+  async getById(id) {
+    this.ensureModels();
+    return await this.Attachment.findByPk(id);
+  }
+
+  async listBySource(sourceTag, sourceId) {
+    this.ensureModels();
+    return await this.Attachment.findAll({
+      where: { source_tag: sourceTag, source_id: sourceId },
+      order: [['created_at', 'DESC']],
+    });
+  }
+
+  async rebindAttachment(id, { sourceTag, sourceId }) {
+    this.ensureModels();
+    const attachment = await this.Attachment.findByPk(id);
+    if (!attachment) {
+      throw new Error(`Attachment not found: ${id}`);
+    }
+    
+    const newAccessLevel = this.resolveDefaultAccessLevel(sourceTag);
+    await attachment.update({
+      source_tag: sourceTag,
+      source_id: sourceId,
+      access_level: newAccessLevel,
+    });
+    
+    logger.info(`[AttachmentService] rebindAttachment: ${id} -> ${sourceTag}:${sourceId} (${newAccessLevel})`);
+    return attachment;
+  }
+
+  async rebindMany(ids, { sourceTag, sourceId }) {
+    this.ensureModels();
+    const { Op } = await import('sequelize');
+    const newAccessLevel = this.resolveDefaultAccessLevel(sourceTag);
+
+    const [count] = await this.Attachment.update(
+      { source_tag: sourceTag, source_id: sourceId, access_level: newAccessLevel },
+      { where: { id: { [Op.in]: ids } } }
+    );
+
+    logger.info(`[AttachmentService] rebindMany: ${count} attachments -> ${sourceTag}:${sourceId} (${newAccessLevel})`);
+    return count;
+  }
+
+  async deleteAttachment(id, options = {}) {
+    this.ensureModels();
+    const { deleteFile = true } = options;
+    
+    const attachment = await this.Attachment.findByPk(id);
+    if (!attachment) {
+      throw new Error(`Attachment not found: ${id}`);
+    }
+
+    if (deleteFile) {
+      const fullPath = path.join(this.getAttachmentBasePath(), attachment.file_path);
+      try {
+        await fs.unlink(fullPath);
+      } catch (err) {
+        logger.warn(`[AttachmentService] Failed to delete file: ${fullPath}`, err.message);
+      }
+    }
+
+    await attachment.destroy();
+    logger.info(`[AttachmentService] deleteAttachment: ${id}`);
+    return true;
+  }
+
+  async deleteMany(ids, options = {}) {
+    this.ensureModels();
+    const { Op } = await import('sequelize');
+    const { deleteFile = true } = options;
+
+    const attachments = await this.Attachment.findAll({
+      where: { id: { [Op.in]: ids } },
+      attributes: ['id', 'file_path'],
+    });
+
+    if (deleteFile) {
+      for (const attachment of attachments) {
+        const fullPath = path.join(this.getAttachmentBasePath(), attachment.file_path);
+        try {
+          await fs.unlink(fullPath);
+        } catch (err) {
+          logger.warn(`[AttachmentService] Failed to delete file: ${fullPath}`, err.message);
+        }
+      }
+    }
+
+    await this.Attachment.destroy({ where: { id: { [Op.in]: ids } } });
+    logger.info(`[AttachmentService] deleteMany: ${ids.length} attachments`);
+    return ids.length;
+  }
+
+  async buildAccessDescriptor(attachment, userContext = {}) {
+    this.ensureModels();
+    const { userId } = userContext;
+
+    const accessLevel = attachment.access_level || 'private';
+
+    if (accessLevel === 'public') {
+      return {
+        access_level: 'public',
+        preview_url: `/attach/public/${attachment.id}`,
+        download_url: `/attach/public/${attachment.id}`,
+      };
+    }
+
+    if (!userId) {
+      return {
+        access_level: 'private',
+        preview_url: null,
+        download_url: null,
+        requires_auth: true,
+      };
+    }
+
+    const sourceTag = attachment.source_tag;
+    const sourceId = attachment.source_id;
+    const token = await this.generateToken(sourceTag, sourceId, userId);
+    return {
+      access_level: 'private',
+      preview_url: `/attach/t/${token.token}/${attachment.id}`,
+      download_url: `/attach/t/${token.token}/${attachment.id}`,
+      expires_at: token.expires_at,
+    };
+  }
+
+  async generateToken(sourceTag, sourceId, userId) {
+    this.ensureModels();
+    const { Op } = await import('sequelize');
+
+    const existingToken = await this.AttachmentToken.findOne({
+      where: {
+        source_tag: sourceTag,
+        source_id: sourceId,
+        user_id: userId,
+        expires_at: { [Op.gt]: new Date() },
+      },
+    });
+
+    if (existingToken) {
+      return {
+        token: existingToken.token,
+        url: `/attach/t/${existingToken.token}`,
+        expires_at: existingToken.expires_at,
+      };
+    }
+
+    const tokenStr = crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + TOKEN_EXPIRES_IN * 1000);
+
+    await this.AttachmentToken.create({
+      token: tokenStr,
+      source_tag: sourceTag,
+      source_id: sourceId,
+      user_id: userId,
+      expires_at: expiresAt,
+    });
+
+    logger.info(`[AttachmentService] generateToken: ${tokenStr} for ${sourceTag}:${sourceId}`);
+    return {
+      token: tokenStr,
+      url: `/attach/t/${tokenStr}`,
+      expires_at: expiresAt,
+    };
+  }
+
+  async readFileContent(attachment) {
+    const fullPath = path.join(this.getAttachmentBasePath(), attachment.file_path);
+    return await fs.readFile(fullPath);
+  }
+
+  async readFileBase64(attachment) {
+    const buffer = await this.readFileContent(attachment);
+    return buffer.toString('base64');
+  }
+
+  mimeToExt(mimeType) {
+    const map = {
+      'text/markdown': 'md',
+      'application/json': 'json',
+      'text/plain': 'txt',
+      'image/png': 'png',
+      'image/jpeg': 'jpg',
+      'image/webp': 'webp',
+      'application/pdf': 'pdf',
+    };
+    return map[mimeType] || 'bin';
+  }
+}
+
+export default AttachmentService;


### PR DESCRIPTION
为附件系统增加统一访问级别模型，并将附件的上传、预览、下载、内嵌访问方式统一到明确的 API/URL 规范中。

## 改动概要

### 数据库
- `attachments` 表新增 `access_level ENUM('public','private')` NOT NULL DEFAULT 'private'
- 新增 `idx_access_level` 索引
- 老数据按 `source_tag` 回填

### 后端
- 新建 `AttachmentService` 统一服务层（`server/services/attachment.service.js`）
- `GET /api/attachments/:id` 不再返回 `data_url`，改为元数据 + 访问 URL
- 新增 `GET /api/attachments/:id/content`（文件流）
- 新增 `GET /attach/public/:id`（公开直链）
- OCR 服务通过 AttachmentService 创建附件，不再直写
- 文档平台批量生成 token 避免 N+1 查询

### 前端
- 移除 Base64 上传 API，统一 FormData 上传
- 5 个上传组件全部切换
- Markdown 预览改用 `/content` 接口
- 下载按钮增加 `download_url` 判空
- 前后端附件类型契约同步

### 安全
- `PUBLIC_ONLY_SOURCE_TAGS` 白名单：仅头像/logo 类可创建 public 附件
- 3 条静态路由全链路流错误处理
- 文件删除路径修复

## 审计
经 8 轮审计，全部阻塞问题已关闭。

Closes #843