### PR TITLE
fix: 文档平台 OCR 调试与配置补充

### DIFF
--- a/frontend/src/api/doc-pipeline.ts
+++ b/frontend/src/api/doc-pipeline.ts
@@ -77,6 +77,20 @@ export interface DocPipelineMetadataStage {
   timeout_ms: number
 }
 
+export interface DocPipelineOutlineStage {
+  enabled: boolean
+  type: string
+  strategy: string
+  model_id: string | null
+  temperature: number
+  window_size: number
+  step_size: number
+  max_heading_level: number
+  preserve_line_info: boolean
+  deduplicate_titles: boolean
+  timeout_ms: number
+}
+
 export interface DocPipelineChunkStage {
   enabled: boolean
   type: string
@@ -116,6 +130,7 @@ export interface DocPipelineConfig {
   ocr_finalize: DocPipelineOcrFinalize
   pending_clean: DocPipelineCleanStage
   pending_metadata: DocPipelineMetadataStage
+  pending_outline: DocPipelineOutlineStage
   pending_chunk: DocPipelineChunkStage
   pending_embedding: DocPipelineEmbeddingStage
   pending_relocate: DocPipelineRelocateStage

--- a/frontend/src/components/docs/DocPipelineConfigDialog.vue
+++ b/frontend/src/components/docs/DocPipelineConfigDialog.vue
@@ -421,6 +421,44 @@
             </el-form-item>
           </template>
 
+          <!-- pending_outline -->
+          <template v-if="activeStage === 'pending_outline'">
+            <el-form-item label="启用"><el-switch v-model="form.pending_outline.enabled" /></el-form-item>
+            <el-form-item label="执行方式">
+              <el-select v-model="form.pending_outline.type">
+                <el-option label="内置 LLM" value="internal_llm" />
+                <el-option label="禁用" value="disabled" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="提取策略">
+              <el-select v-model="form.pending_outline.strategy">
+                <el-option label="LLM 章节提取" value="llm" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="模型">
+              <el-select v-model="form.pending_outline.model_id" placeholder="默认模型" clearable filterable>
+                <el-option v-for="m in models" :key="m.id" :label="m.model_name" :value="m.id" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="温度">
+              <el-input-number v-model="form.pending_outline.temperature" :min="0" :max="2" :step="0.1" />
+            </el-form-item>
+            <el-form-item label="窗口大小">
+              <el-input-number v-model="form.pending_outline.window_size" :min="1000" :step="1000" />
+            </el-form-item>
+            <el-form-item label="步长">
+              <el-input-number v-model="form.pending_outline.step_size" :min="1000" :step="1000" />
+            </el-form-item>
+            <el-form-item label="最大标题层级">
+              <el-input-number v-model="form.pending_outline.max_heading_level" :min="1" :max="10" :step="1" />
+            </el-form-item>
+            <el-form-item label="保留行号信息"><el-switch v-model="form.pending_outline.preserve_line_info" /></el-form-item>
+            <el-form-item label="标题去重"><el-switch v-model="form.pending_outline.deduplicate_titles" /></el-form-item>
+            <el-form-item label="超时(ms)">
+              <el-input-number v-model="form.pending_outline.timeout_ms" :min="5000" :step="10000" />
+            </el-form-item>
+          </template>
+
           <!-- pending_chunk -->
           <template v-if="activeStage === 'pending_chunk'">
             <el-form-item label="启用"><el-switch v-model="form.pending_chunk.enabled" /></el-form-item>
@@ -520,6 +558,7 @@ const stages = [
   { key: 'ocr_finalize', label: 'OCR产物提取' },
   { key: 'pending_clean', label: '文本清洗' },
   { key: 'pending_metadata', label: '元数据提取' },
+  { key: 'pending_outline', label: '章节提取' },
   { key: 'pending_chunk', label: '文本分块' },
   { key: 'pending_embedding', label: '向量化' },
   { key: 'pending_relocate', label: '入库收尾' },
@@ -565,6 +604,19 @@ const defaultForm: DocPipelineConfig = {
     rules: { remove_page_number: true, remove_watermark: true, remove_garbled_text: true, remove_header_footer: true },
   },
   pending_metadata: { enabled: true, type: 'internal_llm', model_id: null, temperature: 0.3, schema_json: {}, prompt_template: '', timeout_ms: 120000 },
+  pending_outline: {
+    enabled: true,
+    type: 'internal_llm',
+    strategy: 'llm',
+    model_id: null,
+    temperature: 0.3,
+    window_size: 60000,
+    step_size: 40000,
+    max_heading_level: 3,
+    preserve_line_info: true,
+    deduplicate_titles: true,
+    timeout_ms: 120000,
+  },
   pending_chunk: { enabled: true, type: 'builtin', chunk_mode: 'heading', max_length: 1000, overlap_length: 100, keep_heading: true, merge_small_chunks: false },
   pending_embedding: { enabled: true, embedding_model_id: null, batch_size: 20, skip_empty_chunks: true, retry_times: 3, timeout_ms: 120000 },
   pending_relocate: { enabled: true, target_strategy: 'current_collection', tag_strategy: 'none', metadata_writeback: false, auto_publish: false },

--- a/frontend/src/views/DocDetailView.vue
+++ b/frontend/src/views/DocDetailView.vue
@@ -78,6 +78,10 @@
                 <span class="status-label">OCR 状态</span>
                 <span class="status-value">{{ docStore.currentResult.ocr_result?.status || '-' }}</span>
               </div>
+              <div v-if="docStore.currentResult.ocr_result?.task_id" class="status-row">
+                <span class="status-label">Task ID</span>
+                <span class="status-value task-id-value">{{ docStore.currentResult.ocr_result.task_id }}</span>
+              </div>
               <div v-if="docStore.currentResult.ocr_result?.progress !== undefined" class="status-row">
                 <span class="status-label">进度</span>
                 <span class="status-value">
@@ -410,6 +414,7 @@ onBeforeUnmount(() => {
 .status-row { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
 .status-label { font-size: 12px; color: #909399; flex-shrink: 0; }
 .status-value { font-size: 13px; color: #303133; text-align: right; }
+.task-id-value { word-break: break-all; font-family: Consolas, 'Courier New', monospace; font-size: 12px; }
 .text-truncate { max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .sidebar-actions { display: flex; flex-direction: column; gap: 6px; }

--- a/frontend/src/views/els/ELSStudyView.vue
+++ b/frontend/src/views/els/ELSStudyView.vue
@@ -501,7 +501,7 @@ async function submitReview() {
     review_type: question.review_type,
     answer: reviewAnswers[question.word_id] || '',
     is_correct: Boolean(reviewAnswers[question.word_id]),
-    self_rating: 'easy',
+    self_rating: 'easy' as const,
   }))
   const result = await submitELSReviews({
     session_id: reviewData.value.session_id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,7 +1059,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2799,7 +2798,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3229,7 +3227,6 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.2.tgz",
       "integrity": "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~1.0.1",
@@ -3884,7 +3881,6 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
       "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
@@ -4672,7 +4668,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -5601,7 +5596,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -133,6 +133,18 @@ async function safeExecute(connection, sql, errorMessages = ['Duplicate', 'alrea
   }
 }
 
+/**
+ * 仅在外键存在时删除，避免不同历史库状态下直接 DROP FOREIGN KEY 失败
+ */
+async function dropForeignKeyIfExists(connection, tableName, constraintName) {
+  const exists = await hasForeignKey(connection, tableName, constraintName);
+  if (!exists) {
+    return false;
+  }
+  await connection.execute(`ALTER TABLE ${tableName} DROP FOREIGN KEY ${constraintName}`);
+  return true;
+}
+
 async function getAnyExistingUserId(connection) {
   const [rows] = await connection.execute(
     `SELECT id FROM users ORDER BY created_at ASC LIMIT 1`


### PR DESCRIPTION
## 变更内容

本次变更主要用于文档平台 OCR 调试与预处理配置补充，包含：

- 修复文档平台相关前端构建问题
- 文档详情页补充 OCR Task ID 展示，便于排查 MinerU 任务状态
- 文档预处理配置页新增 `pending_outline`（章节提取）配置
- 为 `pending_outline` 补充前端类型定义和配置项表单
- 修复数据库升级脚本中外键删除的兼容性问题

## 背景

当前文档平台 OCR 后续链路中，`pending_outline` 实际参与章节提取，但前端配置页缺少该阶段配置，导致无法显式指定该阶段模型，排查 LLM 超时/不可用问题不便。

本次补充后，可以在前端直接为章节提取阶段配置模型与相关参数。

## 影响范围

- 前端文档平台配置页
- 文档详情页状态展示
- 数据库升级脚本兼容性

## 验证情况

- 前端相关文件错误检查通过
- 变更已推送至分支 `feature/20260615-doc-platform-dev`

Closes #<issue-number>