### PR TITLE
feat: app 路由前缀规范化 + 声明式 apis 迁移 + legacy 兼容层

### DIFF
--- a/apps/contract-mgr-v2/manifest.json
+++ b/apps/contract-mgr-v2/manifest.json
@@ -9,9 +9,6 @@
   "license": "MIT",
   "runtime": {
     "tick": "tick/index.js",
-    "server": {
-      "routes": "server/routes.js"
-    },
     "backup": {
       "export": "backup/export.js",
       "import": "backup/import.js"
@@ -367,5 +364,15 @@
     }
   ],
   "component": "ContractV2View",
+  "apis": [
+    { "path": "/org-nodes/tree", "methods": ["GET"], "handler": "server/controllers/org-nodes.js" },
+    { "path": "/org-nodes", "methods": ["POST"], "handler": "server/controllers/org-nodes.js" },
+    { "path": "/contracts", "methods": ["GET"], "handler": "server/controllers/contracts.js" },
+    { "path": "/contracts", "methods": ["POST"], "handler": "server/controllers/contracts.js" },
+    { "path": "/contracts/:contractId", "methods": ["GET"], "handler": "server/controllers/contracts.js" },
+    { "path": "/contracts/:contractId", "methods": ["PUT"], "handler": "server/controllers/contracts.js" },
+    { "path": "/contracts/:contractId", "methods": ["DELETE"], "handler": "server/controllers/contracts.js" },
+    { "path": "/dashboard", "methods": ["GET"], "handler": "server/controllers/dashboard.js" }
+  ],
   "visibility": "all"
 }

--- a/apps/contract-mgr-v2/server/controllers/contracts.js
+++ b/apps/contract-mgr-v2/server/controllers/contracts.js
@@ -1,0 +1,74 @@
+import ContractV2Service from '../../../../server/services/contract-v2.service.js';
+import logger from '../../../../lib/logger.js';
+
+function isAdmin(ctx) {
+  const session = ctx.state.session || {};
+  return session.isAdmin || false;
+}
+
+export async function get(ctx, deps) {
+  try {
+    const service = new ContractV2Service(deps.db);
+    const { contractId } = ctx.params;
+
+    if (contractId) {
+      const contract = await service.getContract(contractId);
+      return ctx.success(contract);
+    }
+
+    const contracts = await service.listContracts(ctx.query);
+    ctx.success(contracts);
+  } catch (err) {
+    logger.error(`[contract-mgr-v2] contracts GET error: ${err.message}`);
+    ctx.error(err.message, err.message.includes('not found') ? 404 : 500);
+  }
+}
+
+export async function post(ctx, deps) {
+  try {
+    if (!isAdmin(ctx)) {
+      return ctx.error('Admin required', 403);
+    }
+
+    const service = new ContractV2Service(deps.db);
+    const contract = await service.createContract(ctx.request.body);
+    ctx.success(contract);
+  } catch (err) {
+    logger.error(`[contract-mgr-v2] createContract error: ${err.message}`);
+    ctx.error(err.message, 400);
+  }
+}
+
+export async function put(ctx, deps) {
+  try {
+    if (!isAdmin(ctx)) {
+      return ctx.error('Admin required', 403);
+    }
+
+    const service = new ContractV2Service(deps.db);
+    const { contractId } = ctx.params;
+    const contract = await service.updateContract(contractId, ctx.request.body);
+    ctx.success(contract);
+  } catch (err) {
+    logger.error(`[contract-mgr-v2] updateContract error: ${err.message}`);
+    ctx.error(err.message, 400);
+  }
+}
+
+async function del(ctx, deps) {
+  try {
+    if (!isAdmin(ctx)) {
+      return ctx.error('Admin required', 403);
+    }
+
+    const service = new ContractV2Service(deps.db);
+    const { contractId } = ctx.params;
+    await service.deleteContract(contractId);
+    ctx.success(null, '删除成功');
+  } catch (err) {
+    logger.error(`[contract-mgr-v2] deleteContract error: ${err.message}`);
+    ctx.error(err.message, 400);
+  }
+}
+
+export { del as delete };

--- a/apps/contract-mgr-v2/server/controllers/dashboard.js
+++ b/apps/contract-mgr-v2/server/controllers/dashboard.js
@@ -1,0 +1,13 @@
+import ContractV2Service from '../../../../server/services/contract-v2.service.js';
+import logger from '../../../../lib/logger.js';
+
+export async function get(ctx, deps) {
+  try {
+    const service = new ContractV2Service(deps.db);
+    const dashboard = await service.getDashboard();
+    ctx.success(dashboard);
+  } catch (err) {
+    logger.error(`[contract-mgr-v2] getDashboard error: ${err.message}`);
+    ctx.error(err.message, 500);
+  }
+}

--- a/apps/contract-mgr-v2/server/controllers/org-nodes.js
+++ b/apps/contract-mgr-v2/server/controllers/org-nodes.js
@@ -1,0 +1,37 @@
+import ContractV2Service from '../../../../server/services/contract-v2.service.js';
+import logger from '../../../../lib/logger.js';
+
+function isAdmin(ctx) {
+  const session = ctx.state.session || {};
+  return session.isAdmin || false;
+}
+
+export async function get(ctx, deps) {
+  try {
+    const service = new ContractV2Service(deps.db);
+    const tree = await service.getTree();
+    ctx.success(tree);
+  } catch (err) {
+    logger.error(`[contract-mgr-v2] getTree error: ${err.message}`);
+    ctx.error(err.message, 500);
+  }
+}
+
+export async function post(ctx, deps) {
+  try {
+    if (!isAdmin(ctx)) {
+      return ctx.error('Admin required', 403);
+    }
+
+    const service = new ContractV2Service(deps.db);
+    const data = ctx.request.body;
+    if (!data.name || !data.node_type) {
+      return ctx.error('name 和 node_type 必填', 400);
+    }
+    const node = await service.createNode(data);
+    ctx.success(node);
+  } catch (err) {
+    logger.error(`[contract-mgr-v2] createNode error: ${err.message}`);
+    ctx.error(err.message, 400);
+  }
+}

--- a/apps/contract-mgr/manifest.json
+++ b/apps/contract-mgr/manifest.json
@@ -362,10 +362,12 @@
     }
   ],
   "component": "ContractMgrView",
-  "runtime": {
-    "server": {
-      "routes": "server/routes.js"
-    }
-  },
+  "apis": [
+    { "path": "/records", "methods": ["GET"], "handler": "server/controllers/records.js" },
+    { "path": "/records/:recordId", "methods": ["GET"], "handler": "server/controllers/records.js" },
+    { "path": "/status-summary", "methods": ["GET"], "handler": "server/controllers/records.js" },
+    { "path": "/records/:recordId/confirm", "methods": ["POST"], "handler": "server/controllers/records.js" },
+    { "path": "/records/:recordId/retry", "methods": ["POST"], "handler": "server/controllers/records.js" }
+  ],
   "visibility": "all"
 }

--- a/apps/contract-mgr/server/controllers/records.js
+++ b/apps/contract-mgr/server/controllers/records.js
@@ -1,0 +1,80 @@
+import ContractService from '../../../../server/services/contract.service.js';
+import logger from '../../../../lib/logger.js';
+
+function getSession(ctx) {
+  return ctx.state.session || {};
+}
+
+function isAdmin(ctx) {
+  const session = getSession(ctx);
+  return session.isAdmin || false;
+}
+
+function requireAdmin(ctx) {
+  if (!isAdmin(ctx)) {
+    ctx.error('Admin required', 403);
+    return false;
+  }
+  return true;
+}
+
+export async function get(ctx, deps) {
+  try {
+    const contractService = new ContractService(deps.db);
+    const { recordId } = ctx.params;
+    const session = getSession(ctx);
+    const userId = session.id;
+    const admin = isAdmin(ctx);
+
+    if (recordId) {
+      const record = await contractService.detail(recordId, { userId, isAdmin: admin });
+      if (!record) return ctx.error('Record not found', 404);
+      return ctx.success(record);
+    }
+
+    if (ctx.path.includes('/status-summary')) {
+      const result = await contractService.statusSummary({ userId, isAdmin: admin });
+      return ctx.success(result);
+    }
+
+    const { page, size, status, search, sort, order } = ctx.query;
+    const result = await contractService.list({
+      page: parseInt(page) || 1,
+      size: parseInt(size) || 20,
+      status, search, sort, order,
+      userId, isAdmin: admin,
+    });
+    ctx.success(result);
+  } catch (err) {
+    logger.error(`[contract-mgr] GET error: ${err.message}`);
+    ctx.error(err.message, 400);
+  }
+}
+
+export async function post(ctx, deps) {
+  try {
+    const contractService = new ContractService(deps.db);
+    const { recordId } = ctx.params;
+
+    if (!recordId) {
+      return ctx.error('recordId is required', 400);
+    }
+
+    if (ctx.path.endsWith('/confirm')) {
+      if (!requireAdmin(ctx)) return;
+      await contractService.confirm(recordId);
+      return ctx.success(null, 'Confirmed');
+    }
+
+    if (ctx.path.endsWith('/retry')) {
+      if (!requireAdmin(ctx)) return;
+      const result = await contractService.retry(recordId);
+      return ctx.success(result);
+    }
+
+    ctx.error('Not implemented', 501);
+  } catch (err) {
+    logger.error(`[contract-mgr] POST error: ${err.message}`);
+    ctx.error(err.message, 400);
+  }
+}

--- a/apps/invoice-mgr/manifest.json
+++ b/apps/invoice-mgr/manifest.json
@@ -217,11 +217,6 @@
           "name": "tax_amount",
           "type": "DECIMAL(12,2)",
           "label": "税额"
-        },
-        {
-          "name": "issuer",
-          "type": "VARCHAR(32)",
-          "label": "开票人"
         }
       ]
     }

