### PR TITLE
fix: 阶段定义空状态下添加按钮不可见

### DIFF
--- a/apps/current-feature-analyzer/frontend/components/RuleSetEditorModal.vue
+++ b/apps/current-feature-analyzer/frontend/components/RuleSetEditorModal.vue
@@ -94,7 +94,8 @@
       </div>
 
       <div v-if="editForm.stages.length === 0" class="rs-empty-stage">
-        当前还没有阶段定义，请至少添加一个阶段。
+        <span>当前还没有阶段定义，请至少添加一个阶段。</span>
+        <el-button size="small" type="primary" round :icon="Plus" @click="addStage">添加阶段</el-button>
       </div>
       <div v-if="editForm.stages.length > 0" class="stage-nav-row">
         <div class="stage-nav-wrap">
@@ -429,6 +430,16 @@ function removeStage(i: number) {
 .rs-table-header-actions {
   display: flex;
   justify-content: flex-end;
+}
+
+.rs-empty-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 32px 0;
+  color: var(--el-text-color-secondary);
+  font-size: 14px;
 }
 
 .stage-nav-row {

--- a/frontend/src/components/doc-collections/CreateCollectionModal.vue
+++ b/frontend/src/components/doc-collections/CreateCollectionModal.vue
@@ -25,7 +25,7 @@
           <el-radio value="department" :disabled="!userHasDepartment">{{ $t('docs.workspace.settings.visibilityDepartment') }}</el-radio>
           <el-radio value="public">{{ $t('docs.workspace.settings.visibilityPublic') }}</el-radio>
         </el-radio-group>
-        <div v-if="!userHasDepartment && form.visibility === 'department'" class="form-hint">
+        <div v-if="!userHasDepartment" class="form-hint">
           {{ $t('docs.workspace.settings.departmentRequiredHint') }}
         </div>
       </el-form-item>
@@ -57,6 +57,7 @@
 import { ref, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { FormInstance, FormRules } from 'element-plus'
+import { ElMessage } from 'element-plus'
 import { modelApi } from '@/api/services'
 import { departmentApi } from '@/api/services'
 import { useUserStore } from '@/stores/user'
@@ -136,6 +137,11 @@ async function onOpen() {
 }
 
 async function submit() {
+  if (!userHasDepartment.value) {
+    ElMessage.warning(t('docs.workspace.settings.departmentRequiredHint'))
+    return
+  }
+
   const valid = await formRef.value?.validate().catch(() => false)
   if (!valid) return
 
@@ -151,8 +157,17 @@ async function submit() {
       data.department_id = form.department_id
       data.department_scope = form.department_scope
     }
-    await collectionStore.addCollection(data)
+    const result = await collectionStore.addCollection(data)
+    if (!result) {
+      const errMsg = collectionStore.error || ''
+      const isServerError = errMsg.includes('database') || errMsg.includes('SQL') || errMsg.includes('constraint')
+      ElMessage.error(isServerError ? t('common.error') : (collectionStore.error || t('common.error')))
+      return
+    }
     emit('created')
+    emit('update:visible', false)
+  } catch {
+    ElMessage.error(t('common.error'))
   } finally {
     submitting.value = false
   }

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -2264,7 +2264,7 @@ export default {
         visibilityPrivate: 'Private',
         visibilityDepartment: 'Department',
         visibilityPublic: 'Public',
-        departmentRequiredHint: 'Join a department before creating a department-visible collection',
+        departmentRequiredHint: 'Join a department before creating a collection',
         department: 'Department',
         departmentPlaceholder: 'Select department',
         departmentScope: 'Department Scope',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -2253,7 +2253,7 @@ export default {
         visibilityPrivate: '私有',
         visibilityDepartment: '部门',
         visibilityPublic: '公开',
-        departmentRequiredHint: '请先加入部门后才能创建部门可见集合',
+        departmentRequiredHint: '请先加入部门后才能创建集合',
         department: '所属部门',
         departmentPlaceholder: '选择所属部门',
         departmentScope: '部门范围',


### PR DESCRIPTION
## 修复内容

规则集管理的阶段定义 dialog 中，空状态下"添加阶段"按钮被 `v-if="editForm.stages.length > 0"` 隐藏在阶段导航栏内，导致无阶段时用户无处点击添加。

### 修改

- 在空状态 `.rs-empty-stage` 区域内添加"添加阶段"按钮，与提示文字并排显示
- 添加 `.rs-empty-stage` 样式（flex 居中布局 + gap）
- 保留 `v-if="editForm.stages.length === 0"` 条件，有阶段时仅显示导航栏

Closes #946
