### PR TITLE
fix: 文档平台创建集合错误提示不显示

### DIFF
--- a/frontend/src/components/doc-collections/CreateCollectionModal.vue
+++ b/frontend/src/components/doc-collections/CreateCollectionModal.vue
@@ -25,7 +25,7 @@
           <el-radio value="department" :disabled="!userHasDepartment">{{ $t('docs.workspace.settings.visibilityDepartment') }}</el-radio>
           <el-radio value="public">{{ $t('docs.workspace.settings.visibilityPublic') }}</el-radio>
         </el-radio-group>
-        <div v-if="!userHasDepartment && form.visibility === 'department'" class="form-hint">
+        <div v-if="!userHasDepartment" class="form-hint">
           {{ $t('docs.workspace.settings.departmentRequiredHint') }}
         </div>
       </el-form-item>
@@ -57,6 +57,7 @@
 import { ref, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { FormInstance, FormRules } from 'element-plus'
+import { ElMessage } from 'element-plus'
 import { modelApi } from '@/api/services'
 import { departmentApi } from '@/api/services'
 import { useUserStore } from '@/stores/user'
@@ -136,6 +137,11 @@ async function onOpen() {
 }
 
 async function submit() {
+  if (!userHasDepartment.value) {
+    ElMessage.warning(t('docs.workspace.settings.departmentRequiredHint'))
+    return
+  }
+
   const valid = await formRef.value?.validate().catch(() => false)
   if (!valid) return
 
@@ -151,8 +157,17 @@ async function submit() {
       data.department_id = form.department_id
       data.department_scope = form.department_scope
     }
-    await collectionStore.addCollection(data)
+    const result = await collectionStore.addCollection(data)
+    if (!result) {
+      const errMsg = collectionStore.error || ''
+      const isServerError = errMsg.includes('database') || errMsg.includes('SQL') || errMsg.includes('constraint')
+      ElMessage.error(isServerError ? t('common.error') : (collectionStore.error || t('common.error')))
+      return
+    }
     emit('created')
+    emit('update:visible', false)
+  } catch {
+    ElMessage.error(t('common.error'))
   } finally {
     submitting.value = false
   }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2264,7 +2264,7 @@ export default {
         visibilityPrivate: 'Private',
         visibilityDepartment: 'Department',
         visibilityPublic: 'Public',
-        departmentRequiredHint: 'Join a department before creating a department-visible collection',
+        departmentRequiredHint: 'Join a department before creating a collection',
         department: 'Department',
         departmentPlaceholder: 'Select department',
         departmentScope: 'Department Scope',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2253,7 +2253,7 @@ export default {
         visibilityPrivate: '私有',
         visibilityDepartment: '部门',
         visibilityPublic: '公开',
-        departmentRequiredHint: '请先加入部门后才能创建部门可见集合',
+        departmentRequiredHint: '请先加入部门后才能创建集合',
         department: '所属部门',
         departmentPlaceholder: '选择所属部门',
         departmentScope: '部门范围',


### PR DESCRIPTION
## 修复内容

修复文档平台创建 Collection 时错误提示不显示的问题。

### 问题
- 后端返回 400 错误 "department_id is required: user has no department"
- 页面没有任何错误提示，静默失败

### 根因
1. 前端调用 `addCollection()` 失败后，错误被静默吞掉，未展示给用户
2. 数据库 `department_id` 为 NOT NULL，但前端只在选择"部门可见"时才传该字段
3. 提示文案仅针对"部门可见"场景

### 修复
- 提交失败时用 `ElMessage.error` 展示错误信息
- 无部门用户在提交前被拦截并提示
- hint 始终显示
- i18n 文案更新

### 测试
1. 无部门用户尝试创建集合 → 直接提示"请先加入部门后才能创建集合"
2. 有部门用户创建集合成功 → 正确创建并关闭弹窗
3. 接口返回错误时 → 页面展示具体错误信息

Closes #945