### PR TITLE
fix: 修复前端类型检查错误

### DIFF
--- a/docs/tasks/active/task-20260625-frontend-typecheck-fix/BRANCH.md
+++ b/docs/tasks/active/task-20260625-frontend-typecheck-fix/BRANCH.md
@@ -1,0 +1,6 @@
+# Branch Mapping
+
+- 当前分支：`fix/20260625-frontend-typecheck-fix`
+- 建议分支：`fix/20260625-frontend-typecheck-fix`
+- Issue：未提供
+- 变更范围：`frontend/src/components/current-feature-analyzer/*`、`frontend/src/stores/currentFeatureAnalyzer.ts`、`frontend/src/views/contract-mgr/ContractMgrView.vue`、`docs/tasks/active/task-20260625-frontend-typecheck-fix/`

--- a/docs/tasks/active/task-20260625-frontend-typecheck-fix/README.md
+++ b/docs/tasks/active/task-20260625-frontend-typecheck-fix/README.md
@@ -1,0 +1,26 @@
+# task-20260625-frontend-typecheck-fix
+
+## 目标
+
+- 修复当前前端 `vue-tsc --build` 阻塞的 TypeScript 类型错误。
+- 保持改动最小，仅处理明确的类型定义、空值保护与模板推断问题。
+
+## 范围
+
+- `frontend/src/components/current-feature-analyzer/CompressedCurrentChart.vue`
+- `frontend/src/components/current-feature-analyzer/FileListPanel.vue`
+- `frontend/src/components/current-feature-analyzer/RuleSetEditorModal.vue`
+- `frontend/src/stores/currentFeatureAnalyzer.ts`
+- `frontend/src/views/contract-mgr/ContractMgrView.vue`
+- `docs/tasks/active/task-20260625-frontend-typecheck-fix/`
+
+## 结果
+
+- 为图表分段映射补全显式类型，消除隐式 `any`。
+- 为文件列表面板补上完成数与总数的计算来源。
+- 修正阶段删除按钮索引类型与 store 首项访问的空值保护。
+- 修正合同详情请求的泛型参数，匹配实际详情类型。
+
+## 验证
+
+- 已通过：`frontend` 目录下 `npx vue-tsc --build`

--- a/frontend/src/components/current-feature-analyzer/CompressedCurrentChart.vue
+++ b/frontend/src/components/current-feature-analyzer/CompressedCurrentChart.vue
@@ -9,6 +9,12 @@
 import { ref, onMounted, nextTick } from 'vue'
 import * as echarts from 'echarts'
 
+interface CompressedSegment {
+  kind: string
+  segment_index: number
+  polyline_points?: [number, number][]
+}
+
 const props = defineProps<{ fileName: string; result: any }>()
 
 const chartRef = ref<HTMLElement | null>(null)
@@ -30,8 +36,8 @@ const kindColors: Record<string, string> = {
 function renderCompressed() {
   if (!chartRef.value) return
   const instance = echarts.init(chartRef.value)
-  const segs = props.result.segments || []
-  const series = segs.map(seg => ({
+  const segs: CompressedSegment[] = props.result?.segments || []
+  const series = segs.map((seg) => ({
     type: 'line',
     name: `${seg.kind} (${seg.segment_index})`,
     data: seg.polyline_points || [],

--- a/frontend/src/components/current-feature-analyzer/FileListPanel.vue
+++ b/frontend/src/components/current-feature-analyzer/FileListPanel.vue
@@ -22,14 +22,18 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { SessionFileItem } from '@/api/current-feature-analyzer'
 import FileListItem from './FileListItem.vue'
 
-defineProps<{
+const props = defineProps<{
   files: SessionFileItem[]
   selectedFileId: string | null
   batchStatus: string
 }>()
+
+const total = computed(() => props.files.length)
+const completed = computed(() => props.files.filter(file => file.analysis_status === 'completed').length)
 
 defineEmits<{
   select: [id: string]

--- a/frontend/src/components/current-feature-analyzer/RuleSetEditorModal.vue
+++ b/frontend/src/components/current-feature-analyzer/RuleSetEditorModal.vue
@@ -73,7 +73,7 @@
               <el-input-number v-model="stage.stage_order" :min="0" size="small" controls-position="right" />
             </el-col>
             <el-col :span="4">
-              <el-button size="small" type="danger" @click="removeStage(i)">删除</el-button>
+              <el-button size="small" type="danger" @click="removeStage(Number(i))">删除</el-button>
             </el-col>
           </el-row>
           <el-input v-model="stage.semantic_definition" placeholder="语义定义" size="small" style="margin-top: 4px" />

--- a/frontend/src/stores/currentFeatureAnalyzer.ts
+++ b/frontend/src/stores/currentFeatureAnalyzer.ts
@@ -49,8 +49,9 @@ export const useCurrentFeatureAnalyzerStore = defineStore('currentFeatureAnalyze
       batchStatus.value = batch.batch_status
       files.value = batch.files || []
       selectedRuleSetId.value = batch.selected_rule_set_id || ruleSetId || null
-      if (files.value.length > 0) {
-        selectedFileId.value = files.value[0].file_id
+      const first_file = files.value[0]
+      if (first_file) {
+        selectedFileId.value = first_file.file_id
       }
     } catch (err: any) {
       const msg = err?.response?.data?.message || err?.message || '上传失败'
@@ -116,8 +117,9 @@ export const useCurrentFeatureAnalyzerStore = defineStore('currentFeatureAnalyze
       batchStatus.value = batch.batch_status
       files.value = batch.files || []
       summary.value = batch.summary
-      if (files.value.length > 0 && !selectedFileId.value) {
-        selectedFileId.value = files.value[0].file_id
+      const first_file = files.value[0]
+      if (first_file && !selectedFileId.value) {
+        selectedFileId.value = first_file.file_id
       }
     } catch (err: any) {
       const msg = err?.response?.data?.message || err?.message || '分析失败'

--- a/frontend/src/views/contract-mgr/ContractMgrView.vue
+++ b/frontend/src/views/contract-mgr/ContractMgrView.vue
@@ -168,7 +168,7 @@ async function loadSummary() {
 
 async function openDetail(row: ContractRecord) {
   try {
-    detail.value = await apiRequest<Record>(apiClient.get(`${BASE}/records/${row.id}`))
+    detail.value = await apiRequest<ContractRecord>(apiClient.get(`${BASE}/records/${row.id}`))
     drawer.value = true
   } catch {}
 }


### PR DESCRIPTION
## Summary

- fix frontend TypeScript errors blocking `vue-tsc --build`
- add required task tracking docs under `docs/tasks/active/`
- keep behavior unchanged with minimal type-only adjustments

## Validation

- `cd frontend && npx vue-tsc --build`

Closes #900
