### PR TITLE
fix: frontend TypeScript type safety and lint fixes

### DIFF
--- a/apps/current-feature-analyzer/frontend/components/CompressionStatsCard.vue
+++ b/apps/current-feature-analyzer/frontend/components/CompressionStatsCard.vue
@@ -88,16 +88,16 @@ const maxCurrent = computed(() => {
   const v = props.globals?.max_current
   return v != null ? `${Number(v).toFixed(2)} A` : '-'
 })
-const plateauKindSet = new Set(['stable', 'normal', 'off', 'plateau-low', 'plateau-mid', 'plateau-high'])
-const trendKindSet = new Set(['transition', 'rising', 'rising-fast', 'falling', 'falling-fast', 'spike', 'surge', 'drop', 'burst'])
+const plateauKindSet = new Set<string>(['stable', 'normal', 'off', 'plateau-low', 'plateau-mid', 'plateau-high'])
+const trendKindSet = new Set<string>(['transition', 'rising', 'rising-fast', 'falling', 'falling-fast', 'spike', 'surge', 'drop', 'burst'])
 
 const plateauCount = computed(() => {
   if (!props.segments) return 0
-  return props.segments.filter(s => plateauKindSet.has(s.kind)).length
+  return props.segments.filter(s => typeof s.kind === 'string' && plateauKindSet.has(s.kind)).length
 })
 const trendCount = computed(() => {
   if (!props.segments) return 0
-  return props.segments.filter(s => trendKindSet.has(s.kind)).length
+  return props.segments.filter(s => typeof s.kind === 'string' && trendKindSet.has(s.kind)).length
 })
 const eventCount = computed(() => props.events?.length ?? 0)
 const duplicateGroups = computed(() => props.duplicateDiagnosis?.duplicate_groups ?? '-')

--- a/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
+++ b/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
@@ -73,7 +73,6 @@
         v-if="file.raw_data?.length"
         :file-name="file.file_name"
         :raw-data="file.raw_data"
