### PR TITLE
fix: 收口文档平台 remediation 审计修复

### DIFF
--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -714,7 +714,7 @@ async function getDocumentId(services, rowId) {
 const DOC_STATUS_MAP = {
   'ocr_submitted': 'ocr_processing',
   'pending_filter': 'pending_clean',
-  'pending_extract': 'pending_metadata',
+  'pending_extract': 'pending_outline',
   'pending_section': 'pending_chunk',
   'pending_review': 'pending_embedding',
   'pending_classify': 'pending_embedding',

--- a/apps/doc-ocr-pipeline/tick/index.js
+++ b/apps/doc-ocr-pipeline/tick/index.js
@@ -13,8 +13,7 @@ export async function tick(context) {
   const documents = await services.query(
     `SELECT id, processing_status, current_revision_id
      FROM documents
-     WHERE processing_status IN ('pending_ocr', 'ocr_processing', 'pending_clean', 'pending_metadata', 'pending_outline', 'pending_chunk')
-     -- NOTE: pending_embedding / pending_relocate 暂不在此调度器范围内，等待对应 handler 实现
+     WHERE processing_status IN ('pending_ocr', 'ocr_processing', 'pending_clean', 'pending_outline', 'pending_chunk', 'pending_embedding')
        AND current_revision_id IS NOT NULL
      ORDER BY processing_updated_at ASC
      LIMIT ?`,
@@ -27,9 +26,10 @@ export async function tick(context) {
 
   let submitted = 0;
   let synced = 0;
-  let skipped = 0;
+  let autoAdvanced = 0;
   let outlineExtracted = 0;
   let chunksGenerated = 0;
+  let embeddingsGenerated = 0;
   let failed = 0;
 
   const advancer = new DocPipelineAdvancer(context.db);
@@ -50,10 +50,10 @@ export async function tick(context) {
         continue;
       }
 
-      if (doc.processing_status === 'pending_clean' || doc.processing_status === 'pending_metadata') {
+      if (doc.processing_status === 'pending_clean') {
         await recordPassThroughRun(services, doc);
         await advancer.advanceToNext(doc.id);
-        skipped += 1;
+        autoAdvanced += 1;
         continue;
       }
 
@@ -80,6 +80,20 @@ export async function tick(context) {
           initiatedById: null,
         });
         chunksGenerated += 1;
+        continue;
+      }
+
+      if (doc.processing_status === 'pending_embedding') {
+        if (!services.documentEmbedding) {
+          failed += 1;
+          continue;
+        }
+        const embeddingResult = await services.documentEmbedding.processDocument(doc.id);
+        if (embeddingResult?.success) {
+          embeddingsGenerated += 1;
+        } else if (!embeddingResult?.skipped) {
+          failed += 1;
+        }
       }
     } catch (error) {
       failed += 1;
@@ -96,9 +110,10 @@ export async function tick(context) {
     processed: documents.length,
     submitted,
     synced,
-    skipped,
+    autoAdvanced,
     outlineExtracted,
     chunksGenerated,
+    embeddingsGenerated,
     failed,
   };
 }

--- a/frontend/src/api/doc-pipeline.ts
+++ b/frontend/src/api/doc-pipeline.ts
@@ -107,7 +107,8 @@ export interface DocPipelineEmbeddingStage {
   batch_size: number
   skip_empty_chunks: boolean
   retry_times: number
-  timeout_ms: number
+  embedding_timeout_ms: number
+  timeout_ms?: number
 }
 
 export interface DocPipelineRelocateStage {

--- a/frontend/src/api/docs.ts
+++ b/frontend/src/api/docs.ts
@@ -1,5 +1,9 @@
 import apiClient, { apiRequest } from './client'
 
+export type DocProcessingStage = 'pending_ocr' | 'ocr_processing' | 'pending_clean' | 'pending_outline' | 'pending_chunk' | 'pending_embedding' | 'ready' | 'error'
+export type DocRevisionStatus = 'draft' | 'review' | 'approved' | 'effective' | 'expired' | 'archived'
+export type DocOcrStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown' | string
+
 export interface DocDocument {
   id: string
   doc_type: 'knowledge' | 'contract' | 'department_doc' | 'standard'
@@ -13,7 +17,7 @@ export interface DocDocument {
   current_version_id: string | null
   current_revision_id: string | null
   ocr_task_id?: string | null
-  processing_status: string | null
+  processing_status: DocProcessingStage | null
   processing_error_code: string | null
   lifecycle_status: string
   metadata: Record<string, unknown>
@@ -29,19 +33,14 @@ export interface DocDocument {
 
 export interface DocVersion {
   id: string
-  document_id: string
-  version_no: number
-  version_label: string | null
-  version_status: 'draft' | 'review' | 'approved' | 'effective' | 'expired' | 'archived'
-  is_current: number | boolean
-  change_summary: string | null
+  revision_no: number
+  revision_label: string | null
+  revision_status: DocRevisionStatus
+  is_current: boolean
+  diff_status: string | null
   created_by: string
-  approved_by: string | null
-  approved_at: string | null
   effective_from: string | null
   effective_to: string | null
-  published_at: string | null
-  metadata: Record<string, unknown>
   created_at: string
   updated_at: string
 }
@@ -50,7 +49,7 @@ export interface DocRevision {
   id: string
   revision_no: number
   revision_label: string | null
-  revision_status: 'draft' | 'review' | 'approved' | 'effective' | 'expired' | 'archived'
+  revision_status: DocRevisionStatus
   is_current: boolean
   effective_from: string | null
   effective_to: string | null
@@ -68,7 +67,7 @@ export interface DocRevisionsResponse {
 
 export interface DocProcessingStatus {
   document_id: string
-  processing_status: string
+  processing_status: DocProcessingStage
   processing_error_code: string | null
   processing_error_message: string | null
   processing_retry_count: number
@@ -78,7 +77,7 @@ export interface DocProcessingStatus {
     id: string
     revision_id: string
     task_id: string | null
-    status: string
+    status: DocOcrStatus
     progress: number
     image_count: number | null
     main_markdown_attachment_id: string | null
@@ -96,7 +95,7 @@ export interface DocProcessingStatus {
 
 export interface DocRetryResult {
   document_id: string
-  processing_status: string
+  processing_status: DocProcessingStage
 }
 
 export interface DocPermissions {
@@ -114,7 +113,7 @@ export interface DocDiffStatus {
 export interface DocIntakeResult {
   document_id: string
   revision_id: string
-  processing_status: string
+  processing_status: DocProcessingStage
   source_ref_id?: string
   attachment_count?: number
 }
@@ -151,7 +150,7 @@ export interface DocResultDetail {
     document_id: string
     revision_no: number
     revision_label: string | null
-    revision_status: string
+    revision_status: DocRevisionStatus
     created_by: string
     created_at: string
     uploader: {
@@ -161,7 +160,7 @@ export interface DocResultDetail {
   } | null
   source_attachment: DocAttachmentInfo | null
   processing: {
-    status: string
+    status: DocProcessingStage
     error_code: string | null
     error_message: string | null
     updated_at: string | null
@@ -169,7 +168,7 @@ export interface DocResultDetail {
   ocr_result: {
     id: string
     task_id: string | null
-    status: string
+    status: DocOcrStatus
     progress: number
     image_count: number | null
     line_count: number | null
@@ -177,6 +176,7 @@ export interface DocResultDetail {
     completed_at: string | null
     error_code: string | null
     error_message: string | null
+    preview_markdown_content?: string | null
     main_markdown_attachment: DocAttachmentInfo | null
     raw_result_attachment: DocAttachmentInfo | null
     deliverables_manifest_attachment: DocAttachmentInfo | null
@@ -198,14 +198,14 @@ export interface SubmitOcrResult {
   document_id: string
   ocr_result_id: string
   task_id: string | null
-  status: string
+  status: DocOcrStatus
   progress: number
 }
 
 export interface SyncOcrResult {
   document_id: string
   ocr_result_id: string
-  status: string
+  status: DocOcrStatus
   progress: number
   completed: boolean
 }
@@ -322,7 +322,7 @@ export async function deleteDocument(documentId: string): Promise<{ deleted: boo
 
 export async function listVersions(documentId: string): Promise<DocVersion[]> {
   const result = await apiRequest<DocRevisionsResponse>(apiClient.get(`/docs/documents/${documentId}/revisions`))
-  return result.items as unknown as DocVersion[]
+  return result.items
 }
 
 export async function getRevisions(documentId: string): Promise<DocRevisionsResponse> {

--- a/frontend/src/components/docs/DocPipelineConfigDialog.vue
+++ b/frontend/src/components/docs/DocPipelineConfigDialog.vue
@@ -483,7 +483,7 @@
               <el-input-number v-model="form.pending_embedding.retry_times" :min="0" :max="10" :step="1" />
             </el-form-item>
             <el-form-item label="超时(ms)">
-              <el-input-number v-model="form.pending_embedding.timeout_ms" :min="5000" :step="10000" />
+              <el-input-number v-model="form.pending_embedding.embedding_timeout_ms" :min="5000" :step="10000" />
             </el-form-item>
           </template>
 
@@ -605,7 +605,7 @@ const defaultForm: DocPipelineConfig = {
     timeout_ms: 120000,
   },
   pending_chunk: { enabled: true, type: 'builtin', chunk_mode: 'heading', max_length: 1000, overlap_length: 100, keep_heading: true, merge_small_chunks: false },
-  pending_embedding: { enabled: true, embedding_model_id: null, batch_size: 20, skip_empty_chunks: true, retry_times: 3, timeout_ms: 120000 },
+  pending_embedding: { enabled: true, embedding_model_id: null, batch_size: 20, skip_empty_chunks: true, retry_times: 3, embedding_timeout_ms: 120000 },
   pending_relocate: { enabled: true, target_strategy: 'current_collection', tag_strategy: 'none', metadata_writeback: false, auto_publish: false },
 }
 

--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -498,19 +498,20 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
-import DOMPurify from 'dompurify'
 import { useTaskStore } from '@/stores/task'
 import { useToastStore } from '@/stores/toast'
 import Pagination from '@/components/Pagination.vue'
 import CodePreview from '@/components/CodePreview.vue'
 import type { Task, TaskFile, TaskStatus } from '@/types'
 import { renderMermaidInHtml } from '@/utils/mermaid'
+import { useMarkdownFormatter } from '@/composables/useMarkdownFormatter'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const taskStore = useTaskStore()
 const toast = useToastStore()
+const markdownFormatter = useMarkdownFormatter()
 
 const searchQuery = ref('')
 const statusFilter = ref<'all' | 'active' | 'archived'>('all')
@@ -1119,6 +1120,61 @@ const previewFileLanguage = computed(() => {
   return ext
 })
 
+// CSV 解析相关
+const CSV_MAX_ROWS = 500
+
+const csvRows = computed(() => {
+  if (previewType.value !== 'csv' || !previewContent.value) return []
+  return parseCSV(previewContent.value)
+})
+
+const csvVisibleRows = computed(() => {
+  return csvRows.value.slice(1, 1 + CSV_MAX_ROWS)
+})
+
+const csvTruncated = computed(() => {
+  return csvRows.value.length - 1 > CSV_MAX_ROWS
+})
+
+const parseCSV = (content: string): string[][] => {
+  const rows: string[][] = []
+  const lines = content.split(/\r?\n/)
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const cells: string[] = []
+    let current = ''
+    let inQuotes = false
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i]
+      if (inQuotes) {
+        if (ch === '"') {
+          if (i + 1 < line.length && line[i + 1] === '"') {
+            current += '"'
+            i++
+          } else {
+            inQuotes = false
+          }
+        } else {
+          current += ch
+        }
+      } else {
+        if (ch === '"') {
+          inQuotes = true
+        } else if (ch === ',') {
+          cells.push(current.trim())
+          current = ''
+        } else {
+          current += ch
+        }
+      }
+    }
+    cells.push(current.trim())
+    if (cells.some(c => c !== '')) {
+      rows.push(cells)
+    }
+  }
+  return rows
+}
 // 判断文件是否可编辑（在 input 目录下的文本文件，或 HTML 源码模式）
 const canEditFile = computed(() => {
   if (!previewFile.value) return false
@@ -1148,24 +1204,7 @@ marked.setOptions({
 const renderMarkdown = (content: string): string => {
   if (!content) return ''
   try {
-    const rawHtml = marked.parse(content) as string
-    return DOMPurify.sanitize(rawHtml, {
-      ALLOWED_TAGS: [
-        'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'ul', 'ol', 'li',
-        'blockquote', 'pre', 'code',
-        'a', 'img',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td',
-        'hr', 'div', 'span'
-      ],
-      ALLOWED_ATTR: [
-        'href', 'src', 'alt', 'title', 'class',
-        'target', 'rel',
-        'width', 'height'
-      ],
-      ALLOW_DATA_ATTR: true,
-    })
+    return markdownFormatter.formatMessage(content)
   } catch (error) {
     console.error('Markdown parsing error:', error)
     return content
@@ -1189,35 +1228,8 @@ const renderMarkdownWithMermaid = async (content: string): Promise<void> => {
   }
   
   try {
-    // 先进行基础 Markdown 渲染
-    const rawHtml = marked.parse(content) as string
+    let cleanHtml = markdownFormatter.formatMessage(content)
     
-    // 使用 DOMPurify 进行 XSS 清理（允许更多标签用于 Mermaid）
-    let cleanHtml = DOMPurify.sanitize(rawHtml, {
-      ALLOWED_TAGS: [
-        'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'ul', 'ol', 'li',
-        'blockquote', 'pre', 'code',
-        'a', 'img',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td',
-        'hr', 'div', 'span',
-        'svg', 'path', 'g', 'rect', 'circle', 'text', 'tspan', 'polygon', 'line', 'polyline', 'ellipse', 'foreignObject', 'tbody'
-      ],
-      ALLOWED_ATTR: [
-        'href', 'src', 'alt', 'title', 'class',
-        'target', 'rel',
-        'width', 'height',
-        'd', 'transform', 'fill', 'stroke', 'stroke-width', 'viewBox',
-        'x', 'y', 'x1', 'y1', 'x2', 'y2',
-        'cx', 'cy', 'r', 'rx', 'ry',
-        'points', 'id', 'style', 'text-anchor', 'font-size', 'font-family', 'font-weight',
-        'xmlns', 'version'
-      ],
-      ALLOW_DATA_ATTR: true,
-    })
-    
-    // 如果包含 Mermaid 代码块，进行异步渲染
     if (containsMermaid(content)) {
       cleanHtml = await renderMermaidInHtml(cleanHtml)
     }

--- a/frontend/src/composables/useMarkdownFormatter.ts
+++ b/frontend/src/composables/useMarkdownFormatter.ts
@@ -11,6 +11,7 @@ marked.setOptions({
 
 const MERMAID_CACHE_MAX_SIZE = 50
 const MESSAGE_HTML_CACHE_MAX_SIZE = 200
+const FORMATTED_CACHE_MAX_SIZE = 256
 
 const formattedCache = new Map<string, string>()
 const messageHtmlCache = new Map<string, { cacheKey: string; html: string }>()
@@ -26,6 +27,64 @@ const escapeHtml = (text: string): string => {
     .replace(/\n/g, '<br>')
 }
 
+const escapeAttribute = (value: string): string => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+const INLINE_MATH_HINT_RE = /(?:\\[a-zA-Z]+|[=^_{}]|\d\s*[+\-*/]\s*\d|[A-Za-z]\s*[+\-*/=^_]\s*[A-Za-z\d])/
+
+const looksLikeInlineMath = (formula: string): boolean => {
+  const normalized = formula.trim()
+  if (!normalized) return false
+
+  // Treat plain money/percentage/unit snippets as normal text, not math.
+  if (/^\d+(?:[.,]\d+)?(?:\s*(?:%|[A-Za-z]{1,5}|[\u4e00-\u9fa5]{1,3}))?$/.test(normalized)) {
+    return false
+  }
+
+  return INLINE_MATH_HINT_RE.test(normalized)
+}
+
+const normalizeInlineMath = (content: string): string => {
+  return content.replace(/(^|[^\\\w])\$([^\n$]+)\$(?!\$)/g, (_, prefix: string, formula: string) => {
+    if (!looksLikeInlineMath(formula)) {
+      return `${prefix}$${formula}$`
+    }
+    return `${prefix}<code class="inline-math" data-inline-math="${escapeAttribute(formula.trim())}"></code>`
+  })
+}
+
+const sanitizeMarkdownHtml = (rawHtml: string): string => {
+  return DOMPurify.sanitize(rawHtml, {
+    ALLOWED_TAGS: [
+      'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      'ul', 'ol', 'li',
+      'blockquote', 'pre', 'code',
+      'a', 'img',
+      'table', 'thead', 'tbody', 'tr', 'th', 'td',
+      'hr', 'div', 'span',
+      'svg', 'path', 'circle', 'rect', 'line', 'polygon', 'polyline', 'ellipse', 'text', 'g', 'title', 'desc', 'defs', 'marker', 'use', 'tspan'
+    ],
+    ALLOWED_ATTR: [
+      'href', 'src', 'alt', 'title', 'class',
+      'target', 'rel',
+      'width', 'height',
+      'd', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
+      'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'x1', 'y1', 'x2', 'y2',
+      'transform', 'viewBox', 'xmlns', 'id', 'points', 'text-anchor',
+      'dominant-baseline', 'font-size', 'font-family', 'font-weight', 'font-style',
+      'opacity', 'marker-end', 'marker-start', 'marker-mid', 'refX', 'refY',
+      'markerWidth', 'markerHeight', 'orient', 'overflow', 'data-*'
+    ],
+    ALLOW_DATA_ATTR: true,
+  })
+}
+
 const formatMessage = (content: string) => {
   if (!content) return ''
 
@@ -35,36 +94,14 @@ const formatMessage = (content: string) => {
   }
 
   try {
-    const rawHtml = marked.parse(content) as string
+    const normalizedContent = normalizeInlineMath(content)
+    const rawHtml = marked.parse(normalizedContent) as string
+    const cleanHtml = sanitizeMarkdownHtml(rawHtml)
 
-    const cleanHtml = DOMPurify.sanitize(rawHtml, {
-      ALLOWED_TAGS: [
-        'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'ul', 'ol', 'li',
-        'blockquote', 'pre', 'code',
-        'a', 'img',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td',
-        'hr', 'div', 'span',
-        'svg', 'path', 'circle', 'rect', 'line', 'polygon', 'polyline', 'ellipse', 'text', 'g', 'title', 'desc', 'defs', 'marker', 'use', 'tspan', 'foreignObject'
-      ],
-      ALLOWED_ATTR: [
-        'href', 'src', 'alt', 'title', 'class',
-        'target', 'rel',
-        'width', 'height',
-        'd', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
-        'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'x1', 'y1', 'x2', 'y2',
-        'transform', 'viewBox', 'xmlns', 'id', 'points', 'text-anchor',
-        'dominant-baseline', 'font-size', 'font-family', 'font-weight', 'font-style',
-        'opacity', 'marker-end', 'marker-start', 'marker-mid', 'refX', 'refY',
-        'markerWidth', 'markerHeight', 'orient', 'overflow', 'style', 'data-*'
-      ],
-      ALLOW_DATA_ATTR: true,
-    })
-
-    if (formattedCache.size > 100) {
-      const firstKey = formattedCache.keys().next().value
-      if (firstKey) formattedCache.delete(firstKey)
+    if (formattedCache.size > FORMATTED_CACHE_MAX_SIZE) {
+      const keysToDelete = formattedCache.size - FORMATTED_CACHE_MAX_SIZE
+      const keys = Array.from(formattedCache.keys()).slice(0, keysToDelete)
+      keys.forEach(key => formattedCache.delete(key))
     }
     formattedCache.set(content, cleanHtml)
 
@@ -175,6 +212,7 @@ function createInstance() {
   return {
     escapeHtml,
     formatMessage,
+    sanitizeMarkdownHtml,
     containsMermaid,
     formatStreamingMessage,
     mermaidRenderedHtml,

--- a/frontend/src/stores/contract-v2.ts
+++ b/frontend/src/stores/contract-v2.ts
@@ -11,8 +11,6 @@ import {
   updateContract,
   deleteContract,
   createVersion,
-  listVersions,
-  updateVersion,
   approveVersion,
   setCurrentVersion,
   deleteVersion,

--- a/frontend/src/stores/doc.ts
+++ b/frontend/src/stores/doc.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
+import axios from 'axios'
 import {
   listDocuments,
   getDocument,
@@ -27,6 +28,20 @@ import type {
   GenerateChunksResult,
 } from '@/api/docs'
 
+type ApiErrorPayload = {
+  message?: string
+}
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (axios.isAxiosError<ApiErrorPayload>(error)) {
+    return error.response?.data?.message || error.message || fallback
+  }
+  if (error instanceof Error) {
+    return error.message || fallback
+  }
+  return fallback
+}
+
 export const useDocStore = defineStore('doc', () => {
   const documents = ref<DocDocument[]>([])
   const total = ref(0)
@@ -45,9 +60,14 @@ export const useDocStore = defineStore('doc', () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
-  function shouldStopPollingForError(err: any) {
-    const status = err?.response?.status
-    const message = String(err?.response?.data?.message || err?.message || '').toLowerCase()
+  type SyncProcessingResult = {
+    processing: DocProcessingStatus | null
+    shouldStop: boolean
+  }
+
+  function shouldStopPollingForError(err: unknown) {
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined
+    const message = getErrorMessage(err, '').toLowerCase()
     return status === 403
       || status === 404
       || message.includes('write access denied')
@@ -67,8 +87,8 @@ export const useDocStore = defineStore('doc', () => {
       documents.value = result.items
       total.value = result.total
       if (params?.page) currentPage.value = params.page
-    } catch (e: any) {
-      error.value = e.message || 'Failed to load documents'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to load documents')
     } finally {
       isLoading.value = false
     }
@@ -80,8 +100,8 @@ export const useDocStore = defineStore('doc', () => {
     try {
       currentDoc.value = await getDocument(documentId)
       return currentDoc.value
-    } catch (e: any) {
-      error.value = e.message || 'Failed to load document'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to load document')
       return null
     } finally {
       isLoading.value = false
@@ -94,8 +114,8 @@ export const useDocStore = defineStore('doc', () => {
     try {
       currentResult.value = await getDocumentResult(documentId)
       return currentResult.value
-    } catch (e: any) {
-      error.value = e.message || 'Failed to load document result'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to load document result')
       return null
     } finally {
       isLoading.value = false
@@ -107,37 +127,42 @@ export const useDocStore = defineStore('doc', () => {
     try {
       processingStatus.value = await getProcessingStatus(documentId)
       return processingStatus.value
-    } catch (e: any) {
-      error.value = e.message || 'Failed to load processing status'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to load processing status')
       return null
     }
   }
 
-  async function syncProcessing(documentId: string) {
+  async function syncProcessing(documentId: string): Promise<SyncProcessingResult> {
     error.value = null
     const status = processingStatus.value?.processing_status
     const isOcrStage = status === 'pending_ocr' || status === 'ocr_processing'
     if (isOcrStage || !processingStatus.value) {
       try {
         await syncOcr(documentId)
-      } catch (e: any) {
+      } catch (e: unknown) {
         if (isOcrStage) {
-          error.value = e.message || 'Failed to sync OCR status'
-          if (shouldStopPollingForError(e)) {
-            stopPolling()
+          error.value = getErrorMessage(e, 'Failed to sync OCR status')
+          return {
+            processing: null,
+            shouldStop: shouldStopPollingForError(e),
           }
-          return null
         }
       }
     }
+
     try {
-      return await fetchProcessing(documentId)
-    } catch (e: any) {
-      error.value = e.message || 'Failed to load processing status'
-      if (shouldStopPollingForError(e)) {
-        stopPolling()
+      processingStatus.value = await getProcessingStatus(documentId)
+      return {
+        processing: processingStatus.value,
+        shouldStop: false,
       }
-      return null
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to load processing status')
+      return {
+        processing: null,
+        shouldStop: shouldStopPollingForError(e),
+      }
     }
   }
 
@@ -161,13 +186,13 @@ export const useDocStore = defineStore('doc', () => {
 
       if (!isPolling.value) return
 
-      if (!result && error.value) {
+      if (result.shouldStop) {
         stopPolling()
         return
       }
 
-      const status = result?.processing_status
-      const terminal = !status || status === 'ready' || status === 'error' || status === 'pending_embedding'
+      const status = result.processing?.processing_status || null
+      const terminal = status === 'ready' || status === 'error'
       if (terminal) {
         stopPolling()
         if (currentResult.value?.revision?.id && currentDoc.value?.id) {
@@ -187,8 +212,8 @@ export const useDocStore = defineStore('doc', () => {
     error.value = null
     try {
       versions.value = await listVersions(documentId)
-    } catch (e: any) {
-      error.value = e.message || 'Failed to load versions'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to load versions')
     } finally {
       isLoading.value = false
     }
@@ -199,8 +224,8 @@ export const useDocStore = defineStore('doc', () => {
     error.value = null
     try {
       contentTree.value = await getContentTree(documentId, versionId)
-    } catch (e: any) {
-      error.value = e.message || 'Failed to load content tree'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to load content tree')
     } finally {
       isLoading.value = false
     }
@@ -212,8 +237,8 @@ export const useDocStore = defineStore('doc', () => {
     try {
       recallResults.value = await recall(params)
       return recallResults.value
-    } catch (e: any) {
-      error.value = e.message || 'Recall failed'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Recall failed')
       return []
     } finally {
       isLoading.value = false
@@ -226,8 +251,8 @@ export const useDocStore = defineStore('doc', () => {
       await setCurrentVersion(documentId, versionId)
       await fetchVersions(documentId)
       await fetchDocument(documentId)
-    } catch (e: any) {
-      error.value = e.message || 'Failed to set current version'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to set current version')
     }
   }
 
@@ -236,8 +261,8 @@ export const useDocStore = defineStore('doc', () => {
     try {
       await transitionVersion(documentId, versionId, toStatus)
       await fetchVersions(documentId)
-    } catch (e: any) {
-      error.value = e.message || 'Failed to transition version'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to transition version')
     }
   }
 
@@ -250,8 +275,8 @@ export const useDocStore = defineStore('doc', () => {
         await fetchDocumentResult(currentDoc.value.id)
       }
       return result
-    } catch (e: any) {
-      error.value = e.message || 'Failed to extract outline'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to extract outline')
       return null
     }
   }
@@ -268,8 +293,8 @@ export const useDocStore = defineStore('doc', () => {
         }
       }
       return result
-    } catch (e: any) {
-      error.value = e.message || 'Failed to generate chunks'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to generate chunks')
       return null
     }
   }
@@ -285,8 +310,8 @@ export const useDocStore = defineStore('doc', () => {
       if (currentResult.value?.document?.id === documentId) currentResult.value = null
       if (processingStatus.value?.document_id === documentId) processingStatus.value = null
       return true
-    } catch (e: any) {
-      error.value = e.message || 'Failed to delete document'
+    } catch (e: unknown) {
+      error.value = getErrorMessage(e, 'Failed to delete document')
       return false
     }
   }

--- a/frontend/src/views/DocDetailView.vue
+++ b/frontend/src/views/DocDetailView.vue
@@ -37,7 +37,7 @@
           <div class="section-card">
             <h3>正文预览</h3>
             <div v-if="markdownLoading" class="loading-state small">加载中...</div>
-            <div v-else-if="markdownPreview" class="markdown-preview">{{ markdownPreview }}</div>
+            <div v-else-if="markdownPreview" class="markdown-preview" v-html="markdownPreview"></div>
             <div v-else class="empty-state small">
               暂无预览结果，文档可能仍在处理中
               <el-tag v-if="docStore.isPolling" type="warning" size="small" class="polling-tag">轮询中</el-tag>
@@ -186,22 +186,27 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDocStore } from '@/stores/doc'
 import apiClient from '@/api/client'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { useMarkdownFormatter } from '@/composables/useMarkdownFormatter'
+import { ErrorCode } from '@/types'
+import { getErrorMessage as getUiErrorMessage } from '@/utils/errorMessages'
 
 const route = useRoute()
 const router = useRouter()
 const docStore = useDocStore()
+const markdownFormatter = useMarkdownFormatter()
 const markdownPreview = ref('')
 const markdownLoading = ref(false)
 const outlineLoading = ref(false)
 const chunkLoading = ref(false)
+let markdownPreviewRequestId = 0
 
 const LONG_RUNNING_THRESHOLD_MS = 20 * 60 * 1000
-const NON_TERMINAL_STATUSES = ['pending_ocr', 'ocr_processing', 'pending_clean', 'pending_metadata', 'pending_outline', 'pending_chunk', 'pending_embedding', 'pending_relocate']
+const NON_TERMINAL_STATUSES = ['pending_ocr', 'ocr_processing', 'pending_clean', 'pending_outline', 'pending_chunk', 'pending_embedding']
 
 const isLongRunning = computed(() => {
   const status = docStore.currentResult?.processing?.status
@@ -251,15 +256,17 @@ function downloadAttachment(url?: string) {
   window.open(url, '_blank')
 }
 
+function showDocError(message: string | null | undefined, fallback: string) {
+  ElMessage.error(message || fallback || getUiErrorMessage(ErrorCode.UNKNOWN_ERROR))
+}
+
 function processingLabel(status?: string) {
   if (status === 'pending_ocr') return '待OCR'
   if (status === 'ocr_processing') return 'OCR处理中'
   if (status === 'pending_clean') return '待文本清洗'
-  if (status === 'pending_metadata') return '待元数据'
   if (status === 'pending_outline') return '待章节提取'
   if (status === 'pending_chunk') return '待文本分块'
   if (status === 'pending_embedding') return '待向量化'
-  if (status === 'pending_relocate') return '待迁移'
   if (status === 'ready') return '已就绪'
   if (status === 'error') return '处理失败'
   return status || '-'
@@ -268,7 +275,7 @@ function processingLabel(status?: string) {
 function processingTagType(status?: string) {
   if (status === 'ready') return 'success'
   if (status === 'ocr_processing' || status === 'pending_ocr') return 'warning'
-  if (status === 'pending_outline' || status === 'pending_chunk' || status === 'pending_clean' || status === 'pending_metadata') return 'info'
+  if (status === 'pending_outline' || status === 'pending_chunk' || status === 'pending_clean' || status === 'pending_embedding') return 'info'
   if (status === 'error') return 'danger'
   return 'info'
 }
@@ -292,7 +299,7 @@ async function onDeleteDocument() {
 
     const ok = await docStore.removeDocument(current.id)
     if (!ok) {
-      ElMessage.error(docStore.error || '删除文档失败')
+      showDocError(docStore.error, '删除文档失败')
       return
     }
 
@@ -305,29 +312,56 @@ async function onDeleteDocument() {
     }
   } catch (error: unknown) {
     if (error === 'cancel' || error === 'close') return
-    ElMessage.error(docStore.error || '删除文档失败')
+    showDocError(docStore.error, '删除文档失败')
   }
 }
 
 async function loadMarkdownPreview() {
-    const attachment = docStore.currentResult?.ocr_result?.main_markdown_attachment
-    if (!attachment?.id) {
+  const requestId = ++markdownPreviewRequestId
+  const attachment = docStore.currentResult?.ocr_result?.main_markdown_attachment
+  if (!attachment?.id) {
+    if (requestId === markdownPreviewRequestId) {
+      markdownPreview.value = ''
+      markdownLoading.value = false
+    }
+    return
+  }
+
+  markdownLoading.value = true
+  try {
+    const response = await apiClient.get(`/attachments/${attachment.id}/content`, {
+      responseType: 'text',
+    })
+    const rawMarkdown = typeof response.data === 'string' ? response.data : ''
+    if (requestId === markdownPreviewRequestId) {
+      markdownPreview.value = rawMarkdown ? markdownFormatter.formatMessage(rawMarkdown) : ''
+    }
+  } catch {
+    if (requestId === markdownPreviewRequestId) {
+      markdownPreview.value = ''
+    }
+  } finally {
+    if (requestId === markdownPreviewRequestId) {
+      markdownLoading.value = false
+    }
+  }
+}
+
+watch(
+  () => docStore.currentResult?.ocr_result?.main_markdown_attachment?.id,
+  async (attachmentId, previousAttachmentId) => {
+    if (!attachmentId) {
       markdownPreview.value = ''
       return
     }
 
-    markdownLoading.value = true
-    try {
-      const response = await apiClient.get(`/attachments/${attachment.id}/content`, {
-        responseType: 'text',
-      })
-      markdownPreview.value = response.data || ''
-    } catch {
-      markdownPreview.value = ''
-    } finally {
-      markdownLoading.value = false
+    if (attachmentId === previousAttachmentId && markdownPreview.value) {
+      return
     }
-  }
+
+    await loadMarkdownPreview()
+  },
+)
 
   async function onExtractOutline() {
     const revId = docStore.currentResult?.revision?.id
@@ -339,7 +373,7 @@ async function loadMarkdownPreview() {
         ElMessage.success(`成功提取 ${result.outline_count} 个章节${result.partial ? '（部分成功）' : ''}`)
         await loadMarkdownPreview()
       } else {
-        ElMessage.error(docStore.error || '章节提取失败')
+        showDocError(docStore.error, '章节提取失败')
       }
     } finally {
       outlineLoading.value = false
@@ -356,7 +390,7 @@ async function loadMarkdownPreview() {
         ElMessage.success(`成功生成 ${result.chunk_count} 个分块`)
         await loadMarkdownPreview()
       } else {
-        ElMessage.error(docStore.error || '分块生成失败')
+        showDocError(docStore.error, '分块生成失败')
       }
     } finally {
       chunkLoading.value = false

--- a/lib/app-clock.js
+++ b/lib/app-clock.js
@@ -9,6 +9,7 @@ import InternalLLMService from './internal-llm-service.js';
 import DocumentOcrService from './document-ocr-service.js';
 import DocumentOutlineService from './document-outline-service.js';
 import DocumentChunkService from './document-chunk-service.js';
+import DocumentEmbeddingService from './document-embedding-service.js';
 import { DOC_PIPELINE_KEYS, mergeWithDefaults, createCallLlmFn } from './doc-pipeline-defaults.js';
 
 const MAX_TICK_OUTPUT_STRING_LENGTH = parseInt(process.env.APP_CLOCK_MAX_OUTPUT_LENGTH || '4096', 10);
@@ -492,6 +493,10 @@ class AppClock {
       getDocPipelineConfig,
     });
 
+    const documentEmbeddingService = new DocumentEmbeddingService(this.db, {
+      getDocPipelineConfig,
+    });
+
     return {
       db: this.db,
       sequelize: this.sequelize,
@@ -566,6 +571,7 @@ class AppClock {
         documentOcr: documentOcrService,
         documentOutline: documentOutlineService,
         documentChunk: documentChunkService,
+        documentEmbedding: documentEmbeddingService,
       }
     };
   }

--- a/lib/doc-pipeline-advancer.js
+++ b/lib/doc-pipeline-advancer.js
@@ -12,11 +12,9 @@ const STATUS_SEQUENCE = [
   'pending_ocr',
   'ocr_processing',
   'pending_clean',
-  'pending_metadata',
   'pending_outline',
   'pending_chunk',
   'pending_embedding',
-  'pending_relocate',
   'ready',
 ];
 

--- a/lib/doc-pipeline-defaults.js
+++ b/lib/doc-pipeline-defaults.js
@@ -142,20 +142,7 @@ const DOC_PIPELINE_DEFAULTS = {
       remove_garbled_text: true,
       remove_header_footer: true,
     },
-    // NOTE: timeout 字段已拆分，但 pending_clean handler 当前为 pass-through，
-    // llm_timeout_ms 留作预留字段，等待对应 handler 实现后生效
-    llm_timeout_ms: 120000,
-  },
-
-  pending_metadata: {
-    enabled: true,
-    type: 'internal_llm',
-    model_id: null,
-    temperature: 0.3,
-    schema_json: {},
-    prompt_template: '',
-    // NOTE: timeout 字段已拆分，但 pending_metadata handler 当前为 pass-through，
-    // llm_timeout_ms 留作预留字段，等待对应 handler 实现后生效
+    // NOTE: timeout 字段已拆分，llm_timeout_ms 用于文本清洗阶段的 LLM 调用超时控制
     llm_timeout_ms: 120000,
   },
 
@@ -189,17 +176,7 @@ const DOC_PIPELINE_DEFAULTS = {
     batch_size: 20,
     skip_empty_chunks: true,
     retry_times: 3,
-    // NOTE: 当前 doc-ocr-pipeline scheduler 未扫描 pending_embedding 状态，
-    // embedding_timeout_ms 留作预留字段，等待对应 handler 实现后生效
     embedding_timeout_ms: 120000,
-  },
-
-  pending_relocate: {
-    enabled: true,
-    target_strategy: 'current_collection',
-    tag_strategy: 'none',
-    metadata_writeback: false,
-    auto_publish: false,
   },
 };
 
@@ -208,11 +185,9 @@ const PIPELINE_STAGE_KEYS = [
   'ocr_processing',
   'ocr_finalize',
   'pending_clean',
-  'pending_metadata',
   'pending_outline',
   'pending_chunk',
   'pending_embedding',
-  'pending_relocate',
 ];
 
 const DOC_PIPELINE_KEYS = ['meta', ...PIPELINE_STAGE_KEYS];

--- a/lib/document-embedding-service.js
+++ b/lib/document-embedding-service.js
@@ -1,0 +1,234 @@
+import logger from './logger.js';
+import EmbeddingClient from './embedding-client.js';
+import { DB_VECTOR_DIM, adjustVectorDimension, vectorToJson } from './vector-utils.js';
+import { getStageDefault } from './doc-pipeline-defaults.js';
+import { getSystemSettingService } from '../server/services/system-setting.service.js';
+
+class DocumentEmbeddingService {
+  constructor(db, options = {}) {
+    this.db = db;
+    this.getDocPipelineConfig = options.getDocPipelineConfig || null;
+  }
+
+  async _loadStageConfig() {
+    if (typeof this.getDocPipelineConfig === 'function') {
+      try {
+        const fullConfig = await this.getDocPipelineConfig();
+        if (fullConfig && fullConfig.pending_embedding) {
+          return fullConfig.pending_embedding;
+        }
+      } catch (err) {
+        logger.warn('[DocumentEmbeddingService] Failed to load pending_embedding config, using defaults:', err.message);
+      }
+    }
+
+    return getStageDefault('pending_embedding');
+  }
+
+  async _resolveTimeoutMs(stageConfig) {
+    if (stageConfig?.embedding_timeout_ms) {
+      return stageConfig.embedding_timeout_ms;
+    }
+
+    if (stageConfig?.timeout_ms) {
+      return stageConfig.timeout_ms;
+    }
+
+    try {
+      const service = getSystemSettingService(this.db);
+      const settings = await service.getAllSettings();
+      return (settings?.timeout?.embedding || 120) * 1000;
+    } catch {
+      return 120000;
+    }
+  }
+
+  buildEmbeddingText(chunk, document, outline = null) {
+    const parts = [];
+    if (document?.title) parts.push(`文档：${document.title}`);
+    if (outline?.title) parts.push(`章节：${outline.title}`);
+    if (chunk?.title) parts.push(`分块标题：${chunk.title}`);
+    if (chunk?.content) parts.push(chunk.content);
+    return parts.filter(Boolean).join('\n');
+  }
+
+  async processDocument(documentId) {
+    const stageConfig = await this._loadStageConfig();
+    const timeoutMs = await this._resolveTimeoutMs(stageConfig);
+
+    const Document = this.db.getModel('document');
+    const DocumentCollection = this.db.getModel('document_collection');
+    const DocumentChunk = this.db.getModel('document_chunk');
+    const DocumentOutline = this.db.getModel('document_outline');
+
+    const document = await Document.findByPk(documentId, {
+      attributes: ['id', 'title', 'collection_id', 'current_revision_id', 'processing_status'],
+      raw: true,
+    });
+    if (!document) {
+      throw new Error(`Document not found: ${documentId}`);
+    }
+
+    if (document.processing_status !== 'pending_embedding' && document.processing_status !== 'error') {
+      return { success: false, skipped: true, reason: `invalid_status:${document.processing_status}` };
+    }
+
+    if (!document.current_revision_id) {
+      await Document.update({
+        processing_status: 'error',
+        processing_error_code: 'embedding_revision_missing',
+        processing_error_message: 'Current revision is missing',
+        processing_updated_at: new Date(),
+      }, { where: { id: documentId } });
+      return { success: false, skipped: false, reason: 'revision_missing' };
+    }
+
+    const collection = document.collection_id
+      ? await DocumentCollection.findByPk(document.collection_id, {
+        attributes: ['id', 'embedding_model_id'],
+        raw: true,
+      })
+      : null;
+
+    const modelId = stageConfig?.embedding_model_id || collection?.embedding_model_id || null;
+    if (!modelId) {
+      await Document.update({
+        processing_status: 'error',
+        processing_error_code: 'embedding_model_missing',
+        processing_error_message: 'No embedding model configured for this document collection',
+        processing_updated_at: new Date(),
+      }, { where: { id: documentId } });
+      return { success: false, skipped: false, reason: 'embedding_model_missing' };
+    }
+
+    const client = await EmbeddingClient.fromModelId(this.db, modelId);
+    if (!client) {
+      await Document.update({
+        processing_status: 'error',
+        processing_error_code: 'embedding_client_init_failed',
+        processing_error_message: `Failed to initialize embedding client for model ${modelId}`,
+        processing_updated_at: new Date(),
+      }, { where: { id: documentId } });
+      return { success: false, skipped: false, reason: 'embedding_client_init_failed' };
+    }
+
+    const chunks = await DocumentChunk.findAll({
+      where: {
+        revision_id: document.current_revision_id,
+        embedding_status: ['pending', 'error'],
+      },
+      attributes: ['id', 'outline_id', 'title', 'content', 'embedding_status'],
+      order: [['seq', 'ASC']],
+      raw: true,
+    });
+
+    if (!chunks.length) {
+      await Document.update({
+        processing_status: 'error',
+        processing_error_code: 'no_chunks_for_embedding',
+        processing_error_message: 'No document chunks found for embedding',
+        processing_updated_at: new Date(),
+      }, { where: { id: documentId } });
+      return { success: false, skipped: false, reason: 'no_chunks_for_embedding' };
+    }
+
+    const outlineIds = [...new Set(chunks.map(chunk => chunk.outline_id).filter(Boolean))];
+    const outlines = outlineIds.length > 0
+      ? await DocumentOutline.findAll({
+        where: { id: outlineIds },
+        attributes: ['id', 'title'],
+        raw: true,
+      })
+      : [];
+    const outlineMap = new Map(outlines.map(outline => [outline.id, outline]));
+
+    let successCount = 0;
+    for (const chunk of chunks) {
+      const content = String(chunk.content || '').trim();
+      if (stageConfig.skip_empty_chunks !== false && !content) {
+        await this.db.execute(
+          'UPDATE document_chunks SET embedding_status = ?, embedding_model_id = ?, embedded_at = COALESCE(embedded_at, ?), updated_at = ? WHERE id = ?',
+          ['ready', modelId, new Date(), new Date(), chunk.id],
+        );
+        successCount += 1;
+        continue;
+      }
+
+      const text = this.buildEmbeddingText(chunk, document, outlineMap.get(chunk.outline_id) || null).trim();
+      if (!text) {
+        await this.db.execute(
+          'UPDATE document_chunks SET embedding_status = ?, embedding_model_id = ?, embedded_at = COALESCE(embedded_at, ?), updated_at = ? WHERE id = ?',
+          ['ready', modelId, new Date(), new Date(), chunk.id],
+        );
+        successCount += 1;
+        continue;
+      }
+
+      try {
+        await this.db.execute(
+          'UPDATE document_chunks SET embedding_status = ?, embedding_model_id = ?, updated_at = ? WHERE id = ?',
+          ['processing', modelId, new Date(), chunk.id],
+        );
+
+        const embedding = await client.embed(text, timeoutMs);
+        if (!embedding) {
+          throw new Error(`Embedding provider returned empty vector for chunk ${chunk.id}`);
+        }
+
+        const { vector: vectorToStore, adjusted, originalDim, message } = adjustVectorDimension(embedding);
+        if (!vectorToStore) {
+          throw new Error(`Invalid embedding vector for chunk ${chunk.id}`);
+        }
+
+        if (adjusted) {
+          logger.warn(`[DocumentEmbeddingService] Vector dimension mismatch for chunk ${chunk.id}: DB requires ${DB_VECTOR_DIM}, got ${originalDim}`);
+          logger.info(`[DocumentEmbeddingService] ${message}`);
+        }
+
+        await this.db.execute(
+          'UPDATE document_chunks SET embedding_vector = VEC_FromText(?), embedding_status = ?, embedding_model_id = ?, embedded_at = ?, updated_at = ? WHERE id = ?',
+          [vectorToJson(vectorToStore), 'ready', modelId, new Date(), new Date(), chunk.id],
+        );
+        successCount += 1;
+      } catch (error) {
+        await this.db.execute(
+          'UPDATE document_chunks SET embedding_status = ?, embedding_model_id = ?, updated_at = ? WHERE id = ?',
+          ['error', modelId, new Date(), chunk.id],
+        );
+        await Document.update({
+          processing_status: 'error',
+          processing_error_code: 'embedding_failed',
+          processing_error_message: error.message,
+          processing_updated_at: new Date(),
+        }, { where: { id: documentId } });
+        logger.error(`[DocumentEmbeddingService] Failed to embed chunk ${chunk.id}: ${error.message}`);
+        return {
+          success: false,
+          skipped: false,
+          reason: 'embedding_failed',
+          failed_chunk_id: chunk.id,
+          success_count: successCount,
+          total_chunks: chunks.length,
+        };
+      }
+    }
+
+    await Document.update({
+      processing_status: 'ready',
+      processing_error_code: null,
+      processing_error_message: null,
+      processing_updated_at: new Date(),
+    }, { where: { id: documentId } });
+
+    logger.info(`[DocumentEmbeddingService] Document ${documentId} embedded: ${successCount}/${chunks.length}`);
+    return {
+      success: true,
+      skipped: false,
+      success_count: successCount,
+      total_chunks: chunks.length,
+      status: 'ready',
+    };
+  }
+}
+
+export default DocumentEmbeddingService;

--- a/models/document.js
+++ b/models/document.js
@@ -53,7 +53,7 @@ export default class document extends Model {
       comment: "文档标题"
     },
     processing_status: {
-      type: DataTypes.ENUM('pending_ocr','ocr_processing','pending_clean','pending_metadata','pending_outline','pending_chunk','pending_embedding','pending_relocate','ready','error'),
+      type: DataTypes.ENUM('pending_ocr','ocr_processing','pending_clean','pending_outline','pending_chunk','pending_embedding','ready','error'),
       allowNull: false,
       defaultValue: "pending_ocr",
       comment: "处理状态"

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -1619,7 +1619,7 @@ const MIGRATIONS = [
           source_system VARCHAR(50) NOT NULL COMMENT '来源系统',
           source_ref_id VARCHAR(32) NOT NULL COMMENT '来源主键',
           title VARCHAR(500) NOT NULL COMMENT '文档标题',
-          processing_status ENUM('pending_ocr','ocr_processing','pending_clean','pending_metadata','pending_chunk','pending_embedding','pending_relocate','ready','error') NOT NULL DEFAULT 'pending_ocr' COMMENT '处理状态',
+          processing_status ENUM('pending_ocr','ocr_processing','pending_clean','pending_outline','pending_chunk','pending_embedding','ready','error') NOT NULL DEFAULT 'pending_ocr' COMMENT '处理状态',
           processing_error_code VARCHAR(64) NULL COMMENT '错误码',
           processing_error_message TEXT NULL COMMENT '错误信息',
           processing_retry_count INT NOT NULL DEFAULT 0 COMMENT '重试次数',
@@ -2208,7 +2208,7 @@ const MIGRATIONS = [
             source_system VARCHAR(50) NOT NULL COMMENT '来源系统',
             source_ref_id VARCHAR(32) NOT NULL COMMENT '来源主键',
             title VARCHAR(500) NOT NULL COMMENT '文档标题',
-            processing_status ENUM('pending_ocr','ocr_processing','pending_clean','pending_metadata','pending_outline','pending_chunk','pending_embedding','pending_relocate','ready','error') NOT NULL DEFAULT 'pending_ocr' COMMENT '处理状态',
+            processing_status ENUM('pending_ocr','ocr_processing','pending_clean','pending_outline','pending_chunk','pending_embedding','ready','error') NOT NULL DEFAULT 'pending_ocr' COMMENT '处理状态',
             processing_error_code VARCHAR(64) NULL COMMENT '错误码',
             processing_error_message TEXT NULL COMMENT '错误信息',
             processing_retry_count INT NOT NULL DEFAULT 0 COMMENT '重试次数',
@@ -2538,6 +2538,32 @@ const MIGRATIONS = [
       } else {
         console.log('  ⏭️  No timeout.remote_llm to migrate');
       }
+    },
+  },
+  {
+    name: 'documents.processing_status enum simplify',
+    check: async (conn) => {
+      const columnType = await getColumnType(conn, 'documents', 'processing_status');
+      if (!columnType) return false;
+      return columnType === "enum('pending_ocr','ocr_processing','pending_clean','pending_outline','pending_chunk','pending_embedding','ready','error')";
+    },
+    migrate: async (conn) => {
+      await conn.execute(
+        `UPDATE documents
+         SET processing_status = CASE
+           WHEN processing_status = 'pending_metadata' THEN 'pending_outline'
+           WHEN processing_status = 'pending_relocate' THEN 'ready'
+           ELSE processing_status
+         END
+         WHERE processing_status IN ('pending_metadata', 'pending_relocate')`
+      );
+
+      await conn.execute(
+        `ALTER TABLE documents
+         MODIFY COLUMN processing_status ENUM('pending_ocr','ocr_processing','pending_clean','pending_outline','pending_chunk','pending_embedding','ready','error')
+         NOT NULL DEFAULT 'pending_ocr' COMMENT '处理状态'`
+      );
+      console.log('  ✓ Simplified documents.processing_status enum and migrated legacy states');
     },
   },
 

--- a/scripts/verify-doc-platform-mineru.js
+++ b/scripts/verify-doc-platform-mineru.js
@@ -222,6 +222,13 @@ async function getProcessingStatus(baseUrl, token, documentId) {
   return result?.data || result;
 }
 
+async function getDocumentResult(baseUrl, token, documentId) {
+  const result = await requestJson(`${baseUrl}/docs/documents/${documentId}/result`, {
+    headers: authHeaders(token, null),
+  });
+  return result?.data || result;
+}
+
 async function waitForCompletion(baseUrl, token, documentId, timeoutMs, pollMs) {
   const startedAt = Date.now();
   let lastStatus = null;
@@ -244,6 +251,30 @@ async function waitForCompletion(baseUrl, token, documentId, timeoutMs, pollMs) 
   }
 
   throw new Error(`Timed out waiting for OCR completion. lastStatus=${JSON.stringify(lastStatus)}`);
+}
+
+async function waitForReady(baseUrl, token, documentId, timeoutMs, pollMs) {
+  const startedAt = Date.now();
+  let lastResult = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const result = await getDocumentResult(baseUrl, token, documentId);
+    lastResult = result;
+    const status = result?.processing?.status || result?.document?.processing_status || 'unknown';
+    console.log(`[ready-poll] doc=${documentId} status=${status} revision=${result?.revision?.id || 'n/a'}`);
+
+    if (status === 'ready') {
+      return lastResult;
+    }
+
+    if (status === 'error') {
+      throw new Error(`Document did not reach ready state: ${JSON.stringify(lastResult)}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+
+  throw new Error(`Timed out waiting for document ready state. lastResult=${JSON.stringify(lastResult)}`);
 }
 
 async function verifyDatabase(documentId) {
@@ -325,6 +356,9 @@ async function main() {
   const completed = await waitForCompletion(options.baseUrl, accessToken, intake.document_id, options.timeoutMs, options.pollMs);
   console.log(`[completed] processing_status=${completed.status.processing_status} ocr_status=${completed.status.ocr_result?.status}`);
 
+  const readyResult = await waitForReady(options.baseUrl, accessToken, intake.document_id, options.timeoutMs, options.pollMs);
+  console.log(`[ready] processing_status=${readyResult.processing?.status} revision=${readyResult.revision?.id || 'n/a'}`);
+
   const summary = await verifyDatabase(intake.document_id);
   assert(summary.document?.id, 'Document not found in database');
   assert(summary.ocrResult?.id, 'doc_ocr_results record missing');
@@ -333,6 +367,7 @@ async function main() {
   assert(summary.ocrResult?.main_markdown_attachment_id, 'main_markdown_attachment_id missing');
   assert(summary.markdownAttachment?.id, 'Markdown attachment missing');
   assert((summary.ocrResult?.line_count || 0) > 0, 'line_count should be > 0');
+  assert(summary.document?.processing_status === 'ready', `Document not ready after pipeline: ${summary.document?.processing_status}`);
 
   printSummary(summary);
   console.log('\nDocument-platform MinerU integration verification passed.');

--- a/server/controllers/doc-collection.controller.js
+++ b/server/controllers/doc-collection.controller.js
@@ -421,7 +421,7 @@ class DocCollectionController {
 
       const currentVersions = await DocVersion.findAll({
         where: { document_id: { [Op.in]: docIds }, is_current: 1 },
-        attributes: ['id'],
+        attributes: ['id', 'document_id'],
         raw: true,
       });
       const versionIds = currentVersions.map(v => v.id);
@@ -439,6 +439,19 @@ class DocCollectionController {
         },
         { where: { revision_id: { [Op.in]: versionIds } } }
       );
+
+      const affectedDocIds = [...new Set(currentVersions.map(v => v.document_id).filter(Boolean))];
+      if (affectedDocIds.length > 0) {
+        await this.models.DocDocument.update(
+          {
+            processing_status: 'pending_embedding',
+            processing_error_code: null,
+            processing_error_message: null,
+            processing_updated_at: new Date(),
+          },
+          { where: { id: { [Op.in]: affectedDocIds }, processing_status: { [Op.in]: ['pending_embedding', 'ready', 'error'] } } }
+        );
+      }
 
       ctx.success({
         message: 'Revectorization triggered',

--- a/server/controllers/doc.controller.js
+++ b/server/controllers/doc.controller.js
@@ -331,6 +331,7 @@ class DocController {
           'processing_status',
           'processing_error_code',
           'processing_error_message',
+          'processing_updated_at',
           'created_at',
           'updated_at',
           'metadata',
@@ -1081,10 +1082,18 @@ async createVersion(ctx) {
   }
 
   /**
-   * 处理状态机重试映射（V1：统一从 pending_ocr 重新开始）
+   * 处理失败重试映射
    */
-  PROCESSING_RETRY_STAGE = {
-    'error': 'pending_ocr',
+  PROCESSING_RETRY_ERROR_STAGE = {
+    ocr_failed: 'pending_ocr',
+    submit_failed: 'pending_ocr',
+    submit_missing_task_id: 'pending_ocr',
+    clean_failed: 'pending_clean',
+    outline_extraction_failed: 'pending_outline',
+    chunk_generation_failed: 'pending_chunk',
+    embedding_failed: 'pending_embedding',
+    embedding_client_init_failed: 'pending_embedding',
+    no_chunks_for_embedding: 'pending_chunk',
   };
 
   /**
@@ -1169,7 +1178,15 @@ async createVersion(ctx) {
         ctx.throw(400, 'Only documents in error state can be retried');
       }
 
-      const retryStage = this.PROCESSING_RETRY_STAGE[document.processing_status] || 'pending_ocr';
+      if (document.processing_error_code === 'embedding_model_missing') {
+        ctx.throw(400, 'Embedding model is missing. Configure the collection embedding model before retrying');
+      }
+
+      if (document.processing_error_code === 'embedding_revision_missing') {
+        ctx.throw(400, 'Current revision is missing. Repair document revision linkage before retrying');
+      }
+
+      const retryStage = this.PROCESSING_RETRY_ERROR_STAGE[document.processing_error_code] || 'pending_ocr';
 
       await document.update({
         processing_status: retryStage,


### PR DESCRIPTION
## Summary

1. 收口文档平台状态机、迁移脚本与 `pending_embedding -> ready` 链路。
2. 修复正文预览、Markdown 渲染、轮询和重试策略问题。
3. 补齐文档平台验证脚本并调查 `sequelize-auto` 外键回退根因。

## Validation

1. `npm run lint`
2. `frontend/npm run build`
3. `node scripts/upgrade-database.js`
4. `node scripts/generate-models.js`

Closes #882
