### PR TITLE
fix: doc processing status build failure

### DIFF
--- a/docs/tasks/active/task-865-doc-processing-status-build/BRANCH.md
+++ b/docs/tasks/active/task-865-doc-processing-status-build/BRANCH.md
@@ -1,0 +1,18 @@
+# Branch Mapping
+
+## 当前分支
+
+- `fix/865-doc-processing-status-build`
+
+## 建议分支
+
+- `fix/865-doc-processing-status-build`
+
+## Issue 映射
+
+- `#865 fix: frontend build fails on doc processing status typing`
+
+## 修改范围
+
+- 修复 `frontend/src/stores/doc.ts` 中与后端契约不一致的轮询判断。
+- 记录本次修复任务、分支映射和验证结论。

--- a/docs/tasks/active/task-865-doc-processing-status-build/README.md
+++ b/docs/tasks/active/task-865-doc-processing-status-build/README.md
@@ -1,0 +1,25 @@
+# task-865-doc-processing-status-build
+
+## 目标
+
+- 修复 `frontend` 构建时 `src/stores/doc.ts` 对不存在处理状态字段的访问导致的 TypeScript 编译失败。
+
+## 范围
+
+- `frontend/src/stores/doc.ts`
+- `docs/tasks/active/task-865-doc-processing-status-build/`
+
+## 结果
+
+- 删除 `doc` store 轮询逻辑中对 `outline_run_id` 和 `outline_run_status` 的依赖。
+- 保持前端轮询逻辑仅依赖当前后端真实返回的 `processing_status` 契约。
+
+## 验证
+
+- `frontend` 下执行 `npm run build`。
+- 仓库根目录执行 `npm run lint`。
+
+## 验证结论
+
+- `frontend` 下 `npm run build` 已通过。
+- 仓库根目录 `npm run lint` 已通过。

--- a/frontend/src/stores/doc.ts
+++ b/frontend/src/stores/doc.ts
@@ -167,18 +167,12 @@ export const useDocStore = defineStore('doc', () => {
       }
 
       const status = result?.processing_status
-      const outlineRunning = status === 'pending_outline' && !!result?.outline_run_id && result?.outline_run_status === 'running'
       const terminal = !status || status === 'ready' || status === 'error' || status === 'pending_embedding'
       if (terminal) {
         stopPolling()
         if (currentResult.value?.revision?.id && currentDoc.value?.id) {
           await fetchContentTree(currentDoc.value.id, currentResult.value.revision.id)
         }
-        return
-      }
-
-      if (outlineRunning) {
-        pollingTimer = window.setTimeout(tick, intervalMs)
         return
       }
 


### PR DESCRIPTION
## Summary

- remove stale `outline_run_id` and `outline_run_status` polling checks from `frontend/src/stores/doc.ts`
- keep doc polling aligned with the actual `getProcessingStatus` response contract
- add `docs/tasks` trace files for the fix and validation results

## Validation

- `npm run lint`
- `cd frontend && npm run build`

Closes #865
