### PR TITLE
fix: resolve frontend build type errors

### DIFF
--- a/frontend/src/components/apps/FileUploader.vue
+++ b/frontend/src/components/apps/FileUploader.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   uploaded: [attachmentIds: string[]]
-}>>()
+}>()
 
 const dragging = ref(false)
 const uploadingFiles = ref<{ name: string; status: string; error?: string }[]>([])

--- a/frontend/src/views/els/ELSStudyView.vue
+++ b/frontend/src/views/els/ELSStudyView.vue
@@ -496,7 +496,7 @@ async function switchReviewBucket(bucket: 'today' | 'new' | 'wrong') {
 
 async function submitReview() {
   if (!reviewData.value) return
-  const results = reviewData.value.questions.map((question) => ({
+  const results: Parameters<typeof submitELSReviews>[0]['results'] = reviewData.value.questions.map((question) => ({
     word_id: question.word_id,
     review_type: question.review_type,
     answer: reviewAnswers[question.word_id] || '',


### PR DESCRIPTION
﻿## Summary
- fix FileUploader.vue emit type declaration syntax so ue-tsc can parse the component during production build
- narrow ELSStudyView.vue review submission payload typing to keep self_rating compatible with submitELSReviews() 
- restore successful rontend production build on the current branch

## Validation
- cd frontend && npm run build