-        :result="file.result"
         :result="file.result || {}"
       />
 

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -746,7 +746,7 @@ export const assistantApi = {
 // ============================================
 
 // MCP 传输类型
-export type McpTransportType = 'stdio' | 'http' | 'sse'
+export type McpTransportType = 'stdio' | 'http' | 'sse' | 'statelessHttp'
 
 // MCP Server 类型
 export interface McpServer {

--- a/frontend/src/components/CodePreview.vue
+++ b/frontend/src/components/CodePreview.vue
@@ -13,7 +13,6 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-// @ts-expect-error - VCodeBlock 没有完整的类型导出
 import VCodeBlock from '@wdns/vue-code-block'
 // 导入 highlight.js 样式 - 使用 github 主题作为亮色，github-dark 作为暗色
 import 'highlight.js/styles/github.css'

--- a/frontend/src/components/PsycheConfigPanel.vue
+++ b/frontend/src/components/PsycheConfigPanel.vue
@@ -21,7 +21,7 @@
         :max="0.5"
         :step="0.05"
         show-input
-        :format-tooltip="(val) => (val * 100).toFixed(0) + '%'"
+        :format-tooltip="(val: number) => (val * 100).toFixed(0) + '%'"
       />
       <div class="el-form-item__tip">{{ $t('settings.maxTokensRatioHint') }}</div>
     </el-form-item>

--- a/frontend/src/components/docs/DocPipelineConfigDialog.vue
+++ b/frontend/src/components/docs/DocPipelineConfigDialog.vue
@@ -597,7 +597,7 @@ interface ToolCacheEntry {
 }
 const toolCache = ref<Record<string, ToolCacheEntry>>({})
 
-function tp(key: string, params?: Record<string, unknown>) {
+function tp(key: string, params: Record<string, unknown> = {}) {
   return t(`docs.workspace.pipeline.${key}`, params)
 }
 

--- a/frontend/src/components/invoice/InvoiceList.vue
+++ b/frontend/src/components/invoice/InvoiceList.vue
@@ -112,13 +112,16 @@ function buildDateFilter(): { start_date?: string; end_date?: string } {
   }
   if (dateMode.value === 'month') {
     const [start, end] = dateValue.value
+    if (!start || !end) return {}
     // end 是 YYYY-MM，取当月最后一天
     const [ey, em] = end.split('-').map(Number)
+    if (ey === undefined || em === undefined) return {}
     const lastDay = new Date(ey, em, 0).getDate()
     return { start_date: `${start}-01`, end_date: `${end}-${String(lastDay).padStart(2, '0')}` }
   }
   if (dateMode.value === 'day') {
     const [start, end] = dateValue.value
+    if (!start || !end) return {}
     return { start_date: start, end_date: end }
   }
   return {}

--- a/frontend/src/components/settings/AppManagementTab.vue
+++ b/frontend/src/components/settings/AppManagementTab.vue
@@ -234,7 +234,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, onMounted, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useToastStore } from '@/stores/toast'
 import { getApps, createApp, updateApp, deleteApp as deleteAppApi, getAppConfig, updateAppConfig } from '@/api/mini-apps'
@@ -292,9 +292,9 @@ const appDialogTabs = computed(() => [
 const appForm = reactive({
   name: '',
   icon: '📱',
-  type: 'document' as string,
+  type: 'document' as MiniApp['type'],
   description: '',
-  visibility: 'all' as string,
+  visibility: 'all' as MiniApp['visibility'],
   is_active: true,
   fields: [] as AppField[],
   states: [] as AppState[],

--- a/frontend/src/components/settings/McpTab.vue
+++ b/frontend/src/components/settings/McpTab.vue
@@ -281,7 +281,7 @@ import { ref, reactive, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/user'
 import { useToastStore } from '@/stores/toast'
-import { mcpApi, type McpServer, type McpToolCache, type McpUserCredential, type McpCredential, type UpdateMcpServerRequest } from '@/api/services'
+import { mcpApi, type McpServer, type McpToolCache, type McpUserCredential, type McpCredential, type CreateMcpServerRequest, type UpdateMcpServerRequest } from '@/api/services'
 
 const { t } = useI18n()
 const userStore = useUserStore()
@@ -351,7 +351,7 @@ const isServerFormValid = computed(() => {
   // 根据传输类型验证必填字段
   if (serverForm.transport_type === 'stdio') {
     return !!serverForm.command.trim()
-  } else if (serverForm.transport_type === 'http' || serverForm.transport_type === 'sse') {
+  } else if (serverForm.transport_type === 'http' || serverForm.transport_type === 'sse' || serverForm.transport_type === 'statelessHttp') {
     return !!serverForm.url.trim()
   }
   return true
@@ -672,7 +672,7 @@ const closeServerDialog = () => {
 // 保存 Server
 const saveServer = async () => {
   try {
-    const normalized_headers = serverForm.headers.trim() ? serverForm.headers : null
+    const normalized_headers = serverForm.headers.trim() ? serverForm.headers : undefined
 
     // 构建请求数据 - 全量更新：表单里有什么就传什么
     const requestData: UpdateMcpServerRequest = {
@@ -693,7 +693,7 @@ const saveServer = async () => {
       await mcpApi.updateServer(editingServer.value.id, requestData)
       toast.success(t('settings.mcp.saveServerSuccess'))
     } else {
-      await mcpApi.createServer(requestData)
+      await mcpApi.createServer(requestData as CreateMcpServerRequest)
       toast.success(t('settings.mcp.createServerSuccess'))
     }
     // 先记住编辑状态再关闭对话框

--- a/frontend/src/stores/systemSettings.ts
+++ b/frontend/src/stores/systemSettings.ts
@@ -260,7 +260,10 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
         return undefined
       }
     }
-    return result
+    if (typeof result === 'string' || typeof result === 'number' || result === undefined) {
+      return result
+    }
+    return undefined
   }
 
   const loadBranding = async (): Promise<BrandingSettings> => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -201,6 +201,7 @@ export interface Expert {
   // 上下文压缩配置
   context_strategy?: 'full' | 'simple' | 'minimal'  // 压缩策略，默认 'full'
   context_threshold?: number    // 压缩阈值，默认 0.70
+  psyche_config?: Record<string, unknown>
   // LLM 参数配置
   temperature?: number          // Expressive Mind 温度，默认 0.70
   reflective_temperature?: number // Reflective Mind 温度，默认 0.30

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -2261,7 +2261,7 @@ const loadExpertSkills = async (expertId: string) => {
   }
 }
 
-const handleSkillToggle = () => {
+const handleSkillToggle = (_skill?: ExpertSkill) => {
   skillsChanged.value = true
 }
 


### PR DESCRIPTION
﻿## Summary

前端 TypeScript 类型安全与 lint 修复：

- 修复 Set 泛型标注和 has() 类型检查（CompressionStatsCard）
- 移除重复的 :result 属性绑定（FileDetailPanel）
- 新增 McpTransportType \statelessHttp\ 并适配 McpTab 逻辑
- 移除不再需要的 @ts-expect-error 注释（CodePreview）
- 修复 format-tooltip 参数类型标注（PsycheConfigPanel）
- 修复 tp() 函数默认参数（DocPipelineConfigDialog）
- 增加 InvoiceList 日期筛选空值守卫
- 修正 AppManagementTab 类型标注（computed import + 字段类型）
- 修正 McpTab headers 空值处理和 CreateMcpServerRequest 类型
- 修复 systemSettings store getSetting 返回值类型收窄
- 补充 Expert psyche_config 类型声明
- 修复 handleSkillToggle 参数签名

## Test plan

- [ ] 前端 typecheck 通过
- [ ] MCP Server 配置页面 statelessHttp 传输类型可用
- [ ] Invoice 日期筛选不报错
