### PR TITLE
fix: 合并 current-feature-analyzer 双图联动拉伸修复

### DIFF
--- a/apps/current-feature-analyzer/frontend/components/CompressedCurrentChart.vue
+++ b/apps/current-feature-analyzer/frontend/components/CompressedCurrentChart.vue
@@ -1,21 +1,22 @@
 <template>
   <el-card v-if="hasData" shadow="never">
     <template #header><span class="card-title">压缩分段曲线</span></template>
-    <div ref="chartRef" class="cfa-chart"></div>
+    <div ref="chartRef" class="cfa-chart" :style="chartStyle"></div>
   </el-card>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch, nextTick, computed } from 'vue'
 import * as echarts from 'echarts'
 import type { FileAnalysisResult } from '../api/current-feature-analyzer'
 
-const props = defineProps<{ fileName: string; result: FileAnalysisResult | null }>()
+const props = defineProps<{ fileName: string; result: FileAnalysisResult | null; chartHeight?: number }>()
 
 const chartRef = ref<HTMLElement | null>(null)
 const hasData = ref(false)
 let chartInstance: any = null
 let resizeHandler: (() => void) | null = null
+const chartStyle = computed(() => ({ height: `${props.chartHeight ?? 280}px` }))
 
 const kindColors: Record<string, string> = {
   stable: '#94a3b8', normal: '#60a5fa', transition: '#6366f1', spike: '#8b5cf6',
@@ -112,6 +113,10 @@ watch(() => props.result?.segments, (newVal) => {
     hasData.value = true
     nextTick(() => renderCompressed())
   }
+})
+
+watch(() => props.chartHeight, () => {
+  nextTick(() => chartInstance?.resize())
 })
 </script>
 

--- a/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
+++ b/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
@@ -3,7 +3,6 @@
     <el-collapse v-if="ruleSetDetail" class="cfa-ruleset-info">
       <el-collapse-item :title="`当前规则集：${ruleSetDetail.rule_set_name}`">
         <div v-if="ruleSetDetail.description" class="cfa-ruleset-desc">{{ ruleSetDetail.description }}</div>
-        <div v-if="ruleSetDetail.business_context" class="cfa-ruleset-ctx">{{ ruleSetDetail.business_context }}</div>
         <div v-if="ruleSetDetail.stages?.length" class="cfa-ruleset-stages">
           <span class="cfa-ruleset-stages-label">识别阶段：</span>
           <el-tag
