### PR TITLE
fix: App Market Registry 远程失败时 fallback 到本地 apps 目录

### DIFF
--- a/apps/current-feature-analyzer/frontend/api/current-feature-analyzer.ts
+++ b/apps/current-feature-analyzer/frontend/api/current-feature-analyzer.ts
@@ -135,6 +135,12 @@ export interface SegmentItem {
   kind?: string | null
   polyline_points?: number[][] | null
   polyline_point_count?: number
+  /** 段首原始点电流值，来源 points[start_index][1] */
+  start_current?: number
+  /** 段尾原始点电流值，来源 points[end_index][1] */
+  end_current?: number
+  /** end_current - start_current */
+  delta_current?: number
 }
 
 export interface CompressionMeta {

--- a/apps/current-feature-analyzer/frontend/components/CompressedSegmentsTable.vue
+++ b/apps/current-feature-analyzer/frontend/components/CompressedSegmentsTable.vue
@@ -20,6 +20,12 @@
           <el-tag size="small" effect="plain">{{ scope.row.kind || '-' }}</el-tag>
         </template>
       </el-table-column>
+      <el-table-column label="开始电流" min-width="110">
+        <template #default="scope">{{ formatNumber(scope.row.start_current) }}</template>
+      </el-table-column>
+      <el-table-column label="结束电流" min-width="110">
+        <template #default="scope">{{ formatNumber(scope.row.end_current) }}</template>
+      </el-table-column>
       <el-table-column label="开始时间" min-width="110">
         <template #default="scope">{{ formatNumber(scope.row.start_time) }}</template>
       </el-table-column>
@@ -56,7 +62,7 @@ defineProps<{ segments: SegmentItem[] }>()
 
 function formatNumber(value?: number | null) {
   if (typeof value !== 'number' || Number.isNaN(value)) return '-'
-  return value.toFixed(4)
+  return value.toFixed(6)
 }
 </script>
 

--- a/apps/current-feature-analyzer/frontend/components/CompressionStatsCard.vue
+++ b/apps/current-feature-analyzer/frontend/components/CompressionStatsCard.vue
@@ -38,18 +38,6 @@
         <div class="cfa-stat-value">{{ vectorizationRatio }}</div>
         <div class="cfa-stat-label">向量化比</div>
       </div>
-      <div class="cfa-stat-card" style="background:#fef3c7">
-        <div class="cfa-stat-value">{{ eventCount }}</div>
-        <div class="cfa-stat-label">尖峰/事件数</div>
-      </div>
-      <div class="cfa-stat-card" style="background:#ffe4e6">
-        <div class="cfa-stat-value">{{ duplicateGroups }}</div>
-        <div class="cfa-stat-label">冲突Y值组数</div>
-      </div>
-      <div class="cfa-stat-card" style="background:#ffeef2">
-        <div class="cfa-stat-value">{{ duplicateRatio }}</div>
-        <div class="cfa-stat-label">冲突Y值占比</div>
-      </div>
       <div class="cfa-stat-card" style="background:#eefaf3">
         <div class="cfa-stat-value">{{ absoluteResolution }}</div>
         <div class="cfa-stat-label">绝对电流分辨率</div>
@@ -80,14 +68,12 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { CompressionMeta, DuplicateDiagnosis, SegmentItem } from '../api/current-feature-analyzer'
+import type { CompressionMeta, SegmentItem } from '../api/current-feature-analyzer'
 
 const props = defineProps<{
   rawPointCount: number
   segments?: SegmentItem[]
-  events?: Array<Record<string, unknown>>
   globals?: Record<string, number> | null
-  duplicateDiagnosis?: DuplicateDiagnosis | null
   compressionMeta?: CompressionMeta | null
 }>()
 
@@ -123,12 +109,6 @@ const plateauCount = computed(() => {
 const trendCount = computed(() => {
   if (!props.segments) return 0
   return props.segments.filter(s => typeof s.kind === 'string' && trendKindSet.has(s.kind)).length
-})
-const eventCount = computed(() => props.events?.length ?? 0)
-const duplicateGroups = computed(() => props.duplicateDiagnosis?.duplicate_groups ?? '-')
-const duplicateRatio = computed(() => {
-  if (!props.rawPointCount || !props.duplicateDiagnosis?.duplicate_groups) return '-'
-  return `${((props.duplicateDiagnosis.duplicate_groups / props.rawPointCount) * 100).toFixed(2)}%`
 })
 const absoluteResolution = computed(() => props.compressionMeta?.absolute_resolution != null ? `${Number(props.compressionMeta.absolute_resolution).toFixed(6)} A` : '-')
 const relativeResolution = computed(() => props.compressionMeta?.relative_resolution != null ? Number(props.compressionMeta.relative_resolution).toFixed(3) : '-')

--- a/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
+++ b/apps/current-feature-analyzer/frontend/components/FileDetailPanel.vue
@@ -45,9 +45,7 @@
           <CompressionStatsCard
             :raw-point-count="file.raw_data?.length ?? file.row_count ?? 0"
             :segments="file.result.segments"
-            :events="file.result.events"
             :globals="file.result.globals"
-            :duplicate-diagnosis="file._duplicate_diagnosis"
             :compression-meta="file.result.compression_meta"
           />
         </el-tab-pane>
@@ -126,9 +124,7 @@
             v-if="file.result?.segments?.length"
             :raw-point-count="file.raw_data?.length ?? file.row_count ?? 0"
             :segments="file.result.segments"
-            :events="file.result.events"
             :globals="file.result.globals"
-            :duplicate-diagnosis="file._duplicate_diagnosis"
             :compression-meta="file.result.compression_meta"
           />
           <div v-else class="cfa-pending-block">

--- a/apps/current-feature-analyzer/frontend/components/LlmResultPanel.vue
+++ b/apps/current-feature-analyzer/frontend/components/LlmResultPanel.vue
@@ -203,7 +203,7 @@ const cycleGroups = computed(() => {
 })
 
 function formatNumber(value: number | null | undefined) {
-  return Number.isFinite(Number(value)) ? Number(value).toFixed(4) : '-'
+  return Number.isFinite(Number(value)) ? Number(value).toFixed(6) : '-'
 }
 
 function formatConfidence(value: number | null | undefined) {

--- a/apps/current-feature-analyzer/frontend/utils/local-analysis.ts
+++ b/apps/current-feature-analyzer/frontend/utils/local-analysis.ts
@@ -266,6 +266,9 @@ function createSegment(points: RawPoint[], startIndex: number, endIndex: number,
     end_time: Number(endTime.toFixed(6)),
     duration: Number(duration.toFixed(6)),
     point_count: pointCount,
+    start_current: Number(startPoint[1].toFixed(6)),
+    end_current: Number(endPoint[1].toFixed(6)),
+    delta_current: Number((endPoint[1] - startPoint[1]).toFixed(6)),
     min_current: Number(minCurrent.toFixed(6)),
     max_current: Number(maxCurrent.toFixed(6)),
     mean_current: Number(meanCurrent.toFixed(6)),
@@ -335,6 +338,9 @@ function summarizeBucket(bucket: InternalSegment[], globals: Globals, options: C
   const bandwidth = maxCurrent - minCurrent
   const slope = duration > 0 ? ((bucket[bucket.length - 1]!.mean_current || 0) - (bucket[0]!.mean_current || 0)) / duration : 0
   const lineFitError = bucket.reduce((sum, item) => sum + (item.line_fit_error || 0) * (item.point_count || 0), 0) / Math.max(pointCount, 1)
+  // 边界电流：取合并前第一个段的 start_current 和最后一个段的 end_current
+  const startCurrent = bucket[0]!.start_current ?? bucket[0]!.mean_current ?? 0
+  const endCurrent = bucket[bucket.length - 1]!.end_current ?? bucket[bucket.length - 1]!.mean_current ?? 0
 
   return {
     segment_index: -1,
@@ -344,6 +350,9 @@ function summarizeBucket(bucket: InternalSegment[], globals: Globals, options: C
     end_time: Number(endTime.toFixed(6)),
     duration: Number(duration.toFixed(6)),
     point_count: pointCount,
+    start_current: Number(startCurrent.toFixed(6)),
+    end_current: Number(endCurrent.toFixed(6)),
+    delta_current: Number((endCurrent - startCurrent).toFixed(6)),
     min_current: Number(minCurrent.toFixed(6)),
     max_current: Number(maxCurrent.toFixed(6)),
     mean_current: Number(meanCurrent.toFixed(6)),
@@ -543,7 +552,11 @@ function runCompression(points: RawPoint[], options: CompressionOptions, globals
   const initialSegments = buildInitialSegments(points, options, globals)
   const mergedSegments = mergeSegments(initialSegments, options, globals)
   const segments = attachPolylinePoints(mergedSegments, points, globals, options) as SegmentItem[]
-  return { globals, segments, events: extractEvents(segments as InternalSegment[]) }
+  return {
+    globals,
+    segments,
+    events: extractEvents(segments as InternalSegment[]),
+  }
 }
 
 function optimizeCompressionOptions(points: RawPoint[], baseOptions: CompressionOptions): OptimizedCompressionResult {

--- a/apps/current-feature-analyzer/server/handlers/analysis/run.js
+++ b/apps/current-feature-analyzer/server/handlers/analysis/run.js
@@ -105,14 +105,19 @@ export async function post(ctx, deps) {
         const globals = normalizedResult.globals || {}
         const segments = Array.isArray(normalizedResult.segments) ? normalizedResult.segments : []
         const events = Array.isArray(normalizedResult.events) ? normalizedResult.events : []
+        const compressionMeta = normalizedResult.compression_meta && typeof normalizedResult.compression_meta === 'object'
+          ? normalizedResult.compression_meta
+          : null
+        const rawData = file.raw_data || []
         const llmResult = await stageRecognitionWorkflowService.recognize(globals, segments, events, ruleSet, appConfig)
-        const stageMetrics = stageMetricsService.calculate(file.raw_data || [], llmResult)
-        const fileMetrics = stageMetricsService.buildFileMetrics(file.raw_data || [], segments, stageMetrics, llmResult)
+        const stageMetrics = stageMetricsService.calculate(rawData, llmResult)
+        const fileMetrics = stageMetricsService.buildFileMetrics(rawData, segments, stageMetrics, llmResult)
 
         uploadSessionService.setFileResult(batch_id, file.file_id, {
           globals,
           segments,
           events,
+          compression_meta: compressionMeta,
           llm_result: llmResult,
           stage_metrics: stageMetrics,
           file_metrics: fileMetrics,

--- a/apps/current-feature-analyzer/server/services/stage-recognition-workflow.service.js
+++ b/apps/current-feature-analyzer/server/services/stage-recognition-workflow.service.js
@@ -349,7 +349,7 @@ class StageRecognitionWorkflowService {
 
     let segText = '';
     for (const seg of segments) {
-      segText += `段${seg.segment_index}: ${seg.kind}, 时间${seg.start_time}s-${seg.end_time}s, 持续${seg.duration}s, 电流均值${seg.mean_current}A, 点数${seg.point_count}, 斜率${seg.slope}, 基线比${seg.baseline_ratio}\n`;
+      segText += `段${seg.segment_index}: ${seg.kind}, 时间${seg.start_time}s-${seg.end_time}s, 持续${seg.duration}s, 电流均值${seg.mean_current}A, 点数${seg.point_count}, 斜率${seg.slope}, 基线比${seg.baseline_ratio}, 开始电流${seg.start_current}A, 结束电流${seg.end_current}A\n`;
     }
 
     let ruleText = '';
@@ -358,19 +358,18 @@ class StageRecognitionWorkflowService {
     }
 
     return `文件摘要:
-总点数: ${segments.reduce((s, seg) => s + seg.point_count, 0)}
-全局: 最小电流 ${globals.min_current}A, 最大电流 ${globals.max_current}A, 均值 ${globals.mean_current}A, 基线均值 ${globals.baseline_mean}A
-  压缩段数量: 原始 ${originalSegmentCount} 段，本次送审 ${segments.length} 段
+ 总点数: ${segments.reduce((s, seg) => s + seg.point_count, 0)}
+ 全局: 最小电流 ${globals.min_current}A, 最大电流 ${globals.max_current}A, 均值 ${globals.mean_current}A, 基线均值 ${globals.baseline_mean}A, 采样间隔${globals.sample_interval}s
+   压缩段数量: 原始 ${originalSegmentCount} 段，本次送审 ${segments.length} 段
 
-压缩段列表:
-${segText}
+ 压缩段列表:
+ ${segText}
+ 当前规则集:
+ 场景说明: ${ruleSet.description || '无'}
+ 阶段定义:
+ ${ruleText}
 
-当前规则集:
-场景说明: ${ruleSet.description || '无'}
-阶段定义:
-${ruleText}
-
-请根据上述压缩段信息和规则集，识别并返回各阶段的起止时间。`;
+ 请根据上述压缩段信息和规则集，识别并返回各阶段的起止时间。`;
   }
 
   reduceSegmentsForLlm(segments) {

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -148,11 +148,23 @@ class AppMarketService {
 
   // ==================== Registry 拉取 ====================
 
+  async fetchLocalIndex() {
+    const indexPath = path.join(this.appsDir, 'index.json');
+    const content = await fs.readFile(indexPath, 'utf-8');
+    return JSON.parse(content);
+  }
+
   /**
-   * 从 GitHub Registry 拉取索引
+   * 从 GitHub Registry 拉取索引（失败时 fallback 到本地）
    */
   async fetchIndex() {
     const config = await this.getRegistryConfig();
+
+    if (config.offline_mode) {
+      logger.info('Offline mode: reading from local apps/index.json');
+      return await this.fetchLocalIndex();
+    }
+
     const url = `${config.registry_url}/index.json`;
     
     logger.info(`Fetching Registry index from: ${url}`);
@@ -169,7 +181,6 @@ class AppMarketService {
       
       const index = await response.json();
       
-      // 更新最后检查时间
       await this.models.SystemSetting.update(
         { setting_value: new Date().toISOString() },
         { where: { setting_key: 'app_market.last_check_at' } }
@@ -177,16 +188,28 @@ class AppMarketService {
       
       return index;
     } catch (error) {
-      logger.error('Failed to fetch Registry index:', error);
-      throw new Error(`无法连接到 App Market Registry: ${error.message}`);
+      logger.warn('Remote Registry failed, fallback to local:', error.message);
+      return await this.fetchLocalIndex();
     }
   }
 
+  async fetchLocalManifest(appId) {
+    const manifestPath = path.join(this.appsDir, appId, 'manifest.json');
+    const content = await fs.readFile(manifestPath, 'utf-8');
+    return JSON.parse(content);
+  }
+
   /**
-   * 从 GitHub Registry 拉取 App manifest
+   * 从 GitHub Registry 拉取 App manifest（失败时 fallback 到本地）
    */
   async fetchManifest(appId) {
     const config = await this.getRegistryConfig();
+
+    if (config.offline_mode) {
+      logger.info(`Offline mode: reading local manifest for ${appId}`);
+      return await this.fetchLocalManifest(appId);
+    }
+
     const url = `${config.registry_url}/${appId}/manifest.json`;
     
     logger.info(`Fetching manifest for ${appId} from: ${url}`);
@@ -206,16 +229,32 @@ class AppMarketService {
       
       return await response.json();
     } catch (error) {
-      logger.error(`Failed to fetch manifest for ${appId}:`, error);
-      throw error;
+      logger.warn(`Remote manifest failed for ${appId}, fallback to local:`, error.message);
+      try {
+        return await this.fetchLocalManifest(appId);
+      } catch (localError) {
+        logger.error(`App ${appId} not found locally either:`, localError.message);
+        throw new Error(`App ${appId} not found in Registry or local apps`);
+      }
     }
   }
 
+  async fetchLocalHandler(appId, handlerName) {
+    const handlerPath = path.join(this.appsDir, appId, 'handlers', handlerName, 'index.js');
+    return await fs.readFile(handlerPath, 'utf-8');
+  }
+
   /**
-   * 拉取处理脚本内容
+   * 拉取处理脚本内容（失败时 fallback 到本地）
    */
   async fetchHandler(appId, handlerName) {
     const config = await this.getRegistryConfig();
+
+    if (config.offline_mode) {
+      logger.info(`Offline mode: reading local handler ${handlerName} for ${appId}`);
+      return await this.fetchLocalHandler(appId, handlerName);
+    }
+
     const url = `${config.registry_url}/${appId}/handlers/${handlerName}/index.js`;
     
     logger.info(`Fetching handler ${handlerName} for ${appId}`);
@@ -229,8 +268,13 @@ class AppMarketService {
       
       return await response.text();
     } catch (error) {
-      logger.error(`Failed to fetch handler ${handlerName}:`, error);
-      throw error;
+      logger.warn(`Remote handler failed for ${handlerName}, fallback to local:`, error.message);
+      try {
+        return await this.fetchLocalHandler(appId, handlerName);
+      } catch (localError) {
+        logger.error(`Handler ${handlerName} not found locally:`, localError.message);
+        throw error;
+      }
     }
   }
 
@@ -315,11 +359,22 @@ class AppMarketService {
     return 0;
   }
 
+  async fetchLocalMigration(appId, scriptPath) {
+    const fullPath = path.join(this.appsDir, appId, scriptPath);
+    return await fs.readFile(fullPath, 'utf-8');
+  }
+
   /**
-   * 拉取迁移脚本
+   * 拉取迁移脚本（失败时 fallback 到本地）
    */
   async fetchMigration(appId, scriptPath) {
     const config = await this.getRegistryConfig();
+
+    if (config.offline_mode) {
+      logger.info(`Offline mode: reading local migration ${scriptPath} for ${appId}`);
+      return await this.fetchLocalMigration(appId, scriptPath);
+    }
+
     const url = `${config.registry_url}/${appId}/${scriptPath}`;
     
     logger.info(`Fetching migration ${scriptPath} for ${appId}`);
@@ -333,8 +388,13 @@ class AppMarketService {
       
       return await response.text();
     } catch (error) {
-      logger.error(`Failed to fetch migration ${scriptPath}:`, error);
-      throw error;
+      logger.warn(`Remote migration failed for ${appId}, fallback to local:`, error.message);
+      try {
+        return await this.fetchLocalMigration(appId, scriptPath);
+      } catch (localError) {
+        logger.error(`Migration ${scriptPath} not found locally:`, localError.message);
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
修复内网服务器无法访问 GitHub 时 App Market 无法使用的问题。

**变更内容：**
- 恢复 fetchIndex/fetchManifest/fetchHandler/fetchMigration 的本地 fallback 逻辑
- 远程 Registry 失败时自动 fallback 到本地 `apps/` 目录
- 离线模式（offline_mode=true）时直接读本地

**测试方法：**
1. 确保服务器上 `apps/` 目录存在且包含所需 App
2. 访问 App Market，验证能正常加载本地应用列表