### PR TITLE
refactor: doc-ocr-pipeline 从 app_tick 内收到 internal_job

### DIFF
--- a/apps/doc-ocr-pipeline/tick/index.js
+++ b/apps/doc-ocr-pipeline/tick/index.js
@@ -1,8 +1,16 @@
-import logger from '../../../lib/logger.js';
-import DocPipelineAdvancer from '../../../lib/doc-pipeline-advancer.js';
-import { getPreviewAttachmentId } from '../../../lib/doc-ocr-utils.js';
+/**
+ * apps/doc-ocr-pipeline/tick/index.js
+ *
+ * COMPATIBILITY SHELL (Phase 1)
+ *
+ * 本文件保留用于向后兼容，实际执行已委托给 lib/doc-pipeline-worker.js。
+ * 当 AppClock 仍然拉取 doc-ocr-pipeline 时，tick() 会将调用转发到新的 run()。
+ *
+ * Phase 2 退役后本文件将被移除。
+ */
 
-const MAX_BATCH_SIZE = 5;
+import logger from '../../../lib/logger.js';
+import { run as docPipelineWorkerRun } from '../../../lib/doc-pipeline-worker.js';
 
 export async function tick(context) {
   const { app, services } = context;
@@ -11,226 +19,15 @@ export async function tick(context) {
     return { skipped: true, reason: 'no_app' };
   }
 
-  const documents = await services.query(
-    `SELECT id, processing_status, current_revision_id
-     FROM documents
-     WHERE processing_status IN ('pending_ocr', 'ocr_processing', 'pending_clean', 'pending_outline', 'pending_chunk', 'pending_embedding')
-       AND current_revision_id IS NOT NULL
-     ORDER BY processing_updated_at ASC
-     LIMIT ?`,
-    [MAX_BATCH_SIZE]
-  );
+  logger.info('[doc-ocr-pipeline:tick] Compatibility shell: delegating to doc-pipeline-worker');
 
-  if (!documents || documents.length === 0) {
-    return { skipped: true, reason: 'no_pending_documents' };
+  try {
+    const result = await docPipelineWorkerRun({ services });
+    return result;
+  } catch (error) {
+    logger.error(`[doc-ocr-pipeline:tick] Delegation failed: ${error.message}`);
+    return { success: false, error: error.message };
   }
-
-  let submitted = 0;
-  let synced = 0;
-  let skipped = 0;
-  let outlineExtracted = 0;
-  let chunksGenerated = 0;
-  let failed = 0;
-
-  const advancer = new DocPipelineAdvancer(context.db);
-
-  for (const doc of documents) {
-    try {
-      if (doc.processing_status === 'pending_ocr') {
-        const submittedResult = await services.documentOcr.submit(doc.id);
-        await syncBoundAppRowOnSubmit(services, doc.id, submittedResult);
-        submitted += 1;
-        continue;
-      }
-
-      if (doc.processing_status === 'ocr_processing') {
-        const syncResult = await services.documentOcr.syncTaskStatus(doc.id);
-        await syncBoundAppRowOnSync(services, doc.id, syncResult);
-        synced += 1;
-        continue;
-      }
-
-      if (doc.processing_status === 'pending_clean') {
-        if (!services.documentClean) {
-          failed += 1;
-          continue;
-        }
-        await services.documentClean.clean(doc.id, {
-          initiatedByType: 'scheduler',
-          initiatedById: null,
-        });
-        skipped += 1;
-        continue;
-      }
-
-      // pending_embedding 由独立后台 worker (document-embedding-worker) 异步处理，
-      // 不做同步透传，避免阻塞 OCR tick 循环
-      if (doc.processing_status === 'pending_embedding') {
-        skipped += 1;
-        continue;
-      }
-
-      if (doc.processing_status === 'pending_outline') {
-        if (!services.documentOutline) {
-          failed += 1;
-          continue;
-        }
-        await services.documentOutline.extract(doc.current_revision_id, {
-          initiatedByType: 'scheduler',
-          initiatedById: null,
-        });
-        outlineExtracted += 1;
-        continue;
-      }
-
-      if (doc.processing_status === 'pending_chunk') {
-        if (!services.documentChunk) {
-          failed += 1;
-          continue;
-        }
-        await services.documentChunk.generate(doc.current_revision_id, {
-          initiatedByType: 'scheduler',
-          initiatedById: null,
-        });
-        chunksGenerated += 1;
-      }
-    } catch (error) {
-      failed += 1;
-      if (error?.code === 'DOCUMENT_DELETED') {
-        logger.warn(`[doc-ocr-pipeline] document ${doc.id} skipped after deletion: ${error.message}`);
-      } else {
-        logger.error(`[doc-ocr-pipeline] document ${doc.id} failed: ${error.message}`);
-      }
-    }
-  }
-
-  return {
-    success: true,
-    processed: documents.length,
-    submitted,
-    synced,
-    skipped,
-    outlineExtracted,
-    chunksGenerated,
-    failed,
-  };
-}
-
-async function syncBoundAppRowOnSubmit(services, documentId, submittedResult) {
-  const binding = await getActiveBinding(services, documentId);
-  if (!binding) return;
-
-  await updateBoundAppOnSubmit(services, binding, submittedResult);
-}
-
-async function syncBoundAppRowOnSync(services, documentId, syncResult) {
-  const binding = await getActiveBinding(services, documentId);
-  if (!binding) return;
-
-  if (!syncResult?.completed) return;
-
-  // 使用统一语义获取预览稿（优先 cleaned_markdown，兼容 main_markdown）
-  const previewAttachmentId = getPreviewAttachmentId(syncResult.ocrResult);
-  const markdownText = await loadAttachmentTextById(services, previewAttachmentId);
-
-  await updateBoundAppOnCompletedSync(services, binding, syncResult, markdownText);
-}
-
-async function updateBoundAppOnSubmit(services, binding, submittedResult) {
-  const provider = submittedResult.provider || 'mineru';
-  const taskId = submittedResult.task_id || '';
-
-  if (binding.app_id === 'contract-mgr-v2') {
-    await services.execute(
-      `UPDATE app_contract_mgr_v2_content SET process_step = 'ocr_submitted', ocr_task_id = ?, ocr_service = ? WHERE row_id = ?`,
-      [taskId, provider, binding.row_id]
-    );
-    return;
-  }
-
-  if (binding.app_id === 'contract-mgr') {
-    // Write to autonomous content table only (no mini_app_rows dependency)
-    await services.execute(
-      `INSERT INTO app_contract_mgr_content (row_id, process_step, ocr_service, ocr_task_id, created_at, updated_at)
-       VALUES (?, 'ocr_submitted', ?, ?, NOW(), NOW())
-       ON DUPLICATE KEY UPDATE process_step = VALUES(process_step), ocr_service = VALUES(ocr_service), ocr_task_id = VALUES(ocr_task_id), updated_at = NOW()`,
-      [binding.row_id, provider, taskId]
-    );
-  }
-}
-
-async function updateBoundAppOnCompletedSync(services, binding, syncResult, markdownText) {
-  const provider = syncResult.ocrResult?.provider || 'mineru';
-
-  if (binding.app_id === 'contract-mgr-v2') {
-    await services.execute(
-      `UPDATE app_contract_mgr_v2_content SET process_step = 'pending_filter', ocr_text = ?, ocr_service = ?, ocr_at = NOW() WHERE row_id = ?`,
-      [markdownText, provider, binding.row_id]
-    );
-    return;
-  }
-
-  if (binding.app_id === 'contract-mgr') {
-    // Write to autonomous content table only (no mini_app_rows dependency)
-    await services.execute(
-      `INSERT INTO app_contract_mgr_content (row_id, ocr_text, ocr_service, ocr_at, process_step, created_at, updated_at)
-       VALUES (?, ?, ?, NOW(), 'pending_filter', NOW(), NOW())
-       ON DUPLICATE KEY UPDATE ocr_text = VALUES(ocr_text), ocr_service = VALUES(ocr_service), ocr_at = VALUES(ocr_at), process_step = VALUES(process_step), updated_at = NOW()` ,
-      [binding.row_id, markdownText, provider]
-    );
-  }
-}
-
-async function recordPassThroughRun(services, doc) {
-  const DocProcessRun = services.getModel('doc_process_run');
-  if (!DocProcessRun) return;
-  const Utils = await import('../../../lib/utils.js');
-  const { STATUS_SEQUENCE } = await import('../../../lib/doc-pipeline-advancer.js');
-  const currentIdx = STATUS_SEQUENCE.indexOf(doc.processing_status);
-  const nextStage = currentIdx >= 0 && currentIdx < STATUS_SEQUENCE.length - 1
-    ? STATUS_SEQUENCE[currentIdx + 1]
-    : 'next';
-  await DocProcessRun.create({
-    id: Utils.default.newID(),
-    revision_id: doc.current_revision_id,
-    subject_type: 'documents',
-    subject_id: doc.id,
-    pipeline_step: doc.processing_status,
-    operation: 'start',
-    initiated_by_type: 'scheduler',
-    initiated_by_id: null,
-    result_status: 'ok',
-    attempt_no: 1,
-    message: `Auto-passed ${doc.processing_status} → ${nextStage} (no handler)`,
-    started_at: new Date(),
-    finished_at: new Date(),
-  });
-}
-
-async function getActiveBinding(services, documentId) {
-  const rows = await services.query(
-    `SELECT app_id, row_id, document_id
-     FROM app_doc_bindings
-     WHERE document_id = ? AND binding_status = 'active'
-     ORDER BY created_at DESC
-     LIMIT 1`,
-    [documentId]
-  );
-  return rows && rows.length > 0 ? rows[0] : null;
-}
-
-async function loadAttachmentTextById(services, attachmentId) {
-  if (!attachmentId) return '';
-  const rows = await services.query(
-    `SELECT file_path FROM attachments WHERE id = ? LIMIT 1`,
-    [attachmentId]
-  );
-  if (!rows || rows.length === 0 || !rows[0].file_path) return '';
-
-  const fs = await import('fs/promises');
-  const path = await import('path');
-  const fullPath = path.resolve(process.env.ATTACHMENT_BASE_PATH || './data/attachments', rows[0].file_path);
-  return await fs.readFile(fullPath, 'utf8');
 }
 
 export default { tick };

--- a/lib/clock/clock-core.js
+++ b/lib/clock/clock-core.js
@@ -1,0 +1,228 @@
+/**
+ * ClockCore - 统一时钟核心（Phase 1 最小骨架）
+ *
+ * 职责：
+ * - 只支持 internal_job 的注册、启动、停止
+ * - 提供 interval 调度、preventOverlap、cooldown、failure count
+ * - Phase 1 不吞并 app_tick，不替换 AppClock
+ *
+ * 使用示例：
+ *   const clock = new ClockCore(db);
+ *   clock.register('doc-pipeline-worker', {
+ *     interval: 10000,
+ *     handler: async (context) => { ... },
+ *   });
+ *   clock.startAll();
+ */
+
+import logger from '../logger.js';
+
+class ClockCore {
+  constructor(db, config = {}) {
+    this.db = db;
+    this.jobs = new Map();
+    this.maxConsecutiveFailures = config.maxConsecutiveFailures || 3;
+    this.failureCooldownMs = config.failureCooldownMs || 2 * 60 * 1000;
+    this.jobFailures = new Map();
+    this.running = false;
+  }
+
+  /**
+   * 注册 internal job
+   * @param {string} name - 唯一 job 名称
+   * @param {Object} options
+   * @param {number} options.interval - 执行间隔 (ms)
+   * @param {Function} options.handler - async (context) => result
+   * @param {boolean} options.immediate - 是否立即执行一次
+   * @param {boolean} options.preventOverlap - 是否防重叠
+   */
+  register(name, { interval, handler, immediate = true, preventOverlap = true }) {
+    if (!name || typeof name !== 'string') {
+      throw new Error('[ClockCore] Job name must be a non-empty string');
+    }
+    if (!interval || typeof interval !== 'number' || interval < 1000) {
+      throw new Error('[ClockCore] Job interval must be >= 1000ms');
+    }
+    if (!handler || typeof handler !== 'function') {
+      throw new Error('[ClockCore] Job handler must be a function');
+    }
+
+    if (this.jobs.has(name)) {
+      logger.warn(`[ClockCore] Job "${name}" already registered, overwriting`);
+    }
+
+    this.jobs.set(name, {
+      interval,
+      handler,
+      intervalId: null,
+      isRunning: false,
+      isExecuting: false,
+      immediate,
+      preventOverlap,
+    });
+
+    logger.info(`[ClockCore] Internal job "${name}" registered (interval=${interval}ms)`);
+  }
+
+  /**
+   * 启动单个 job
+   */
+  start(name) {
+    const job = this.jobs.get(name);
+    if (!job) {
+      logger.error(`[ClockCore] Job "${name}" not found`);
+      return;
+    }
+    if (job.isRunning) {
+      logger.warn(`[ClockCore] Job "${name}" already running`);
+      return;
+    }
+
+    job.isRunning = true;
+
+    if (job.immediate) {
+      this._executeJob(name);
+    }
+
+    job.intervalId = setInterval(() => {
+      this._executeJob(name);
+    }, job.interval);
+
+    logger.info(`[ClockCore] Job "${name}" started`);
+  }
+
+  /**
+   * 停止单个 job
+   */
+  stop(name) {
+    const job = this.jobs.get(name);
+    if (!job) return;
+
+    if (job.intervalId) {
+      clearInterval(job.intervalId);
+      job.intervalId = null;
+    }
+    job.isRunning = false;
+    logger.info(`[ClockCore] Job "${name}" stopped`);
+  }
+
+  /**
+   * 启动所有已注册 job
+   */
+  startAll() {
+    for (const name of this.jobs.keys()) {
+      this.start(name);
+    }
+    this.running = true;
+    logger.info(`[ClockCore] All jobs started (${this.jobs.size} total)`);
+  }
+
+  /**
+   * 停止所有 job
+   */
+  stopAll() {
+    for (const name of this.jobs.keys()) {
+      this.stop(name);
+    }
+    this.running = false;
+    logger.info('[ClockCore] All jobs stopped');
+  }
+
+  /**
+   * 获取 job 状态
+   */
+  getStatus(name) {
+    const job = this.jobs.get(name);
+    if (!job) return null;
+    return {
+      name,
+      interval: job.interval,
+      isRunning: job.isRunning,
+      isExecuting: job.isExecuting,
+      consecutiveFailures: this.jobFailures.get(name) || 0,
+    };
+  }
+
+  /**
+   * 获取所有 job 状态
+   */
+  getAllStatus() {
+    const result = [];
+    for (const [name, job] of this.jobs) {
+      result.push({
+        name,
+        interval: job.interval,
+        isRunning: job.isRunning,
+        isExecuting: job.isExecuting,
+        consecutiveFailures: this.jobFailures.get(name) || 0,
+      });
+    }
+    return result;
+  }
+
+  /**
+   * 执行 job（带 cooldown / failure count / preventOverlap）
+   *
+   * Phase 1 日志策略：
+   * - 不写入 app_tick_log / app_tick_run（因 app_tick_log.registry_id 为 FK 到 app_clock_registry，
+   *   internal job 无对应 registry 记录，无法满足 NOT NULL 约束）
+   * - 改用 logger 输出执行摘要，后续 Phase 统一迁移到新 job 日志表
+   */
+  async _executeJob(name) {
+    const job = this.jobs.get(name);
+    if (!job || !job.isRunning) return;
+
+    // 检查是否在 cooldown
+    const failures = this.jobFailures.get(name) || 0;
+    if (failures >= this.maxConsecutiveFailures) {
+      return;
+    }
+
+    // 防止重叠执行
+    if (job.preventOverlap && job.isExecuting) {
+      return;
+    }
+
+    job.isExecuting = true;
+    const startTime = Date.now();
+
+    try {
+      // 构造上下文
+      const context = {
+        db: this.db,
+        jobName: name,
+      };
+
+      // 执行 handler
+      const result = await job.handler(context);
+
+      // 成功：重置失败计数
+      this.jobFailures.set(name, 0);
+
+      const elapsed = Date.now() - startTime;
+      if (result && !result.skipped) {
+        logger.info(`[ClockCore] Job "${name}" completed in ${elapsed}ms: ${JSON.stringify(result)}`);
+      }
+    } catch (error) {
+      // 累加失败计数
+      const newFailures = (this.jobFailures.get(name) || 0) + 1;
+      this.jobFailures.set(name, newFailures);
+
+      const elapsed = Date.now() - startTime;
+      logger.error(`[ClockCore] Job "${name}" failed (${newFailures}/${this.maxConsecutiveFailures}, ${elapsed}ms): ${error.message}`);
+
+      // 达到上限后启动 cooldown
+      if (newFailures >= this.maxConsecutiveFailures) {
+        logger.warn(`[ClockCore] Job "${name}" entering cooldown for ${this.failureCooldownMs}ms`);
+        setTimeout(() => {
+          this.jobFailures.set(name, 0);
+          logger.info(`[ClockCore] Job "${name}" cooldown expired, resuming`);
+        }, this.failureCooldownMs);
+      }
+    } finally {
+      job.isExecuting = false;
+    }
+  }
+}
+
+export default ClockCore;

--- a/lib/clock/clock-core.js
+++ b/lib/clock/clock-core.js
@@ -16,6 +16,11 @@
  */
 
 import logger from '../logger.js';
+import fs from 'fs';
+import path from 'path';
+
+const RUNLOG_DIR = path.resolve(process.env.DATA_BASE_PATH || './data', 'work');
+const RUNLOG_FILE = path.join(RUNLOG_DIR, 'clock-core-runlog.jsonl');
 
 class ClockCore {
   constructor(db, config = {}) {
@@ -166,7 +171,8 @@ class ClockCore {
    * Phase 1 日志策略：
    * - 不写入 app_tick_log / app_tick_run（因 app_tick_log.registry_id 为 FK 到 app_clock_registry，
    *   internal job 无对应 registry 记录，无法满足 NOT NULL 约束）
-   * - 改用 logger 输出执行摘要，后续 Phase 统一迁移到新 job 日志表
+   * - 每轮执行写入 JSONL 结构化运行记录到 data/work/clock-core-runlog.jsonl
+   * - 同时保留 logger 输出作为实时观测通道
    */
   async _executeJob(name) {
     const job = this.jobs.get(name);
@@ -184,7 +190,11 @@ class ClockCore {
     }
 
     job.isExecuting = true;
+    const startedAt = new Date();
     const startTime = Date.now();
+    let status = 'error';
+    let summary = null;
+    let errorMessage = null;
 
     try {
       // 构造上下文
@@ -198,6 +208,8 @@ class ClockCore {
 
       // 成功：重置失败计数
       this.jobFailures.set(name, 0);
+      status = 'success';
+      summary = result;
 
       const elapsed = Date.now() - startTime;
       if (result && !result.skipped) {
@@ -208,6 +220,7 @@ class ClockCore {
       const newFailures = (this.jobFailures.get(name) || 0) + 1;
       this.jobFailures.set(name, newFailures);
 
+      errorMessage = error.message;
       const elapsed = Date.now() - startTime;
       logger.error(`[ClockCore] Job "${name}" failed (${newFailures}/${this.maxConsecutiveFailures}, ${elapsed}ms): ${error.message}`);
 
@@ -221,6 +234,36 @@ class ClockCore {
       }
     } finally {
       job.isExecuting = false;
+
+      // 写入结构化运行记录
+      const finishedAt = new Date();
+      await this._writeRunRecord({
+        job_name: name,
+        started_at: startedAt.toISOString(),
+        finished_at: finishedAt.toISOString(),
+        elapsed_ms: finishedAt - startedAt,
+        status,
+        summary: summary ? JSON.stringify(summary) : null,
+        error: errorMessage,
+      });
+    }
+  }
+
+  /**
+   * 写入 JSONL 运行记录
+   *
+   * Phase 1 最小方案：不引入新数据库表，
+   * 使用本地 JSONL 文件 (data/work/clock-core-runlog.jsonl) 存储结构化记录。
+   * 可通过 scripts/read-clockcore-runlog.mjs 查询。
+   */
+  async _writeRunRecord(record) {
+    try {
+      await fs.promises.mkdir(RUNLOG_DIR, { recursive: true });
+      const line = JSON.stringify(record) + '\n';
+      await fs.promises.appendFile(RUNLOG_FILE, line, 'utf8');
+    } catch (err) {
+      // 日志写入失败不影响主流程
+      logger.error(`[ClockCore] Failed to write runlog: ${err.message}`);
     }
   }
 }

--- a/lib/clock/job-context-builder.js
+++ b/lib/clock/job-context-builder.js
@@ -1,0 +1,52 @@
+/**
+ * job-context-builder - 为 doc-pipeline-worker 构造运行上下文
+ *
+ * 职责：将 worker 所需的平台能力（db, services）从 AppClock 依赖中解耦，
+ * 使 doc-pipeline-worker 可以在 ClockCore 的 internal job 模型下独立运行。
+ *
+ * Phase 1 只构造 doc-pipeline-worker 所需的最小上下文。
+ */
+
+import DocumentOcrService from '../document-ocr-service.js';
+import DocumentCleanService from '../document-clean-service.js';
+import DocumentOutlineService from '../document-outline-service.js';
+import DocumentChunkService from '../document-chunk-service.js';
+import DocumentEmbeddingService from '../document-embedding-service.js';
+import logger from '../logger.js';
+
+/**
+ * 为 doc-pipeline-worker 构造完整的服务上下文
+ *
+ * @param {Object} db - Database 实例
+ * @param {Object} [options]
+ * @param {Function} [options.callMcp] - MCP 调用函数
+ * @param {Function} [options.callLlm] - LLM 调用函数
+ * @returns {Object} { query, execute, getModel, documentOcr, documentClean, documentOutline, documentChunk, documentEmbedding }
+ */
+function buildDocPipelineContext(db, options = {}) {
+  const sequelize = db.sequelize;
+
+  const documentOcr = new DocumentOcrService(db, {
+    callMcp: options.callMcp,
+    callLlm: options.callLlm,
+    getDocPipelineConfig: options.getDocPipelineConfig,
+  });
+
+  const documentClean = new DocumentCleanService(db);
+  const documentOutline = new DocumentOutlineService(db);
+  const documentChunk = new DocumentChunkService(db);
+  const documentEmbedding = new DocumentEmbeddingService(db);
+
+  return {
+    query: (sql, params) => sequelize.query(sql, { replacements: params, type: sequelize.QueryTypes.SELECT }),
+    execute: (sql, params) => sequelize.query(sql, { replacements: params }),
+    getModel: (name) => db.getModel(name),
+    documentOcr,
+    documentClean,
+    documentOutline,
+    documentChunk,
+    documentEmbedding,
+  };
+}
+
+export { buildDocPipelineContext };

--- a/lib/clock/job-context-builder.js
+++ b/lib/clock/job-context-builder.js
@@ -1,8 +1,41 @@
 /**
- * job-context-builder - 为 doc-pipeline-worker 构造运行上下文
+ * job-context-builder — Internal Job 上下文构造器
  *
  * 职责：将 worker 所需的平台能力（db, services）从 AppClock 依赖中解耦，
  * 使 doc-pipeline-worker 可以在 ClockCore 的 internal job 模型下独立运行。
+ *
+ * ## 上下文协议 (Internal Job Context Protocol)
+ *
+ * 每个 internal job 的 handler 接收 context 对象，由调用方（ClockCore / 兼容层）注入。
+ * doc-pipeline-worker 的 handler 期望 context 包含：
+ *
+ * ```
+ * context.services = {
+ *   query(sql, params)     → Promise<Array>      // SELECT 查询
+ *   execute(sql, params)   → Promise<Result>      // INSERT/UPDATE/DELETE
+ *   getModel(name)         → Sequelize Model      // 获取 ORM 模型
+ *   documentOcr            → DocumentOcrService   // OCR 提交/同步
+ *   documentClean          → DocumentCleanService // 文本清洗
+ *   documentOutline        → DocumentOutlineService  // 大纲提取
+ *   documentChunk          → DocumentChunkService    // 分块生成
+ *   documentEmbedding      → DocumentEmbeddingService // 向量化
+ * }
+ * ```
+ *
+ * ## 依赖注入来源
+ *
+ * | 能力               | Phase 1 来源                          | 后续方向             |
+ * |--------------------|---------------------------------------|----------------------|
+ * | callMcp            | `this.appClock.callMcp.bind()` 桥接   | 独立 MCP client 注入 |
+ * | callLlm            | null（各 service 自行调用 createCallLlmFn） | 统一 LLM 工厂       |
+ * | getDocPipelineConfig | systemSettingService.getDocPipelineConfig | 保持不变           |
+ *
+ * ## 扩展指南
+ *
+ * 后续新增 internal job 时：
+ * 1. 定义该 job 的 context.services 最小字段集合
+ * 2. 在本模块中新增对应的 buildXxxContext() 工厂函数
+ * 3. 保持 { query, execute, getModel } 作为所有 job 的公共基底
  *
  * Phase 1 只构造 doc-pipeline-worker 所需的最小上下文。
  */
@@ -19,9 +52,10 @@ import logger from '../logger.js';
  *
  * @param {Object} db - Database 实例
  * @param {Object} [options]
- * @param {Function} [options.callMcp] - MCP 调用函数
- * @param {Function} [options.callLlm] - LLM 调用函数
- * @returns {Object} { query, execute, getModel, documentOcr, documentClean, documentOutline, documentChunk, documentEmbedding }
+ * @param {Function} [options.callMcp] - MCP 调用函数，Phase 1 通过 AppClock 桥接
+ * @param {Function} [options.callLlm] - LLM 调用函数，Phase 1 各 service 自行解析
+ * @param {Function} [options.getDocPipelineConfig] - 获取 doc pipeline 配置
+ * @returns {Object} services — 见上述上下文协议
  */
 function buildDocPipelineContext(db, options = {}) {
   const sequelize = db.sequelize;

--- a/lib/doc-pipeline-advancer.js
+++ b/lib/doc-pipeline-advancer.js
@@ -17,10 +17,15 @@ class DocPipelineAdvancer {
 
   /**
    * 推进处理状态到指定阶段
+   * @param {string} documentId
+   * @param {string} targetStatus
+   * @param {Object} [options]
+   * @param {Object} [options.transaction] - 可选的事务对象
    */
-  async advance(documentId, targetStatus) {
+  async advance(documentId, targetStatus, options = {}) {
+    const { transaction } = options;
     const Document = this.db.getModel('document');
-    const doc = await Document.findByPk(documentId);
+    const doc = await Document.findByPk(documentId, { transaction });
     if (!doc) throw new Error(`Document not found: ${documentId}`);
 
     const currentIdx = DOC_PROCESSING_SEQUENCE.indexOf(doc.processing_status);
@@ -34,15 +39,21 @@ class DocPipelineAdvancer {
       processing_error_code: null,
       processing_error_message: null,
       processing_updated_at: new Date(),
-    });
+    }, { transaction });
   }
 
   /**
    * 标记处理失败
+   * @param {string} documentId
+   * @param {string} errorCode
+   * @param {string} errorMessage
+   * @param {Object} [options]
+   * @param {Object} [options.transaction] - 可选的事务对象
    */
-  async fail(documentId, errorCode, errorMessage) {
+  async fail(documentId, errorCode, errorMessage, options = {}) {
+    const { transaction } = options;
     const Document = this.db.getModel('document');
-    const doc = await Document.findByPk(documentId);
+    const doc = await Document.findByPk(documentId, { transaction });
     if (!doc) throw new Error(`Document not found: ${documentId}`);
 
     return await doc.update({
@@ -50,22 +61,29 @@ class DocPipelineAdvancer {
       processing_error_code: errorCode || null,
       processing_error_message: errorMessage || null,
       processing_updated_at: new Date(),
-    });
+    }, { transaction });
   }
 
   /**
    * 标记处理完成
+   * @param {string} documentId
+   * @param {Object} [options]
+   * @param {Object} [options.transaction] - 可选的事务对象
    */
-  async complete(documentId) {
-    return await this.advance(documentId, 'ready');
+  async complete(documentId, options = {}) {
+    return await this.advance(documentId, 'ready', options);
   }
 
   /**
    * 推进到状态链中的下一阶段
+   * @param {string} documentId
+   * @param {Object} [options]
+   * @param {Object} [options.transaction] - 可选的事务对象
    */
-  async advanceToNext(documentId) {
+  async advanceToNext(documentId, options = {}) {
+    const { transaction } = options;
     const Document = this.db.getModel('document');
-    const doc = await Document.findByPk(documentId);
+    const doc = await Document.findByPk(documentId, { transaction });
     if (!doc) throw new Error(`Document not found: ${documentId}`);
 
     const currentIdx = DOC_PROCESSING_SEQUENCE.indexOf(doc.processing_status);
@@ -79,7 +97,7 @@ class DocPipelineAdvancer {
       processing_error_code: null,
       processing_error_message: null,
       processing_updated_at: new Date(),
-    });
+    }, { transaction });
   }
 }
 

--- a/lib/doc-pipeline-binding-sync.js
+++ b/lib/doc-pipeline-binding-sync.js
@@ -1,0 +1,107 @@
+/**
+ * doc-pipeline-binding-sync - 文档流水线业务 app 绑定同步辅助
+ *
+ * 职责：处理 contract-mgr / contract-mgr-v2 等业务 app 的 OCR 结果回填，
+ * 与平台内部文档推进主链隔离。
+ *
+ * Phase 1 从 apps/doc-ocr-pipeline/tick/index.js 迁移而来，保留原有语义。
+ */
+
+import { getPreviewAttachmentId } from './doc-ocr-utils.js';
+
+/**
+ * 获取文档的活跃绑定
+ */
+async function getActiveBinding(services, documentId) {
+  const rows = await services.query(
+    `SELECT app_id, row_id, document_id
+     FROM app_doc_bindings
+     WHERE document_id = ? AND binding_status = 'active'
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [documentId]
+  );
+  return rows && rows.length > 0 ? rows[0] : null;
+}
+
+/**
+ * 读取附件文本内容
+ */
+async function loadAttachmentTextById(services, attachmentId) {
+  if (!attachmentId) return '';
+  const rows = await services.query(
+    `SELECT file_path FROM attachments WHERE id = ? LIMIT 1`,
+    [attachmentId]
+  );
+  if (!rows || rows.length === 0 || !rows[0].file_path) return '';
+
+  const fs = await import('fs/promises');
+  const path = await import('path');
+  const fullPath = path.resolve(process.env.ATTACHMENT_BASE_PATH || './data/attachments', rows[0].file_path);
+  return await fs.readFile(fullPath, 'utf8');
+}
+
+/**
+ * OCR 提交后同步绑定 app 行
+ */
+async function syncDocBindingOnOcrSubmit(services, documentId, submittedResult) {
+  const binding = await getActiveBinding(services, documentId);
+  if (!binding) return;
+
+  const provider = submittedResult.provider || 'mineru';
+  const taskId = submittedResult.task_id || '';
+
+  if (binding.app_id === 'contract-mgr-v2') {
+    await services.execute(
+      `UPDATE app_contract_mgr_v2_content SET process_step = 'ocr_submitted', ocr_task_id = ?, ocr_service = ? WHERE row_id = ?`,
+      [taskId, provider, binding.row_id]
+    );
+    return;
+  }
+
+  if (binding.app_id === 'contract-mgr') {
+    await services.execute(
+      `INSERT INTO app_contract_mgr_content (row_id, process_step, ocr_service, ocr_task_id, created_at, updated_at)
+       VALUES (?, 'ocr_submitted', ?, ?, NOW(), NOW())
+       ON DUPLICATE KEY UPDATE process_step = VALUES(process_step), ocr_service = VALUES(ocr_service), ocr_task_id = VALUES(ocr_task_id), updated_at = NOW()`,
+      [binding.row_id, provider, taskId]
+    );
+  }
+}
+
+/**
+ * OCR 完成后同步绑定 app 行
+ */
+async function syncDocBindingOnOcrCompleted(services, documentId, syncResult) {
+  const binding = await getActiveBinding(services, documentId);
+  if (!binding) return;
+
+  if (!syncResult?.completed) return;
+
+  const previewAttachmentId = getPreviewAttachmentId(syncResult.ocrResult);
+  const markdownText = await loadAttachmentTextById(services, previewAttachmentId);
+
+  const provider = syncResult.ocrResult?.provider || 'mineru';
+
+  if (binding.app_id === 'contract-mgr-v2') {
+    await services.execute(
+      `UPDATE app_contract_mgr_v2_content SET process_step = 'pending_filter', ocr_text = ?, ocr_service = ?, ocr_at = NOW() WHERE row_id = ?`,
+      [markdownText, provider, binding.row_id]
+    );
+    return;
+  }
+
+  if (binding.app_id === 'contract-mgr') {
+    await services.execute(
+      `INSERT INTO app_contract_mgr_content (row_id, ocr_text, ocr_service, ocr_at, process_step, created_at, updated_at)
+       VALUES (?, ?, ?, NOW(), 'pending_filter', NOW(), NOW())
+       ON DUPLICATE KEY UPDATE ocr_text = VALUES(ocr_text), ocr_service = VALUES(ocr_service), ocr_at = VALUES(ocr_at), process_step = VALUES(process_step), updated_at = NOW()`,
+      [binding.row_id, markdownText, provider]
+    );
+  }
+}
+
+export {
+  syncDocBindingOnOcrSubmit,
+  syncDocBindingOnOcrCompleted,
+};

--- a/lib/doc-pipeline-worker.js
+++ b/lib/doc-pipeline-worker.js
@@ -1,0 +1,135 @@
+/**
+ * doc-pipeline-worker - 文档平台流水线推进器 (internal job)
+ *
+ * 职责：扫描待处理文档，按 processing_status 阶段路由到对应 service，
+ * 推进文档平台处理链（OCR → Clean → Outline → Chunk → Embedding）。
+ *
+ * 这是 Unified Clock Phase 1 的第一个 internal job 样板。
+ * 核心逻辑从 apps/doc-ocr-pipeline/tick/index.js 迁移而来。
+ *
+ * 导出: export async function run(context)
+ */
+
+import logger from './logger.js';
+import { syncDocBindingOnOcrSubmit, syncDocBindingOnOcrCompleted } from './doc-pipeline-binding-sync.js';
+
+const MAX_BATCH_SIZE = 5;
+
+/**
+ * 文档流水线推进主入口
+ *
+ * @param {Object} context - 由 ClockCore 或兼容层注入
+ * @param {Object} context.services - { query, execute, getModel, documentOcr, documentClean, documentOutline, documentChunk, documentEmbedding }
+ * @returns {Object} { success, processed, submitted, synced, skipped, outlineExtracted, chunksGenerated, failed }
+ */
+export async function run(context) {
+  const { services } = context;
+
+  if (!services) {
+    return { skipped: true, reason: 'no_services' };
+  }
+
+  const documents = await services.query(
+    `SELECT id, processing_status, current_revision_id
+     FROM documents
+     WHERE processing_status IN ('pending_ocr', 'ocr_processing', 'pending_clean', 'pending_outline', 'pending_chunk', 'pending_embedding')
+       AND current_revision_id IS NOT NULL
+     ORDER BY processing_updated_at ASC
+     LIMIT ?`,
+    [MAX_BATCH_SIZE]
+  );
+
+  if (!documents || documents.length === 0) {
+    return { skipped: true, reason: 'no_pending_documents' };
+  }
+
+  let submitted = 0;
+  let synced = 0;
+  let skipped = 0;
+  let outlineExtracted = 0;
+  let chunksGenerated = 0;
+  let failed = 0;
+
+  for (const doc of documents) {
+    try {
+      if (doc.processing_status === 'pending_ocr') {
+        const submittedResult = await services.documentOcr.submit(doc.id);
+        await syncDocBindingOnOcrSubmit(services, doc.id, submittedResult);
+        submitted += 1;
+        continue;
+      }
+
+      if (doc.processing_status === 'ocr_processing') {
+        const syncResult = await services.documentOcr.syncTaskStatus(doc.id);
+        await syncDocBindingOnOcrCompleted(services, doc.id, syncResult);
+        synced += 1;
+        continue;
+      }
+
+      if (doc.processing_status === 'pending_clean') {
+        if (!services.documentClean) {
+          failed += 1;
+          continue;
+        }
+        await services.documentClean.clean(doc.id, {
+          initiatedByType: 'scheduler',
+          initiatedById: null,
+        });
+        skipped += 1;
+        continue;
+      }
+
+      // pending_embedding 由独立后台 worker (document-embedding-worker) 异步处理，
+      // 不做同步透传，避免阻塞主循环
+      if (doc.processing_status === 'pending_embedding') {
+        skipped += 1;
+        continue;
+      }
+
+      if (doc.processing_status === 'pending_outline') {
+        if (!services.documentOutline) {
+          failed += 1;
+          continue;
+        }
+        await services.documentOutline.extract(doc.current_revision_id, {
+          initiatedByType: 'scheduler',
+          initiatedById: null,
+        });
+        outlineExtracted += 1;
+        continue;
+      }
+
+      if (doc.processing_status === 'pending_chunk') {
+        if (!services.documentChunk) {
+          failed += 1;
+          continue;
+        }
+        await services.documentChunk.generate(doc.current_revision_id, {
+          initiatedByType: 'scheduler',
+          initiatedById: null,
+        });
+        chunksGenerated += 1;
+      }
+    } catch (error) {
+      failed += 1;
+      if (error?.code === 'DOCUMENT_DELETED') {
+        logger.warn(`[doc-pipeline-worker] document ${doc.id} skipped after deletion: ${error.message}`);
+      } else {
+        logger.error(`[doc-pipeline-worker] document ${doc.id} failed: ${error.message}`);
+      }
+    }
+  }
+
+  return {
+    success: true,
+    processed: documents.length,
+    submitted,
+    synced,
+    skipped,
+    outlineExtracted,
+    chunksGenerated,
+    failed,
+  };
+}
+
+export default { run };

--- a/lib/document-chunk-service.js
+++ b/lib/document-chunk-service.js
@@ -96,16 +96,7 @@ class DocumentChunkService {
 
       await this._saveChunks(revisionId, enrichedChunks, transaction);
 
-      const Document = this.db.getModel('document');
-      await Document.update(
-        {
-          processing_status: 'pending_embedding',
-          processing_error_code: null,
-          processing_error_message: null,
-          processing_updated_at: new Date(),
-        },
-        { where: { id: revision.document_id }, transaction }
-      );
+      await this.advancer.advance(revision.document_id, 'pending_embedding', { transaction });
 
       await DocProcessRun.update(
         {
@@ -138,16 +129,7 @@ class DocumentChunkService {
         { where: { id: runId } }
       );
 
-      const Document = this.db.getModel('document');
-      await Document.update(
-        {
-          processing_status: 'error',
-          processing_error_code: 'chunk_generation_failed',
-          processing_error_message: error.message,
-          processing_updated_at: new Date(),
-        },
-        { where: { id: revision.document_id } }
-      );
+      await this.advancer.fail(revision.document_id, 'chunk_generation_failed', error.message, { transaction });
 
       throw error;
     }

--- a/lib/document-clean-service.js
+++ b/lib/document-clean-service.js
@@ -155,13 +155,7 @@ class DocumentCleanService {
 
       await ocrResult.update({ metadata: JSON.stringify(metadata) }, { transaction });
 
-      const Document = this.db.getModel('document');
-      await Document.update({
-        processing_status: 'pending_outline',
-        processing_error_code: null,
-        processing_error_message: null,
-        processing_updated_at: new Date(),
-      }, { where: { id: documentId }, transaction });
+      await this.advancer.advance(documentId, 'pending_outline', { transaction });
 
       await DocProcessRun.update({
         result_status: 'ok',
@@ -187,13 +181,7 @@ class DocumentCleanService {
         message: error.message,
       }, { where: { id: runId } });
 
-      const Document = this.db.getModel('document');
-      await Document.update({
-        processing_status: 'error',
-        processing_error_code: 'clean_failed',
-        processing_error_message: error.message,
-        processing_updated_at: new Date(),
-      }, { where: { id: documentId } });
+      await this.advancer.fail(documentId, 'clean_failed', error.message, { transaction });
 
       throw error;
     }

--- a/lib/document-embedding-service.js
+++ b/lib/document-embedding-service.js
@@ -1,5 +1,6 @@
 import logger from './logger.js';
 import EmbeddingClient from './embedding-client.js';
+import DocPipelineAdvancer from './doc-pipeline-advancer.js';
 import { DB_VECTOR_DIM, adjustVectorDimension, vectorToJson } from './vector-utils.js';
 import { getStageDefault } from './doc-pipeline-defaults.js';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
@@ -8,6 +9,7 @@ class DocumentEmbeddingService {
   constructor(db, options = {}) {
     this.db = db;
     this.getDocPipelineConfig = options.getDocPipelineConfig || null;
+    this.advancer = new DocPipelineAdvancer(db);
   }
 
   pickEmbeddingModel(pipelineConfig, collection, stageConfig) {
@@ -93,12 +95,7 @@ class DocumentEmbeddingService {
     }
 
     if (!document.current_revision_id) {
-      await Document.update({
-        processing_status: 'error',
-        processing_error_code: 'embedding_revision_missing',
-        processing_error_message: 'Current revision is missing',
-        processing_updated_at: new Date(),
-      }, { where: { id: documentId } });
+      await this.advancer.fail(documentId, 'embedding_revision_missing', 'Current revision is missing');
       return { success: false, skipped: false, reason: 'revision_missing' };
     }
 
@@ -111,23 +108,13 @@ class DocumentEmbeddingService {
 
     const modelId = stageConfig?.embedding_model_id || collection?.embedding_model_id || null;
     if (!modelId) {
-      await Document.update({
-        processing_status: 'error',
-        processing_error_code: 'embedding_model_missing',
-        processing_error_message: 'No embedding model configured for this document collection',
-        processing_updated_at: new Date(),
-      }, { where: { id: documentId } });
+      await this.advancer.fail(documentId, 'embedding_model_missing', 'No embedding model configured for this document collection');
       return { success: false, skipped: false, reason: 'embedding_model_missing' };
     }
 
     const client = await EmbeddingClient.fromModelId(this.db, modelId);
     if (!client) {
-      await Document.update({
-        processing_status: 'error',
-        processing_error_code: 'embedding_client_init_failed',
-        processing_error_message: `Failed to initialize embedding client for model ${modelId}`,
-        processing_updated_at: new Date(),
-      }, { where: { id: documentId } });
+      await this.advancer.fail(documentId, 'embedding_client_init_failed', `Failed to initialize embedding client for model ${modelId}`);
       return { success: false, skipped: false, reason: 'embedding_client_init_failed' };
     }
 
@@ -142,12 +129,7 @@ class DocumentEmbeddingService {
     });
 
     if (!chunks.length) {
-      await Document.update({
-        processing_status: 'error',
-        processing_error_code: 'no_chunks_for_embedding',
-        processing_error_message: 'No document chunks found for embedding',
-        processing_updated_at: new Date(),
-      }, { where: { id: documentId } });
+      await this.advancer.fail(documentId, 'no_chunks_for_embedding', 'No document chunks found for embedding');
       return { success: false, skipped: false, reason: 'no_chunks_for_embedding' };
     }
 
@@ -214,12 +196,7 @@ class DocumentEmbeddingService {
           'UPDATE document_chunks SET embedding_status = ?, embedding_model_id = ?, updated_at = ? WHERE id = ?',
           ['error', modelId, new Date(), chunk.id],
         );
-        await Document.update({
-          processing_status: 'error',
-          processing_error_code: 'embedding_failed',
-          processing_error_message: error.message,
-          processing_updated_at: new Date(),
-        }, { where: { id: documentId } });
+        await this.advancer.fail(documentId, 'embedding_failed', error.message);
         logger.error(`[DocumentEmbeddingService] Failed to embed chunk ${chunk.id}: ${error.message}`);
         return {
           success: false,
@@ -232,12 +209,7 @@ class DocumentEmbeddingService {
       }
     }
 
-    await Document.update({
-      processing_status: 'ready',
-      processing_error_code: null,
-      processing_error_message: null,
-      processing_updated_at: new Date(),
-    }, { where: { id: documentId } });
+    await this.advancer.complete(documentId);
 
     logger.info(`[DocumentEmbeddingService] Document ${documentId} embedded: ${successCount}/${chunks.length}`);
     return {

--- a/lib/document-outline-service.js
+++ b/lib/document-outline-service.js
@@ -128,16 +128,7 @@ class DocumentOutlineService {
 
       await this._saveOutlines(revisionId, enrichedOutlines, transaction);
 
-      const Document = this.db.getModel('document');
-      await Document.update(
-        {
-          processing_status: 'pending_chunk',
-          processing_error_code: null,
-          processing_error_message: null,
-          processing_updated_at: new Date(),
-        },
-        { where: { id: revision.document_id }, transaction }
-      );
+      await this.advancer.advance(revision.document_id, 'pending_chunk', { transaction });
 
       const isPartial = extractionMeta.failedChunks > 0;
       const partialInfo = isPartial
@@ -177,16 +168,7 @@ class DocumentOutlineService {
         { where: { id: runId } }
       );
 
-      const Document = this.db.getModel('document');
-      await Document.update(
-        {
-          processing_status: 'error',
-          processing_error_code: 'outline_extraction_failed',
-          processing_error_message: error.message,
-          processing_updated_at: new Date(),
-        },
-        { where: { id: revision.document_id } }
-      );
+      await this.advancer.fail(revision.document_id, 'outline_extraction_failed', error.message, { transaction });
 
       throw error;
     }

--- a/scripts/read-clockcore-runlog.mjs
+++ b/scripts/read-clockcore-runlog.mjs
@@ -1,0 +1,122 @@
+/**
+ * read-clockcore-runlog.mjs — 读取 ClockCore JSONL 运行记录
+ *
+ * 用法:
+ *   node scripts/read-clockcore-runlog.mjs              # 最近 20 条
+ *   node scripts/read-clockcore-runlog.mjs --last 50    # 最近 50 条
+ *   node scripts/read-clockcore-runlog.mjs --errors     # 只看失败记录
+ *   node scripts/read-clockcore-runlog.mjs --job doc-pipeline-worker  # 按 job 过滤
+ *   node scripts/read-clockcore-runlog.mjs --tail       # 持续输出（类似 tail -f）
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_BASE_PATH = process.env.DATA_BASE_PATH || path.resolve(__dirname, '..', 'data');
+const RUNLOG_FILE = path.join(DATA_BASE_PATH, 'work', 'clock-core-runlog.jsonl');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { last: 20, errors: false, job: null, tail: false };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--last' && args[i + 1]) {
+      opts.last = parseInt(args[++i], 10);
+    } else if (args[i] === '--errors') {
+      opts.errors = true;
+    } else if (args[i] === '--job' && args[i + 1]) {
+      opts.job = args[++i];
+    } else if (args[i] === '--tail') {
+      opts.tail = true;
+    }
+  }
+  return opts;
+}
+
+function readRecords() {
+  if (!fs.existsSync(RUNLOG_FILE)) {
+    console.log('(no runlog file yet)');
+    return [];
+  }
+  const content = fs.readFileSync(RUNLOG_FILE, 'utf8').trim();
+  if (!content) return [];
+  return content.split('\n').map(line => {
+    try { return JSON.parse(line); } catch { return null; }
+  }).filter(Boolean);
+}
+
+function formatRecord(r, i) {
+  const statusIcon = r.status === 'success' ? '✓' : '✗';
+  const elapsed = r.elapsed_ms != null ? `${r.elapsed_ms}ms` : '?';
+  let summary = '';
+  if (r.summary) {
+    try {
+      const s = JSON.parse(r.summary);
+      if (s.skipped) {
+        summary = ` [skipped: ${s.reason || '?'}]`;
+      } else if (s.processed != null) {
+        summary = ` [processed=${s.processed}]`;
+      }
+    } catch { /* ignore */ }
+  }
+  return `${statusIcon} ${r.job_name} ${r.status} ${elapsed}${summary}  ${r.started_at}`;
+}
+
+function formatError(r, i) {
+  return `✗ ${r.job_name}  ${r.started_at}\n     error: ${r.error || '(none)'}`;
+}
+
+const opts = parseArgs();
+
+if (opts.tail) {
+  console.log(`Watching ${RUNLOG_FILE}...\n`);
+  // Initial read
+  let records = readRecords();
+  let lastCount = records.length;
+  for (let i = Math.max(0, lastCount - opts.last); i < lastCount; i++) {
+    const r = records[i];
+    if (opts.job && r.job_name !== opts.job) continue;
+    if (opts.errors && r.status !== 'error') continue;
+    console.log(formatRecord(r, i));
+  }
+  // Poll for new records
+  setInterval(() => {
+    records = readRecords();
+    if (records.length > lastCount) {
+      for (let i = lastCount; i < records.length; i++) {
+        const r = records[i];
+        if (opts.job && r.job_name !== opts.job) continue;
+        if (opts.errors && r.status !== 'error') continue;
+        console.log(formatRecord(r, i));
+      }
+      lastCount = records.length;
+    }
+  }, 2000);
+} else {
+  const records = readRecords();
+  let filtered = records;
+  if (opts.job) filtered = filtered.filter(r => r.job_name === opts.job);
+  if (opts.errors) filtered = filtered.filter(r => r.status === 'error');
+
+  const display = filtered.slice(-opts.last);
+  if (display.length === 0) {
+    console.log('(no matching records)');
+  } else {
+    console.log(`Showing ${display.length} of ${filtered.length} records (total: ${records.length}):\n`);
+    for (let i = 0; i < display.length; i++) {
+      const r = display[i];
+      if (opts.errors) {
+        console.log(formatError(r, i));
+      } else {
+        console.log(formatRecord(r, i));
+      }
+    }
+
+    // Summary
+    const total = filtered.length;
+    const success = filtered.filter(r => r.status === 'success').length;
+    const errors = filtered.filter(r => r.status === 'error').length;
+    console.log(`\n--- Summary: ${total} total, ${success} success, ${errors} error ---`);
+  }
+}

--- a/scripts/verify-contract-v2-platform-bridge.js
+++ b/scripts/verify-contract-v2-platform-bridge.js
@@ -6,7 +6,6 @@ dotenv.config();
 
 import Database from '../lib/db.js';
 import Utils from '../lib/utils.js';
-import { tick as docOcrPipelineTick } from '../apps/doc-ocr-pipeline/tick/index.js';
 import { run as docPipelineWorkerRun } from '../lib/doc-pipeline-worker.js';
 
 const DB_CONFIG = {
@@ -284,15 +283,13 @@ async function main() {
     seeded = await seedBridgeScenario(db, userId, collectionId);
 
     const services = createServices(db);
-    const result = await docOcrPipelineTick({
-      app: { id: 'doc-ocr-pipeline', name: 'doc-ocr-pipeline' },
-      services,
-    });
+    const result = await docPipelineWorkerRun({ services });
 
     const verification = await loadResult(db, seeded.ids.rowId);
 
     console.log(JSON.stringify({
       success: true,
+      entrypoint: 'docPipelineWorkerRun',
       pipelineResult: result,
       verification,
       tempContentTableCreated: createdTempContentTable,

--- a/scripts/verify-contract-v2-platform-bridge.js
+++ b/scripts/verify-contract-v2-platform-bridge.js
@@ -7,6 +7,7 @@ dotenv.config();
 import Database from '../lib/db.js';
 import Utils from '../lib/utils.js';
 import { tick as docOcrPipelineTick } from '../apps/doc-ocr-pipeline/tick/index.js';
+import { run as docPipelineWorkerRun } from '../lib/doc-pipeline-worker.js';
 
 const DB_CONFIG = {
   host: process.env.DB_HOST || 'localhost',

--- a/scripts/verify-doc-ocr-pipeline-offline.js
+++ b/scripts/verify-doc-ocr-pipeline-offline.js
@@ -6,10 +6,16 @@ import path from 'path';
 import docOcrPipeline from '../apps/doc-ocr-pipeline/tick/index.js';
 import { run as docPipelineWorkerRun } from '../lib/doc-pipeline-worker.js';
 
+/**
+ * createServices — 构造 mock 服务对象
+ *
+ * Phase 1 修订：移除了 mini_app_rows 相关 mock（rowData / SELECT data FROM mini_app_rows），
+ * 因为 binding-sync 已不再写入 mini_app_rows。
+ * 断言基线：以 lib/doc-pipeline-binding-sync.js 中的真实 SQL 为准。
+ */
 function createServices(options = {}) {
   const executeCalls = [];
   const queryLog = [];
-  const rowData = options.rowData || {};
   const attachmentMap = options.attachmentMap || {};
   const documents = options.documents || [];
   const bindings = options.bindings || {};
@@ -33,9 +39,6 @@ function createServices(options = {}) {
       if (sql.includes('FROM app_doc_bindings')) {
         return bindings[params[0]] ? [bindings[params[0]]] : [];
       }
-      if (sql.includes('SELECT data FROM mini_app_rows')) {
-        return [{ data: JSON.stringify(rowData[params[0]] || {}) }];
-      }
       if (sql.includes('SELECT file_path FROM attachments')) {
         const filePath = attachmentMap[params[0]];
         return filePath ? [{ file_path: filePath }] : [];
@@ -49,14 +52,15 @@ function createServices(options = {}) {
   };
 }
 
+/**
+ * contract-mgr submit 用例
+ * 断言基线：binding-sync 写入 app_contract_mgr_content (INSERT ... ON DUPLICATE KEY UPDATE)
+ */
 async function runContractMgrSubmitCase() {
   const services = createServices({
     documents: [{ id: 'doc-1', processing_status: 'pending_ocr', current_revision_id: 'rev-1' }],
     bindings: {
       'doc-1': { app_id: 'contract-mgr', row_id: 'row-1', document_id: 'doc-1' },
-    },
-    rowData: {
-      'row-1': { existing: true },
     },
     documentOcr: {
       submit: async () => ({ provider: 'erix-mineru', task_id: 'task-123' }),
@@ -68,16 +72,16 @@ async function runContractMgrSubmitCase() {
   assert.equal(result.submitted, 1);
   assert.equal(result.synced, 0);
 
-  const upsertContent = services.executeCalls.find(call => call.sql.includes('INSERT INTO app_contract_mgr_content'));
-  assert.ok(upsertContent, 'contract-mgr submit 应 upsert app_contract_mgr_content');
-
-  const updateRow = services.executeCalls.find(call => call.sql.includes('UPDATE mini_app_rows SET status = \'ocr_submitted\''));
-  assert.ok(updateRow, 'contract-mgr submit 应更新 mini_app_rows 状态');
-  const data = JSON.parse(updateRow.params[0]);
-  assert.equal(data._ocr_task_id, 'task-123');
-  assert.equal(data._ocr_service, 'erix-mineru');
+  const upsertContent = services.executeCalls.find(
+    call => call.sql.includes('INSERT INTO app_contract_mgr_content') && call.sql.includes('ocr_submitted')
+  );
+  assert.ok(upsertContent, 'contract-mgr submit 应 upsert app_contract_mgr_content (binding-sync baseline)');
 }
 
+/**
+ * contract-mgr-v2 submit 用例
+ * 断言基线：binding-sync 写入 app_contract_mgr_v2_content (UPDATE SET process_step = 'ocr_submitted')
+ */
 async function runContractMgrV2SubmitCase() {
   const services = createServices({
     documents: [{ id: 'doc-2', processing_status: 'pending_ocr', current_revision_id: 'rev-2' }],
@@ -93,11 +97,17 @@ async function runContractMgrV2SubmitCase() {
   const result = await docOcrPipeline.tick({ app: { id: 'doc-ocr-pipeline' }, services });
   assert.equal(result.submitted, 1);
 
-  const updateContent = services.executeCalls.find(call => call.sql.includes('UPDATE app_contract_mgr_v2_content SET process_step = \'ocr_submitted\''));
-  assert.ok(updateContent, 'contract-mgr-v2 submit 应更新扩展表');
+  const updateContent = services.executeCalls.find(
+    call => call.sql.includes("UPDATE app_contract_mgr_v2_content SET process_step = 'ocr_submitted'")
+  );
+  assert.ok(updateContent, 'contract-mgr-v2 submit 应更新扩展表 (binding-sync baseline)');
   assert.deepEqual(updateContent.params, ['task-456', 'erix-mineru', 'row-2']);
 }
 
+/**
+ * contract-mgr sync 完成用例
+ * 断言基线：binding-sync 回填 ocr_text 到 app_contract_mgr_content
+ */
 async function runContractMgrSyncCase() {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'doc-ocr-pipeline-test-'));
   process.env.ATTACHMENT_BASE_PATH = tempDir;
@@ -110,9 +120,6 @@ async function runContractMgrSyncCase() {
     documents: [{ id: 'doc-3', processing_status: 'ocr_processing', current_revision_id: 'rev-3' }],
     bindings: {
       'doc-3': { app_id: 'contract-mgr', row_id: 'row-3', document_id: 'doc-3' },
-    },
-    rowData: {
-      'row-3': { before: true },
     },
     attachmentMap: {
       'att-789': markdownRelPath,
@@ -132,14 +139,17 @@ async function runContractMgrSyncCase() {
   const result = await docOcrPipeline.tick({ app: { id: 'doc-ocr-pipeline' }, services });
   assert.equal(result.synced, 1);
 
-  const upsertContent = services.executeCalls.find(call => call.sql.includes('INSERT INTO app_contract_mgr_content') && call.sql.includes('ocr_text'));
-  assert.ok(upsertContent, 'contract-mgr sync 完成应回填 ocr_text');
+  const upsertContent = services.executeCalls.find(
+    call => call.sql.includes('INSERT INTO app_contract_mgr_content') && call.sql.includes('ocr_text')
+  );
+  assert.ok(upsertContent, 'contract-mgr sync 完成应回填 ocr_text (binding-sync baseline)');
   assert.equal(upsertContent.params[1], '# OCR Result\nhello world');
-
-  const updateRow = services.executeCalls.find(call => call.sql.includes('UPDATE mini_app_rows SET status = \'pending_filter\''));
-  assert.ok(updateRow, 'contract-mgr sync 完成应更新 mini_app_rows 状态');
 }
 
+/**
+ * contract-mgr-v2 sync 完成用例
+ * 断言基线：binding-sync 回填到 app_contract_mgr_v2_content
+ */
 async function runContractMgrV2SyncCase() {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'doc-ocr-pipeline-test-'));
   process.env.ATTACHMENT_BASE_PATH = tempDir;
@@ -171,8 +181,10 @@ async function runContractMgrV2SyncCase() {
   const result = await docOcrPipeline.tick({ app: { id: 'doc-ocr-pipeline' }, services });
   assert.equal(result.synced, 1);
 
-  const updateContent = services.executeCalls.find(call => call.sql.includes('UPDATE app_contract_mgr_v2_content SET process_step = \'pending_filter\''));
-  assert.ok(updateContent, 'contract-mgr-v2 sync 完成应回填扩展表');
+  const updateContent = services.executeCalls.find(
+    call => call.sql.includes("UPDATE app_contract_mgr_v2_content SET process_step = 'pending_filter'")
+  );
+  assert.ok(updateContent, 'contract-mgr-v2 sync 完成应回填扩展表 (binding-sync baseline)');
   assert.equal(updateContent.params[0], 'contract v2 markdown');
   assert.equal(updateContent.params[1], 'erix-mineru');
   assert.equal(updateContent.params[2], 'row-4');

--- a/scripts/verify-doc-ocr-pipeline-offline.js
+++ b/scripts/verify-doc-ocr-pipeline-offline.js
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 
 import docOcrPipeline from '../apps/doc-ocr-pipeline/tick/index.js';
+import { run as docPipelineWorkerRun } from '../lib/doc-pipeline-worker.js';
 
 function createServices(options = {}) {
   const executeCalls = [];
@@ -182,7 +183,32 @@ async function main() {
   await runContractMgrV2SubmitCase();
   await runContractMgrSyncCase();
   await runContractMgrV2SyncCase();
+
+  // Phase 1: 验证新 run() 入口与兼容 tick() 等价
+  console.log('\n--- Phase 1: New run() entry point validation ---');
+  await runNewEntryEquivalenceCase();
+
   console.log('doc-ocr-pipeline offline tests passed');
+}
+
+/**
+ * Phase 1: 验证新 run() 与旧 tick() 行为等价
+ */
+async function runNewEntryEquivalenceCase() {
+  const services = createServices({
+    documents: [{ id: 'doc-eq', processing_status: 'pending_ocr', current_revision_id: 'rev-eq' }],
+    bindings: {
+      'doc-eq': { app_id: 'contract-mgr-v2', row_id: 'row-eq', document_id: 'doc-eq' },
+    },
+    documentOcr: {
+      submit: async () => ({ provider: 'erix-mineru', task_id: 'task-eq' }),
+      syncTaskStatus: async () => ({ completed: false }),
+    },
+  });
+
+  const result = await docPipelineWorkerRun({ services });
+  assert.equal(result.submitted, 1);
+  console.log('  ✓ run() returns correct submitted count');
 }
 
 main().catch((error) => {

--- a/scripts/verify-doc-ocr-platform.js
+++ b/scripts/verify-doc-ocr-platform.js
@@ -62,14 +62,30 @@ async function main() {
   await check('document_revisions 表存在', async () => await tableExists(conn, 'document_revisions'));
   await check('doc_ocr_results.main_markdown_attachment_id 字段存在', async () => await columnExists(conn, 'doc_ocr_results', 'main_markdown_attachment_id'));
 
-  await check('doc-ocr-pipeline mini_apps 已注册', async () => {
+  await check('doc-ocr-pipeline mini_apps 已注册 (Phase 1 legacy, Phase 2 退役)', async () => {
     const row = await queryOne(conn, `SELECT id, visibility, type FROM mini_apps WHERE id = 'doc-ocr-pipeline' LIMIT 1`);
-    return row ? `visibility=${row.visibility}, type=${row.type}` : '';
+    return row ? `visibility=${row.visibility}, type=${row.type} (legacy)` : 'not-registered (expected in Phase 2)';
   });
 
-  await check('doc-ocr-pipeline app_clock_registry 已注册', async () => {
+  await check('doc-ocr-pipeline app_clock_registry 已注册 (Phase 1 legacy, Phase 2 退役)', async () => {
     const row = await queryOne(conn, `SELECT id, app_id, is_active FROM app_clock_registry WHERE app_id = 'doc-ocr-pipeline' LIMIT 1`);
-    return row ? `is_active=${row.is_active}` : '';
+    return row ? `is_active=${row.is_active} (legacy)` : 'not-registered (expected in Phase 2)';
+  });
+
+  // Phase 1 新增：验证 doc-pipeline-worker 为 internal job 的核心文件存在
+  await check('lib/doc-pipeline-worker.js 已创建 (Phase 1 新入口)', async () => {
+    const fs = await import('fs');
+    return fs.existsSync('lib/doc-pipeline-worker.js') ? 'exists' : 'missing';
+  });
+
+  await check('lib/clock/clock-core.js 已创建 (Phase 1 Clock Core 骨架)', async () => {
+    const fs = await import('fs');
+    return fs.existsSync('lib/clock/clock-core.js') ? 'exists' : 'missing';
+  });
+
+  await check('lib/doc-pipeline-binding-sync.js 已创建 (Phase 1 绑定同步隔离)', async () => {
+    const fs = await import('fs');
+    return fs.existsSync('lib/doc-pipeline-binding-sync.js') ? 'exists' : 'missing';
   });
 
   await check('ocr-tool component 已补齐', async () => {

--- a/server/index.js
+++ b/server/index.js
@@ -247,6 +247,12 @@ const isFeatureEnabled = (envName) => {
   return !['0', 'false', 'off', 'no'].includes(String(value).trim().toLowerCase());
 };
 
+const isFeatureEnabledOptIn = (envName) => {
+  const value = process.env[envName];
+  if (value == null) return false;
+  return !['0', 'false', 'off', 'no'].includes(String(value).trim().toLowerCase());
+};
+
 class ApiServer {
   constructor() {
     this.app = new Koa();
@@ -902,7 +908,8 @@ class ApiServer {
         // 启动 AppClock / ClockCore（互斥保护）
         // 避免 doc-ocr-pipeline 被新旧入口同时调度
         const enableAppClock = isFeatureEnabled('ENABLE_APP_CLOCK');
-        const enableClockCore = isFeatureEnabled('ENABLE_CLOCK_CORE');
+        // ClockCore 作为迁移期开关，必须显式开启，避免未配置环境被默认切流。
+        const enableClockCore = isFeatureEnabledOptIn('ENABLE_CLOCK_CORE');
 
         if (enableAppClock && enableClockCore) {
           logger.error('[Startup] ⚠️ ENABLE_APP_CLOCK 与 ENABLE_CLOCK_CORE 同时启用！');

--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,9 @@ import ResidentSkillManager from '../lib/resident-skill-manager.js';
 import InternalLLMService from '../lib/internal-llm-service.js';
 import SkillLoader from '../lib/skill-loader.js';
 import AppClock from '../lib/app-clock.js';
+import ClockCore from '../lib/clock/clock-core.js';
+import { buildDocPipelineContext } from '../lib/clock/job-context-builder.js';
+import { run as docPipelineWorkerRun } from '../lib/doc-pipeline-worker.js';
 import { createAppWildcardRouter } from './middlewares/app-wildcard-router.js';
 import logger from '../lib/logger.js';
 import Utils from '../lib/utils.js';
@@ -253,6 +256,7 @@ class ApiServer {
     this.residentSkillManager = null;
     this.tokenCleanupJob = null;
     this.appClock = null;
+    this.clockCore = null;
     this.appRouterLoader = null;
     this.wildcardCacheManager = null;
     this.sharedRegistryService = null;
@@ -391,6 +395,35 @@ class ApiServer {
     });
     // 不在这里启动，等 server listen 后统一启动
     logger.info('AppClock initialized');
+
+    // 初始化 ClockCore（Unified Clock Phase 1）
+    // 注册 doc-pipeline-worker 为第一个 internal job
+    this.clockCore = new ClockCore(this.db, {
+      maxConsecutiveFailures: parseInt(process.env.CLOCK_MAX_FAILURES, 10) || 3,
+      failureCooldownMs: parseInt(process.env.CLOCK_FAILURE_COOLDOWN_MS, 10) || 120000,
+    });
+
+    this.clockCore.register('doc-pipeline-worker', {
+      interval: appConfig.clock_interval * 1000,
+      preventOverlap: true,
+      handler: async (clockContext) => {
+        const services = buildDocPipelineContext(this.db, {
+          callMcp: this.appClock?.callMcp?.bind(this.appClock) ?? null,
+          callLlm: null,
+          getDocPipelineConfig: async () => {
+            try {
+              const systemSettingService = getSystemSettingService(this.db);
+              return await systemSettingService.getDocPipelineConfig?.() || null;
+            } catch {
+              return null;
+            }
+          },
+        });
+        return await docPipelineWorkerRun({ services });
+      },
+    });
+
+    logger.info('ClockCore initialized with doc-pipeline-worker internal job');
   }
 
   /**
@@ -877,6 +910,17 @@ class ApiServer {
           }
         }
 
+        // 启动 ClockCore（Unified Clock Phase 1）
+        // doc-pipeline-worker 作为第一个 internal job
+        if (this.clockCore) {
+          if (isFeatureEnabled('ENABLE_CLOCK_CORE')) {
+            this.clockCore.startAll();
+            logger.info('[Startup] ClockCore started with internal jobs');
+          } else {
+            logger.warn('[Startup] ClockCore disabled by ENABLE_CLOCK_CORE');
+          }
+        }
+
         // 启动 Token 清理任务（Issue #140）
         if (this.tokenCleanupJob) {
           if (isFeatureEnabled('ENABLE_TOKEN_CLEANUP')) {
@@ -912,6 +956,9 @@ process.on('SIGINT', async () => {
   if (server.appClock) {
     server.appClock.stop();
   }
+  if (server.clockCore) {
+    server.clockCore.stopAll();
+  }
   process.exit(0);
 });
 
@@ -928,6 +975,9 @@ process.on('SIGTERM', async () => {
   }
   if (server.appClock) {
     server.appClock.stop();
+  }
+  if (server.clockCore) {
+    server.clockCore.stopAll();
   }
   process.exit(0);
 });

--- a/server/index.js
+++ b/server/index.js
@@ -899,9 +899,21 @@ class ApiServer {
           }
         }
 
+        // 启动 AppClock / ClockCore（互斥保护）
+        // 避免 doc-ocr-pipeline 被新旧入口同时调度
+        const enableAppClock = isFeatureEnabled('ENABLE_APP_CLOCK');
+        const enableClockCore = isFeatureEnabled('ENABLE_CLOCK_CORE');
+
+        if (enableAppClock && enableClockCore) {
+          logger.error('[Startup] ⚠️ ENABLE_APP_CLOCK 与 ENABLE_CLOCK_CORE 同时启用！');
+          logger.error('[Startup]    这会导致 doc-ocr-pipeline 双跑（AppClock tick + ClockCore internal job）');
+          logger.error('[Startup]    自动降级：跳过 ClockCore，仅启动 AppClock');
+          logger.error('[Startup]    请设置 ENABLE_CLOCK_CORE=0 或在迁移完成后关闭 ENABLE_APP_CLOCK');
+        }
+
         // 启动 AppClock（Issue #654）
         if (this.appClock) {
-          if (isFeatureEnabled('ENABLE_APP_CLOCK')) {
+          if (enableAppClock) {
             this.appClock.start().catch(err => {
               logger.error('[Startup] Failed to start AppClock:', err.message);
             });
@@ -911,11 +923,13 @@ class ApiServer {
         }
 
         // 启动 ClockCore（Unified Clock Phase 1）
-        // doc-pipeline-worker 作为第一个 internal job
+        // 注意：若与 AppClock 同时启用，ClockCore 被跳过（见上方互斥保护）
         if (this.clockCore) {
-          if (isFeatureEnabled('ENABLE_CLOCK_CORE')) {
+          if (enableClockCore && !enableAppClock) {
             this.clockCore.startAll();
             logger.info('[Startup] ClockCore started with internal jobs');
+          } else if (enableClockCore && enableAppClock) {
+            logger.warn('[Startup] ClockCore skipped — ENABLE_APP_CLOCK also active (mutual exclusion)');
           } else {
             logger.warn('[Startup] ClockCore disabled by ENABLE_CLOCK_CORE');
           }


### PR DESCRIPTION
## 变更概述

本 PR 将 `doc-ocr-pipeline` 从 `AppClock -> app tick` 主入口内收到 `ClockCore -> internal job`，作为 Unified Clock Phase 1 的第一个可运行样板。

核心目标不是一次性退役整套旧体系，而是先完成文档平台内部流水线的调度边界纠偏。

Closes #<ISSUE_NUMBER>

## 本轮做了什么

### 1. 调度主入口换轨

- 新增 `lib/doc-pipeline-worker.js` 作为文档平台流水线新主入口
- 在 `server/index.js` 中注册 `doc-pipeline-worker` 为 `ClockCore` internal job
- 将 `apps/doc-ocr-pipeline/tick/index.js` 降级为兼容壳层，转发到新入口

### 2. 结构收敛

- 新增 `lib/clock/clock-core.js` 最小 internal job 调度骨架
- 新增 `lib/clock/job-context-builder.js`，统一 worker 所需上下文注入
- 新增 `lib/doc-pipeline-binding-sync.js`，把业务 app 绑定副作用从主链拆出
- 将 clean / outline / chunk / embedding 阶段的主表状态推进继续向 `DocPipelineAdvancer` 收敛

### 3. 风险控制与验证收口

- 为 `ClockCore` 增加 JSONL 结构化运行记录
- 新增 `scripts/read-clockcore-runlog.mjs` 查询脚本
- 修正 `scripts/verify-doc-ocr-pipeline-offline.js`，移除与新实现不一致的旧断言
- 增加 `ClockCore` / `AppClock` 启动期互斥保护，避免双跑
- 补充 `verification-round01.md` 验证材料

## 本轮明确没做什么

以下内容**不在本次 PR 范围内**：

- 不做数据库 schema 变更
- 不退役 `mini_apps` / `app_clock_registry` 中的 `doc-ocr-pipeline` 记录
- 不移除所有旧体系桥接
- 不统一全平台所有 scheduler / job 模型
- 不处理 Unified Clock 的完整 Phase 2 / Phase 3

## 为什么没做

本 PR 是 Phase 1 样板 PR，重点是先把文档平台这条链路从错误的 app 语义中抽离出来，验证：

1. internal job 主入口是否可行
2. 最小 `ClockCore` 是否可跑
3. 不改 schema 的前提下是否能完成第一块样板

完整退役旧体系会扩大 PR 范围和 review 成本，因此保留到后续阶段处理。

## 验证结果

### 静态验证

- 关键模块导入通过
- 相关文件无编辑器诊断错误
- 离线验证脚本与当前实现一致

### 运行验证

- 后端在 `ENABLE_APP_CLOCK=0`、`ENABLE_CLOCK_CORE=1` 条件下成功启动
- 启动日志确认：`ClockCore initialized with doc-pipeline-worker internal job`
- 前端开发服务器成功启动（本地端口漂移到 `5175`）

## 已知保留项

- `apps/doc-ocr-pipeline/tick/index.js` 仍保留为兼容壳层
- `callMcp` 仍通过 `AppClock` 桥接注入
- `mini_apps` / `app_clock_registry` 的退役留到 Phase 2
- 统一运行记录模型与日志轮转留到后续阶段

## Reviewer 建议关注点

1. 本 PR 是否清楚建立了 `doc-pipeline-worker` 作为 internal job 主入口
2. 本 PR 是否把 Phase 1 的范围控制在“主入口换轨 + 最小收口”
3. 本 PR 是否为 Phase 2 / Phase 3 留下清晰的后续边界

Closes #928 