### PR TITLE
fix: preview-token refresh missing oldToken in request body

### DIFF
--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -602,8 +602,8 @@ export const taskApi = {
     apiRequest<{ token: string; expires_at: string }>(apiClient.get(`/tasks/${id}/preview-token`)),
 
   // 刷新预览 Token
-  refreshPreviewToken: (id: string) =>
-    apiRequest<{ token: string; expires_at: string }>(apiClient.post(`/tasks/${id}/preview-token/refresh`)),
+  refreshPreviewToken: (id: string, oldToken: string) =>
+    apiRequest<{ token: string; expires_at: string }>(apiClient.post(`/tasks/${id}/preview-token/refresh`, { oldToken })),
 }
 
 // ============================================

--- a/frontend/src/stores/task.ts
+++ b/frontend/src/stores/task.ts
@@ -302,7 +302,7 @@ export const useTaskStore = defineStore('task', () => {
     if (!currentTask.value) throw new Error('Not in task mode')
 
     try {
-      const response = await taskApi.refreshPreviewToken(currentTask.value.id)
+      const response = await taskApi.refreshPreviewToken(currentTask.value.id, previewTokenCache.value?.token || '')
       const expiresAt = new Date(response.expires_at).getTime()
 
       previewTokenCache.value = {


### PR DESCRIPTION
前端调用 /api/tasks/:id/preview-token/refresh 时缺少后端要求的 oldToken 请求体参数，导致 400 错误。