--- a/apps/invoice-mgr/migrations/install.js
+++ b/apps/invoice-mgr/migrations/install.js
@@ -1,80 +1,118 @@
 export default {
   async check(sequelize) {
-    const rows = await sequelize.query(`
-      SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
-      WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (
-        'app_invoice_mgr_rows',
-        'app_invoice_mgr_items'
-      )
-    `, { type: sequelize.QueryTypes.SELECT });
-
-    return rows.length < 2;
+    if (!await hasTable(sequelize, 'app_invoice_mgr_rows')) return true;
+    if (!await hasColumn(sequelize, 'app_invoice_mgr_rows', 'issuer')) return true;
+    if (!await hasTable(sequelize, 'app_invoice_mgr_items')) return true;
+    if (!await hasColumn(sequelize, 'app_invoice_mgr_items', 'sort_order')) return true;
+    return false;
   },
 
   async up(sequelize) {
-    await sequelize.query(`
-      CREATE TABLE IF NOT EXISTS app_invoice_mgr_rows (
-        row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 app_invoice_mgr_records.id',
-        invoice_number VARCHAR(20) COMMENT '发票号码（20位），用于去重',
-        invoice_date DATE COMMENT '开票日期',
-        invoice_type VARCHAR(64) COMMENT '发票类型',
-        seller_name VARCHAR(128) COMMENT '销售方名称',
-        seller_tax_id VARCHAR(20) COMMENT '销售方税号',
-        buyer_name VARCHAR(128) COMMENT '购买方名称',
-        buyer_tax_id VARCHAR(20) COMMENT '购买方税号',
-        total_amount DECIMAL(12,2) DEFAULT 0 COMMENT '合计金额',
-        total_tax DECIMAL(12,2) DEFAULT 0 COMMENT '税额',
-        total_with_tax DECIMAL(12,2) DEFAULT 0 COMMENT '价税合计',
-        item_count INT DEFAULT 0 COMMENT '商品明细总数',
-        page_count INT DEFAULT 0 COMMENT 'PDF页数',
-        remarks TEXT COMMENT '备注',
-        issuer VARCHAR(32) COMMENT '开票人',
-        ocr_method VARCHAR(32) COMMENT '识别方法：fapiao/markitdown',
-        ocr_raw LONGTEXT COMMENT 'OCR原始输出JSON',
-        extraction_status VARCHAR(16) DEFAULT 'success' COMMENT '提取状态',
-        text_items_count INT DEFAULT 0 COMMENT 'PDF文本项总数',
-        keyword_count INT DEFAULT 0 COMMENT '发票关键词匹配数',
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        UNIQUE KEY uk_invoice_number (invoice_number),
-        INDEX idx_seller (seller_name),
-        INDEX idx_buyer (buyer_name),
-        INDEX idx_date (invoice_date),
-        INDEX idx_amount (total_with_tax)
-      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-        COMMENT='发票元数据扩展表'
-    `);
-    console.log('  ✓ Created app_invoice_mgr_rows table');
+    if (!await hasTable(sequelize, 'app_invoice_mgr_rows')) {
+      await sequelize.query(`
+        CREATE TABLE IF NOT EXISTS app_invoice_mgr_rows (
+          row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 app_invoice_mgr_records.id',
+          invoice_number VARCHAR(20) COMMENT '发票号码（20位），用于去重',
+          invoice_date DATE COMMENT '开票日期',
+          invoice_type VARCHAR(64) COMMENT '发票类型',
+          seller_name VARCHAR(128) COMMENT '销售方名称',
+          seller_tax_id VARCHAR(20) COMMENT '销售方税号',
+          buyer_name VARCHAR(128) COMMENT '购买方名称',
+          buyer_tax_id VARCHAR(20) COMMENT '购买方税号',
+          total_amount DECIMAL(12,2) DEFAULT 0 COMMENT '合计金额',
+          total_tax DECIMAL(12,2) DEFAULT 0 COMMENT '税额',
+          total_with_tax DECIMAL(12,2) DEFAULT 0 COMMENT '价税合计',
+          item_count INT DEFAULT 0 COMMENT '商品明细总数',
+          page_count INT DEFAULT 0 COMMENT 'PDF页数',
+          remarks TEXT COMMENT '备注',
+          issuer VARCHAR(32) COMMENT '开票人',
+          ocr_method VARCHAR(32) COMMENT '识别方法：fapiao/markitdown',
+          ocr_raw LONGTEXT COMMENT 'OCR原始输出JSON',
+          extraction_status VARCHAR(16) DEFAULT 'success' COMMENT '提取状态',
+          text_items_count INT DEFAULT 0 COMMENT 'PDF文本项总数',
+          keyword_count INT DEFAULT 0 COMMENT '发票关键词匹配数',
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY uk_invoice_number (invoice_number),
+          INDEX idx_seller (seller_name),
+          INDEX idx_buyer (buyer_name),
+          INDEX idx_date (invoice_date),
+          INDEX idx_amount (total_with_tax)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+          COMMENT='发票元数据扩展表'
+      `);
+      try {
+        await sequelize.query(`
+          ALTER TABLE app_invoice_mgr_rows
+          ADD CONSTRAINT fk_app_invoice_mgr_rows_row_id
+          FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
+        `);
+      } catch {}
+      console.log('  ✓ Created app_invoice_mgr_rows table');
+    } else {
+      const missingRowsCols = [
+        { col: 'issuer', def: "VARCHAR(32) COMMENT '开票人'", after: 'remarks' },
+        { col: 'ocr_method', def: "VARCHAR(32) COMMENT '识别方法：fapiao/markitdown'", after: 'issuer' },
+        { col: 'ocr_raw', def: "LONGTEXT COMMENT 'OCR原始输出JSON'", after: 'ocr_method' },
+        { col: 'extraction_status', def: "VARCHAR(16) DEFAULT 'success' COMMENT '提取状态'", after: 'ocr_raw' },
+        { col: 'text_items_count', def: "INT DEFAULT 0 COMMENT 'PDF文本项总数'", after: 'extraction_status' },
+        { col: 'keyword_count', def: "INT DEFAULT 0 COMMENT '发票关键词匹配数'", after: 'text_items_count' },
+      ];
+      for (const c of missingRowsCols) {
+        if (!await hasColumn(sequelize, 'app_invoice_mgr_rows', c.col)) {
+          await sequelize.query(`ALTER TABLE app_invoice_mgr_rows ADD COLUMN ${c.col} ${c.def} AFTER ${c.after}`);
+          console.log(`  ✓ Added column ${c.col} to app_invoice_mgr_rows`);
+        }
+      }
+      console.log('  ✓ Incrementally upgraded app_invoice_mgr_rows');
+    }
 
-    await sequelize.query(`
-      ALTER TABLE app_invoice_mgr_rows
-      ADD CONSTRAINT fk_app_invoice_mgr_rows_row_id
-      FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
-    `);
-    console.log('  ✓ Added FK for app_invoice_mgr_rows');
-
-    await sequelize.query(`
-      CREATE TABLE IF NOT EXISTS app_invoice_mgr_items (
-        id VARCHAR(32) PRIMARY KEY,
-        row_id VARCHAR(32) NOT NULL COMMENT '关联 app_invoice_mgr_records.id',
-        page_number INT DEFAULT 1 COMMENT '所在页码',
-        sort_order INT DEFAULT 0 COMMENT '行内排序',
-        category VARCHAR(64) COMMENT '商品分类',
-        name VARCHAR(128) COMMENT '商品名称',
-        model VARCHAR(64) COMMENT '规格型号',
-        unit VARCHAR(16) COMMENT '单位',
-        quantity DECIMAL(12,4) COMMENT '数量',
-        price DECIMAL(12,4) COMMENT '单价',
-        amount DECIMAL(12,2) COMMENT '金额',
-        tax_rate VARCHAR(8) COMMENT '税率',
-        tax_amount DECIMAL(12,2) COMMENT '税额',
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        INDEX idx_row_id (row_id),
-        FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
-      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-        COMMENT='发票商品明细表'
-    `);
-    console.log('  ✓ Created app_invoice_mgr_items table');
+    if (!await hasTable(sequelize, 'app_invoice_mgr_items')) {
+      await sequelize.query(`
+        CREATE TABLE IF NOT EXISTS app_invoice_mgr_items (
+          id VARCHAR(32) PRIMARY KEY,
+          row_id VARCHAR(32) NOT NULL COMMENT '关联 app_invoice_mgr_records.id',
+          page_number INT DEFAULT 1 COMMENT '所在页码',
+          sort_order INT DEFAULT 0 COMMENT '行内排序',
+          category VARCHAR(64) COMMENT '商品分类',
+          name VARCHAR(128) COMMENT '商品名称',
+          model VARCHAR(64) COMMENT '规格型号',
+          unit VARCHAR(16) COMMENT '单位',
+          quantity DECIMAL(12,4) COMMENT '数量',
+          price DECIMAL(12,4) COMMENT '单价',
+          amount DECIMAL(12,2) COMMENT '金额',
+          tax_rate VARCHAR(8) COMMENT '税率',
+          tax_amount DECIMAL(12,2) COMMENT '税额',
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          INDEX idx_row_id (row_id),
+          FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+          COMMENT='发票商品明细表'
+      `);
+      console.log('  ✓ Created app_invoice_mgr_items table');
+    } else {
+      const missingItemsCols = [
+        { col: 'page_number', def: "INT DEFAULT 1 COMMENT '所在页码'", after: 'row_id' },
+        { col: 'sort_order', def: "INT DEFAULT 0 COMMENT '行内排序'", after: 'page_number' },
+        { col: 'category', def: "VARCHAR(64) COMMENT '商品分类'", after: 'sort_order' },
+        { col: 'name', def: "VARCHAR(128) COMMENT '商品名称'", after: 'category' },
+        { col: 'model', def: "VARCHAR(64) COMMENT '规格型号'", after: 'name' },
+        { col: 'unit', def: "VARCHAR(16) COMMENT '单位'", after: 'model' },
+        { col: 'quantity', def: "DECIMAL(12,4) COMMENT '数量'", after: 'unit' },
+        { col: 'price', def: "DECIMAL(12,4) COMMENT '单价'", after: 'quantity' },
+        { col: 'amount', def: "DECIMAL(12,2) COMMENT '金额'", after: 'price' },
+        { col: 'tax_rate', def: "VARCHAR(8) COMMENT '税率'", after: 'amount' },
+        { col: 'tax_amount', def: "DECIMAL(12,2) COMMENT '税额'", after: 'tax_rate' },
+        { col: 'created_at', def: "DATETIME DEFAULT CURRENT_TIMESTAMP", after: 'tax_amount' },
+      ];
+      for (const c of missingItemsCols) {
+        if (!await hasColumn(sequelize, 'app_invoice_mgr_items', c.col)) {
+          await sequelize.query(`ALTER TABLE app_invoice_mgr_items ADD COLUMN ${c.col} ${c.def} AFTER ${c.after}`);
+          console.log(`  ✓ Added column ${c.col} to app_invoice_mgr_items`);
+        }
+      }
+      console.log('  ✓ Incrementally upgraded app_invoice_mgr_items');
+    }
   },
 
   async down(sequelize) {
@@ -85,3 +123,19 @@ export default {
     console.log('  ✓ Dropped app_invoice_mgr_rows table');
   }
 };
+
+async function hasTable(sequelize, tableName) {
+  const [rows] = await sequelize.query(
+    `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`,
+    { replacements: [tableName], type: sequelize.QueryTypes.SELECT }
+  );
+  return rows.length > 0;
+}
+
+async function hasColumn(sequelize, tableName, columnName) {
+  const [rows] = await sequelize.query(
+    `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+    { replacements: [tableName, columnName], type: sequelize.QueryTypes.SELECT }
+  );
+  return rows.length > 0;
+}

--- a/frontend/src/api/current-feature-analyzer.ts
+++ b/frontend/src/api/current-feature-analyzer.ts
@@ -69,23 +69,23 @@ export const currentFeatureAnalyzerApi = {
     files.forEach(f => formData.append('files', f))
     if (ruleSetId) formData.append('rule_set_id', ruleSetId)
     return apiRequest<BatchSession>(
-      apiClient.post('/api/apps/current-feature-analyzer/uploads', formData, {
+      apiClient.post('/current-feature-analyzer/uploads', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       })
     )
   },
 
   getBatch: (batchId: string) =>
-    apiRequest<BatchSession>(apiClient.get(`/api/apps/current-feature-analyzer/batches/${batchId}`)),
+    apiRequest<BatchSession>(apiClient.get(`/current-feature-analyzer/batches/${batchId}`)),
 
   getFileDetail: (batchId: string, fileId: string) =>
     apiRequest<SessionFileItem>(
-      apiClient.get(`/api/apps/current-feature-analyzer/batches/${batchId}/files/${fileId}`)
+      apiClient.get(`/current-feature-analyzer/batches/${batchId}/files/${fileId}`)
     ),
 
   runAnalysis: (batchId: string, ruleSetId: string, options?: Record<string, number>) =>
     apiRequest<BatchSession>(
-      apiClient.post('/api/apps/current-feature-analyzer/analysis/run', {
+      apiClient.post('/current-feature-analyzer/analysis/run', {
         batch_id: batchId,
         rule_set_id: ruleSetId,
         analysis_options: options,
@@ -93,34 +93,34 @@ export const currentFeatureAnalyzerApi = {
     ),
 
   getReport: (batchId: string) =>
-    apiRequest<BatchSession>(apiClient.get(`/api/apps/current-feature-analyzer/reports/${batchId}`)),
+    apiRequest<BatchSession>(apiClient.get(`/current-feature-analyzer/reports/${batchId}`)),
 
   exportReport: (batchId: string) =>
-    apiClient.post(`/api/apps/current-feature-analyzer/reports/${batchId}/export`, {}, {
+    apiClient.post(`/current-feature-analyzer/reports/${batchId}/export`, {}, {
       responseType: 'blob',
     }),
 
   listRuleSets: () =>
-    apiRequest<{ items: RuleSetItem[] }>(apiClient.get('/api/apps/current-feature-analyzer/rule-sets')),
+    apiRequest<{ items: RuleSetItem[] }>(apiClient.get('/current-feature-analyzer/rule-sets')),
 
   getRuleSet: (id: string) =>
-    apiRequest<RuleSetDetail>(apiClient.get(`/api/apps/current-feature-analyzer/rule-sets/${id}`)),
+    apiRequest<RuleSetDetail>(apiClient.get(`/current-feature-analyzer/rule-sets/${id}`)),
 
   createRuleSet: (data: any) =>
-    apiRequest<RuleSetDetail>(apiClient.post('/api/apps/current-feature-analyzer/rule-sets', data)),
+    apiRequest<RuleSetDetail>(apiClient.post('/current-feature-analyzer/rule-sets', data)),
 
   updateRuleSet: (id: string, data: any) =>
-    apiRequest<RuleSetDetail>(apiClient.put(`/api/apps/current-feature-analyzer/rule-sets/${id}`, data)),
+    apiRequest<RuleSetDetail>(apiClient.put(`/current-feature-analyzer/rule-sets/${id}`, data)),
 
   deleteRuleSet: (id: string) =>
-    apiRequest<{ deleted: boolean }>(apiClient.delete(`/api/apps/current-feature-analyzer/rule-sets/${id}`)),
+    apiRequest<{ deleted: boolean }>(apiClient.delete(`/current-feature-analyzer/rule-sets/${id}`)),
 
   copyRuleSet: (id: string) =>
-    apiRequest<RuleSetDetail>(apiClient.post(`/api/apps/current-feature-analyzer/rule-sets/${id}/copy`)),
+    apiRequest<RuleSetDetail>(apiClient.post(`/current-feature-analyzer/rule-sets/${id}/copy`)),
 
   getConfig: () =>
-    apiRequest<any>(apiClient.get('/api/apps/current-feature-analyzer/config')),
+    apiRequest<any>(apiClient.get('/current-feature-analyzer/config')),
 
   saveConfig: (data: any) =>
-    apiRequest<any>(apiClient.put('/api/apps/current-feature-analyzer/config', data)),
+    apiRequest<any>(apiClient.put('/current-feature-analyzer/config', data)),
 }

--- a/scripts/test-app-registry-api.js
+++ b/scripts/test-app-registry-api.js
@@ -44,35 +44,59 @@ async function runTests() {
     return;
   }
 
-  console.log('--- 基础接口 ---');
-  await testEndpoint('列出可访问 app', 'GET', '/api/apps', token, 200);
-  await testEndpoint('列出已安装 app', 'GET', '/api/apps/installed', token, 200);
-  await testEndpoint('列出时钟注册', 'GET', '/api/apps/clock-registry', token, 200);
+  console.log('--- 新前缀 /api/app-registry/* (Phase 1 主目标) ---');
+  await testEndpoint('新前缀：列出可访问 app', 'GET', '/api/app-registry', token, 200);
+  await testEndpoint('新前缀：列出已安装 app', 'GET', '/api/app-registry/installed', token, 200);
+  await testEndpoint('新前缀：列出时钟注册', 'GET', '/api/app-registry/clock-registry', token, 200);
 
-  console.log('\n--- 动态路由（需真实 appId）---');
-  const appsResp = await fetch(`${BASE_URL}/api/apps`, {
+  const appsRespNew = await fetch(`${BASE_URL}/api/app-registry`, {
     headers: { 'Authorization': `Bearer ${token}` }
   });
-  const appsData = await appsResp.json();
-  const apps = appsData.data || [];
-  
-  if (apps.length > 0) {
-    const appId = apps[0].id;
-    console.log(`使用 appId: ${appId}\n`);
+  const appsDataNew = await appsRespNew.json();
+  const appsNew = appsDataNew.data || [];
+
+  if (appsNew.length > 0) {
+    const appId = appsNew[0].id;
+    console.log(`新前缀使用 appId: ${appId}\n`);
     
-    await testEndpoint('获取 app 详情', 'GET', `/api/apps/${appId}`, token, 200);
-    await testEndpoint('获取 runtime 信息', 'GET', `/api/apps/${appId}/runtime`, token, 200);
-    await testEndpoint('获取 manifest', 'GET', `/api/apps/${appId}/manifest`, token, 200);
-    await testEndpoint('验证 runtime', 'GET', `/api/apps/${appId}/validate-runtime`, token, 200);
-    await testEndpoint('获取配置', 'GET', `/api/apps/${appId}/config`, token, 200);
-    await testEndpoint('获取时钟注册', 'GET', `/api/apps/${appId}/clock-registry`, token, 200);
+    await testEndpoint('新前缀：获取 app 详情', 'GET', `/api/app-registry/${appId}`, token, 200);
+    await testEndpoint('新前缀：获取 runtime 信息', 'GET', `/api/app-registry/${appId}/runtime`, token, 200);
+    await testEndpoint('新前缀：获取 manifest', 'GET', `/api/app-registry/${appId}/manifest`, token, 200);
+    await testEndpoint('新前缀：验证 runtime', 'GET', `/api/app-registry/${appId}/validate-runtime`, token, 200);
+    await testEndpoint('新前缀：获取配置', 'GET', `/api/app-registry/${appId}/config`, token, 200);
+    await testEndpoint('新前缀：获取时钟注册', 'GET', `/api/app-registry/${appId}/clock-registry`, token, 200);
   } else {
-    console.log('⚠️ 无已安装 app，跳过动态路由测试');
+    console.log('⚠️ 无已安装 app，跳过新前缀动态路由测试');
+  }
+
+  console.log('\n--- Legacy 兼容层 /api/apps/* (向后兼容验证) ---');
+  await testEndpoint('Legacy：列出可访问 app', 'GET', '/api/apps', token, 200);
+  await testEndpoint('Legacy：列出已安装 app', 'GET', '/api/apps/installed', token, 200);
+  await testEndpoint('Legacy：列出时钟注册', 'GET', '/api/apps/clock-registry', token, 200);
+  
+  const appsRespLegacy = await fetch(`${BASE_URL}/api/apps`, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  const appsDataLegacy = await appsRespLegacy.json();
+  const appsLegacy = appsDataLegacy.data || [];
+  
+  if (appsLegacy.length > 0) {
+    const appId = appsLegacy[0].id;
+    console.log(`Legacy 使用 appId: ${appId}\n`);
+    
+    await testEndpoint('Legacy：获取 app 详情', 'GET', `/api/apps/${appId}`, token, 200);
+    await testEndpoint('Legacy：获取 runtime 信息', 'GET', `/api/apps/${appId}/runtime`, token, 200);
+    await testEndpoint('Legacy：获取 manifest', 'GET', `/api/apps/${appId}/manifest`, token, 200);
+    await testEndpoint('Legacy：验证 runtime', 'GET', `/api/apps/${appId}/validate-runtime`, token, 200);
+    await testEndpoint('Legacy：获取配置', 'GET', `/api/apps/${appId}/config`, token, 200);
+    await testEndpoint('Legacy：获取时钟注册', 'GET', `/api/apps/${appId}/clock-registry`, token, 200);
+  } else {
+    console.log('⚠️ 无已安装 app，跳过 Legacy 动态路由测试');
   }
 
   console.log('\n--- 错误状态码验证 ---');
-  await testEndpoint('不存在的 app', 'GET', '/api/apps/non-existent-app-id', token, 404);
-  await testEndpoint('不存在的 manifest', 'GET', '/api/apps/non-existent-app-id/manifest', token, 422);
+  await testEndpoint('新前缀：不存在的 app', 'GET', '/api/app-registry/non-existent-app-id', token, 404);
+  await testEndpoint('新前缀：不存在的 manifest', 'GET', '/api/app-registry/non-existent-app-id/manifest', token, 422);
 
   console.log('\n=== 测试结果汇总 ===');
   const passed = RESULTS.filter(r => r.passed).length;

--- a/scripts/test-app-runtime-complete.js
+++ b/scripts/test-app-runtime-complete.js
@@ -2,7 +2,9 @@ const BASE_URL = 'http://localhost:3000';
 const RESULTS = {
   interface: [],
   clock: [],
-  compatibility: []
+  compatibility: [],
+  newPrefix: [],
+  legacyPrefix: []
 };
 
 async function getAuthToken() {
@@ -16,25 +18,7 @@ async function getAuthToken() {
   return data.data.access_token;
 }
 
-async function testInterface(name, method, path, token, expectStatus) {
-  const headers = {
-    'Authorization': `Bearer ${token}`,
-    'Content-Type': 'application/json'
-  };
-  
-  const url = `${BASE_URL}${path}`;
-  const resp = await fetch(url, { method, headers });
-  const status = resp.status;
-  const data = await resp.json().catch(() => ({}));
-  
-  const passed = status === expectStatus;
-  RESULTS.interface.push({ name, method, path, expected: expectStatus, actual: status, passed, data });
-  
-  console.log(`${passed ? '✅' : '❌'} ${name}: ${status} (expected ${expectStatus})`);
-  return { passed, data, status };
-}
-
-async function testClockInterface(name, method, path, token, expectStatus) {
+async function testEndpoint(category, name, method, path, token, expectStatus) {
   const headers = {
     'Authorization': `Bearer ${token}`,
     'Content-Type': 'application/json'
@@ -47,7 +31,7 @@ async function testClockInterface(name, method, path, token, expectStatus) {
   
   const allowed = Array.isArray(expectStatus) ? expectStatus : [expectStatus];
   const passed = allowed.includes(status);
-  RESULTS.clock.push({ name, method, path, expected: expectStatus, actual: status, passed, data });
+  RESULTS[category].push({ name, method, path, expected: expectStatus, actual: status, passed, data });
   
   console.log(`${passed ? '✅' : '❌'} ${name}: ${status} (expected ${allowed.join(' or ')})`);
   return { passed, data, status };
@@ -98,41 +82,58 @@ async function runTests() {
     return;
   }
 
-  console.log('--- Part 1: 基础接口测试 ---');
-  await testInterface('列出可访问 app', 'GET', '/api/apps', token, 200);
-  await testInterface('列出已安装 app', 'GET', '/api/apps/installed', token, 200);
-  await testInterface('列出时钟注册', 'GET', '/api/apps/clock-registry', token, 200);
+  console.log('--- Part 0: 新前缀 /api/app-registry/* 验证 (Phase 1 主目标) ---');
+  await testEndpoint('newPrefix', '新前缀：列出可访问 app', 'GET', '/api/app-registry', token, 200);
+  await testEndpoint('newPrefix', '新前缀：列出已安装 app', 'GET', '/api/app-registry/installed', token, 200);
+  await testEndpoint('newPrefix', '新前缀：列出时钟注册', 'GET', '/api/app-registry/clock-registry', token, 200);
 
-  console.log('\n--- Part 2: AppClock 接口测试 ---');
-  await testClockInterface('获取时钟状态', 'GET', '/api/app-clock/status', token, 200);
-
-  console.log('\n--- Part 3: 动态路由接口（真实 appId）---');
-  const appsResp = await fetch(`${BASE_URL}/api/apps`, {
+  const appsRespNew = await fetch(`${BASE_URL}/api/app-registry`, {
     headers: { 'Authorization': `Bearer ${token}` }
   });
-  const appsData = await appsResp.json();
-  const apps = appsData.data || [];
-  
+  const appsDataNew = await appsRespNew.json();
+  const appsNew = appsDataNew.data || [];
+
   const testApps = ['contract-mgr-v2', 'contract-mgr', 'invoice-mgr', 'ocr-tool', 'doc-ocr-pipeline'];
   
   for (const appId of testApps) {
-    if (apps.some(a => a.id === appId)) {
-      console.log(`\n测试 app: ${appId}`);
-      await testInterface(`获取 ${appId} 详情`, 'GET', `/api/apps/${appId}`, token, 200);
-      await testInterface(`获取 ${appId} manifest`, 'GET', `/api/apps/${appId}/manifest`, token, 200);
-      await testInterface(`验证 ${appId} runtime`, 'GET', `/api/apps/${appId}/validate-runtime`, token, 200);
-      await testInterface(`获取 ${appId} runtime`, 'GET', `/api/apps/${appId}/runtime`, token, 200);
-      await testClockInterface(`获取 ${appId} 时钟状态`, 'GET', `/api/app-clock/status/${appId}`, token, [200, 404]);
-    } else {
-      console.log(`⚠️ app ${appId} 未安装，跳过`);
+    if (appsNew.some(a => a.id === appId)) {
+      await testEndpoint('newPrefix', `新前缀：获取 ${appId} 详情`, 'GET', `/api/app-registry/${appId}`, token, 200);
+      await testEndpoint('newPrefix', `新前缀：获取 ${appId} manifest`, 'GET', `/api/app-registry/${appId}/manifest`, token, 200);
+      await testEndpoint('newPrefix', `新前缀：验证 ${appId} runtime`, 'GET', `/api/app-registry/${appId}/validate-runtime`, token, 200);
+      await testEndpoint('newPrefix', `新前缀：获取 ${appId} runtime`, 'GET', `/api/app-registry/${appId}/runtime`, token, 200);
     }
   }
 
-  console.log('\n--- Part 4: 错误状态码验证 ---');
-  await testInterface('不存在的 app', 'GET', '/api/apps/non-existent-app-id', token, 404);
-  await testInterface('不存在 app manifest', 'GET', '/api/apps/non-existent-app-id/manifest', token, 422);
+  await testEndpoint('newPrefix', '新前缀：不存在的 app', 'GET', '/api/app-registry/non-existent-app-id', token, 404);
 
-  console.log('\n--- Part 5: legacy 兼容性验证 ---');
+  console.log('\n--- Part 1: Legacy 兼容层 /api/apps/* 验证 ---');
+  await testEndpoint('legacyPrefix', 'Legacy：列出可访问 app', 'GET', '/api/apps', token, 200);
+  await testEndpoint('legacyPrefix', 'Legacy：列出已安装 app', 'GET', '/api/apps/installed', token, 200);
+  await testEndpoint('legacyPrefix', 'Legacy：列出时钟注册', 'GET', '/api/apps/clock-registry', token, 200);
+
+  const appsRespLegacy = await fetch(`${BASE_URL}/api/apps`, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  const appsDataLegacy = await appsRespLegacy.json();
+  const appsLegacy = appsDataLegacy.data || [];
+  
+  for (const appId of testApps) {
+    if (appsLegacy.some(a => a.id === appId)) {
+      await testEndpoint('legacyPrefix', `Legacy：获取 ${appId} 详情`, 'GET', `/api/apps/${appId}`, token, 200);
+      await testEndpoint('legacyPrefix', `Legacy：获取 ${appId} manifest`, 'GET', `/api/apps/${appId}/manifest`, token, 200);
+      await testEndpoint('legacyPrefix', `Legacy：验证 ${appId} runtime`, 'GET', `/api/apps/${appId}/validate-runtime`, token, 200);
+      await testEndpoint('legacyPrefix', `Legacy：获取 ${appId} runtime`, 'GET', `/api/apps/${appId}/runtime`, token, 200);
+    }
+  }
+
+  console.log('\n--- Part 2: AppClock 接口测试 ---');
+  await testEndpoint('clock', '获取时钟状态', 'GET', '/api/app-clock/status', token, 200);
+
+  console.log('\n--- Part 3: 错误状态码验证 ---');
+  await testEndpoint('interface', 'Legacy：不存在的 app', 'GET', '/api/apps/non-existent-app-id', token, 404);
+  await testEndpoint('interface', 'Legacy：不存在 app manifest', 'GET', '/api/apps/non-existent-app-id/manifest', token, 422);
+
+  console.log('\n--- Part 4: legacy 兼容性验证 ---');
   for (const appId of testApps) {
     const status = await getAppManifestStatus(appId);
     console.log(`\n${appId}:`);
@@ -151,20 +152,27 @@ async function runTests() {
 
   console.log('\n=== 测试结果汇总 ===');
   
+  const newPrefixPassed = RESULTS.newPrefix.filter(r => r.passed).length;
+  const newPrefixFailed = RESULTS.newPrefix.filter(r => !r.passed).length;
+  const legacyPassed = RESULTS.legacyPrefix.filter(r => r.passed).length;
+  const legacyFailed = RESULTS.legacyPrefix.filter(r => !r.passed).length;
   const interfacePassed = RESULTS.interface.filter(r => r.passed).length;
   const interfaceFailed = RESULTS.interface.filter(r => !r.passed).length;
   const clockPassed = RESULTS.clock.filter(r => r.passed).length;
   const clockFailed = RESULTS.clock.filter(r => !r.passed).length;
   
-  console.log(`\nPart 1-4 接口测试: 通过 ${interfacePassed}, 失败 ${interfaceFailed}`);
-  console.log(`Part 5 AppClock 测试: 通过 ${clockPassed}, 失败 ${clockFailed}`);
+  console.log(`\nPart 0 新前缀测试: 通过 ${newPrefixPassed}, 失败 ${newPrefixFailed}`);
+  console.log(`Part 1 Legacy 兼容层: 通过 ${legacyPassed}, 失败 ${legacyFailed}`);
+  console.log(`Part 2-3 接口测试: 通过 ${interfacePassed}, 失败 ${interfaceFailed}`);
+  console.log(`Part 4 AppClock 测试: 通过 ${clockPassed}, 失败 ${clockFailed}`);
   
   console.log('\n--- Legacy 兼容性矩阵 ---');
   for (const item of RESULTS.compatibility) {
     console.log(`${item.appId}: manifest=${item.manifest}, runtimeTick=${item.runtimeTick}, legacyTick=${item.legacyTick}, forceTick=${item.forceTickPassed}`);
   }
   
-  if (interfaceFailed > 0 || clockFailed > 0) {
+  const totalFailed = newPrefixFailed + legacyFailed + interfaceFailed + clockFailed;
+  if (totalFailed > 0) {
     console.log('\n❌ 存在失败项，详见上方输出');
   } else {
     console.log('\n✅ 所有测试通过');

--- a/scripts/test-current-feature-analyzer-prefix.js
+++ b/scripts/test-current-feature-analyzer-prefix.js
@@ -1,0 +1,166 @@
+const BASE_URL = 'http://localhost:3000';
+const RESULTS = {
+  newPrefix: [],
+  legacyPrefix: [],
+  assertions: []
+};
+
+async function getAuthToken() {
+  const resp = await fetch(`${BASE_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ account: 'admin', password: 'password123' })
+  });
+  const data = await resp.json();
+  if (data.code !== 200) throw new Error('Login failed: ' + data.message);
+  return data.data.access_token;
+}
+
+async function testEndpoint(category, name, method, path, token, expectStatus, body = null) {
+  const headers = {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json'
+  };
+  
+  const url = `${BASE_URL}${path}`;
+  const options = { method, headers };
+  if (body) options.body = JSON.stringify(body);
+  
+  const resp = await fetch(url, options);
+  const status = resp.status;
+  const data = await resp.json().catch(() => ({}));
+  const deprecatedHeader = resp.headers.get('X-Deprecated');
+  
+  const allowed = Array.isArray(expectStatus) ? expectStatus : [expectStatus];
+  const passed = allowed.includes(status);
+  RESULTS[category].push({ 
+    name, method, path, expected: expectStatus, actual: status, passed, 
+    deprecated: deprecatedHeader,
+    data 
+  });
+  
+  const deprecatedMark = deprecatedHeader ? ' [DEPRECATED]' : '';
+  console.log(`${passed ? '✅' : '❌'} ${name}: ${status} (expected ${allowed.join(' or ')})${deprecatedMark}`);
+  return { passed, data, status, deprecated: deprecatedHeader };
+}
+
+function assertDeprecatedHeader(result, testName) {
+  const passed = result.deprecated === 'true';
+  RESULTS.assertions.push({
+    name: testName,
+    expected: 'X-Deprecated: true',
+    actual: result.deprecated || '(not set)',
+    passed
+  });
+  
+  if (!passed) {
+    console.log(`❌ ${testName}: X-Deprecated header not set (expected 'true', got '${result.deprecated || '(not set)'}')`);
+  } else {
+    console.log(`✅ ${testName}: X-Deprecated header correctly set`);
+  }
+  
+  return passed;
+}
+
+async function runTests() {
+  console.log('=== Current Feature Analyzer 前缀迁移验证 ===\n');
+  
+  let token;
+  try {
+    token = await getAuthToken();
+    console.log('✅ 登录成功\n');
+  } catch (e) {
+    console.log('❌ 登录失败:', e.message);
+    console.log('\n请确保服务器已启动 (node server/index.js)');
+    return;
+  }
+
+  console.log('--- Part 0: 新前缀 /api/current-feature-analyzer/* (Phase 1 主目标) ---');
+  
+  await testEndpoint('newPrefix', '新前缀：获取规则集列表', 'GET', '/api/current-feature-analyzer/rule-sets', token, 200);
+  await testEndpoint('newPrefix', '新前缀：获取配置', 'GET', '/api/current-feature-analyzer/config', token, [200, 404]);
+
+  const ruleSetsResp = await fetch(`${BASE_URL}/api/current-feature-analyzer/rule-sets`, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  const ruleSetsData = await ruleSetsResp.json();
+  const ruleSets = ruleSetsData.data?.items || [];
+
+  if (ruleSets.length > 0) {
+    const ruleSetId = ruleSets[0].id;
+    console.log(`使用规则集 ID: ${ruleSetId}\n`);
+    await testEndpoint('newPrefix', '新前缀：获取规则集详情', 'GET', `/api/current-feature-analyzer/rule-sets/${ruleSetId}`, token, 200);
+  } else {
+    console.log('⚠️ 无现有规则集，跳过规则集详情测试');
+  }
+
+  console.log('\n--- Part 1: Legacy 兼容层 /api/apps/current-feature-analyzer/* ---');
+  
+  const legacyResult1 = await testEndpoint('legacyPrefix', 'Legacy：获取规则集列表', 'GET', '/api/apps/current-feature-analyzer/rule-sets', token, 200);
+  const legacyResult2 = await testEndpoint('legacyPrefix', 'Legacy：获取配置', 'GET', '/api/apps/current-feature-analyzer/config', token, [200, 404]);
+
+  console.log('\n--- Part 1.5: Deprecated Header 断言 ---');
+  assertDeprecatedHeader(legacyResult1, 'Legacy 规则集列表 deprecated header');
+  assertDeprecatedHeader(legacyResult2, 'Legacy 配置 deprecated header');
+
+  if (ruleSets.length > 0) {
+    const ruleSetId = ruleSets[0].id;
+    const legacyDetailResult = await testEndpoint('legacyPrefix', 'Legacy：获取规则集详情', 'GET', `/api/apps/current-feature-analyzer/rule-sets/${ruleSetId}`, token, 200);
+    assertDeprecatedHeader(legacyDetailResult, 'Legacy 规则集详情 deprecated header');
+  }
+
+  console.log('\n--- Part 2: 前缀响应一致性验证 ---');
+  
+  const newPrefixRuleSets = RESULTS.newPrefix.find(r => r.name === '新前缀：获取规则集列表');
+  const legacyRuleSets = RESULTS.legacyPrefix.find(r => r.name === 'Legacy：获取规则集列表');
+  
+  if (newPrefixRuleSets && legacyRuleSets && newPrefixRuleSets.data && legacyRuleSets.data) {
+    const newItems = newPrefixRuleSets.data?.data?.items || [];
+    const legacyItems = legacyRuleSets.data?.data?.items || [];
+    
+    const consistencyPassed = JSON.stringify(newItems) === JSON.stringify(legacyItems);
+    RESULTS.assertions.push({
+      name: '新旧前缀规则集列表响应一致性',
+      expected: 'JSON.stringify 相等',
+      actual: consistencyPassed ? '一致' : '不一致',
+      passed: consistencyPassed
+    });
+    
+    if (consistencyPassed) {
+      console.log('✅ 新旧前缀规则集列表响应一致');
+    } else {
+      console.log('❌ 新旧前缀规则集列表响应不一致');
+      console.log(`   新前缀 items count: ${newItems.length}`);
+      console.log(`   Legacy items count: ${legacyItems.length}`);
+    }
+  }
+
+  console.log('\n=== 测试结果汇总 ===');
+  
+  const newPrefixPassed = RESULTS.newPrefix.filter(r => r.passed).length;
+  const newPrefixFailed = RESULTS.newPrefix.filter(r => !r.passed).length;
+  const legacyPassed = RESULTS.legacyPrefix.filter(r => r.passed).length;
+  const legacyFailed = RESULTS.legacyPrefix.filter(r => !r.passed).length;
+  const assertionsPassed = RESULTS.assertions.filter(r => r.passed).length;
+  const assertionsFailed = RESULTS.assertions.filter(r => !r.passed).length;
+  
+  console.log(`\n新前缀测试: 通过 ${newPrefixPassed}, 失败 ${newPrefixFailed}`);
+  console.log(`Legacy 兼容层: 通过 ${legacyPassed}, 失败 ${legacyFailed}`);
+  console.log(`断言检查: 通过 ${assertionsPassed}, 失败 ${assertionsFailed}`);
+  
+  const totalFailed = newPrefixFailed + legacyFailed + assertionsFailed;
+  if (totalFailed > 0) {
+    console.log('\n❌ 存在失败项，详见上方输出');
+    console.log('\n失败的测试项:');
+    RESULTS.newPrefix.filter(r => !r.passed).forEach(r => console.log(`  - ${r.name}: ${r.actual} (expected ${r.expected})`));
+    RESULTS.legacyPrefix.filter(r => !r.passed).forEach(r => console.log(`  - ${r.name}: ${r.actual} (expected ${r.expected})`));
+    RESULTS.assertions.filter(r => !r.passed).forEach(r => console.log(`  - ${r.name}: ${r.actual} (expected ${r.expected})`));
+  } else {
+    console.log('\n✅ 所有测试通过');
+    console.log('\n--- Phase 1 验证结论 ---');
+    console.log('/api/current-feature-analyzer/* 新前缀可用');
+    console.log('/api/apps/current-feature-analyzer/* legacy 兼容层可用并带有 deprecated 标记');
+  }
+}
+
+runTests().catch(e => console.error('测试执行错误:', e));

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -2154,6 +2154,194 @@ const MIGRATIONS = [
     },
   },
 
