### PR TITLE
feat: Phase 4 doc-ocr-pipeline 标准化 + contract-mgr-v2 解绑方案

### DIFF
--- a/apps/contract-mgr-v2/backup/export.js
+++ b/apps/contract-mgr-v2/backup/export.js
@@ -12,7 +12,7 @@ export async function exportBackup(context, options = {}) {
   }
 
   try {
-    const content = await query('SELECT * FROM app_contract_mgr_v2_content');
+    const content = await query('SELECT row_id, content_id, process_step, document_id, ocr_text, filtered_text, sections, extract_json, extract_model, extract_at, classification_json FROM app_contract_mgr_v2_content');
     tables.push({ name: 'app_contract_mgr_v2_content', rows: content });
   } catch {
     tables.push({ name: 'app_contract_mgr_v2_content', rows: [], error: 'table not found' });

--- a/apps/contract-mgr-v2/controllers/batch-upload.js
+++ b/apps/contract-mgr-v2/controllers/batch-upload.js
@@ -64,6 +64,7 @@ export async function execute(context, params) {
       if (attachment.created_by !== userId) continue;
 
       const rowId = Utils.newID(20);
+      const contentId = Utils.newID(20);
       const documentId = Utils.newID(20);
       const revisionId = Utils.newID(20);
 
@@ -85,9 +86,9 @@ export async function execute(context, params) {
         );
         await db.sequelize.query(
           `INSERT INTO app_contract_mgr_v2_content
-          (row_id, process_step, file_id, document_id, created_at, updated_at)
-          VALUES (?, 'pending_ocr', ?, ?, NOW(), NOW())`,
-          { replacements: [rowId, attId, documentId], transaction: t }
+          (row_id, content_id, process_step, file_id, document_id, created_at, updated_at)
+          VALUES (?, ?, 'pending_ocr', ?, ?, NOW(), NOW())`,
+          { replacements: [rowId, contentId, attId, documentId], transaction: t }
         );
         await db.getModel('attachment').update(
           { source_tag: 'doc-platform', source_id: revisionId },
@@ -97,6 +98,7 @@ export async function execute(context, params) {
 
       records.push({
         id: rowId,
+        content_id: contentId,
         process_step: 'pending_ocr',
         file_id: attId,
         title: attachment.file_name || 'Unknown',

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -115,7 +115,7 @@ export async function tick(context) {
   }
   
   const pending = await services.query(`
-    SELECT row_id, process_step, ocr_task_id, file_id, filter_carried_over, filter_chunk_index
+    SELECT row_id, content_id, process_step, ocr_task_id, file_id, filter_carried_over, filter_chunk_index
     FROM ${CONTENT_TABLE}
     WHERE process_step IN ('pending_ocr', 'ocr_submitted', 'pending_filter', 'pending_extract', 'pending_section', 'pending_classify')
     ORDER BY created_at ASC

--- a/apps/doc-ocr-pipeline/manifest.json
+++ b/apps/doc-ocr-pipeline/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "doc-ocr-pipeline",
+  "name": "文档 OCR 处理管线",
+  "version": "1.0.0",
+  "description": "文档平台的 OCR、清洗、大纲提取、分块、向量化处理管线",
+  "icon": "📄",
+  "type": "workflow",
+  "author": "Touwaka Team",
+  "runtime": {
+    "tick": "tick/index.js"
+  }
+}

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -2040,6 +2040,20 @@ const MIGRATIONS = [
         ['extract_failed', '提取失败', '结构化提取失败', 92, 0, 1, 1, null, null],
         ['section_failed', '分章失败', '章节分析失败', 93, 0, 1, 1, null, null],
         ['classify_failed', '分类失败', '版本建议失败', 94, 0, 1, 1, null, null]
+      ];
+
+      for (const [name, label, description, sortOrder, isInitial, isTerminal, isError, successNext, failureNext] of states) {
+        await conn.execute(
+          `INSERT INTO app_state (id, app_id, name, label, description, sort_order, is_initial, is_terminal, is_error, handler_id, success_next_state, failure_next_state)
+           VALUES (?, 'contract-mgr-v2', ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`,
+          [crypto.randomBytes(10).toString('hex').slice(0, 20), name, label, description, sortOrder, isInitial, isTerminal, isError, successNext, failureNext]
+        );
+      }
+
+      console.log('  ✓ Ensured contract-mgr-v2 installation metadata/states');
+    }
+  },
+
   // 41. contract-mgr-v2 解除 row_id 绑定：content 表加 content_id
   {
     name: 'app_contract_mgr_v2_content add content_id',
@@ -2068,20 +2082,7 @@ const MIGRATIONS = [
     },
   },
 