@@ -315,7 +314,6 @@ onMounted(() => {
 .cfa-ruleset-info { margin-bottom: 16px; }
 .cfa-result-tabs { margin-bottom: 16px; }
 .cfa-ruleset-desc { font-size: 13px; color: var(--el-text-color-secondary); margin-bottom: 6px; }
-.cfa-ruleset-ctx { font-size: 13px; color: var(--el-text-color-regular); margin-bottom: 8px; line-height: 1.5; }
 .cfa-ruleset-stages { margin-top: 6px; }
 .cfa-ruleset-stages-label { font-size: 12px; color: var(--el-text-color-secondary); margin-right: 4px; }
 .cfa-error-block, .cfa-loading-block, .cfa-pending-block {

--- a/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
+++ b/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
@@ -3,6 +3,7 @@
     <el-collapse v-if="ruleSetDetail" class="cfa-ruleset-info">
       <el-collapse-item :title="`当前规则集：${ruleSetDetail.rule_set_name}`">
         <div v-if="ruleSetDetail.description" class="cfa-ruleset-desc">{{ ruleSetDetail.description }}</div>
+        <div v-if="ruleSetDetail.business_context" class="cfa-ruleset-ctx">{{ ruleSetDetail.business_context }}</div>
         <div v-if="ruleSetDetail.stages?.length" class="cfa-ruleset-stages">
           <span class="cfa-ruleset-stages-label">识别阶段：</span>
           <el-tag
@@ -21,13 +22,22 @@
     <FileSummaryCard v-if="file" :file="file" />
 
     <template v-if="file.result && ['completed', 'failed'].includes(file.analysis_status)">
-      <div class="cfa-chart-stack cfa-chart-stack-always">
-        <RawCurrentChart :file-name="file.file_name" :result="file.result" :raw-data="file.raw_data" />
-        <CompressedCurrentChart :file-name="file.file_name" :result="file.result" />
+      <RawCurrentChart
+        :file-name="file.file_name"
+        :result="file.result"
+        :raw-data="file.raw_data"
+        :chart-height="rawChartHeight"
+      />
+      <div v-if="showChartResizer" class="cfa-chart-resizer" @pointerdown="startChartResize">
+        <span class="cfa-chart-resizer-handle" />
       </div>
+      <CompressedCurrentChart
+        :file-name="file.file_name"
+        :result="file.result"
+        :chart-height="compressedChartHeight"
+      />
 
       <el-tabs v-model="activeResultTab" class="cfa-result-tabs">
-
         <el-tab-pane label="概览" name="overview">
           <StageSummaryCard :metrics="file.result.stage_metrics || []" />
           <CompressionStatsCard
@@ -86,25 +96,26 @@
       </div>
     </template>
 
-    <!-- 分析中：先画可用的图，LLM 结果区域显示等待 -->
     <template v-else-if="['analyzing', 'compressing', 'llm_recognizing', 'stage_metrics'].includes(file.analysis_status)">
-      <div class="cfa-chart-stack cfa-chart-stack-always">
-        <RawCurrentChart
-          v-if="file.raw_data?.length"
-          :file-name="file.file_name"
-          :raw-data="file.raw_data"
-          :result="file.result || {}"
-        />
+      <RawCurrentChart
+        :file-name="file.file_name"
+        :raw-data="file.raw_data"
+        :result="file.result || {}"
+        :chart-height="rawChartHeight"
+      />
 
-        <CompressedCurrentChart
-          v-if="file.result?.segments?.length"
-          :file-name="file.file_name"
-          :result="file.result"
-        />
+      <div v-if="showChartResizer" class="cfa-chart-resizer" @pointerdown="startChartResize">
+        <span class="cfa-chart-resizer-handle" />
       </div>
 
-      <el-tabs v-model="activeResultTab" class="cfa-result-tabs">
+      <CompressedCurrentChart
+        v-if="file.result?.segments?.length"
+        :file-name="file.file_name"
+        :result="file.result"
+        :chart-height="compressedChartHeight"
+      />
 
+      <el-tabs v-model="activeResultTab" class="cfa-result-tabs">
         <el-tab-pane label="统计" name="overview">
           <CompressionStatsCard
             v-if="file.result?.segments?.length"
@@ -143,7 +154,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { Loading } from '@element-plus/icons-vue'
 import type { SessionFileItem, RuleSetDetail, AppConfig } from '../api/current-feature-analyzer'
 import FileSummaryCard from './FileSummaryCard.vue'
@@ -156,27 +167,153 @@ import StageMetricsTable from './StageMetricsTable.vue'
 import AuxiliaryMetricsPanel from './AuxiliaryMetricsPanel.vue'
 import LlmResultPanel from './LlmResultPanel.vue'
 
-defineProps<{
+const props = defineProps<{
   file: SessionFileItem
   appConfig: AppConfig | null
   ruleSetDetail: RuleSetDetail | null
 }>()
 
 const activeResultTab = ref('overview')
+
+const DESKTOP_CHART_TOTAL_HEIGHT = 560
+const MOBILE_CHART_TOTAL_HEIGHT = 440
+const RAW_CHART_MIN_HEIGHT = 220
+const COMPRESSED_CHART_MIN_HEIGHT = 140
+const RAW_CHART_DEFAULT_RATIO = 0.57
+
+const canResizeCharts = computed(() => (props.file.result?.segments?.length ?? 0) > 0)
+const hasRawRenderableData = computed(() => {
+  if (props.file.raw_data?.length) return true
+  return !!props.file.result?.segments?.some((seg) => (seg.polyline_points?.length ?? 0) > 0)
+})
+const showChartResizer = computed(() => canResizeCharts.value && hasRawRenderableData.value)
+
+const chartTotalHeight = ref(RAW_CHART_MIN_HEIGHT + COMPRESSED_CHART_MIN_HEIGHT)
+const rawChartHeight = ref(Math.round(chartTotalHeight.value * RAW_CHART_DEFAULT_RATIO))
+const compressedChartHeight = ref(chartTotalHeight.value - rawChartHeight.value)
+
+let isResizing = false
+let startY = 0
+let startRawHeight = RAW_CHART_MIN_HEIGHT
+let activePointerId: number | null = null
+
+function clampHeight(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function calcResponsiveChartTotalHeight() {
+  const minTotal = RAW_CHART_MIN_HEIGHT + COMPRESSED_CHART_MIN_HEIGHT
+  const preferred = window.innerWidth <= 768 ? MOBILE_CHART_TOTAL_HEIGHT : DESKTOP_CHART_TOTAL_HEIGHT
+  const maxByViewport = Math.round(window.innerHeight * 0.62)
+  return clampHeight(preferred, minTotal, Math.max(minTotal, maxByViewport))
+}
+
+function ensureChartBounds() {
+  if (!canResizeCharts.value) {
+    compressedChartHeight.value = 0
+    rawChartHeight.value = Math.max(RAW_CHART_MIN_HEIGHT, chartTotalHeight.value)
+    return
+  }
+
+  const minRaw = RAW_CHART_MIN_HEIGHT
+  const maxRaw = chartTotalHeight.value - COMPRESSED_CHART_MIN_HEIGHT
+  rawChartHeight.value = clampHeight(rawChartHeight.value, minRaw, maxRaw)
+  compressedChartHeight.value = chartTotalHeight.value - rawChartHeight.value
+}
+
+function updateChartTotalHeight() {
+  const nextTotal = calcResponsiveChartTotalHeight()
+
+  if (!canResizeCharts.value) {
+    chartTotalHeight.value = nextTotal
+    ensureChartBounds()
+    return
+  }
+
+  const ratio = rawChartHeight.value / chartTotalHeight.value
+  chartTotalHeight.value = nextTotal
+  rawChartHeight.value = Math.round(nextTotal * ratio)
+  ensureChartBounds()
+}
+
+function resetChartHeights() {
+  if (canResizeCharts.value) {
+    rawChartHeight.value = Math.round(chartTotalHeight.value * RAW_CHART_DEFAULT_RATIO)
+    compressedChartHeight.value = chartTotalHeight.value - rawChartHeight.value
+    ensureChartBounds()
+    return
+  }
+
+  ensureChartBounds()
+}
+
+function stopChartResize() {
+  if (!isResizing) return
+
+  isResizing = false
+  activePointerId = null
+  document.removeEventListener('pointermove', onChartResize)
+  document.removeEventListener('pointerup', stopChartResize)
+  document.removeEventListener('pointercancel', stopChartResize)
+  document.body.style.cursor = ''
+  document.body.style.userSelect = ''
+}
+
+function onChartResize(event: PointerEvent) {
+  if (!isResizing || !canResizeCharts.value || activePointerId !== event.pointerId) return
+
+  const deltaY = event.clientY - startY
+  const nextRaw = clampHeight(
+    startRawHeight - deltaY,
+    RAW_CHART_MIN_HEIGHT,
+    chartTotalHeight.value - COMPRESSED_CHART_MIN_HEIGHT,
+  )
+
+  rawChartHeight.value = nextRaw
+  compressedChartHeight.value = chartTotalHeight.value - nextRaw
+}
+
+function startChartResize(event: PointerEvent) {
+  if (!canResizeCharts.value || isResizing) return
+
+  isResizing = true
+  activePointerId = event.pointerId
+  startY = event.clientY
+  startRawHeight = rawChartHeight.value
+
+  document.addEventListener('pointermove', onChartResize)
+  document.addEventListener('pointerup', stopChartResize)
+  document.addEventListener('pointercancel', stopChartResize)
+  document.body.style.cursor = 'row-resize'
+  document.body.style.userSelect = 'none'
+  event.preventDefault()
+}
+
+watch(
+  () => [props.file.file_id, canResizeCharts.value],
+  () => {
+    activeResultTab.value = 'overview'
+    resetChartHeights()
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(() => {
+  stopChartResize()
+  window.removeEventListener('resize', updateChartTotalHeight)
+})
+
+onMounted(() => {
+  updateChartTotalHeight()
+  resetChartHeights()
+  window.addEventListener('resize', updateChartTotalHeight)
+})
 </script>
 
 <style scoped>
 .cfa-file-detail > * { margin-bottom: 16px; }
 .cfa-ruleset-info { margin-bottom: 16px; }
 .cfa-result-tabs { margin-bottom: 16px; }
-.cfa-chart-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-.cfa-chart-stack-always {
-  margin-bottom: 16px;
-}
 .cfa-ruleset-desc { font-size: 13px; color: var(--el-text-color-secondary); margin-bottom: 6px; }
 .cfa-ruleset-ctx { font-size: 13px; color: var(--el-text-color-regular); margin-bottom: 8px; line-height: 1.5; }
 .cfa-ruleset-stages { margin-top: 6px; }
@@ -186,5 +323,25 @@ const activeResultTab = ref('overview')
   text-align: center;
   font-size: 15px;
   color: var(--el-text-color-secondary);
+}
+.cfa-chart-resizer {
+  height: 14px;
+  margin: -2px 0 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: row-resize;
+  touch-action: none;
+}
+.cfa-chart-resizer-handle {
+  display: block;
+  width: 56px;
+  height: 4px;
+  border-radius: 4px;
+  background: var(--el-border-color);
+  transition: background-color 0.2s ease;
+}
+.cfa-chart-resizer:hover .cfa-chart-resizer-handle {
+  background: var(--el-color-primary);
 }
 </style>

--- a/apps/current-feature-analyzer/frontend/components/RawCurrentChart.vue
+++ b/apps/current-feature-analyzer/frontend/components/RawCurrentChart.vue
@@ -4,19 +4,24 @@
       <span class="card-title">电流曲线（原始数据）</span>
       <el-tag v-if="isSampled" size="small" type="info" style="margin-left: 8px">已采样 {{ sampledCount }} / {{ totalCount }} 点</el-tag>
     </template>
-    <div class="cfa-chart-wrap">
-      <div ref="chartRef" class="cfa-chart" v-show="hasData"></div>
-      <div v-if="!hasData" class="cfa-chart-empty">暂无原始数据曲线</div>
+    <div class="cfa-chart-wrap" :style="chartStyle">
+      <div ref="chartRef" class="cfa-chart" :style="chartStyle" v-show="hasData"></div>
+      <div v-if="!hasData" class="cfa-chart-empty" :style="chartStyle">暂无原始数据曲线</div>
     </div>
   </el-card>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch, nextTick, computed } from 'vue'
 import * as echarts from 'echarts'
 import type { FileAnalysisResult } from '../api/current-feature-analyzer'
 
-const props = defineProps<{ fileName: string; result: FileAnalysisResult | null; rawData?: number[][] | null }>()
+const props = defineProps<{
+  fileName: string
+  result: FileAnalysisResult | null
+  rawData?: number[][] | null
+  chartHeight?: number
+}>()
 
 const chartRef = ref<HTMLElement | null>(null)
 const hasData = ref(false)
@@ -27,6 +32,7 @@ let chartInstance: any = null
 let resizeHandler: (() => void) | null = null
 
 const MAX_POINTS = 3000
+const chartStyle = computed(() => ({ height: `${props.chartHeight ?? 250}px` }))
 
 function getPoints(): number[][] {
   if (props.rawData && Array.isArray(props.rawData) && props.rawData.length > 0) {
@@ -104,6 +110,10 @@ onBeforeUnmount(() => {
 
 watch([() => props.rawData, () => props.result], () => {
   nextTick(() => renderRaw())
+})
+
+watch(() => props.chartHeight, () => {
+  nextTick(() => chartInstance?.resize())
 })
 </script>
 


### PR DESCRIPTION
## 变更说明
- 解决原 PR 分支与 `master` 冲突，基于最新 `master` 重新整理修复。
- 保留 current-feature-analyzer 双图联动拉伸：上拉阶段图区域时，原始图放大。
- 拖拽事件统一为 Pointer Events（鼠标/触控均可用），并加入防重入。
- 图表高度采用响应式总高策略，避免固定高度在小屏拥挤。
- 原始图与压缩图都支持动态高度并在变化后触发 ECharts `resize()`。

## 影响文件
- apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
- apps/current-feature-analyzer/frontend/components/RawCurrentChart.vue
- apps/current-feature-analyzer/frontend/components/CompressedCurrentChart.vue

## 验证
- npm run lint
- 前端 type-check 当前分支存在历史存量错误（与本次文件无关），已完成本次文件冲突处理与可合并性验证。
