### PR TITLE
fix: clamp contract v2 pagination params

### DIFF
--- a/server/services/contract-v2.service.js
+++ b/server/services/contract-v2.service.js
@@ -238,8 +238,8 @@ class ContractV2Service {
     if (filters.contract_type) where.contract_type = filters.contract_type;
     if (filters.status) where.status = filters.status;
 
-    const page = filters.page || 1;
-    const pageSize = filters.page_size || 20;
+    const page = Math.max(parseInt(filters.page, 10) || 1, 1);
+    const pageSize = Math.min(Math.max(parseInt(filters.page_size, 10) || 20, 1), 100);
     const offset = (page - 1) * pageSize;
 
     const result = await this.models.MainRecord.findAndCountAll({


### PR DESCRIPTION
## Summary

- clamp `page` to a minimum of `1`
- clamp `page_size` to a safe range of `1` to `100`
- avoid invalid pagination values causing unstable offsets or oversized result windows

## Testing

- not run
