### PR TITLE
feat: widen task file types and add csv preview

### DIFF
--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -30,7 +30,7 @@
                 </el-button>
               </template>
               <!-- 自动刷新控制 -->
-              <template v-if="previewType === 'html' || previewType === 'pdf' || previewType === 'markdown'">
+              <template v-if="previewType === 'html' || previewType === 'pdf' || previewType === 'markdown' || previewType === 'csv'">
                 <el-button
                   class="btn-action"
                   :class="{ active: autoRefreshEnabled }"
@@ -130,6 +130,35 @@
                   class="embed-editor markdown-editor"
                 ></textarea>
                 <div v-else class="embed-markdown" v-html="previewRenderedHtml"></div>
+              </template>
+              
+              <!-- CSV 预览（表格视图） -->
+              <template v-else-if="previewType === 'csv'">
+                <textarea
+                  v-if="isEditing"
+                  v-model="previewContent"
+                  class="embed-editor"
+                ></textarea>
+                <div v-else class="csv-table-wrapper">
+                  <table class="csv-table" v-if="csvRows.length > 0">
+                    <thead>
+                      <tr>
+                        <th v-for="(col, ci) in csvRows[0]" :key="ci">{{ col }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="(row, ri) in csvVisibleRows" :key="ri">
+                        <td v-for="(col, ci) in row" :key="ci">{{ col }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <div v-if="csvTruncated" class="csv-truncated-hint">
+                    {{ $t('tasks.csvTruncated', { shown: CSV_MAX_ROWS, total: csvRows.length - 1 }) || `仅显示前 ${CSV_MAX_ROWS} 行，共 ${csvRows.length - 1} 行数据` }}
+                  </div>
+                  <div v-else-if="csvRows.length === 0" class="preview-unsupported">
+                    <p>{{ $t('tasks.csvEmpty') || 'CSV 文件为空或无法解析' }}</p>
+                  </div>
+                </div>
               </template>
               
               <!-- 文本/代码预览 -->
@@ -498,20 +527,19 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 import { useTaskStore } from '@/stores/task'
 import { useToastStore } from '@/stores/toast'
 import Pagination from '@/components/Pagination.vue'
 import CodePreview from '@/components/CodePreview.vue'
 import type { Task, TaskFile, TaskStatus } from '@/types'
 import { renderMermaidInHtml } from '@/utils/mermaid'
-import { useMarkdownFormatter } from '@/composables/useMarkdownFormatter'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const taskStore = useTaskStore()
 const toast = useToastStore()
-const markdownFormatter = useMarkdownFormatter()
 
 const searchQuery = ref('')
 const statusFilter = ref<'all' | 'active' | 'archived'>('all')
@@ -537,7 +565,7 @@ const taskForm = ref({
 // 文件预览相关
 const showEmbedPreview = ref(false)  // 嵌入式预览模式
 const previewFile = ref<TaskFile | null>(null)
-const previewType = ref<'text' | 'code' | 'markdown' | 'image' | 'pdf' | 'html' | 'unsupported'>('text')
+const previewType = ref<'text' | 'code' | 'markdown' | 'image' | 'pdf' | 'html' | 'csv' | 'unsupported'>('text')
 const previewContent = ref('')
 const previewOriginalContent = ref('')  // 保存原始内容，用于取消编辑
 const previewRenderedHtml = ref('')  // 渲染后的 HTML（包含 Mermaid 图表）
@@ -686,7 +714,7 @@ const handleToggleAutonomousFromList = async (task: Task, event: Event) => {
 }
 
 // 允许的文件类型
-const allowedFileTypes = '.pdf,.doc,.docx,.txt,.md,.csv,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.zip,.json'
+const allowedFileTypes = '.pdf,.doc,.docx,.txt,.md,.csv,.xlsx,.xls,.ppt,.pptx,.png,.jpg,.jpeg,.gif,.zip,.json,.html,.htm,.js,.mjs,.cjs,.ts,.mts,.cts,.jsx,.tsx,.vue,.css,.scss,.less,.py,.java,.c,.cpp,.h,.hpp,.cs,.go,.rs,.php,.rb,.sh,.bash,.zsh,.sql,.xml,.yaml,.yml'
 
 // 根据状态和搜索过滤任务
 const filteredTasks = computed(() => {
@@ -914,15 +942,16 @@ const handleFileClick = async (file: TaskFile) => {
 }
 
 // 判断文件预览类型
-const getPreviewType = (filename: string): 'text' | 'code' | 'markdown' | 'image' | 'pdf' | 'html' | 'unsupported' => {
+const getPreviewType = (filename: string): 'text' | 'code' | 'markdown' | 'image' | 'pdf' | 'html' | 'csv' | 'unsupported' => {
   const ext = filename.split('.').pop()?.toLowerCase() || ''
 
-  const textExts = ['txt', 'csv', 'log']
+  const textExts = ['txt', 'log']
   const codeExts = ['js', 'ts', 'vue', 'jsx', 'tsx', 'py', 'java', 'c', 'cpp', 'h', 'css', 'scss', 'json', 'xml', 'yaml', 'yml', 'sh', 'sql']
   const imageExts = ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg']
 
   if (ext === 'md') return 'markdown'
   if (ext === 'html' || ext === 'htm') return 'html'
+  if (ext === 'csv') return 'csv'
   if (textExts.includes(ext)) return 'text'
   if (codeExts.includes(ext)) return 'code'
   if (imageExts.includes(ext)) return 'image'
@@ -970,9 +999,9 @@ const openPreview = async (file: TaskFile) => {
       return
     }
 
-    // 文本/代码/Markdown 文件也使用静态文件服务
+    // 文本/代码/Markdown/CSV 文件也使用静态文件服务
     // Token 在 URL 中，可以直接 fetch
-    if (previewType.value === 'text' || previewType.value === 'code' || previewType.value === 'markdown') {
+    if (previewType.value === 'text' || previewType.value === 'code' || previewType.value === 'markdown' || previewType.value === 'csv') {
       const contentUrl = await taskStore.getEmbedPreviewUrl(file.path)
       const response = await fetch(contentUrl)
       if (!response.ok) {
@@ -1169,20 +1198,21 @@ const parseCSV = (content: string): string[][] => {
       }
     }
     cells.push(current.trim())
-    if (cells.some(c => c !== '')) {
+    if (cells.length > 0 && cells.some(c => c !== '')) {
       rows.push(cells)
     }
   }
   return rows
 }
+
 // 判断文件是否可编辑（在 input 目录下的文本文件，或 HTML 源码模式）
 const canEditFile = computed(() => {
   if (!previewFile.value) return false
   const path = previewFile.value.path
   const isInInputDir = path.startsWith('input/') || path === previewFile.value.name || currentPath.value.startsWith('input')
 
-  // 文本、代码、Markdown 文件在 input 目录下可编辑
-  if (previewType.value === 'text' || previewType.value === 'code' || previewType.value === 'markdown') {
+  // 文本、代码、Markdown、CSV 文件在 input 目录下可编辑
+  if (previewType.value === 'text' || previewType.value === 'code' || previewType.value === 'markdown' || previewType.value === 'csv') {
     return isInInputDir
   }
 
@@ -1204,7 +1234,24 @@ marked.setOptions({
 const renderMarkdown = (content: string): string => {
   if (!content) return ''
   try {
-    return markdownFormatter.formatMessage(content)
+    const rawHtml = marked.parse(content) as string
+    return DOMPurify.sanitize(rawHtml, {
+      ALLOWED_TAGS: [
+        'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'ul', 'ol', 'li',
+        'blockquote', 'pre', 'code',
+        'a', 'img',
+        'table', 'thead', 'tbody', 'tr', 'th', 'td',
+        'hr', 'div', 'span'
+      ],
+      ALLOWED_ATTR: [
+        'href', 'src', 'alt', 'title', 'class',
+        'target', 'rel',
+        'width', 'height'
+      ],
+      ALLOW_DATA_ATTR: true,
+    })
   } catch (error) {
     console.error('Markdown parsing error:', error)
     return content
@@ -1228,8 +1275,35 @@ const renderMarkdownWithMermaid = async (content: string): Promise<void> => {
   }
   
   try {
-    let cleanHtml = markdownFormatter.formatMessage(content)
+    // 先进行基础 Markdown 渲染
+    const rawHtml = marked.parse(content) as string
     
+    // 使用 DOMPurify 进行 XSS 清理（允许更多标签用于 Mermaid）
+    let cleanHtml = DOMPurify.sanitize(rawHtml, {
+      ALLOWED_TAGS: [
+        'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'ul', 'ol', 'li',
+        'blockquote', 'pre', 'code',
+        'a', 'img',
+        'table', 'thead', 'tbody', 'tr', 'th', 'td',
+        'hr', 'div', 'span',
+        'svg', 'path', 'g', 'rect', 'circle', 'text', 'tspan', 'polygon', 'line', 'polyline', 'ellipse', 'foreignObject', 'tbody'
+      ],
+      ALLOWED_ATTR: [
+        'href', 'src', 'alt', 'title', 'class',
+        'target', 'rel',
+        'width', 'height',
+        'd', 'transform', 'fill', 'stroke', 'stroke-width', 'viewBox',
+        'x', 'y', 'x1', 'y1', 'x2', 'y2',
+        'cx', 'cy', 'r', 'rx', 'ry',
+        'points', 'id', 'style', 'text-anchor', 'font-size', 'font-family', 'font-weight',
+        'xmlns', 'version'
+      ],
+      ALLOW_DATA_ATTR: true,
+    })
+    
+    // 如果包含 Mermaid 代码块，进行异步渲染
     if (containsMermaid(content)) {
       cleanHtml = await renderMermaidInHtml(cleanHtml)
     }
@@ -1342,6 +1416,38 @@ const getFileIcon = (filename: string): string => {
     gif: '🖼️',
     zip: '📦',
     json: '📋',
+    html: '🌐',
+    htm: '🌐',
+    js: '📜',
+    mjs: '📜',
+    cjs: '📜',
+    ts: '📘',
+    mts: '📘',
+    cts: '📘',
+    jsx: '⚛️',
+    tsx: '⚛️',
+    vue: '💚',
+    css: '🎨',
+    scss: '🎨',
+    less: '🎨',
+    py: '🐍',
+    java: '☕',
+    c: '⚙️',
+    cpp: '⚙️',
+    h: '⚙️',
+    hpp: '⚙️',
+    cs: '🔷',
+    go: '🔵',
+    rs: '🦀',
+    php: '🐘',
+    rb: '💎',
+    sh: '💻',
+    bash: '💻',
+    zsh: '💻',
+    sql: '🗄️',
+    xml: '📋',
+    yaml: '📋',
+    yml: '📋',
   }
   return iconMap[ext] || '📄'
 }
@@ -2541,6 +2647,62 @@ onUnmounted(() => {
   object-fit: contain;
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.csv-table-wrapper {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.csv-table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.csv-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 8px 12px;
+  background: var(--primary-color, #2563eb);
+  color: #fff;
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.csv-table td {
+  padding: 6px 12px;
+  border: 1px solid var(--border-color, #e5e7eb);
+  white-space: nowrap;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.csv-table tbody tr:nth-child(even) {
+  background: var(--table-stripe-bg, #f9fafb);
+}
+
+.csv-table tbody tr:hover {
+  background: var(--primary-bg, #eff6ff);
+}
+
+.csv-truncated-hint {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: var(--warning-bg, #fffbeb);
+  color: var(--warning-color, #92400e);
+  border-radius: 6px;
+  font-size: 12px;
+  text-align: center;
 }
 
 .embed-editor {

--- a/frontend/src/components/panel/TasksTab.vue
+++ b/frontend/src/components/panel/TasksTab.vue
@@ -527,19 +527,20 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
-import DOMPurify from 'dompurify'
 import { useTaskStore } from '@/stores/task'
 import { useToastStore } from '@/stores/toast'
 import Pagination from '@/components/Pagination.vue'
 import CodePreview from '@/components/CodePreview.vue'
 import type { Task, TaskFile, TaskStatus } from '@/types'
 import { renderMermaidInHtml } from '@/utils/mermaid'
+import { useMarkdownFormatter } from '@/composables/useMarkdownFormatter'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const taskStore = useTaskStore()
 const toast = useToastStore()
+const markdownFormatter = useMarkdownFormatter()
 
 const searchQuery = ref('')
 const statusFilter = ref<'all' | 'active' | 'archived'>('all')
@@ -1198,7 +1199,7 @@ const parseCSV = (content: string): string[][] => {
       }
     }
     cells.push(current.trim())
-    if (cells.length > 0 && cells.some(c => c !== '')) {
+    if (cells.some(c => c !== '')) {
       rows.push(cells)
     }
   }
@@ -1234,24 +1235,7 @@ marked.setOptions({
 const renderMarkdown = (content: string): string => {
   if (!content) return ''
   try {
-    const rawHtml = marked.parse(content) as string
-    return DOMPurify.sanitize(rawHtml, {
-      ALLOWED_TAGS: [
-        'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'ul', 'ol', 'li',
-        'blockquote', 'pre', 'code',
-        'a', 'img',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td',
-        'hr', 'div', 'span'
-      ],
-      ALLOWED_ATTR: [
-        'href', 'src', 'alt', 'title', 'class',
-        'target', 'rel',
-        'width', 'height'
-      ],
-      ALLOW_DATA_ATTR: true,
-    })
+    return markdownFormatter.formatMessage(content)
   } catch (error) {
     console.error('Markdown parsing error:', error)
     return content
@@ -1275,35 +1259,8 @@ const renderMarkdownWithMermaid = async (content: string): Promise<void> => {
   }
   
   try {
-    // 先进行基础 Markdown 渲染
-    const rawHtml = marked.parse(content) as string
-    
-    // 使用 DOMPurify 进行 XSS 清理（允许更多标签用于 Mermaid）
-    let cleanHtml = DOMPurify.sanitize(rawHtml, {
-      ALLOWED_TAGS: [
-        'p', 'br', 'strong', 'em', 'u', 's', 'del', 'ins',
-        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'ul', 'ol', 'li',
-        'blockquote', 'pre', 'code',
-        'a', 'img',
-        'table', 'thead', 'tbody', 'tr', 'th', 'td',
-        'hr', 'div', 'span',
-        'svg', 'path', 'g', 'rect', 'circle', 'text', 'tspan', 'polygon', 'line', 'polyline', 'ellipse', 'foreignObject', 'tbody'
-      ],
-      ALLOWED_ATTR: [
-        'href', 'src', 'alt', 'title', 'class',
-        'target', 'rel',
-        'width', 'height',
-        'd', 'transform', 'fill', 'stroke', 'stroke-width', 'viewBox',
-        'x', 'y', 'x1', 'y1', 'x2', 'y2',
-        'cx', 'cy', 'r', 'rx', 'ry',
-        'points', 'id', 'style', 'text-anchor', 'font-size', 'font-family', 'font-weight',
-        'xmlns', 'version'
-      ],
-      ALLOW_DATA_ATTR: true,
-    })
-    
-    // 如果包含 Mermaid 代码块，进行异步渲染
+    let cleanHtml = markdownFormatter.formatMessage(content)
+
     if (containsMermaid(content)) {
       cleanHtml = await renderMermaidInHtml(cleanHtml)
     }

--- a/server/routes/task.routes.js
+++ b/server/routes/task.routes.js
@@ -20,7 +20,11 @@ const WORKSPACE_ROOT = getWorkspaceRoot();
 // 允许的文件类型
 const ALLOWED_FILE_TYPES = [
   '.pdf', '.doc', '.docx', '.txt', '.md', '.csv', '.xlsx', '.xls',
-  '.ppt', '.pptx', '.png', '.jpg', '.jpeg', '.gif', '.zip', '.json'
+  '.ppt', '.pptx', '.png', '.jpg', '.jpeg', '.gif', '.zip', '.json',
+  '.html', '.htm', '.js', '.mjs', '.cjs', '.ts', '.mts', '.cts',
+  '.jsx', '.tsx', '.vue', '.css', '.scss', '.less', '.py', '.java',
+  '.c', '.cpp', '.h', '.hpp', '.cs', '.go', '.rs', '.php', '.rb',
+  '.sh', '.bash', '.zsh', '.sql', '.xml', '.yaml', '.yml'
 ];
 
 // 创建上传中间件工厂函数


### PR DESCRIPTION
## Summary

1. 扩大任务工作空间允许的文件类型范围。
2. 为任务文件增加 CSV 表格预览与编辑支持。
3. 让任务文件的自动刷新与预览逻辑覆盖 CSV 文件。

## Validation

1. 复核变更仅触及 `frontend/src/components/panel/TasksTab.vue` 与 `server/routes/task.routes.js`
2. `frontend/npm run build` 当前被仓库既有 `current-feature-analyzer` 类型错误阻断，与本次改动无关
