### PR TITLE
fix: 修复 skill-runner 相对路径解析错误

### DIFF
--- a/data/skills/fs/index.js
+++ b/data/skills/fs/index.js
@@ -2,7 +2,7 @@
  * FS Skill - Node.js Implementation
  * 
  * File system operations including read, write, search, and manage files.
- * 注意：进程 cwd 已在 VM 启动时设置为正确的工作目录，技能代码直接使用相对路径即可。
+ * 注意：相对路径由 skill-runner 的沙箱层按工作目录统一解析，技能代码无需自行拼接绝对路径。
  * 
  * @module fs-skill
  */
@@ -20,7 +20,7 @@ console.error(`  USER_ID: ${process.env.USER_ID || 'default'}`);
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
 
 /**
- * Resolve path - VM 已设置 cwd，直接使用相对路径即可
+ * Resolve path - 相对路径由沙箱层解析到工作目录
  */
 function resolvePath(relativePath) {
   if (path.isAbsolute(relativePath)) {

--- a/docs/tasks/active/task-20260616-skill-runner-relative-path-fix/BRANCH.md
+++ b/docs/tasks/active/task-20260616-skill-runner-relative-path-fix/BRANCH.md
@@ -1,0 +1,19 @@
+# Branch Mapping
+
+## 当前分支
+
+- `master`
+
+## 建议分支
+
+- `fix/20260616-skill-runner-relative-path`
+
+## Issue 映射
+
+- 暂无正式 Issue
+
+## 修改范围
+
+- `lib/skill-runner.js`
+- `data/skills/fs/index.js`
+- `tests/test-sandbox-fs-restriction.js`

--- a/docs/tasks/active/task-20260616-skill-runner-relative-path-fix/README.md
+++ b/docs/tasks/active/task-20260616-skill-runner-relative-path-fix/README.md
@@ -1,0 +1,52 @@
+# Skill Runner Relative Path Fix
+
+## 目标
+
+- 修复 Node 技能沙箱中相对路径错误按宿主进程 cwd 解析的问题。
+- 确保 `fs` 技能和其他依赖受限 `fs` 的 Node 技能按工作目录读写文件。
+
+## 范围
+
+- `lib/skill-runner.js`
+- `data/skills/fs/index.js`
+- `tests/test-sandbox-fs-restriction.js`
+
+## 问题现象
+
+- 技能传入相对路径如 `奇瑞标准对比分析报告.md` 时，被受限 `fs` 解析到宿主容器目录 `/app/...`。
+- 沙箱允许路径实际是用户工作目录，如 `/data/work/<workspace>/<task>`。
+- 最终导致合法相对路径被误判为越权访问。
+
+## 根因
+
+- `skill-runner` 已计算出 `effectiveCwd` 作为沙箱工作目录和允许目录。
+- 但受限 `fs` 在校验路径时使用 `path.resolve(filePath)`，相对路径会基于宿主进程 cwd 解析，而不是 `effectiveCwd`。
+
+## 修复方案
+
+- 给受限 `fs` 和 `fs.promises` 的路径检查增加 `baseCwd`。
+- 相对路径统一使用 `path.resolve(baseCwd, relativePath)`。
+- 保持现有白名单校验不变。
+
+## 验证
+
+- 补充并运行沙箱路径限制回归测试。
+- 验证相对路径、子目录相对路径、越权路径、`fs.promises` 行为一致性。
+
+## 结果
+
+- 已修复 Node 技能沙箱相对路径解析错误。
+- 受限 `fs` 与 `fs.promises` 现在都会先把相对路径解析到 `effectiveCwd`，再执行白名单校验与实际文件操作。
+- `fs` 技能注释已同步修正，避免将 VM 的伪 `process.cwd()` 与宿主 `fs` 代理行为混淆。
+
+## 验证结果
+
+- `node tests/test-sandbox-fs-restriction.js` 通过（10/10）
+- `node tests/test-skill-runner-relative-path.js` 通过（7/7）
+- `node --check lib/skill-runner.js` 通过
+
+## 额外补强
+
+- 已补充真实 `skill-runner` 级别的 `fs.promises` 端到端测试。
+- 已覆盖双路径参数 `rename(from, to)` 场景。
+- 已覆盖 `file://` URL 形式路径在允许目录内的执行场景。

--- a/lib/skill-runner.js
+++ b/lib/skill-runner.js
@@ -177,39 +177,43 @@ const FS_PROMISES_PATH_METHODS = new Set([
  * @param {object} originalPromises - 原始的 fs.promises 对象
  * @returns {Proxy} 受限的 fs.promises 代理
  */
-function createRestrictedFsPromises(allowedPaths, originalPromises) {
+function resolveSandboxPath(filePath, allowedPaths, baseCwd) {
+  const pathStr = Buffer.isBuffer(filePath) ? filePath.toString('utf8') : String(filePath);
+
+  let resolvedPath = pathStr;
+  if (pathStr.startsWith('file://')) {
+    try {
+      resolvedPath = url.fileURLToPath(pathStr);
+    } catch {
+      resolvedPath = pathStr;
+    }
+  }
+
+  const absolutePath = path.isAbsolute(resolvedPath)
+    ? path.resolve(resolvedPath)
+    : path.resolve(baseCwd, resolvedPath);
+
+  const isAllowed = allowedPaths.some(allowedPath => {
+    const normalizedAllowed = path.resolve(allowedPath);
+    return absolutePath.startsWith(normalizedAllowed + path.sep) ||
+           absolutePath === normalizedAllowed;
+  });
+
+  if (!isAllowed) {
+    throw new Error(
+      `Path not allowed in sandbox: ${absolutePath}\n` +
+      `Allowed paths: ${allowedPaths.map(p => path.resolve(p)).join(', ')}`
+    );
+  }
+
+  return absolutePath;
+}
+
+function createRestrictedFsPromises(allowedPaths, originalPromises, baseCwd) {
   /**
    * 检查路径是否在允许范围内
    */
-  const checkPath = (filePath) => {
-    const pathStr = Buffer.isBuffer(filePath) ? filePath.toString('utf8') : String(filePath);
-    
-    let resolvedPath = pathStr;
-    if (pathStr.startsWith('file://')) {
-      try {
-        resolvedPath = url.fileURLToPath(pathStr);
-      } catch {
-        resolvedPath = pathStr;
-      }
-    }
-    
-    const absolutePath = path.resolve(resolvedPath);
-    
-    const isAllowed = allowedPaths.some(allowedPath => {
-      const normalizedAllowed = path.resolve(allowedPath);
-      return absolutePath.startsWith(normalizedAllowed + path.sep) ||
-             absolutePath === normalizedAllowed;
-    });
-    
-    if (!isAllowed) {
-      throw new Error(
-        `Path not allowed in sandbox: ${absolutePath}\n` +
-        `Allowed paths: ${allowedPaths.map(p => path.resolve(p)).join(', ')}`
-      );
-    }
-    
-    return absolutePath;
-  };
+  const checkPath = (filePath) => resolveSandboxPath(filePath, allowedPaths, baseCwd);
 
   return new Proxy(originalPromises, {
     get(target, prop) {
@@ -219,12 +223,12 @@ function createRestrictedFsPromises(allowedPaths, originalPromises) {
       if (FS_PROMISES_PATH_METHODS.has(prop) && typeof originalValue === 'function') {
         return function(...args) {
           if (args.length > 0 && args[0] !== undefined && args[0] !== null) {
-            checkPath(args[0]);
+            args[0] = checkPath(args[0]);
           }
           
           // 对于某些方法，第二个参数也可能是路径
           if (['rename', 'copyFile', 'link'].includes(prop) && args.length > 1) {
-            checkPath(args[1]);
+            args[1] = checkPath(args[1]);
           }
           
           return originalValue.apply(target, args);
@@ -243,53 +247,20 @@ function createRestrictedFsPromises(allowedPaths, originalPromises) {
  * @param {string[]} allowedPaths - 允许访问的路径前缀列表
  * @returns {Proxy} 受限的 fs 模块代理
  */
-function createRestrictedFs(allowedPaths) {
+function createRestrictedFs(allowedPaths, baseCwd) {
   /**
    * 检查路径是否在允许范围内
    * @param {string} filePath - 要检查的文件路径
    * @throws {Error} 如果路径不在允许范围内
    */
-  const checkPath = (filePath) => {
-    // 处理 Buffer 类型的路径
-    const pathStr = Buffer.isBuffer(filePath) ? filePath.toString('utf8') : String(filePath);
-    
-    // 处理 file:// URL
-    let resolvedPath = pathStr;
-    if (pathStr.startsWith('file://')) {
-      try {
-        resolvedPath = url.fileURLToPath(pathStr);
-      } catch {
-        // 如果解析失败，使用原始路径
-        resolvedPath = pathStr;
-      }
-    }
-    
-    // 规范化路径
-    const absolutePath = path.resolve(resolvedPath);
-    
-    // 检查是否在允许的路径前缀中
-    const isAllowed = allowedPaths.some(allowedPath => {
-      const normalizedAllowed = path.resolve(allowedPath);
-      return absolutePath.startsWith(normalizedAllowed + path.sep) ||
-             absolutePath === normalizedAllowed;
-    });
-    
-    if (!isAllowed) {
-      throw new Error(
-        `Path not allowed in sandbox: ${absolutePath}\n` +
-        `Allowed paths: ${allowedPaths.map(p => path.resolve(p)).join(', ')}`
-      );
-    }
-    
-    return absolutePath;
-  };
+  const checkPath = (filePath) => resolveSandboxPath(filePath, allowedPaths, baseCwd);
 
   // 创建 fs 模块的代理
   return new Proxy(fs, {
     get(target, prop) {
       // 特殊处理 fs.promises
       if (prop === 'promises') {
-        return createRestrictedFsPromises(allowedPaths, target.promises);
+        return createRestrictedFsPromises(allowedPaths, target.promises, baseCwd);
       }
       
       const originalValue = target[prop];
@@ -300,12 +271,12 @@ function createRestrictedFs(allowedPaths) {
           // 第一个参数通常是路径（除了 fd 开头的方法和一些特殊情况）
           if (args.length > 0 && args[0] !== undefined && args[0] !== null) {
             // 检查第一个路径参数
-            checkPath(args[0]);
+            args[0] = checkPath(args[0]);
           }
           
           // 对于某些方法，第二个参数也可能是路径（如 rename, copyFile）
           if (['rename', 'renameSync', 'copyFile', 'copyFileSync', 'link', 'linkSync'].includes(prop) && args.length > 1) {
-            checkPath(args[1]);
+            args[1] = checkPath(args[1]);
           }
           
           // 调用原始方法
@@ -326,9 +297,9 @@ function createRestrictedFs(allowedPaths) {
  * @param {string} skillId - 技能ID
  * @param {string[]} allowedPaths - 允许访问的路径前缀列表
  */
-function createSafeRequire(skillId, allowedPaths = []) {
+function createSafeRequire(skillId, allowedPaths = [], baseCwd = process.cwd()) {
   // 创建受限的 fs 模块
-  const restrictedFs = createRestrictedFs(allowedPaths);
+  const restrictedFs = createRestrictedFs(allowedPaths, baseCwd);
   
   return (moduleName) => {
     // 禁止相对路径引用
@@ -543,7 +514,7 @@ function executeSkill(code, skillId) {
   const context = {
     module: { exports: {} },
     exports: {},  // 添加独立的 exports
-    require: createSafeRequire(skillId, allowedPaths),  // 传入允许的路径列表
+    require: createSafeRequire(skillId, allowedPaths, effectiveCwd),  // 传入允许的路径列表和工作目录
     console: {
       log: (...args) => process.stderr.write(`[${skillId}] ${args.join(' ')}\n`),
       error: (...args) => process.stderr.write(`[${skillId}:ERROR] ${args.join(' ')}\n`),

--- a/tests/test-sandbox-fs-restriction.js
+++ b/tests/test-sandbox-fs-restriction.js
@@ -6,6 +6,7 @@
 
 import vm from 'vm';
 import fs from 'fs';
+import fsPromises from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -26,41 +27,79 @@ const FS_PATH_METHODS = new Set([
   'createReadStream', 'createWriteStream',
 ]);
 
-function createRestrictedFs(allowedPaths) {
-  const checkPath = (filePath) => {
-    const pathStr = Buffer.isBuffer(filePath) ? filePath.toString('utf8') : String(filePath);
-    let resolvedPath = pathStr;
-    
-    const absolutePath = path.resolve(resolvedPath);
-    
-    const isAllowed = allowedPaths.some(allowedPath => {
-      const normalizedAllowed = path.resolve(allowedPath);
-      return absolutePath.startsWith(normalizedAllowed + path.sep) || 
-             absolutePath === normalizedAllowed;
-    });
-    
-    if (!isAllowed) {
-      throw new Error(
-        `Path not allowed in sandbox: ${absolutePath}\n` +
-        `Allowed paths: ${allowedPaths.map(p => path.resolve(p)).join(', ')}`
-      );
+const FS_PROMISES_PATH_METHODS = new Set([
+  'readFile', 'writeFile', 'appendFile', 'readdir', 'mkdir', 'rmdir', 'rm',
+  'stat', 'lstat', 'access', 'open', 'rename', 'copyFile', 'link', 'unlink',
+  'symlink', 'readlink', 'truncate', 'mkdtemp', 'watch',
+]);
+
+function createRestrictedFsPromises(allowedPaths, originalPromises, baseCwd) {
+  const checkPath = (filePath) => resolveSandboxPath(filePath, allowedPaths, baseCwd);
+
+  return new Proxy(originalPromises, {
+    get(target, prop) {
+      const originalValue = target[prop];
+
+      if (FS_PROMISES_PATH_METHODS.has(prop) && typeof originalValue === 'function') {
+        return function(...args) {
+          if (args.length > 0 && args[0] !== undefined && args[0] !== null) {
+            args[0] = checkPath(args[0]);
+          }
+
+          if (['rename', 'copyFile', 'link'].includes(prop) && args.length > 1) {
+            args[1] = checkPath(args[1]);
+          }
+
+          return originalValue.apply(target, args);
+        };
+      }
+
+      return originalValue;
     }
-    
-    return absolutePath;
-  };
+  });
+}
+
+function resolveSandboxPath(filePath, allowedPaths, baseCwd) {
+  const pathStr = Buffer.isBuffer(filePath) ? filePath.toString('utf8') : String(filePath);
+  const absolutePath = path.isAbsolute(pathStr)
+    ? path.resolve(pathStr)
+    : path.resolve(baseCwd, pathStr);
+
+  const isAllowed = allowedPaths.some(allowedPath => {
+    const normalizedAllowed = path.resolve(allowedPath);
+    return absolutePath.startsWith(normalizedAllowed + path.sep) ||
+           absolutePath === normalizedAllowed;
+  });
+
+  if (!isAllowed) {
+    throw new Error(
+      `Path not allowed in sandbox: ${absolutePath}\n` +
+      `Allowed paths: ${allowedPaths.map(p => path.resolve(p)).join(', ')}`
+    );
+  }
+
+  return absolutePath;
+}
+
+function createRestrictedFs(allowedPaths, baseCwd) {
+  const checkPath = (filePath) => resolveSandboxPath(filePath, allowedPaths, baseCwd);
 
   return new Proxy(fs, {
     get(target, prop) {
+      if (prop === 'promises') {
+        return createRestrictedFsPromises(allowedPaths, target.promises, baseCwd);
+      }
+
       const originalValue = target[prop];
       
       if (FS_PATH_METHODS.has(prop) && typeof originalValue === 'function') {
         return function(...args) {
           if (args.length > 0 && args[0] !== undefined && args[0] !== null) {
-            checkPath(args[0]);
+            args[0] = checkPath(args[0]);
           }
           
           if (['rename', 'renameSync', 'copyFile', 'copyFileSync', 'link', 'linkSync'].includes(prop) && args.length > 1) {
-            checkPath(args[1]);
+            args[1] = checkPath(args[1]);
           }
           
           return originalValue.apply(target, args);
@@ -93,7 +132,7 @@ async function runTests() {
   fs.writeFileSync(disallowedFile, 'This file is outside allowed path', 'utf-8');
   
   // 创建受限 fs
-  const restrictedFs = createRestrictedFs([testDataDir]);
+  const restrictedFs = createRestrictedFs([testDataDir], testDataDir);
   
   console.log('='.repeat(60));
   console.log('沙箱 fs 路径限制测试');
@@ -174,7 +213,7 @@ async function runTests() {
   }
   
   // 测试 6: 管理员权限测试（多个允许路径）
-  const adminFs = createRestrictedFs([testDataDir, outsideDir]);
+  const adminFs = createRestrictedFs([testDataDir, outsideDir], testDataDir);
   try {
     adminFs.readFileSync(disallowedFile, 'utf-8');
     console.log(`✅ 测试 6 通过: 管理员可以访问多个路径`);
@@ -191,6 +230,56 @@ async function runTests() {
     passed++;
   } catch (error) {
     console.log(`❌ 测试 7 失败: ${error.message}`);
+    failed++;
+  }
+
+  // 测试 8: 相对路径应按 baseCwd 解析到允许目录
+  try {
+    const relativeFile = 'relative-write.txt';
+    restrictedFs.writeFileSync(relativeFile, 'relative content', 'utf-8');
+    const expectedPath = path.join(testDataDir, relativeFile);
+    const content = fs.readFileSync(expectedPath, 'utf-8');
+    if (content !== 'relative content') {
+      throw new Error('写入内容不匹配');
+    }
+    console.log('✅ 测试 8 通过: 相对路径正确解析到工作目录');
+    passed++;
+    fs.unlinkSync(expectedPath);
+  } catch (error) {
+    console.log(`❌ 测试 8 失败: ${error.message}`);
+    failed++;
+  }
+
+  // 测试 9: 相对路径越权应被阻止
+  try {
+    restrictedFs.writeFileSync('../escape.txt', 'escape', 'utf-8');
+    console.log('❌ 测试 9 失败: 应该阻止通过相对路径越权');
+    failed++;
+  } catch (error) {
+    if (error.message.includes('Path not allowed')) {
+      console.log('✅ 测试 9 通过: 正确阻止了相对路径越权');
+      passed++;
+    } else {
+      console.log(`❌ 测试 9 失败: 错误类型不正确 - ${error.message}`);
+      failed++;
+    }
+  }
+
+  // 测试 10: fs.promises 相对路径应按 baseCwd 解析
+  try {
+    const restrictedPromises = restrictedFs.promises;
+    const relativeFile = 'promises-write.txt';
+    await restrictedPromises.writeFile(relativeFile, 'promises content', 'utf-8');
+    const expectedPath = path.join(testDataDir, relativeFile);
+    const content = await fsPromises.readFile(expectedPath, 'utf-8');
+    if (content !== 'promises content') {
+      throw new Error('写入内容不匹配');
+    }
+    console.log('✅ 测试 10 通过: fs.promises 相对路径正确解析到工作目录');
+    passed++;
+    fs.unlinkSync(expectedPath);
+  } catch (error) {
+    console.log(`❌ 测试 10 失败: ${error.message}`);
     failed++;
   }
   

--- a/tests/test-skill-runner-relative-path.js
+++ b/tests/test-skill-runner-relative-path.js
@@ -1,0 +1,259 @@
+/**
+ * 测试 skill-runner 中相对路径按工作目录解析
+ *
+ * 使用方式:
+ * node tests/test-skill-runner-relative-path.js
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SKILL_RUNNER = path.join(__dirname, '..', 'lib', 'skill-runner.js');
+const SKILL_PATH = path.join(__dirname, '..', 'data', 'skills', 'fs');
+
+const FS_PROMISES_SKILL_CODE = `
+const fs = require('fs');
+const path = require('path');
+
+async function execute(toolName, params) {
+  switch (toolName) {
+    case 'promises_write_read': {
+      const { path: filePath, content } = params;
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.promises.writeFile(filePath, content, 'utf-8');
+      const readBack = await fs.promises.readFile(filePath, 'utf-8');
+      return { success: true, content: readBack };
+    }
+    case 'promises_rename': {
+      const { from, to, content } = params;
+      await fs.promises.mkdir(path.dirname(from), { recursive: true });
+      await fs.promises.mkdir(path.dirname(to), { recursive: true });
+      await fs.promises.writeFile(from, content, 'utf-8');
+      await fs.promises.rename(from, to);
+      const readBack = await fs.promises.readFile(to, 'utf-8');
+      return { success: true, content: readBack };
+    }
+    default:
+      throw new Error('Unknown tool: ' + toolName);
+  }
+}
+
+module.exports = { execute };
+`;
+
+function runSkillTool(skillId, skillPath, toolName, params, envOverrides = {}) {
+  return new Promise((resolve, reject) => {
+    const env = {
+      ...process.env,
+      SKILL_PATH: skillPath,
+      SCRIPT_PATH: 'index.js',
+      IS_ADMIN: 'false',
+      IS_SKILL_CREATOR: 'false',
+      ALLOWED_NODE_MODULES: JSON.stringify([
+        'fs', 'path', 'url', 'querystring', 'crypto',
+        'util', 'stream', 'http', 'https', 'zlib',
+        'string_decoder', 'buffer', 'events', 'os'
+      ]),
+      ALLOWED_PYTHON_PACKAGES: JSON.stringify([]),
+      VM_TIMEOUT: '30000',
+      PYTHON_TIMEOUT: '300000',
+      ...envOverrides,
+    };
+
+    const proc = spawn('node', [SKILL_RUNNER, skillId, toolName], {
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      if (!stdout.trim()) {
+        reject(new Error(`No stdout. exit=${code}\n${stderr}`));
+        return;
+      }
+
+      try {
+        resolve({
+          code,
+          stderr,
+          result: JSON.parse(stdout),
+        });
+      } catch (error) {
+        reject(new Error(`Failed to parse stdout: ${error.message}\nstdout=${stdout}\nstderr=${stderr}`));
+      }
+    });
+
+    proc.on('error', (error) => {
+      reject(error);
+    });
+
+    proc.stdin.write(JSON.stringify({ params, context: {} }));
+    proc.stdin.end();
+  });
+}
+
+function runFsTool(toolName, params, envOverrides = {}) {
+  return runSkillTool('fs', SKILL_PATH, toolName, params, envOverrides);
+}
+
+async function main() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runner-relative-path-'));
+  const dataBasePath = path.join(tempRoot, 'data');
+  const workDir = path.join(dataBasePath, 'work', 'user-1', 'task-1');
+  const promisesSkillPath = path.join(tempRoot, 'skills', 'fs-promises-skill');
+
+  fs.mkdirSync(workDir, { recursive: true });
+  fs.mkdirSync(promisesSkillPath, { recursive: true });
+  fs.writeFileSync(path.join(promisesSkillPath, 'index.js'), FS_PROMISES_SKILL_CODE, 'utf-8');
+
+  const baseEnv = {
+    DATA_BASE_PATH: dataBasePath,
+    USER_ID: 'user-1',
+    WORKING_DIRECTORY: 'work/user-1/task-1',
+  };
+
+  let passed = 0;
+  let failed = 0;
+
+  try {
+    const writeResult = await runFsTool('write_file', {
+      path: 'report.md',
+      content: '# hello',
+    }, baseEnv);
+
+    const expectedFile = path.join(workDir, 'report.md');
+    const content = fs.readFileSync(expectedFile, 'utf-8');
+    if (writeResult.code === 0 && content === '# hello') {
+      console.log('✅ 测试 1 通过: 相对路径写入到了工作目录');
+      passed++;
+    } else {
+      console.log('❌ 测试 1 失败: 写入结果不正确');
+      failed++;
+    }
+
+    const nestedWriteResult = await runFsTool('write_file', {
+      path: 'docs/nested.md',
+      content: 'nested',
+    }, baseEnv);
+
+    const nestedFile = path.join(workDir, 'docs', 'nested.md');
+    if (nestedWriteResult.code === 0 && fs.readFileSync(nestedFile, 'utf-8') === 'nested') {
+      console.log('✅ 测试 2 通过: 子目录相对路径写入成功');
+      passed++;
+    } else {
+      console.log('❌ 测试 2 失败: 子目录写入结果不正确');
+      failed++;
+    }
+
+    const escapeResult = await runFsTool('write_file', {
+      path: '../escape.md',
+      content: 'escape',
+    }, baseEnv);
+
+    if (escapeResult.code !== 0 && escapeResult.result?.error?.includes('Path not allowed')) {
+      console.log('✅ 测试 3 通过: 相对路径越权被正确拦截');
+      passed++;
+    } else {
+      console.log('❌ 测试 3 失败: 越权路径未被拦截');
+      failed++;
+    }
+
+    const absoluteEscapeResult = await runFsTool('write_file', {
+      path: path.join(tempRoot, 'outside.md'),
+      content: 'outside',
+    }, baseEnv);
+
+    if (absoluteEscapeResult.code !== 0 && absoluteEscapeResult.result?.error?.includes('Absolute path not allowed')) {
+      console.log('✅ 测试 4 通过: 绝对路径仍被技能层禁止');
+      passed++;
+    } else {
+      console.log('❌ 测试 4 失败: 绝对路径限制不符合预期');
+      failed++;
+    }
+
+    const promisesWriteReadResult = await runSkillTool('fs-promises-skill', promisesSkillPath, 'promises_write_read', {
+      path: 'promises/report.txt',
+      content: 'promises hello',
+    }, baseEnv);
+
+    const promisesReportFile = path.join(workDir, 'promises', 'report.txt');
+    if (
+      promisesWriteReadResult.code === 0 &&
+      promisesWriteReadResult.result?.data?.content === 'promises hello' &&
+      fs.readFileSync(promisesReportFile, 'utf-8') === 'promises hello'
+    ) {
+      console.log('✅ 测试 5 通过: 真实 skill-runner 下 fs.promises 写读按工作目录执行');
+      passed++;
+    } else {
+      console.log('❌ 测试 5 失败: fs.promises 写读结果不正确');
+      failed++;
+    }
+
+    const promisesRenameResult = await runSkillTool('fs-promises-skill', promisesSkillPath, 'promises_rename', {
+      from: 'promises/from.txt',
+      to: 'promises/to.txt',
+      content: 'rename content',
+    }, baseEnv);
+
+    const renamedFile = path.join(workDir, 'promises', 'to.txt');
+    const oldFile = path.join(workDir, 'promises', 'from.txt');
+    if (
+      promisesRenameResult.code === 0 &&
+      promisesRenameResult.result?.data?.content === 'rename content' &&
+      fs.existsSync(renamedFile) &&
+      !fs.existsSync(oldFile)
+    ) {
+      console.log('✅ 测试 6 通过: 真实 skill-runner 下 fs.promises 双路径参数按工作目录执行');
+      passed++;
+    } else {
+      console.log('❌ 测试 6 失败: fs.promises rename 结果不正确');
+      failed++;
+    }
+
+    const fileUrlPath = pathToFileURL(path.join(workDir, 'file-url.txt')).href;
+    const fileUrlResult = await runSkillTool('fs-promises-skill', promisesSkillPath, 'promises_write_read', {
+      path: fileUrlPath,
+      content: 'file url content',
+    }, baseEnv);
+
+    const fileUrlTarget = path.join(workDir, 'file-url.txt');
+    if (
+      fileUrlResult.code === 0 &&
+      fileUrlResult.result?.data?.content === 'file url content' &&
+      fs.readFileSync(fileUrlTarget, 'utf-8') === 'file url content'
+    ) {
+      console.log('✅ 测试 7 通过: file:// 路径按允许目录正常执行');
+      passed++;
+    } else {
+      console.log('❌ 测试 7 失败: file:// 路径结果不正确');
+      failed++;
+    }
+
+    console.log(`\n测试结果: ${passed} 通过, ${failed} 失败`);
+    process.exit(failed > 0 ? 1 : 0);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error('测试执行失败:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

修复 `skill-runner` 中 Node 技能沙箱对相对路径的错误解析问题，避免合法相对路径被错误解析到宿主进程 cwd（如 `/app`）并被误判为越权访问。

## Changes

- 在 `lib/skill-runner.js` 中提取统一的 `resolveSandboxPath()`
- 让受限 `fs` / `fs.promises` 基于 `effectiveCwd` 解析相对路径
- 将校验后的绝对路径回写给底层原始 `fs` 调用参数
- 修正 `data/skills/fs/index.js` 注释，明确相对路径由沙箱层解析
- 补充沙箱代理和真实 `skill-runner` 端到端测试
- 覆盖 `fs.promises`、`rename(from, to)` 双路径参数和 `file://` 路径场景

## Validation

- `node tests/test-skill-runner-relative-path.js`
- `node tests/test-sandbox-fs-restriction.js`

## Issue

Closes #863
