### PR TITLE
fix: speed up doc OCR submit flow

### DIFF
--- a/frontend/src/components/docs/CollectionCard.vue
+++ b/frontend/src/components/docs/CollectionCard.vue
@@ -30,6 +30,7 @@
 
 <script setup lang="ts">
 import { Document, RefreshRight } from '@element-plus/icons-vue'
+import { useI18n } from 'vue-i18n'
 import type { DocCollection } from '@/api/collections'
 import VisibilityTag from './VisibilityTag.vue'
 
@@ -42,6 +43,8 @@ defineEmits<{
   open: [collection: DocCollection]
   settings: [collection: DocCollection]
 }>()
+
+const { t } = useI18n()
 
 function formatRelativeTime(timeStr: string) {
   if (!timeStr) return ''

--- a/lib/document-ocr-service.js
+++ b/lib/document-ocr-service.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import Utils from './utils.js';
 import logger from './logger.js';
+import { Op } from 'sequelize';
 import DocPipelineAdvancer from './doc-pipeline-advancer.js';
 import { getStageDefault } from './doc-pipeline-defaults.js';
 import { getPreviewAttachmentId } from './doc-ocr-utils.js';
@@ -17,6 +18,7 @@ const MAX_SAFE_SUMMARY_DEPTH = 4;
 const MAX_IMAGE_METADATA_ITEMS = 20;
 const MAX_ATTACHMENT_ALT_TEXT_LENGTH = 500;
 const MAX_ATTACHMENT_DESCRIPTION_LENGTH = 4000;
+const SUBMIT_IN_PROGRESS_STALE_GRACE_MS = 30000;
 
 const EXTERNAL_TO_OCR_STATUS_MAP = {
   pending: 'pending',
@@ -296,13 +298,6 @@ class DocumentOcrService {
   }
 
   async submit(documentId, options = {}) {
-    this.ensureCallMcp();
-    const config = await this._loadStageConfig('pending_ocr');
-    const serverName = this._resolveMcpServer(config);
-    const toolName = this._resolveMcpTool(config, 'create_task_from_file');
-    const timeoutMs = this._resolveMcpTimeout(config, await this._getSystemMcpTimeoutMs());
-    const provider = config.provider_name || this.provider;
-
     const ctx = await this.loadDocumentContext(documentId);
     const existingOcrResult = await this.getLatestOcrResult(ctx.revision.id);
     if (existingOcrResult?.task_id && ['pending', 'processing', 'completed'].includes(existingOcrResult.status)) {
@@ -316,84 +311,205 @@ class DocumentOcrService {
 
     const ocrResult = await this.ensureOcrResult(ctx);
 
-    const attachment = await this.resolveSourceAttachment(ctx.document, ctx.revision, options.attachmentId, options.userId || null);
-    if (!attachment) {
-      await this.markFailed(ctx, 'attachment_not_found', '未找到可用于OCR的源附件');
-      throw new Error(`No source attachment found for document ${documentId}`);
+    const submitState = await this.getSubmitInProgressState(ocrResult);
+    if (submitState.active) {
+      logger.info(`[DocumentOcrService] Submit already in progress for ${documentId}: ocr_result=${ocrResult.id}`);
+      return ocrResult;
     }
 
-    const fileBase64 = await this.readAttachmentBase64(attachment);
-    const attachmentContext = {
-      file_base64: fileBase64,
-      file_name: attachment.file_name || `document-${documentId}.bin`,
-    };
-
-    const runtimeOverrides = {};
-    if (options.lang !== undefined) runtimeOverrides.lang = options.lang;
-    if (options.formulaEnable !== undefined) runtimeOverrides.formula_enable = options.formulaEnable;
-    if (options.tableEnable !== undefined) runtimeOverrides.table_enable = options.tableEnable;
-    if (options.imageAnalysis !== undefined) runtimeOverrides.image_analysis = options.imageAnalysis;
-
-    const mcpParams = this._buildMcpParams(config, runtimeOverrides, attachmentContext);
-
-    const submitToolResult = await this.callMcp(
-      serverName,
-      toolName,
-      mcpParams,
-      timeoutMs,
-    );
-    const result = this.extractStructuredToolResult(submitToolResult);
-
-    const judged = await this._runJudge(config, result, { stage: 'pending_ocr' });
-    const normalized = judged?._normalized || {};
-
-    const taskId = normalized.task_id || result?.task_id || null;
-    const resolvedProvider = normalized.provider || provider;
-    const isSuccess = normalized.is_success !== false;
-    const normalizedStatus = isSuccess ? this.normalizeOcrResultStatus(result?.status || 'pending') : 'failed';
-    const failMessage = !isSuccess ? (normalized.message || 'OCR submit failed') : null;
-
-    logger.info(`[DocumentOcrService] submit result: document=${documentId} ocr_result=${ocrResult.id} task_id=${taskId || 'null'} status=${normalizedStatus} provider=${resolvedProvider}`);
+    if (submitState.stale) {
+      logger.warn(`[DocumentOcrService] Clearing stale submit_in_progress for ${documentId}: ocr_result=${ocrResult.id}`);
+      await this.clearSubmitInProgress(ocrResult, {
+        submit_recovered_at: new Date().toISOString(),
+        submit_recovered_reason: 'stale_submit_in_progress',
+      });
+      await ocrResult.reload();
+    }
 
     await ocrResult.update({
-      provider: resolvedProvider,
-      task_id: taskId,
-      status: normalizedStatus,
-      progress: normalizedStatus === 'failed' ? -1 : 0,
+      provider: this.provider,
+      status: 'pending',
+      progress: 0,
       started_at: new Date(),
-      error_code: normalizedStatus === 'failed' ? 'submit_failed' : null,
-      error_message: normalizedStatus === 'failed' ? failMessage : null,
+      completed_at: null,
+      error_code: null,
+      error_message: null,
       metadata: this.buildMergedMetadata(ocrResult.metadata, {
-        submit_tool_result: this.buildToolResultSummary(submitToolResult),
-        submit_result: this.buildResultSummary(result),
-        judge_result: judged?._normalized || null,
+        submit_in_progress: true,
+        submit_requested_at: new Date().toISOString(),
       }),
     });
 
-    if (normalizedStatus === 'failed') {
-      await this.advancer.fail(documentId, 'ocr_submit_failed', failMessage || 'OCR submit failed');
-      return ocrResult;
+    this.scheduleSubmitTask(documentId, ocrResult.id, options);
+
+    return ocrResult;
+  }
+
+  scheduleSubmitTask(documentId, ocrResultId, options = {}) {
+    setImmediate(() => {
+      this.executeSubmitTask(documentId, ocrResultId, options).catch(error => {
+        logger.error(`[DocumentOcrService] background submit failed for ${documentId}: ${error.message}`);
+      });
+    });
+  }
+
+  async executeSubmitTask(documentId, ocrResultId, options = {}) {
+    this.ensureCallMcp();
+    const ocrResult = await this.getOcrResultById(ocrResultId);
+    if (!ocrResult) {
+      logger.warn(`[DocumentOcrService] Skip background submit for ${documentId}: OCR result ${ocrResultId} not found`);
+      return null;
     }
 
-    if (!taskId) {
-      const missingTaskMessage = normalized.message || result?.message || result?.error || 'OCR submit missing task_id';
+    let ctx = null;
+    let taskCreated = false;
+
+    try {
+      await ocrResult.reload();
+      const queuedSubmitState = await this.getSubmitInProgressState(ocrResult);
+      if (!queuedSubmitState.active || this.isCancelledOcrResult(ocrResult)) {
+        logger.info(`[DocumentOcrService] Skip background submit for ${documentId}: submit no longer active`);
+        return ocrResult;
+      }
+
+      const config = await this._loadStageConfig('pending_ocr');
+      const serverName = this._resolveMcpServer(config);
+      const toolName = this._resolveMcpTool(config, 'create_task_from_file');
+      const timeoutMs = this._resolveMcpTimeout(config, await this._getSystemMcpTimeoutMs());
+      const provider = config.provider_name || this.provider;
+
+      ctx = await this.loadDocumentContext(documentId);
+      await ocrResult.reload();
+      const activeSubmitState = await this.getSubmitInProgressState(ocrResult);
+      if (ocrResult.task_id || !activeSubmitState.active || this.isCancelledOcrResult(ocrResult, ctx.document)) {
+        logger.info(`[DocumentOcrService] Skip background submit for ${documentId}: OCR result ${ocrResult.id} already has task_id=${ocrResult.task_id}`);
+        return ocrResult;
+      }
+
+      const attachment = await this.resolveSourceAttachment(ctx.document, ctx.revision, options.attachmentId, options.userId || null);
+      if (!attachment) {
+        throw new Error(`No source attachment found for document ${documentId}`);
+      }
+
+      const fileBase64 = await this.readAttachmentBase64(attachment);
+      const attachmentContext = {
+        file_base64: fileBase64,
+        file_name: attachment.file_name || `document-${documentId}.bin`,
+      };
+
+      const runtimeOverrides = {};
+      if (options.lang !== undefined) runtimeOverrides.lang = options.lang;
+      if (options.formulaEnable !== undefined) runtimeOverrides.formula_enable = options.formulaEnable;
+      if (options.tableEnable !== undefined) runtimeOverrides.table_enable = options.tableEnable;
+      if (options.imageAnalysis !== undefined) runtimeOverrides.image_analysis = options.imageAnalysis;
+
+      const mcpParams = this._buildMcpParams(config, runtimeOverrides, attachmentContext);
+
+      const submitToolResult = await this.callMcp(
+        serverName,
+        toolName,
+        mcpParams,
+        timeoutMs,
+      );
+      const result = this.extractStructuredToolResult(submitToolResult);
+
+      const judged = await this._runJudge(config, result, { stage: 'pending_ocr' });
+      const normalized = judged?._normalized || {};
+
+      const taskId = normalized.task_id || result?.task_id || null;
+      const resolvedProvider = normalized.provider || provider;
+      const isSuccess = normalized.is_success !== false;
+      const normalizedStatus = isSuccess ? this.normalizeOcrResultStatus(result?.status || 'pending') : 'failed';
+      const failMessage = !isSuccess ? (normalized.message || 'OCR submit failed') : null;
+
+      await ocrResult.reload();
+      if (this.isCancelledOcrResult(ocrResult, ctx.document)) {
+        logger.info(`[DocumentOcrService] Ignore submit result for cancelled document ${documentId}: ocr_result=${ocrResult.id}`);
+        await this.clearSubmitInProgress(ocrResult, {
+          submit_post_cancel_result: this.buildResultSummary(result),
+        });
+        return ocrResult;
+      }
+
+      logger.info(`[DocumentOcrService] submit result: document=${documentId} ocr_result=${ocrResult.id} task_id=${taskId || 'null'} status=${normalizedStatus} provider=${resolvedProvider}`);
+
+      const persisted = await this.updateOcrResultIfNotCancelled(ocrResult, {
+        provider: resolvedProvider,
+        task_id: taskId,
+        status: normalizedStatus,
+        progress: normalizedStatus === 'failed' ? -1 : 0,
+        started_at: new Date(),
+        error_code: normalizedStatus === 'failed' ? 'submit_failed' : null,
+        error_message: normalizedStatus === 'failed' ? failMessage : null,
+        metadata: this.buildMergedMetadata(ocrResult.metadata, {
+          submit_in_progress: false,
+          submit_tool_result: this.buildToolResultSummary(submitToolResult),
+          submit_result: this.buildResultSummary(result),
+          judge_result: judged?._normalized || null,
+        }),
+      });
+      if (!persisted) {
+        logger.info(`[DocumentOcrService] Skip submit persistence for cancelled document ${documentId}: ocr_result=${ocrResult.id}`);
+        return ocrResult;
+      }
+      taskCreated = Boolean(taskId);
+
+      if (normalizedStatus === 'failed') {
+        await this.advancer.fail(documentId, 'ocr_submit_failed', failMessage || 'OCR submit failed');
+        return ocrResult;
+      }
+
+      if (!taskId) {
+        const missingTaskMessage = normalized.message || result?.message || result?.error || 'OCR submit missing task_id';
+        await ocrResult.update({
+          status: 'failed',
+          progress: -1,
+          error_code: 'submit_missing_task_id',
+          error_message: missingTaskMessage,
+          completed_at: new Date(),
+          metadata: this.buildMergedMetadata(ocrResult.metadata, {
+            submit_in_progress: false,
+            submit_missing_task_id: true,
+          }),
+        });
+        await this.advancer.fail(documentId, 'ocr_submit_failed', missingTaskMessage);
+        return ocrResult;
+      }
+
+      await this.advancer.advance(documentId, 'ocr_processing');
+
+      return ocrResult;
+    } catch (error) {
+      const normalizedError = this.normalizeError(error);
+
+      if (taskCreated || ocrResult.task_id) {
+        await ocrResult.update({
+          metadata: this.buildMergedMetadata(ocrResult.metadata, {
+            submit_in_progress: false,
+            submit_post_task_error: normalizedError.summary || normalizedError.message,
+          }),
+        });
+        throw error;
+      }
+
       await ocrResult.update({
         status: 'failed',
         progress: -1,
-        error_code: 'submit_missing_task_id',
-        error_message: missingTaskMessage,
+        error_code: ocrResult.error_code || 'ocr_submit_failed',
+        error_message: normalizedError.message,
         completed_at: new Date(),
         metadata: this.buildMergedMetadata(ocrResult.metadata, {
-          submit_missing_task_id: true,
+          submit_in_progress: false,
+          last_error: normalizedError.summary || normalizedError.message,
         }),
       });
-      await this.advancer.fail(documentId, 'ocr_submit_failed', missingTaskMessage);
-      return ocrResult;
+
+      if (ctx) {
+        await this.advancer.fail(documentId, 'ocr_submit_failed', normalizedError.message);
+      }
+
+      throw error;
     }
-
-    await this.advancer.advance(documentId, 'ocr_processing');
-
-    return ocrResult;
   }
 
   async syncTaskStatus(documentId, options = {}) {
@@ -407,20 +523,23 @@ class DocumentOcrService {
     this.ensureDocumentWritableForOcr(ctx.document);
     const ocrResult = await this.ensureOcrResult(ctx);
     if (!ocrResult.task_id) {
-      logger.info(`[DocumentOcrService] OCR task missing for ${documentId}, retrying submit`);
-      const retriedSubmit = await this.submit(documentId, options);
-      const retried = await this.ensureOcrResult(ctx);
-      if (!retried.task_id && retried.status !== 'failed') {
-        const missingTaskMessage = retriedSubmit?.error_message || 'OCR task missing after submit retry';
-        await retried.update({
-          status: 'failed',
-          progress: -1,
-          error_code: 'submit_missing_task_id',
-          error_message: missingTaskMessage,
-          completed_at: new Date(),
-        });
-        await this.advancer.fail(documentId, 'ocr_submit_failed', missingTaskMessage);
+      const submitState = await this.getSubmitInProgressState(ocrResult);
+      if (submitState.active) {
+        logger.info(`[DocumentOcrService] sync waiting for background submit: document=${documentId} ocr_result=${ocrResult.id}`);
+        return { ocrResult, statusResult: null, completed: false };
       }
+
+      if (submitState.stale) {
+        logger.warn(`[DocumentOcrService] sync clearing stale submit flag: document=${documentId} ocr_result=${ocrResult.id}`);
+        await this.clearSubmitInProgress(ocrResult, {
+          submit_recovered_at: new Date().toISOString(),
+          submit_recovered_reason: 'stale_submit_in_progress_sync',
+        });
+        await ocrResult.reload();
+      }
+
+      logger.info(`[DocumentOcrService] OCR task missing for ${documentId}, retrying submit`);
+      const retried = await this.submit(documentId, options);
       return { ocrResult: retried, statusResult: null, completed: false };
     }
 
@@ -505,9 +624,16 @@ class DocumentOcrService {
 
     if (!ocrResult.task_id || !runningStatuses.includes(ocrResult.status)) {
       await ocrResult.update({
+        status: 'failed',
+        progress: -1,
         error_code: ocrResult.error_code || 'document_deleted',
         error_message: ocrResult.error_message || 'Document deleted by user',
         completed_at: ocrResult.completed_at || new Date(),
+        metadata: this.buildMergedMetadata(ocrResult.metadata, {
+          submit_in_progress: false,
+          cancel_reason: 'task_not_running',
+          cancelled_at: new Date().toISOString(),
+        }),
       });
       return { ...result, skipped: true, reason: 'task_not_running' };
     }
@@ -531,8 +657,10 @@ class DocumentOcrService {
         error_message: 'Document deleted by user',
         completed_at: new Date(),
         metadata: this.buildMergedMetadata(ocrResult.metadata, {
+          submit_in_progress: false,
           cancel_tool_result: this.buildToolResultSummary(cancelToolResult),
           cancel_result: this.buildResultSummary(cancelResult),
+          cancelled_at: new Date().toISOString(),
         }),
       });
 
@@ -544,6 +672,11 @@ class DocumentOcrService {
         error_code: 'document_deleted',
         error_message: `Document deleted by user (cancel failed: ${error.message})`,
         completed_at: new Date(),
+        metadata: this.buildMergedMetadata(ocrResult.metadata, {
+          submit_in_progress: false,
+          cancelled_at: new Date().toISOString(),
+          cancel_error: this.truncateText(error.message || String(error), 500),
+        }),
       });
       return {
         ...result,
@@ -772,6 +905,74 @@ class DocumentOcrService {
       where: { revision_id: revisionId },
       order: [['created_at', 'DESC']],
     });
+  }
+
+  async getOcrResultById(ocrResultId) {
+    if (!ocrResultId) return null;
+    const DocOcrResult = this.db.getModel('doc_ocr_result');
+    return await DocOcrResult.findByPk(ocrResultId);
+  }
+
+  async getSubmitInProgressState(ocrResult) {
+    if (!ocrResult) return { active: false, stale: false, requestedAt: null };
+    const metadata = this.toPlainObject(ocrResult.metadata);
+    if (metadata.submit_in_progress !== true) {
+      return { active: false, stale: false, requestedAt: null };
+    }
+
+    const requestedAtRaw = metadata.submit_requested_at || ocrResult.updated_at || ocrResult.started_at || null;
+    const requestedAtMs = requestedAtRaw ? Date.parse(requestedAtRaw) : Number.NaN;
+    const timeoutMs = await this._getSystemMcpTimeoutMs();
+    const staleAfterMs = timeoutMs + SUBMIT_IN_PROGRESS_STALE_GRACE_MS;
+    const stale = Number.isNaN(requestedAtMs) || (Date.now() - requestedAtMs) > staleAfterMs;
+
+    return {
+      active: !stale,
+      stale,
+      requestedAt: requestedAtRaw,
+    };
+  }
+
+  async clearSubmitInProgress(ocrResult, patch = {}) {
+    if (!ocrResult) return;
+    await ocrResult.update({
+      metadata: this.buildMergedMetadata(ocrResult.metadata, {
+        submit_in_progress: false,
+        ...patch,
+      }),
+    });
+  }
+
+  async updateOcrResultIfNotCancelled(ocrResult, values) {
+    if (!ocrResult?.id) return false;
+    const DocOcrResult = this.db.getModel('doc_ocr_result');
+    const [affectedRows] = await DocOcrResult.update(values, {
+      where: {
+        id: ocrResult.id,
+        [Op.or]: [
+          { status: { [Op.ne]: 'failed' } },
+          { error_code: { [Op.ne]: 'document_deleted' } },
+          { error_code: null },
+        ],
+      },
+    });
+
+    if (!affectedRows) {
+      await ocrResult.reload();
+      return false;
+    }
+
+    await ocrResult.reload();
+    return true;
+  }
+
+  isCancelledOcrResult(ocrResult, document = null) {
+    if (document?.processing_error_code === 'document_deleted') {
+      return true;
+    }
+
+    if (!ocrResult) return false;
+    return ocrResult.status === 'failed' && ocrResult.error_code === 'document_deleted';
   }
 
   async loadDocumentContext(documentId) {
@@ -1015,6 +1216,7 @@ class DocumentOcrService {
       error_message: errorMessage,
       completed_at: new Date(),
       metadata: this.buildMergedMetadata(ocrResult.metadata, {
+        submit_in_progress: false,
         last_error: {
           code: errorCode,
           message: errorMessage,


### PR DESCRIPTION
## Summary

- fix `CollectionCard` missing i18n injection that caused doc platform render errors
- make doc OCR submit return faster by moving remote submit work to background execution
- harden OCR state transitions around submit timeout, cancel, and duplicate submit races

## Testing

- `npm run lint`
- `node -e "import('./lib/document-ocr-service.js').then(() => console.log('document-ocr-service OK')).catch(err => { console.error(err); process.exit(1); })"`