+  // 42c. invoice-mgr 扩展表 rows（增量升级：新建 + 逐列补齐 + 补索引 + 补 FK）
+  {
+    name: 'app_invoice_mgr_rows table (incremental)',
+    check: async (conn) => {
+      if (!await hasTable(conn, 'app_invoice_mgr_rows')) return false;
+      return await hasColumn(conn, 'app_invoice_mgr_rows', 'issuer');
+    },
+    migrate: async (conn) => {
+      if (!await hasTable(conn, 'app_invoice_mgr_rows')) {
+        await conn.execute(`
+          CREATE TABLE app_invoice_mgr_rows (
+            row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 app_invoice_mgr_records.id',
+            invoice_number VARCHAR(20) COMMENT '发票号码（20位），用于去重',
+            invoice_date DATE COMMENT '开票日期',
+            invoice_type VARCHAR(64) COMMENT '发票类型',
+            seller_name VARCHAR(128) COMMENT '销售方名称',
+            seller_tax_id VARCHAR(20) COMMENT '销售方税号',
+            buyer_name VARCHAR(128) COMMENT '购买方名称',
+            buyer_tax_id VARCHAR(20) COMMENT '购买方税号',
+            total_amount DECIMAL(12,2) DEFAULT 0 COMMENT '合计金额',
+            total_tax DECIMAL(12,2) DEFAULT 0 COMMENT '税额',
+            total_with_tax DECIMAL(12,2) DEFAULT 0 COMMENT '价税合计',
+            item_count INT DEFAULT 0 COMMENT '商品明细总数',
+            page_count INT DEFAULT 0 COMMENT 'PDF页数',
+            remarks TEXT COMMENT '备注',
+            issuer VARCHAR(32) COMMENT '开票人',
+            ocr_method VARCHAR(32) COMMENT '识别方法：fapiao/markitdown',
+            ocr_raw LONGTEXT COMMENT 'OCR原始输出JSON',
+            extraction_status VARCHAR(16) DEFAULT 'success' COMMENT '提取状态',
+            text_items_count INT DEFAULT 0 COMMENT 'PDF文本项总数',
+            keyword_count INT DEFAULT 0 COMMENT '发票关键词匹配数',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uk_invoice_number (invoice_number),
+            INDEX idx_seller (seller_name),
+            INDEX idx_buyer (buyer_name),
+            INDEX idx_date (invoice_date),
+            INDEX idx_amount (total_with_tax)
+          ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            COMMENT='发票元数据扩展表'
+        `);
+        if (!await hasForeignKey(conn, 'app_invoice_mgr_rows', 'fk_app_invoice_mgr_rows_row_id')) {
+          await conn.execute(`
+            ALTER TABLE app_invoice_mgr_rows
+            ADD CONSTRAINT fk_app_invoice_mgr_rows_row_id
+            FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
+          `);
+        }
+        console.log('  ✓ Created app_invoice_mgr_rows table with full schema');
+        return;
+      }
+
+      const missingCols = [
+        { col: 'issuer', def: "VARCHAR(32) COMMENT '开票人'", after: 'remarks' },
+        { col: 'ocr_method', def: "VARCHAR(32) COMMENT '识别方法：fapiao/markitdown'", after: 'issuer' },
+        { col: 'ocr_raw', def: "LONGTEXT COMMENT 'OCR原始输出JSON'", after: 'ocr_method' },
+        { col: 'extraction_status', def: "VARCHAR(16) DEFAULT 'success' COMMENT '提取状态'", after: 'ocr_raw' },
+        { col: 'text_items_count', def: "INT DEFAULT 0 COMMENT 'PDF文本项总数'", after: 'extraction_status' },
+        { col: 'keyword_count', def: "INT DEFAULT 0 COMMENT '发票关键词匹配数'", after: 'text_items_count' },
+      ];
+      for (const c of missingCols) {
+        if (!await hasColumn(conn, 'app_invoice_mgr_rows', c.col)) {
+          await conn.execute(`ALTER TABLE app_invoice_mgr_rows ADD COLUMN ${c.col} ${c.def} AFTER ${c.after}`);
+          console.log(`  ✓ Added column ${c.col} to app_invoice_mgr_rows`);
+        }
+      }
+
+      const missingIndexes = [
+        { name: 'uk_invoice_number', def: 'UNIQUE KEY uk_invoice_number (invoice_number)' },
+        { name: 'idx_seller', def: 'INDEX idx_seller (seller_name)' },
+        { name: 'idx_buyer', def: 'INDEX idx_buyer (buyer_name)' },
+        { name: 'idx_date', def: 'INDEX idx_date (invoice_date)' },
+        { name: 'idx_amount', def: 'INDEX idx_amount (total_with_tax)' },
+      ];
+      for (const idx of missingIndexes) {
+        if (!await hasIndex(conn, 'app_invoice_mgr_rows', idx.name)) {
+          try {
+            await conn.execute(`ALTER TABLE app_invoice_mgr_rows ADD ${idx.def}`);
+            console.log(`  ✓ Added index ${idx.name} to app_invoice_mgr_rows`);
+          } catch (e) {
+            console.log(`  ⚠ Skipped index ${idx.name}: ${e.message}`);
+          }
+        }
+      }
+
+      if (!await hasForeignKey(conn, 'app_invoice_mgr_rows', 'fk_app_invoice_mgr_rows_row_id')) {
+        try {
+          await conn.execute(`
+            ALTER TABLE app_invoice_mgr_rows
+            ADD CONSTRAINT fk_app_invoice_mgr_rows_row_id
+            FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
+          `);
+          console.log('  ✓ Added FK fk_app_invoice_mgr_rows_row_id');
+        } catch (e) {
+          console.log(`  ⚠ Skipped FK: ${e.message}`);
+        }
+      }
+
+      console.log('  ✓ Incrementally upgraded app_invoice_mgr_rows');
+    },
+  },
+
+  // 42d. invoice-mgr 商品明细表 items（增量升级：新建 + 逐列补齐 + 补索引 + 补 FK）
+  {
+    name: 'app_invoice_mgr_items table (incremental)',
+    check: async (conn) => {
+      if (!await hasTable(conn, 'app_invoice_mgr_items')) return false;
+      return await hasColumn(conn, 'app_invoice_mgr_items', 'sort_order');
+    },
+    migrate: async (conn) => {
+      if (!await hasTable(conn, 'app_invoice_mgr_items')) {
+        await conn.execute(`
+          CREATE TABLE app_invoice_mgr_items (
+            id VARCHAR(32) PRIMARY KEY,
+            row_id VARCHAR(32) NOT NULL COMMENT '关联 app_invoice_mgr_records.id',
+            page_number INT DEFAULT 1 COMMENT '所在页码',
+            sort_order INT DEFAULT 0 COMMENT '行内排序',
+            category VARCHAR(64) COMMENT '商品分类',
+            name VARCHAR(128) COMMENT '商品名称',
+            model VARCHAR(64) COMMENT '规格型号',
+            unit VARCHAR(16) COMMENT '单位',
+            quantity DECIMAL(12,4) COMMENT '数量',
+            price DECIMAL(12,4) COMMENT '单价',
+            amount DECIMAL(12,2) COMMENT '金额',
+            tax_rate VARCHAR(8) COMMENT '税率',
+            tax_amount DECIMAL(12,2) COMMENT '税额',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_row_id (row_id),
+            FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
+          ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            COMMENT='发票商品明细表'
+        `);
+        console.log('  ✓ Created app_invoice_mgr_items table');
+        return;
+      }
+
+      const missingCols = [
+        { col: 'page_number', def: "INT DEFAULT 1 COMMENT '所在页码'", after: 'row_id' },
+        { col: 'sort_order', def: "INT DEFAULT 0 COMMENT '行内排序'", after: 'page_number' },
+        { col: 'category', def: "VARCHAR(64) COMMENT '商品分类'", after: 'sort_order' },
+        { col: 'name', def: "VARCHAR(128) COMMENT '商品名称'", after: 'category' },
+        { col: 'model', def: "VARCHAR(64) COMMENT '规格型号'", after: 'name' },
+        { col: 'unit', def: "VARCHAR(16) COMMENT '单位'", after: 'model' },
+        { col: 'quantity', def: "DECIMAL(12,4) COMMENT '数量'", after: 'unit' },
+        { col: 'price', def: "DECIMAL(12,4) COMMENT '单价'", after: 'quantity' },
+        { col: 'amount', def: "DECIMAL(12,2) COMMENT '金额'", after: 'price' },
+        { col: 'tax_rate', def: "VARCHAR(8) COMMENT '税率'", after: 'amount' },
+        { col: 'tax_amount', def: "DECIMAL(12,2) COMMENT '税额'", after: 'tax_rate' },
+        { col: 'created_at', def: "DATETIME DEFAULT CURRENT_TIMESTAMP", after: 'tax_amount' },
+      ];
+      for (const c of missingCols) {
+        if (!await hasColumn(conn, 'app_invoice_mgr_items', c.col)) {
+          await conn.execute(`ALTER TABLE app_invoice_mgr_items ADD COLUMN ${c.col} ${c.def} AFTER ${c.after}`);
+          console.log(`  ✓ Added column ${c.col} to app_invoice_mgr_items`);
+        }
+      }
+
+      if (!await hasIndex(conn, 'app_invoice_mgr_items', 'idx_row_id')) {
+        try {
+          await conn.execute(`ALTER TABLE app_invoice_mgr_items ADD INDEX idx_row_id (row_id)`);
+          console.log('  ✓ Added index idx_row_id to app_invoice_mgr_items');
+        } catch (e) {
+          console.log(`  ⚠ Skipped index idx_row_id: ${e.message}`);
+        }
+      }
+
+      const [fkRows] = await conn.execute(
+        `SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'app_invoice_mgr_items' AND COLUMN_NAME = 'row_id' AND REFERENCED_TABLE_NAME IS NOT NULL`,
+        [DB_CONFIG.database]
+      );
+      if (fkRows.length === 0) {
+        try {
+          await conn.execute(`
+            ALTER TABLE app_invoice_mgr_items
+            ADD CONSTRAINT fk_app_invoice_mgr_items_row_id
+            FOREIGN KEY (row_id) REFERENCES app_invoice_mgr_records(id) ON DELETE CASCADE
+          `);
+          console.log('  ✓ Added FK fk_app_invoice_mgr_items_row_id');
+        } catch (e) {
+          console.log(`  ⚠ Skipped FK: ${e.message}`);
+        }
+      }
+
+      console.log('  ✓ Incrementally upgraded app_invoice_mgr_items');
+    },
+  },
+
   // 43. contract-mgr 自治主表
   {
     name: 'app_contract_mgr_records table',

--- a/server/controllers/app-market.controller.js
+++ b/server/controllers/app-market.controller.js
@@ -7,9 +7,24 @@ import path from 'path';
  * App Market 控制器
  */
 class AppMarketController {
-  constructor(db) {
+  constructor(db, registryService = null) {
     this.db = db;
     this.appMarketService = new AppMarketService(db);
+    this.registryService = registryService;
+    this.wildcardCacheManager = null;
+  }
+
+  setWildcardCacheManager(cacheManager) {
+    this.wildcardCacheManager = cacheManager;
+    if (this.registryService) {
+      this.registryService.setWildcardCacheManager(cacheManager);
+    }
+  }
+
+  clearAppCache(appId) {
+    if (this.registryService) {
+      this.registryService.clearAppCache(appId);
+    }
   }
 
   // ==================== Registry 配置 ====================

--- a/server/controllers/app-registry.controller.js
+++ b/server/controllers/app-registry.controller.js
@@ -2,9 +2,13 @@ import logger from '../../lib/logger.js';
 import AppRegistryService from '../services/app-registry.service.js';
 
 class AppRegistryController {
-  constructor(db) {
+  constructor(db, registryService = null) {
     this.db = db;
-    this.registryService = new AppRegistryService(db);
+    this.registryService = registryService || new AppRegistryService(db);
+  }
+
+  setWildcardCacheManager(cacheManager) {
+    this.registryService.setWildcardCacheManager(cacheManager);
   }
 
   async listApps(ctx) {

--- a/server/index.js
+++ b/server/index.js
@@ -81,6 +81,7 @@ import ELSController from './controllers/els.controller.js';
 import OcrToolController from './controllers/ocr-tool.controller.js';
 import CurrentFeatureAnalyzerController from './controllers/current-feature-analyzer.controller.js';
 import { getAssistantManager } from './services/assistant/index.js';
+import AppRegistryService from './services/app-registry.service.js';
 
 // 路由
 import authRoutes from './routes/auth.routes.js';
@@ -260,6 +261,8 @@ class ApiServer {
     this.tokenCleanupJob = null;
     this.appClock = null;
     this.appRouterLoader = null;
+    this.wildcardCacheManager = null;
+    this.sharedRegistryService = null;
     this.controllers = {};
   }
 
@@ -395,6 +398,8 @@ class ApiServer {
     // 先创建 StreamController，获取 SSE 连接池
     const streamController = new StreamController(this.db, this.chatService);
 
+    this.sharedRegistryService = new AppRegistryService(this.db);
+
     this.controllers = {
       auth: new AuthController(this.db),
       user: new UserController(this.db),
@@ -417,8 +422,8 @@ class ApiServer {
       assistant: new AssistantController(this.db),
       attachment: new AttachmentController(this.db),
       miniApp: new MiniAppController(this.db),
-      appMarket: new AppMarketController(this.db),
-      appRegistry: new AppRegistryController(this.db),
+      appMarket: new AppMarketController(this.db, this.sharedRegistryService),
+      appRegistry: new AppRegistryController(this.db, this.sharedRegistryService),
       appBackup: new AppBackupController(this.db),
       contractV2: new ContractV2Controller(this.db),
       invoice: new InvoiceController(this.db),

--- a/server/middlewares/app-wildcard-router.js
+++ b/server/middlewares/app-wildcard-router.js
@@ -1,0 +1,315 @@
+import logger from '../../lib/logger.js';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import AppRuntimeLoader from '../../lib/app-runtime-loader.js';
+
+const APPS_DIR = path.join(process.cwd(), 'apps');
+const ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'];
+
+function parseApiPath(apiPath) {
+  const segments = apiPath.split('/').filter(Boolean);
+  const paramNames = [];
+  const pattern = [];
+
+  for (const seg of segments) {
+    if (seg.startsWith(':')) {
+      paramNames.push(seg.slice(1));
+      pattern.push({ type: 'param', name: seg.slice(1) });
+    } else {
+      pattern.push({ type: 'static', value: seg });
+    }
+  }
+
+  return { segments, paramNames, pattern };
+}
+
+function matchPath(requestSegments, apiPattern) {
+  if (requestSegments.length !== apiPattern.length) {
+    return null;
+  }
+
+  const params = {};
+
+  for (let i = 0; i < requestSegments.length; i++) {
+    const reqSeg = requestSegments[i];
+    const apiSeg = apiPattern[i];
+
+    if (apiSeg.type === 'static') {
+      if (reqSeg !== apiSeg.value) {
+        return null;
+      }
+    } else if (apiSeg.type === 'param') {
+      params[apiSeg.name] = reqSeg;
+    }
+  }
+
+  return params;
+}
+
+function validateApis(apis) {
+  if (!Array.isArray(apis)) {
+    return { valid: false, errors: ['apis must be an array'] };
+  }
+
+  const errors = [];
+  const seen = new Set();
+
+  for (const api of apis) {
+    if (!api.path) {
+      errors.push(`api missing path field`);
+      continue;
+    }
+
+    if (!api.path.startsWith('/')) {
+      errors.push(`api path "${api.path}" must start with /`);
+    }
+
+    if (!api.methods || !Array.isArray(api.methods) || api.methods.length === 0) {
+      errors.push(`api "${api.path}" missing methods array`);
+      continue;
+    }
+
+    for (const method of api.methods) {
+      if (!ALLOWED_METHODS.includes(method)) {
+        errors.push(`api "${api.path}" has invalid method "${method}"`);
+      }
+
+      const key = `${api.path}:${method}`;
+      if (seen.has(key)) {
+        errors.push(`duplicate api declaration: ${key}`);
+      }
+      seen.add(key);
+    }
+
+    if (!api.handler) {
+      errors.push(`api "${api.path}" missing handler field`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+async function loadHandler(appId, handlerPath, appsDir) {
+  const fullPath = path.join(appsDir, appId, handlerPath);
+  const normalizedPath = path.normalize(fullPath);
+
+  if (!normalizedPath.startsWith(path.normalize(appsDir))) {
+    throw new Error(`Handler path not allowed: ${handlerPath}`);
+  }
+
+  const cacheBuster = process.env.NODE_ENV === 'development' ? `?t=${Date.now()}` : '';
+  const module = await import(`${pathToFileURL(normalizedPath).href}${cacheBuster}`);
+
+  return module;
+}
+
+function buildDeps(db, appId) {
+  const Sequelize = db.sequelize.constructor;
+
+  return {
+    db,
+    services: {
+      query: async (sql, replacements = []) => {
+        return await db.sequelize.query(sql, {
+          replacements,
+          type: Sequelize.QueryTypes.SELECT,
+        });
+      },
+      execute: async (sql, replacements = []) => {
+        return await db.sequelize.query(sql, {
+          replacements,
+          type: Sequelize.QueryTypes.RAW,
+        });
+      },
+      getModel: (modelName) => {
+        return db.getModel(modelName);
+      },
+      log: (level, message, meta = {}) => {
+        if (level === 'error') {
+          logger.error(`[App:${appId}] ${message}`, meta);
+        } else if (level === 'warn') {
+          logger.warn(`[App:${appId}] ${message}`, meta);
+        } else {
+          logger.info(`[App:${appId}] ${message}`, meta);
+        }
+      },
+    },
+  };
+}
+
+export function createAppWildcardRouter(db, options = {}) {
+  const runtimeLoader = options.runtimeLoader || new AppRuntimeLoader(db, APPS_DIR);
+  const handlerCache = new Map();
+  const apisCache = new Map();
+
+  const cacheManager = {
+    clearAppCache(appId) {
+      runtimeLoader.clearCache(appId);
+      const apisKey = `apis:${appId}`;
+      apisCache.delete(apisKey);
+      for (const key of handlerCache.keys()) {
+        if (key.startsWith(`handler:${appId}:`)) {
+          handlerCache.delete(key);
+        }
+      }
+      logger.info(`[WildcardRouter] Cache cleared for ${appId}`);
+    },
+  };
+
+  if (options.onCacheReady) {
+    options.onCacheReady(cacheManager);
+  }
+
+  async function getAppApis(appId) {
+    const cacheKey = `apis:${appId}`;
+
+    if (apisCache.has(cacheKey) && process.env.NODE_ENV !== 'development') {
+      return apisCache.get(cacheKey);
+    }
+
+    const manifest = await runtimeLoader.loadManifest(appId);
+    const apis = manifest.apis;
+
+    if (!apis || (Array.isArray(apis) && apis.length === 0)) {
+      const result = { parsedApis: [], hasApis: false };
+      apisCache.set(cacheKey, result);
+      return result;
+    }
+
+    const validation = validateApis(apis);
+
+    if (!validation.valid) {
+      logger.error(`[WildcardRouter] Invalid apis for ${appId}: ${validation.errors.join(', ')}`);
+      const result = { parsedApis: [], hasApis: false, validationErrors: validation.errors };
+      apisCache.set(cacheKey, result);
+      return result;
+    }
+
+    const parsedApis = apis.map(api => ({
+      ...api,
+      parsed: parseApiPath(api.path),
+    }));
+
+    const result = { parsedApis, hasApis: true };
+    apisCache.set(cacheKey, result);
+    return result;
+  }
+
+  async function getHandler(appId, handlerPath) {
+    const cacheKey = `handler:${appId}:${handlerPath}`;
+
+    if (handlerCache.has(cacheKey) && process.env.NODE_ENV !== 'development') {
+      return handlerCache.get(cacheKey);
+    }
+
+    const module = await loadHandler(appId, handlerPath, APPS_DIR);
+    handlerCache.set(cacheKey, module);
+    return module;
+  }
+
+  return async function appWildcardRouter(ctx, next) {
+    if (!ctx.path.startsWith('/api/apps/')) {
+      return await next();
+    }
+
+    const pathParts = ctx.path.slice('/api/apps/'.length).split('/');
+    const appId = pathParts[0];
+
+    if (!appId) {
+      ctx.error('Missing appId in path', 400);
+      return;
+    }
+
+    const appInternalPath = '/' + pathParts.slice(1).join('/');
+    const requestSegments = pathParts.slice(1).filter(Boolean);
+    const method = ctx.method.toUpperCase();
+
+    try {
+      const MiniApp = db.getModel('mini_app');
+
+      if (!MiniApp) {
+        ctx.error(`mini_app model not available`, 500);
+        return;
+      }
+
+      const appRecord = await MiniApp.findOne({ where: { id: appId } });
+
+      if (!appRecord) {
+        ctx.error(`App "${appId}" not found`, 404);
+        return;
+      }
+
+      if (!appRecord.is_active) {
+        ctx.error(`App "${appId}" is not active`, 404);
+        return;
+      }
+
+      const apisResult = await getAppApis(appId);
+
+      if (!apisResult.hasApis) {
+        return await next();
+      }
+
+      const apis = apisResult.parsedApis;
+      const matchedApis = [];
+
+      for (const api of apis) {
+        const params = matchPath(requestSegments, api.parsed.pattern);
+        if (params !== null) {
+          matchedApis.push({ api, params });
+        }
+      }
+
+      if (matchedApis.length === 0) {
+        ctx.error(`API "${appInternalPath}" not declared in manifest.apis`, 404);
+        return;
+      }
+
+      let matchedApi = null;
+      let matchedParams = null;
+
+      for (const { api, params } of matchedApis) {
+        if (api.methods.includes(method)) {
+          matchedApi = api;
+          matchedParams = params;
+          break;
+        }
+      }
+
+      if (!matchedApi) {
+        const allMethods = matchedApis.flatMap(m => m.api.methods);
+        const uniqueMethods = [...new Set(allMethods)];
+        ctx.error(`Method ${method} not allowed for "${appInternalPath}"`, 405);
+        ctx.body.data = { allowed_methods: uniqueMethods };
+        return;
+      }
+
+      const methodLower = method.toLowerCase();
+      const handlerModule = await getHandler(appId, matchedApi.handler);
+      const handlerFn = handlerModule[methodLower] || handlerModule.default?.[methodLower];
+
+      if (!handlerFn || typeof handlerFn !== 'function') {
+        ctx.error(`Handler function "${methodLower}" not found in ${matchedApi.handler}`, 500);
+        return;
+      }
+
+      ctx.params = { ...ctx.params, ...matchedParams };
+
+      const deps = buildDeps(db, appId);
+
+      logger.info(`[WildcardRouter] ${method} ${ctx.path} -> ${appId}:${matchedApi.handler}:${methodLower}`);
+
+      await handlerFn(ctx, deps);
+
+    } catch (err) {
+      logger.error(`[WildcardRouter] Error handling ${ctx.path}: ${err.message}`);
+
+      if (err.message.includes('not allowed')) {
+        ctx.error('Handler path not allowed', 403);
+        return;
+      }
+
+      ctx.error(err.message || 'Internal server error', 500);
+    }
+  };
+}

--- a/server/routes/app-registry.routes.js
+++ b/server/routes/app-registry.routes.js
@@ -1,58 +1,124 @@
 import Router from '@koa/router';
 import { authenticate, requireAdmin } from '../middlewares/auth.js';
+import logger from '../../lib/logger.js';
 
 export default (controller) => {
   const router = new Router();
 
-  router.get('/api/apps', authenticate(), (ctx) => controller.listApps(ctx));
+  router.get('/api/app-registry', authenticate(), (ctx) => controller.listApps(ctx));
   
-  router.get('/api/apps/installed', authenticate(), requireAdmin(), (ctx) => 
+  router.get('/api/app-registry/installed', authenticate(), requireAdmin(), (ctx) => 
     controller.listInstalledApps(ctx)
   );
 
-  router.get('/api/apps/clock-registry', authenticate(), requireAdmin(), (ctx) => 
+  router.get('/api/app-registry/clock-registry', authenticate(), requireAdmin(), (ctx) => 
     controller.listClockRegistry(ctx)
   );
 
-  router.post('/api/apps', authenticate(), requireAdmin(), (ctx) => controller.createApp(ctx));
+  router.post('/api/app-registry', authenticate(), requireAdmin(), (ctx) => controller.createApp(ctx));
 
-  router.get('/api/apps/:appId', authenticate(), (ctx) => controller.getApp(ctx));
+  router.get('/api/app-registry/:appId', authenticate(), (ctx) => controller.getApp(ctx));
   
-  router.get('/api/apps/:appId/runtime', authenticate(), requireAdmin(), (ctx) => 
+  router.get('/api/app-registry/:appId/runtime', authenticate(), requireAdmin(), (ctx) => 
     controller.getAppWithRuntime(ctx)
   );
   
-  router.put('/api/apps/:appId', authenticate(), requireAdmin(), (ctx) => 
+  router.put('/api/app-registry/:appId', authenticate(), requireAdmin(), (ctx) => 
     controller.updateApp(ctx)
   );
   
-  router.delete('/api/apps/:appId', authenticate(), requireAdmin(), (ctx) => 
+  router.delete('/api/app-registry/:appId', authenticate(), requireAdmin(), (ctx) => 
     controller.deleteApp(ctx)
   );
 
-  router.get('/api/apps/:appId/config', authenticate(), requireAdmin(), (ctx) => 
+  router.get('/api/app-registry/:appId/config', authenticate(), requireAdmin(), (ctx) => 
     controller.getAppConfig(ctx)
   );
   
-  router.put('/api/apps/:appId/config', authenticate(), requireAdmin(), (ctx) => 
+  router.put('/api/app-registry/:appId/config', authenticate(), requireAdmin(), (ctx) => 
     controller.updateAppConfig(ctx)
   );
 
-  router.get('/api/apps/:appId/manifest', authenticate(), requireAdmin(), (ctx) => 
+  router.get('/api/app-registry/:appId/manifest', authenticate(), requireAdmin(), (ctx) => 
     controller.getAppManifest(ctx)
   );
   
-  router.get('/api/apps/:appId/validate-runtime', authenticate(), requireAdmin(), (ctx) => 
+  router.get('/api/app-registry/:appId/validate-runtime', authenticate(), requireAdmin(), (ctx) => 
     controller.validateAppRuntime(ctx)
   );
   
-  router.get('/api/apps/:appId/clock-registry', authenticate(), requireAdmin(), (ctx) => 
+  router.get('/api/app-registry/:appId/clock-registry', authenticate(), requireAdmin(), (ctx) => 
     controller.getClockRegistry(ctx)
   );
   
-  router.put('/api/apps/:appId/clock-registry', authenticate(), requireAdmin(), (ctx) => 
+  router.put('/api/app-registry/:appId/clock-registry', authenticate(), requireAdmin(), (ctx) => 
     controller.updateClockRegistry(ctx)
   );
 
-  return router;
+  const legacyRouter = new Router();
+
+  legacyRouter.use(async (ctx, next) => {
+    if (ctx.path === '/api/apps' || ctx.path.startsWith('/api/apps/')) {
+      logger.warn(`[DEPRECATED] Legacy route accessed: ${ctx.path}. Use /api/app-registry/* instead.`);
+      ctx.set('X-Deprecated', 'true');
+      ctx.set('X-Deprecated-Message', 'Use /api/app-registry/* instead of /api/apps/* for registry APIs');
+    }
+    await next();
+  });
+
+  legacyRouter.get('/api/apps', authenticate(), (ctx) => controller.listApps(ctx));
+  
+  legacyRouter.get('/api/apps/installed', authenticate(), requireAdmin(), (ctx) => 
+    controller.listInstalledApps(ctx)
+  );
+
+  legacyRouter.get('/api/apps/clock-registry', authenticate(), requireAdmin(), (ctx) => 
+    controller.listClockRegistry(ctx)
+  );
+
+  legacyRouter.post('/api/apps', authenticate(), requireAdmin(), (ctx) => controller.createApp(ctx));
+
+  legacyRouter.get('/api/apps/:appId', authenticate(), (ctx) => controller.getApp(ctx));
+  
+  legacyRouter.get('/api/apps/:appId/runtime', authenticate(), requireAdmin(), (ctx) => 
+    controller.getAppWithRuntime(ctx)
+  );
+  
+  legacyRouter.put('/api/apps/:appId', authenticate(), requireAdmin(), (ctx) => 
+    controller.updateApp(ctx)
+  );
+  
+  legacyRouter.delete('/api/apps/:appId', authenticate(), requireAdmin(), (ctx) => 
+    controller.deleteApp(ctx)
+  );
+
+  legacyRouter.get('/api/apps/:appId/config', authenticate(), requireAdmin(), (ctx) => 
+    controller.getAppConfig(ctx)
+  );
+  
+  legacyRouter.put('/api/apps/:appId/config', authenticate(), requireAdmin(), (ctx) => 
+    controller.updateAppConfig(ctx)
+  );
+
+  legacyRouter.get('/api/apps/:appId/manifest', authenticate(), requireAdmin(), (ctx) => 
+    controller.getAppManifest(ctx)
+  );
+  
+  legacyRouter.get('/api/apps/:appId/validate-runtime', authenticate(), requireAdmin(), (ctx) => 
+    controller.validateAppRuntime(ctx)
+  );
+  
+  legacyRouter.get('/api/apps/:appId/clock-registry', authenticate(), requireAdmin(), (ctx) => 
+    controller.getClockRegistry(ctx)
+  );
+  
+  legacyRouter.put('/api/apps/:appId/clock-registry', authenticate(), requireAdmin(), (ctx) => 
+    controller.updateClockRegistry(ctx)
+  );
+
+  const combinedRouter = new Router();
+  combinedRouter.use(router.routes(), router.allowedMethods());
+  combinedRouter.use(legacyRouter.routes(), legacyRouter.allowedMethods());
+
+  return combinedRouter;
 };

--- a/server/routes/current-feature-analyzer.routes.js
+++ b/server/routes/current-feature-analyzer.routes.js
@@ -1,8 +1,9 @@
 import Router from '@koa/router';
 import { authenticate, requireAdmin } from '../middlewares/auth.js';
+import logger from '../../lib/logger.js';
 
 export default (controller) => {
-  const router = new Router({ prefix: '/api/apps/current-feature-analyzer' });
+  const router = new Router({ prefix: '/api/current-feature-analyzer' });
 
   router.post('/uploads', authenticate(), (ctx) => controller.upload(ctx));
   router.get('/batches/:batch_id', authenticate(), (ctx) => controller.getBatch(ctx));
@@ -22,5 +23,36 @@ export default (controller) => {
   router.get('/config', authenticate(), (ctx) => controller.getConfig(ctx));
   router.put('/config', authenticate(), requireAdmin(), (ctx) => controller.saveConfig(ctx));
 
-  return router;
+  const legacyRouter = new Router({ prefix: '/api/apps/current-feature-analyzer' });
+
+  legacyRouter.use(async (ctx, next) => {
+    logger.warn(`[DEPRECATED] Legacy route accessed: ${ctx.path}. Use /api/current-feature-analyzer/* instead.`);
+    ctx.set('X-Deprecated', 'true');
+    ctx.set('X-Deprecated-Message', 'Use /api/current-feature-analyzer/* instead of /api/apps/current-feature-analyzer/*');
+    await next();
+  });
+
+  legacyRouter.post('/uploads', authenticate(), (ctx) => controller.upload(ctx));
+  legacyRouter.get('/batches/:batch_id', authenticate(), (ctx) => controller.getBatch(ctx));
+  legacyRouter.get('/batches/:batch_id/files/:file_id', authenticate(), (ctx) => controller.getFileDetail(ctx));
+
+  legacyRouter.post('/analysis/run', authenticate(), (ctx) => controller.runAnalysis(ctx));
+  legacyRouter.get('/reports/:batch_id', authenticate(), (ctx) => controller.getReport(ctx));
+  legacyRouter.post('/reports/:batch_id/export', authenticate(), (ctx) => controller.exportReport(ctx));
+
+  legacyRouter.get('/rule-sets', authenticate(), (ctx) => controller.listRuleSets(ctx));
+  legacyRouter.get('/rule-sets/:id', authenticate(), (ctx) => controller.getRuleSet(ctx));
+  legacyRouter.post('/rule-sets', authenticate(), requireAdmin(), (ctx) => controller.createRuleSet(ctx));
+  legacyRouter.put('/rule-sets/:id', authenticate(), requireAdmin(), (ctx) => controller.updateRuleSet(ctx));
+  legacyRouter.delete('/rule-sets/:id', authenticate(), requireAdmin(), (ctx) => controller.deleteRuleSet(ctx));
+  legacyRouter.post('/rule-sets/:id/copy', authenticate(), requireAdmin(), (ctx) => controller.copyRuleSet(ctx));
+
+  legacyRouter.get('/config', authenticate(), (ctx) => controller.getConfig(ctx));
+  legacyRouter.put('/config', authenticate(), requireAdmin(), (ctx) => controller.saveConfig(ctx));
+
+  const combinedRouter = new Router();
+  combinedRouter.use(router.routes(), router.allowedMethods());
+  combinedRouter.use(legacyRouter.routes(), legacyRouter.allowedMethods());
+
+  return combinedRouter;
 };

--- a/server/services/app-registry.service.js
+++ b/server/services/app-registry.service.js
@@ -12,6 +12,18 @@ class AppRegistryService {
     this.appsDir = appsDir;
     this.models = {};
     this.runtimeLoader = new AppRuntimeLoader(db, appsDir);
+    this.wildcardCacheManager = null;
+  }
+
+  setWildcardCacheManager(cacheManager) {
+    this.wildcardCacheManager = cacheManager;
+  }
+
+  clearAppCache(appId) {
+    this.runtimeLoader.clearCache(appId);
+    if (this.wildcardCacheManager) {
+      this.wildcardCacheManager.clearAppCache(appId);
+    }
   }
 
   ensureModels() {

--- a/server/services/invoice.service.js
+++ b/server/services/invoice.service.js
@@ -32,8 +32,8 @@ class InvoiceService {
   }
 
   _buildConditions({ invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin }) {
-    const conditions = ['m.app_id = ?'];
-    const replacements = ['invoice-mgr'];
+    const conditions = ['m.status IS NOT NULL'];
+    const replacements = [];
 
     if (!isAdmin) {
       conditions.push('m.user_id = ?');
@@ -96,7 +96,8 @@ class InvoiceService {
                 r.invoice_number, r.invoice_date, r.invoice_type,
                 r.seller_name, r.seller_tax_id, r.buyer_name, r.buyer_tax_id,
                 r.total_amount, r.total_tax, r.total_with_tax,
-                r.item_count, r.remarks, r.issuer, r.ocr_method, r.extraction_status
+                r.item_count, r.remarks, r.issuer, r.ocr_method, r.extraction_status,
+                r.page_count, r.text_items_count, r.keyword_count
          FROM app_invoice_mgr_records m
          LEFT JOIN app_invoice_mgr_rows r ON r.row_id = m.id
          ${where}
@@ -122,8 +123,8 @@ class InvoiceService {
   }
 
   async detail(rowId, userId, isAdmin) {
-    const conditions = ['m.id = ?', 'm.app_id = ?'];
-    const replacements = [rowId, 'invoice-mgr'];
+    const conditions = ['m.id = ?'];
+    const replacements = [rowId];
 
     if (!isAdmin) {
       conditions.push('m.user_id = ?');
@@ -138,7 +139,8 @@ class InvoiceService {
                 r.invoice_number, r.invoice_date, r.invoice_type,
                 r.seller_name, r.seller_tax_id, r.buyer_name, r.buyer_tax_id,
                 r.total_amount, r.total_tax, r.total_with_tax,
-                r.item_count, r.page_count, r.remarks, r.issuer, r.ocr_method, r.ocr_raw, r.extraction_status
+                r.item_count, r.page_count, r.remarks, r.issuer, r.ocr_method, r.ocr_raw, r.extraction_status,
+                r.text_items_count, r.keyword_count
          FROM app_invoice_mgr_records m
          LEFT JOIN app_invoice_mgr_rows r ON r.row_id = m.id
          ${where}`,
@@ -176,7 +178,8 @@ class InvoiceService {
               r.invoice_number, r.invoice_date, r.invoice_type,
               r.seller_name, r.seller_tax_id, r.buyer_name, r.buyer_tax_id,
               r.total_amount, r.total_tax, r.total_with_tax,
-              r.item_count, r.remarks, r.issuer, r.ocr_method, r.extraction_status
+              r.item_count, r.remarks, r.issuer, r.ocr_method, r.extraction_status,
+              r.page_count, r.text_items_count, r.keyword_count
        FROM app_invoice_mgr_records m
        LEFT JOIN app_invoice_mgr_rows r ON r.row_id = m.id
        ${where}
@@ -308,7 +311,8 @@ class InvoiceService {
               r.invoice_number, r.invoice_date, r.invoice_type,
               r.seller_name, r.seller_tax_id, r.buyer_name, r.buyer_tax_id,
               r.total_amount, r.total_tax, r.total_with_tax,
-              r.item_count, r.remarks, r.issuer, r.ocr_method, r.extraction_status
+              r.item_count, r.remarks, r.issuer, r.ocr_method, r.extraction_status,
+              r.page_count, r.text_items_count, r.keyword_count
        FROM app_invoice_mgr_records m
        LEFT JOIN app_invoice_mgr_rows r ON r.row_id = m.id
        ${where}


### PR DESCRIPTION
﻿## 变更内容

### API 路由前缀规范化
- /api/apps/* → /api/app-registry/*（新增正式路由）
- /api/apps/current-feature-analyzer/* → /api/current-feature-analyzer/*（新增正式路由）
- 旧路由保留为 legacy 兼容层，添加 X-Deprecated 响应头 + logger 警告

### 声明式 apis 路由迁移
- contract-mgr / contract-mgr-v2 manifest.json：untime.server.routes → pis 数组声明
- 新增对应 controller 文件

### Invoice-mgr 改进
- 迁移脚本重构为增量模式（hasTable/hasColumn 逐列补齐）
- upgrade-database.js 新增 42c/42d 迁移条目
- 移除 service 层 pp_id = 'invoice-mgr' 硬编码条件
- 补选 page_count/	ext_items_count/keyword_count 字段
- manifest.json 移除 issuer 字段定义（字段已在 rows 表中保留）

### 架构改进
- 提取共享 AppRegistryService 实例注入到多 controller
- 新增 WildcardCacheManager + clearAppCache 方法
- 新增 pp-wildcard-router 中间件

### 测试
- 测试脚本适配新/旧双前缀验证
- 新增 	est-current-feature-analyzer-prefix.js

## 影响范围
- 后端路由层（新增前缀 + legacy 兼容）
- App manifest 格式
- Invoice 数据库迁移
- 前端 API 路径