-];
-      for (const [name, label, description, sortOrder, isInitial, isTerminal, isError, successNext, failureNext] of states) {
-        await conn.execute(
-          `INSERT INTO app_state (id, app_id, name, label, description, sort_order, is_initial, is_terminal, is_error, handler_id, success_next_state, failure_next_state)
-           VALUES (?, 'contract-mgr-v2', ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)`,
-          [crypto.randomBytes(10).toString('hex').slice(0, 20), name, label, description, sortOrder, isInitial, isTerminal, isError, successNext, failureNext]
-        );
-      }
-
-      console.log('  ✓ Ensured contract-mgr-v2 installation metadata/states');
-    }
-  },
-
-  // ==================== 清理旧 doc_* 表（彻底替换） ====================
+// ==================== 清理旧 doc_* 表（彻底替换） ====================
 
   // 34. 删除旧 doc_chunks 表
   {

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -2040,8 +2040,35 @@ const MIGRATIONS = [
         ['extract_failed', '提取失败', '结构化提取失败', 92, 0, 1, 1, null, null],
         ['section_failed', '分章失败', '章节分析失败', 93, 0, 1, 1, null, null],
         ['classify_failed', '分类失败', '版本建议失败', 94, 0, 1, 1, null, null]
-      ];
+  // 41. contract-mgr-v2 解除 row_id 绑定：content 表加 content_id
+  {
+    name: 'app_contract_mgr_v2_content add content_id',
+    check: async (conn) =>
+      await hasColumn(conn, 'app_contract_mgr_v2_content', 'content_id'),
+    migrate: async (conn) => {
+      await conn.execute(
+        `ALTER TABLE app_contract_mgr_v2_content
+         ADD COLUMN content_id VARCHAR(32) NOT NULL DEFAULT '' AFTER row_id`
+      );
+      const [rows] = await conn.execute(
+        `SELECT row_id FROM app_contract_mgr_v2_content WHERE content_id = ''`
+      );
+      for (const row of rows) {
+        const newId = crypto.randomUUID().replace(/-/g, '').substring(0, 32);
+        await conn.execute(
+          `UPDATE app_contract_mgr_v2_content SET content_id = ? WHERE row_id = ?`,
+          [newId, row.row_id]
+        );
+      }
+      await conn.execute(
+        `ALTER TABLE app_contract_mgr_v2_content
+         ADD UNIQUE KEY uk_content_id (content_id)`
+      );
+      console.log('  ✓ Added content_id to app_contract_mgr_v2_content and populated existing rows');
+    },
+  },
 
+];
       for (const [name, label, description, sortOrder, isInitial, isTerminal, isError, successNext, failureNext] of states) {
         await conn.execute(
           `INSERT INTO app_state (id, app_id, name, label, description, sort_order, is_initial, is_terminal, is_error, handler_id, success_next_state, failure_next_state)

--- a/server/services/contract-v2.service.js
+++ b/server/services/contract-v2.service.js
@@ -256,6 +256,7 @@ class ContractV2Service {
       if (existing) throw new Error(`版本号 ${versionNumber} 已存在`);
 
       const rowId = Utils.newID(20);
+      const contentId = Utils.newID(20);
       const isFirst = existingCount === 0;
       
       const version = await this.models.Version.create({
@@ -274,10 +275,10 @@ class ContractV2Service {
       // 创建 content 记录，启动处理流程
       await this.db.sequelize.query(`
         INSERT INTO app_contract_mgr_v2_content 
-        (row_id, process_step, file_id, created_at, updated_at)
-        VALUES (?, 'pending_ocr', ?, NOW(), NOW())
+        (row_id, content_id, process_step, file_id, created_at, updated_at)
+        VALUES (?, ?, 'pending_ocr', ?, NOW(), NOW())
       `, {
-        replacements: [rowId, data.file_id || null],
+        replacements: [rowId, contentId, data.file_id || null],
         transaction: t
       });
 


### PR DESCRIPTION
﻿## Phase 4: App 迁移主战场 (P0)

### doc-ocr-pipeline 标准化
- 补齐 manifest.json
- 声明 runtime.tick
- 启动日志确认: runtime validated (hasTick=true)，不再走 legacy fallback

### contract-mgr-v2 解除 row_id 绑定方案
- 已输出迁移方案文档 CONTRACT-V2-UNBIND-PLAN.md
- DB 变更需单独审批

### 后续
- contract-mgr 摆脱 mini_app_rows
- invoice-mgr 迁移

