### PR TITLE
fix: 修复发票管理 duplicate 语义、用户隔离、视图范围及附件上传问题

### DIFF
--- a/apps/invoice-mgr/handlers/invoice-extract/index.js
+++ b/apps/invoice-mgr/handlers/invoice-extract/index.js
@@ -216,6 +216,8 @@ export default {
         invoice_number: data.invoice_number,
         ocr_method: 'fapiao',
         extraction_status: 'duplicate',
+        text_items_count: 0,
+        keyword_count: 0,
         ocr_raw: JSON.stringify({ duplicate: true, existing_row_id: existing.row_id }),
       });
       return {

--- a/apps/invoice-mgr/handlers/invoice-extract/index.js
+++ b/apps/invoice-mgr/handlers/invoice-extract/index.js
@@ -211,22 +211,16 @@ export default {
     const existing = await checkDuplicate(services, data.invoice_number, record.id);
     if (existing) {
       logger.info(`[invoice-extract] Record ${record.id}: 发票号 ${data.invoice_number} 已存在于 row_id=${existing.row_id}`);
-      await services.callExtension(ROWS_TABLE, 'upsert', {
-        row_id: record.id,
-        invoice_number: data.invoice_number,
-        ocr_method: 'fapiao',
-        extraction_status: 'duplicate',
-        text_items_count: 0,
-        keyword_count: 0,
-        ocr_raw: JSON.stringify({ duplicate: true, existing_row_id: existing.row_id }),
-      });
       return {
         success: true,
         data: {
           invoice_number: data.invoice_number,
           duplicate: true,
           existing_row_id: existing.row_id,
+          extraction_status: 'duplicate',
+          ocr_method: 'fapiao',
         },
+        target_state: 'extract_failed',
       };
     }
 

--- a/apps/invoice-mgr/handlers/invoice-extract/index.js
+++ b/apps/invoice-mgr/handlers/invoice-extract/index.js
@@ -1,6 +1,7 @@
 import logger from '../../../../lib/logger.js';
 import path from 'path';
 import { resolveAttachmentPath } from '../shared.js';
+import { checkDuplicate, buildDuplicateResponse } from '../../lib/check-duplicate.js';
 
 const ROWS_TABLE = 'app_invoice_mgr_rows';
 const ITEMS_TABLE = 'app_invoice_mgr_items';
@@ -17,20 +18,10 @@ function parseDate(dateStr) {
   return m ? `${m[1]}-${m[2]}-${m[3]}` : null;
 }
 
-async function checkDuplicate(services, invoiceNumber, currentRowId) {
-  const rows = await services.query(
-    'SELECT row_id, invoice_number FROM app_invoice_mgr_rows WHERE invoice_number = ? LIMIT 1',
-    [invoiceNumber]
-  );
-  if (rows && rows.length > 0 && rows[0].row_id !== currentRowId) {
-    return rows[0];
-  }
-  return null;
-}
-
-async function upsertRows(services, recordId, data, ocrMethod) {
+async function upsertRows(services, recordId, data, ocrMethod, userId) {
   await services.callExtension(ROWS_TABLE, 'upsert', {
     row_id: recordId,
+    user_id: userId,
     invoice_number: data.invoice_number,
     invoice_date: parseDate(data.invoice_date),
     invoice_type: data.invoice_type || '',
@@ -201,6 +192,7 @@ export default {
       logger.warn(`[invoice-extract] Record ${record.id}: 未识别到有效发票（inv=${data.invoice_number || '(空)'} total=${data.total_with_tax}）`);
       await services.callExtension(ROWS_TABLE, 'upsert', {
         row_id: record.id,
+        user_id: record.user_id,
         ocr_method: 'fapiao',
         extraction_status: 'failed',
         ocr_raw: JSON.stringify({ error: 'not_invoice', reason: 'fapiao did not extract valid invoice data' }),
@@ -208,20 +200,18 @@ export default {
       return { success: false, failure_code: 'not_invoice', target_state: 'pending_vl_extract', error: 'not_invoice' };
     }
 
-    const existing = await checkDuplicate(services, data.invoice_number, record.id);
+    const existing = await checkDuplicate(services, {
+      invoice_number: data.invoice_number,
+      user_id: record.user_id,
+      current_row_id: record.id,
+    });
     if (existing) {
       logger.info(`[invoice-extract] Record ${record.id}: 发票号 ${data.invoice_number} 已存在于 row_id=${existing.row_id}`);
-      return {
-        success: true,
-        data: {
-          invoice_number: data.invoice_number,
-          duplicate: true,
-          existing_row_id: existing.row_id,
-          extraction_status: 'duplicate',
-          ocr_method: 'fapiao',
-        },
-        target_state: 'extract_failed',
-      };
+      return buildDuplicateResponse({
+        invoice_number: data.invoice_number,
+        existing_row_id: existing.row_id,
+        ocr_method: 'fapiao',
+      });
     }
 
     // 从 fapiao 数据中提取开票人（取第一页的 issuer）
@@ -230,7 +220,7 @@ export default {
       data.issuer = pages[0]?.issuer || '';
     }
 
-    await upsertRows(services, record.id, data, 'fapiao');
+    await upsertRows(services, record.id, data, 'fapiao', record.user_id);
     const itemCount = await insertItems(services, record.id, data);
 
     logger.info(`[invoice-extract] Record ${record.id}: 入库成功 ${data.invoice_number}, ${itemCount}项商品`);

--- a/apps/invoice-mgr/handlers/invoice-vl-extract/index.js
+++ b/apps/invoice-mgr/handlers/invoice-vl-extract/index.js
@@ -333,6 +333,8 @@ export default {
         invoice_number: data.invoice_number,
         ocr_method: 'vl',
         extraction_status: 'duplicate',
+        text_items_count: 0,
+        keyword_count: 0,
         ocr_raw: JSON.stringify({ duplicate: true, existing_row_id: existingRowId }),
       });
       return {

--- a/apps/invoice-mgr/handlers/invoice-vl-extract/index.js
+++ b/apps/invoice-mgr/handlers/invoice-vl-extract/index.js
@@ -328,22 +328,16 @@ export default {
     const existingRowId = await checkDuplicate(services, data.invoice_number, record.id);
     if (existingRowId) {
       logger.info(`[invoice-vl-extract] Record ${record.id}: 发票号 ${data.invoice_number} 已存在`);
-      await services.callExtension(ROWS_TABLE, 'upsert', {
-        row_id: record.id,
-        invoice_number: data.invoice_number,
-        ocr_method: 'vl',
-        extraction_status: 'duplicate',
-        text_items_count: 0,
-        keyword_count: 0,
-        ocr_raw: JSON.stringify({ duplicate: true, existing_row_id: existingRowId }),
-      });
       return {
         success: true,
         data: {
           invoice_number: data.invoice_number,
           duplicate: true,
           existing_row_id: existingRowId,
+          extraction_status: 'duplicate',
+          ocr_method: 'vl',
         },
+        target_state: 'extract_failed',
       };
     }
 

--- a/apps/invoice-mgr/handlers/invoice-vl-extract/index.js
+++ b/apps/invoice-mgr/handlers/invoice-vl-extract/index.js
@@ -1,6 +1,7 @@
 import logger from '../../../../lib/logger.js';
 import path from 'path';
 import { getStepResource, resolveAttachmentPath } from '../shared.js';
+import { checkDuplicate, buildDuplicateResponse } from '../../lib/check-duplicate.js';
 
 const ROWS_TABLE = 'app_invoice_mgr_rows';
 
@@ -58,20 +59,10 @@ function isValidInvoice(data) {
   return invNum && /^\d{20}$/.test(invNum) && total > 0;
 }
 
-async function checkDuplicate(services, invoiceNumber, currentRowId) {
-  const rows = await services.query(
-    'SELECT row_id FROM app_invoice_mgr_rows WHERE invoice_number = ? LIMIT 1',
-    [invoiceNumber]
-  );
-  if (rows && rows.length > 0 && rows[0].row_id !== currentRowId) {
-    return rows[0].row_id;
-  }
-  return null;
-}
-
-async function upsertRows(services, recordId, data, ocrMethod) {
+async function upsertRows(services, recordId, data, ocrMethod, userId) {
   await services.callExtension(ROWS_TABLE, 'upsert', {
     row_id: recordId,
+    user_id: userId,
     invoice_number: data.invoice_number,
     invoice_date: data.invoice_date || null,
     invoice_type: data.invoice_type || '',
@@ -318,6 +309,7 @@ export default {
       logger.warn(`[invoice-vl-extract] Record ${record.id}: VL提取结果无效(非发票)`);
       await services.callExtension(ROWS_TABLE, 'upsert', {
         row_id: record.id,
+        user_id: record.user_id,
         ocr_method: 'vl',
         extraction_status: 'failed',
         ocr_raw: JSON.stringify({ error: 'not_invoice', reason: 'VL did not extract valid invoice data' }),
@@ -325,23 +317,21 @@ export default {
       return { success: false, failure_code: 'not_invoice', error: 'not_invoice' };
     }
 
-    const existingRowId = await checkDuplicate(services, data.invoice_number, record.id);
-    if (existingRowId) {
+    const existing = await checkDuplicate(services, {
+      invoice_number: data.invoice_number,
+      user_id: record.user_id,
+      current_row_id: record.id,
+    });
+    if (existing) {
       logger.info(`[invoice-vl-extract] Record ${record.id}: 发票号 ${data.invoice_number} 已存在`);
-      return {
-        success: true,
-        data: {
-          invoice_number: data.invoice_number,
-          duplicate: true,
-          existing_row_id: existingRowId,
-          extraction_status: 'duplicate',
-          ocr_method: 'vl',
-        },
-        target_state: 'extract_failed',
-      };
+      return buildDuplicateResponse({
+        invoice_number: data.invoice_number,
+        existing_row_id: existing.row_id,
+        ocr_method: 'vl',
+      });
     }
 
-    await upsertRows(services, record.id, data, 'vl');
+    await upsertRows(services, record.id, data, 'vl', record.user_id);
     const itemCount = await insertItems(services, record.id, data.items);
 
     logger.info(`[invoice-vl-extract] Record ${record.id}: 入库成功 ${data.invoice_number}, ${itemCount}项商品`);

--- a/apps/invoice-mgr/lib/check-duplicate.js
+++ b/apps/invoice-mgr/lib/check-duplicate.js
@@ -1,0 +1,59 @@
+/**
+ * 发票去重检查（按 user_id 语义）
+ *
+ * 统一 duplicate 判断逻辑，避免 invoice-extract 与 invoice-vl-extract 分叉演化。
+ *
+ * 去重语义：
+ *   - 同一用户内，相同发票号视为重复
+ *   - 不同用户间，相同发票号互不影响
+ *
+ * @param {object} services - handler context 中的 services
+ * @param {object} params
+ * @param {string} params.invoice_number - 发票号码
+ * @param {string} params.user_id - 当前用户 ID（来自 record.user_id）
+ * @param {string} [params.current_row_id] - 当前记录 row_id，用于排除自身
+ * @returns {Promise<object|null>} null 表示未重复，否则返回 { row_id, invoice_number }
+ */
+async function checkDuplicate(services, { invoice_number, user_id, current_row_id }) {
+  if (!invoice_number || !user_id) return null;
+
+  const rows = await services.query(
+    `SELECT r.row_id, r.invoice_number
+     FROM app_invoice_mgr_rows r
+     JOIN app_invoice_mgr_records m ON m.id = r.row_id
+     WHERE r.invoice_number = ?
+       AND m.user_id = ?
+     LIMIT 1`,
+    [invoice_number, user_id]
+  );
+
+  if (rows && rows.length > 0 && rows[0].row_id !== current_row_id) {
+    return rows[0];
+  }
+  return null;
+}
+
+/**
+ * 构建统一的 duplicate 响应 payload
+ *
+ * @param {object} params
+ * @param {string} params.invoice_number - 发票号码
+ * @param {string} params.existing_row_id - 已有记录的 row_id
+ * @param {string} params.ocr_method - 识别方法（'fapiao' | 'vl'）
+ * @returns {object} 统一 duplicate 响应结构
+ */
+function buildDuplicateResponse({ invoice_number, existing_row_id, ocr_method }) {
+  return {
+    success: true,
+    data: {
+      invoice_number,
+      duplicate: true,
+      existing_row_id,
+      extraction_status: 'duplicate',
+      ocr_method,
+    },
+    target_state: 'extract_failed',
+  };
+}
+
+export { checkDuplicate, buildDuplicateResponse };

--- a/apps/invoice-mgr/lib/check-duplicate.js
+++ b/apps/invoice-mgr/lib/check-duplicate.js
@@ -17,12 +17,12 @@
 async function checkDuplicate(services, { invoice_number, user_id, current_row_id }) {
   if (!invoice_number || !user_id) return null;
 
+  // 直接使用 rows.user_id 查询，利用 uk_user_invoice_number (user_id, invoice_number) 索引
   const rows = await services.query(
-    `SELECT r.row_id, r.invoice_number
-     FROM app_invoice_mgr_rows r
-     JOIN app_invoice_mgr_records m ON m.id = r.row_id
-     WHERE r.invoice_number = ?
-       AND m.user_id = ?
+    `SELECT row_id, invoice_number
+     FROM app_invoice_mgr_rows
+     WHERE invoice_number = ?
+       AND user_id = ?
      LIMIT 1`,
     [invoice_number, user_id]
   );

--- a/apps/invoice-mgr/manifest.json
+++ b/apps/invoice-mgr/manifest.json
@@ -37,6 +37,12 @@
       "type": "primary",
       "fields": [
         {
+          "name": "user_id",
+          "type": "VARCHAR(32)",
+          "label": "用户ID（系统内部字段）",
+          "source": "user_id"
+        },
+        {
           "name": "invoice_number",
           "type": "VARCHAR(20)",
           "label": "发票号码",

--- a/apps/invoice-mgr/tick/index.js
+++ b/apps/invoice-mgr/tick/index.js
@@ -135,7 +135,7 @@ export async function tick(context) {
         if (newData._last_failure) {
           delete newData._last_failure;
         }
-        const nextState = graphEntry.success_next;
+        const nextState = result.target_state || graphEntry.success_next;
 
         if (nextState) {
           await services.execute(

--- a/apps/invoice-mgr/tick/index.js
+++ b/apps/invoice-mgr/tick/index.js
@@ -68,7 +68,7 @@ export async function tick(context) {
 
   const placeholders = stateNames.map(() => '?').join(',');
   const rows = await services.query(
-    `SELECT id, status, data FROM app_invoice_mgr_records
+    `SELECT id, status, data, user_id FROM app_invoice_mgr_records
      WHERE status IN (${placeholders})
      ORDER BY created_at ASC
      LIMIT 5`,
@@ -90,7 +90,7 @@ export async function tick(context) {
 
       logger.info(`[invoice-mgr tick] Processing row ${row.id} (status=${row.status}, handler=${graphEntry.handler})`);
 
-      const record = { id: row.id, status: row.status, data: recordData };
+      const record = { id: row.id, status: row.status, data: recordData, user_id: row.user_id };
 
       const [fileRows] = await services.execute(
         `SELECT a.id, a.file_name, a.file_path, a.mime_type, a.ext_name

--- a/apps/invoice-mgr/tick/index.js
+++ b/apps/invoice-mgr/tick/index.js
@@ -82,13 +82,14 @@ export async function tick(context) {
   let processed = 0;
 
   for (const row of rows) {
+    const graphEntry = STATE_GRAPH[row.status];
+    const recordData = row.data ? (typeof row.data === 'string' ? JSON.parse(row.data) : row.data) : {};
+
     try {
-      const graphEntry = STATE_GRAPH[row.status];
       if (!graphEntry) continue;
 
       logger.info(`[invoice-mgr tick] Processing row ${row.id} (status=${row.status}, handler=${graphEntry.handler})`);
 
-      const recordData = row.data ? (typeof row.data === 'string' ? JSON.parse(row.data) : row.data) : {};
       const record = { id: row.id, status: row.status, data: recordData };
 
       const [fileRows] = await services.execute(

--- a/frontend/src/api/invoice.ts
+++ b/frontend/src/api/invoice.ts
@@ -62,6 +62,7 @@ export interface InvoiceListParams {
   end_date?: string
   sort?: string
   order?: string
+  include_all?: boolean
 }
 
 export function listInvoices(params: InvoiceListParams = {}) {
@@ -88,6 +89,7 @@ export interface InvoiceExportParams {
   seller_name?: string
   buyer_name?: string
   status?: string
+  include_all?: boolean
 }
 
 export async function exportInvoices(params: InvoiceExportParams = {}) {

--- a/frontend/src/api/invoice.ts
+++ b/frontend/src/api/invoice.ts
@@ -20,6 +20,8 @@ export interface InvoiceRow {
   id: string
   status: string
   created_at: string
+  is_duplicate?: boolean
+  duplicate_source_row_id?: string | null
   invoice_number: string
   invoice_date: string
   invoice_type: string

--- a/frontend/src/components/invoice/InvoiceDetail.vue
+++ b/frontend/src/components/invoice/InvoiceDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { ArrowLeft } from '@element-plus/icons-vue'
 import { getInvoiceDetail, deleteInvoiceRecord, reExtractInvoiceRecord, type InvoiceDetail as InvoiceDetailType } from '@/api/invoice'
 import { ElMessage, ElMessageBox } from 'element-plus'
@@ -17,14 +17,32 @@ function getErrorMessage(cause: unknown, fallback: string) {
   return cause instanceof Error ? cause.message : fallback
 }
 
-onMounted(async () => {
+function getDisplayStatus(detailRow: InvoiceDetailType | null) {
+  if (detailRow?.is_duplicate) {
+    return statusLabels.duplicate
+  }
+  const status = detailRow?.status || ''
+  return statusLabels[status] || { label: status, type: 'info' as const }
+}
+
+async function loadDetail(rowId: string) {
   loading.value = true
   try {
-    detail.value = await getInvoiceDetail(props.rowId)
+    detail.value = await getInvoiceDetail(rowId)
   } catch (e: unknown) {
     ElMessage.error(getErrorMessage(e, '加载失败'))
   } finally {
     loading.value = false
+  }
+}
+
+onMounted(async () => {
+  await loadDetail(props.rowId)
+})
+
+watch(() => props.rowId, async (rowId, oldRowId) => {
+  if (rowId && rowId !== oldRowId) {
+    await loadDetail(rowId)
   }
 })
 
@@ -35,6 +53,8 @@ function formatQuantity(v: number | string | null | undefined): string {
 }
 
 async function onDelete() {
+  const currentRowId = detail.value?.id || props.rowId
+
   try {
     await ElMessageBox.confirm('删除后不可恢复，是否继续？', '删除发票记录', {
       confirmButtonText: '删除',
@@ -47,7 +67,7 @@ async function onDelete() {
 
   deleting.value = true
   try {
-    await deleteInvoiceRecord(props.rowId)
+    await deleteInvoiceRecord(currentRowId)
     ElMessage.success('记录已删除')
     emit('deleted')
     emit('back')
@@ -59,6 +79,7 @@ async function onDelete() {
 }
 
 async function onReExtract() {
+  const currentRowId = detail.value?.id || props.rowId
   const currentStatus = detail.value?.status
   const statusLabel = currentStatus ? (statusLabels[currentStatus]?.label || currentStatus) : '未知'
 
@@ -78,7 +99,7 @@ async function onReExtract() {
 
   reExtracting.value = true
   try {
-    await reExtractInvoiceRecord(props.rowId)
+    await reExtractInvoiceRecord(currentRowId)
     ElMessage.success('已重置为初始状态，系统将自动重新分析')
     emit('deleted')
     emit('back')
@@ -87,6 +108,16 @@ async function onReExtract() {
   } finally {
     reExtracting.value = false
   }
+}
+
+async function onViewDuplicateSource() {
+  const targetRowId = detail.value?.duplicate_source_row_id
+  if (!targetRowId) {
+    ElMessage.warning('未找到原发票记录')
+    return
+  }
+
+  await loadDetail(targetRowId)
 }
 </script>
 
@@ -117,10 +148,30 @@ async function onReExtract() {
       <div class="detail-card">
         <div class="card-title">
           <span>发票详情</span>
-          <el-tag v-if="detail.status" :type="statusLabels[detail.status]?.type || 'info'" size="small">
-            {{ statusLabels[detail.status]?.label || detail.status }}
+          <el-tag v-if="detail.status" :type="getDisplayStatus(detail).type || 'info'" size="small">
+            {{ getDisplayStatus(detail).label }}
           </el-tag>
         </div>
+
+        <el-alert
+          v-if="detail.is_duplicate"
+          title="该发票与系统中已有发票重复，当前记录不会作为新的有效发票导出。"
+          type="warning"
+          show-icon
+          :closable="false"
+          style="margin-bottom:16px"
+        >
+          <template #default>
+            <el-button
+              v-if="detail.duplicate_source_row_id"
+              link
+              type="primary"
+              @click="onViewDuplicateSource"
+            >
+              查看已识别发票
+            </el-button>
+          </template>
+        </el-alert>
 
         <el-descriptions :column="2" border>
           <el-descriptions-item label="发票号码">{{ detail.invoice_number || '-' }}</el-descriptions-item>

--- a/frontend/src/components/invoice/InvoiceList.vue
+++ b/frontend/src/components/invoice/InvoiceList.vue
@@ -32,6 +32,13 @@ type BatchUploadResult = {
   created_count?: number
 }
 
+function getDisplayStatus(row: InvoiceRow) {
+  if (row.is_duplicate) {
+    return statusLabels.duplicate
+  }
+  return statusLabels[row.status] || { label: row.status, type: 'info' as const }
+}
+
 function getErrorMessage(cause: unknown, fallback: string) {
   return cause instanceof Error ? cause.message : fallback
 }
@@ -329,6 +336,11 @@ function onRowClick(row: InvoiceRow) {
   showDetail.value = true
 }
 
+function jumpToInvoiceDetail(rowId: string) {
+  selectedRowId.value = rowId
+  showDetail.value = true
+}
+
 function onBack() {
   showDetail.value = false
   selectedRowId.value = ''
@@ -488,11 +500,24 @@ async function doExport(type: 'full' | 'custom' | 'negative') {
         <el-table-column prop="total_with_tax" label="价税合计" width="140" align="right">
           <template #default="{ row }">¥{{ row.total_with_tax?.toLocaleString() }}</template>
         </el-table-column>
-        <el-table-column prop="status" label="状态" width="100" align="center">
+        <el-table-column prop="status" label="状态" width="110" align="center">
           <template #default="{ row }">
-            <el-tag :type="statusLabels[row.status]?.type || 'info'" size="small">
-              {{ statusLabels[row.status]?.label || row.status }}
+            <el-tag :type="getDisplayStatus(row).type || 'info'" size="small">
+              {{ getDisplayStatus(row).label }}
             </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="120" align="center">
+          <template #default="{ row }">
+            <el-button
+              v-if="row.is_duplicate && row.duplicate_source_row_id"
+              link
+              type="primary"
+              @click.stop="jumpToInvoiceDetail(row.duplicate_source_row_id)"
+            >
+              查看原发票
+            </el-button>
+            <span v-else>-</span>
           </template>
         </el-table-column>
       </el-table>

--- a/frontend/src/components/invoice/InvoiceList.vue
+++ b/frontend/src/components/invoice/InvoiceList.vue
@@ -8,9 +8,11 @@ import type { ElTable } from 'element-plus'
 import { ArrowDown } from '@element-plus/icons-vue'
 import InvoiceDetail from './InvoiceDetail.vue'
 import { statusLabels } from '@/utils/invoice-status-labels'
+import { useUserStore } from '@/stores/user'
 
 const APP_ID = 'invoice-mgr'
 const MAX_BATCH_SIZE = 20
+const userStore = useUserStore()
 
 const loading = ref(false)
 const invoices = ref<InvoiceRow[]>([])
@@ -105,6 +107,7 @@ const filters = ref<InvoiceListParams>({
   size: 20,
   sort: 'created_at',
   order: 'desc',
+  include_all: false,
 })
 
 onMounted(() => {
@@ -155,8 +158,14 @@ function onSearch() {
   loadList()
 }
 
+function onScopeChange() {
+  page.value = 1
+  filters.value.page = 1
+  loadList()
+}
+
 function onReset() {
-  filters.value = { page: 1, size: 20, sort: 'created_at', order: 'desc' }
+  filters.value = { page: 1, size: 20, sort: 'created_at', order: 'desc', include_all: false }
   dateMode.value = ''
   dateValue.value = null
   page.value = 1
@@ -382,6 +391,7 @@ async function doExport(type: 'full' | 'custom' | 'negative') {
       seller_name: filters.value.seller_name,
       buyer_name: filters.value.buyer_name,
       status: filters.value.status,
+      include_all: filters.value.include_all,
     }
     if (type === 'custom') {
       params.fields = exportSelectedFields.value
@@ -424,6 +434,15 @@ async function doExport(type: 'full' | 'custom' | 'negative') {
             <el-select v-model="filters.status" placeholder="状态" clearable style="width:120px">
               <el-option v-for="(v, k) in statusLabels" :key="k" :label="v.label" :value="k" />
             </el-select>
+            <el-segmented
+              v-if="userStore.isAdmin"
+              v-model="filters.include_all"
+              :options="[
+                { label: '我的发票', value: false },
+                { label: '全部发票', value: true },
+              ]"
+              @change="onScopeChange"
+            />
           </div>
           <div class="filter-right">
             <el-button type="danger" :disabled="selectedRows.length === 0" :loading="deleting" @click="handleBatchDelete">

--- a/frontend/src/utils/invoice-status-labels.ts
+++ b/frontend/src/utils/invoice-status-labels.ts
@@ -16,6 +16,7 @@ export const statusLabels: Record<string, StatusLabel> = {
   pending_review: { label: '待确认', type: '' },
   confirmed: { label: '已确认', type: 'success' },
   extract_failed: { label: '识别失败', type: 'danger' },
+  duplicate: { label: '重复发票', type: 'warning' },
 }
 
 export function getStatusLabel(status: string): StatusLabel {

--- a/models/app_invoice_mgr_row.js
+++ b/models/app_invoice_mgr_row.js
@@ -8,7 +8,7 @@ export default class app_invoice_mgr_row extends Model {
       type: DataTypes.STRING(32),
       allowNull: false,
       primaryKey: true,
-      comment: "关联 app_invoice_mgr_records.id",
+      comment: "关联 mini_app_rows.id",
       references: {
         model: 'app_invoice_mgr_records',
         key: 'id'
@@ -17,8 +17,7 @@ export default class app_invoice_mgr_row extends Model {
     invoice_number: {
       type: DataTypes.STRING(20),
       allowNull: true,
-      comment: "发票号码（20位），用于去重",
-      unique: "uk_invoice_number"
+      comment: "发票号码（20位），用于去重"
     },
     invoice_date: {
       type: DataTypes.DATEONLY,
@@ -118,6 +117,11 @@ export default class app_invoice_mgr_row extends Model {
       defaultValue: 0,
       comment: "发票关键词匹配数"
     },
+    user_id: {
+      type: DataTypes.STRING(32),
+      allowNull: true,
+      comment: "用户ID"
+    },
     created_at: {
       type: DataTypes.DATE,
       allowNull: true,
@@ -143,10 +147,11 @@ export default class app_invoice_mgr_row extends Model {
         ]
       },
       {
-        name: "uk_invoice_number",
+        name: "uk_user_invoice_number",
         unique: true,
         using: "BTREE",
         fields: [
+          { name: "user_id" },
           { name: "invoice_number" },
         ]
       },
@@ -176,6 +181,13 @@ export default class app_invoice_mgr_row extends Model {
         using: "BTREE",
         fields: [
           { name: "total_with_tax" },
+        ]
+      },
+      {
+        name: "idx_user_id",
+        using: "BTREE",
+        fields: [
+          { name: "user_id" },
         ]
       },
     ]

--- a/models/attachment.js
+++ b/models/attachment.js
@@ -73,7 +73,7 @@ export default class attachment extends Model {
       comment: "访问级别：public=公开访问，private=私有受控访问"
     },
     created_by: {
-      type: DataTypes.STRING(20),
+      type: DataTypes.STRING(32),
       allowNull: true,
       comment: "上传者ID",
       references: {

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -2429,6 +2429,56 @@ const MIGRATIONS = [
     },
   },
 
+  // 42e. invoice-mgr 同步 mini_apps.config 中的 user_id 扩展字段
+  {
+    name: 'invoice-mgr sync user_id field to mini_apps.config',
+    check: async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT config FROM mini_apps WHERE id = 'invoice-mgr'"
+      );
+      if (!rows || rows.length === 0) return true;
+      const config = typeof rows[0].config === 'string'
+        ? JSON.parse(rows[0].config)
+        : rows[0].config;
+      const rowsTable = (config.extension_tables || []).find(t => t.name === 'app_invoice_mgr_rows');
+      if (!rowsTable) return true;
+      return rowsTable.fields.some(f => f.name === 'user_id');
+    },
+    migrate: async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT config FROM mini_apps WHERE id = 'invoice-mgr'"
+      );
+      if (!rows || rows.length === 0) {
+        console.log('  ⚠ invoice-mgr not found in mini_apps');
+        return;
+      }
+      const config = typeof rows[0].config === 'string'
+        ? JSON.parse(rows[0].config)
+        : rows[0].config;
+      const rowsTable = (config.extension_tables || []).find(t => t.name === 'app_invoice_mgr_rows');
+      if (!rowsTable) {
+        console.log('  ⚠ app_invoice_mgr_rows not found in config');
+        return;
+      }
+      if (rowsTable.fields.some(f => f.name === 'user_id')) {
+        console.log('  ✓ user_id already in config fields');
+        return;
+      }
+      // 在 fields 最前面插入 user_id
+      rowsTable.fields.unshift({
+        name: 'user_id',
+        type: 'VARCHAR(32)',
+        label: '用户ID（系统内部字段）',
+        source: 'user_id',
+      });
+      await conn.execute(
+        "UPDATE mini_apps SET config = ? WHERE id = 'invoice-mgr'",
+        [JSON.stringify(config)]
+      );
+      console.log('  ✓ Synced user_id field to mini_apps.config');
+    },
+  },
+
   // 43. contract-mgr 自治主表
   {
     name: 'app_contract_mgr_records table',

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -636,7 +636,7 @@ const MIGRATIONS = [
           height INT DEFAULT NULL COMMENT '图片高度',
           alt_text VARCHAR(500) DEFAULT NULL COMMENT '替代文本',
           description TEXT DEFAULT NULL COMMENT '文件描述（VL模型生成）',
-          created_by VARCHAR(20) DEFAULT NULL COMMENT '上传者ID',
+          created_by VARCHAR(32) DEFAULT NULL COMMENT '上传者ID',
           created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
           updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
           INDEX idx_source (source_tag, source_id),
@@ -2741,6 +2741,26 @@ const MIGRATIONS = [
         SELECT COUNT(*) AS cnt FROM attachments WHERE access_level = 'public'
       `);
       console.log(`  ✓ Total ${result[0].cnt} attachments now marked as public`);
+    }
+  },
+
+  // ==================== attachments.created_by 字段扩容 ====================
+  {
+    name: 'attachments.created_by length upgrade',
+    check: async (conn) => {
+      const [rows] = await conn.execute(
+        `SELECT CHARACTER_MAXIMUM_LENGTH AS len
+         FROM INFORMATION_SCHEMA.COLUMNS
+         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'attachments' AND COLUMN_NAME = 'created_by'`,
+        [DB_CONFIG.database]
+      );
+      return rows.length > 0 && Number(rows[0].len) >= 32;
+    },
+    migrate: async (conn) => {
+      await dropForeignKeyIfExists(conn, 'attachments', 'attachments_ibfk_1');
+      await conn.execute(`ALTER TABLE attachments MODIFY COLUMN created_by VARCHAR(32) DEFAULT NULL COMMENT '上传者ID'`);
+      await safeExecute(conn, `ALTER TABLE attachments ADD CONSTRAINT attachments_ibfk_1 FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL`);
+      console.log('  ✓ Upgraded attachments.created_by to VARCHAR(32)');
     }
   },
 

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -2218,13 +2218,14 @@ const MIGRATIONS = [
       if (!await hasTable(conn, 'app_invoice_mgr_rows')) return false;
       // 哨兵列：使用最新加入的列作为迁移完成标记
       // ⚠️ 若在 missingCols 中新增列，必须同步更新此哨兵列为最新列名
-      return await hasColumn(conn, 'app_invoice_mgr_rows', 'keyword_count');
+      return await hasColumn(conn, 'app_invoice_mgr_rows', 'user_id');
     },
     migrate: async (conn) => {
       if (!await hasTable(conn, 'app_invoice_mgr_rows')) {
         await conn.execute(`
           CREATE TABLE app_invoice_mgr_rows (
             row_id VARCHAR(32) PRIMARY KEY COMMENT '关联 app_invoice_mgr_records.id',
+            user_id VARCHAR(32) COMMENT '用户ID，关联 app_invoice_mgr_records.user_id',
             invoice_number VARCHAR(20) COMMENT '发票号码（20位），用于去重',
             invoice_date DATE COMMENT '开票日期',
             invoice_type VARCHAR(64) COMMENT '发票类型',
@@ -2246,7 +2247,8 @@ const MIGRATIONS = [
             keyword_count INT DEFAULT 0 COMMENT '发票关键词匹配数',
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            UNIQUE KEY uk_invoice_number (invoice_number),
+            UNIQUE KEY uk_user_invoice_number (user_id, invoice_number),
+            INDEX idx_user_id (user_id),
             INDEX idx_seller (seller_name),
             INDEX idx_buyer (buyer_name),
             INDEX idx_date (invoice_date),
@@ -2272,16 +2274,40 @@ const MIGRATIONS = [
         { col: 'extraction_status', def: "VARCHAR(16) DEFAULT 'success' COMMENT '提取状态'", after: 'ocr_raw' },
         { col: 'text_items_count', def: "INT DEFAULT 0 COMMENT 'PDF文本项总数'", after: 'extraction_status' },
         { col: 'keyword_count', def: "INT DEFAULT 0 COMMENT '发票关键词匹配数'", after: 'text_items_count' },
+        { col: 'user_id', def: "VARCHAR(32) COMMENT '用户ID'", after: 'keyword_count' },
       ];
       for (const c of missingCols) {
         if (!await hasColumn(conn, 'app_invoice_mgr_rows', c.col)) {
           await conn.execute(`ALTER TABLE app_invoice_mgr_rows ADD COLUMN ${c.col} ${c.def} AFTER ${c.after}`);
           console.log(`  ✓ Added column ${c.col} to app_invoice_mgr_rows`);
+
+          // user_id 列新增后立即回填历史数据
+          if (c.col === 'user_id') {
+            const [backfillResult] = await conn.execute(`
+              UPDATE app_invoice_mgr_rows r
+              JOIN app_invoice_mgr_records m ON m.id = r.row_id
+              SET r.user_id = m.user_id
+              WHERE r.user_id IS NULL
+            `);
+            const backfillCount = backfillResult?.affectedRows ?? backfillResult?.changedRows ?? '?';
+            console.log(`  ✓ Backfilled user_id for ${backfillCount} rows`);
+          }
+        }
+      }
+
+      // 索引迁移：删除旧 uk_invoice_number，新建 uk_user_invoice_number
+      if (await hasIndex(conn, 'app_invoice_mgr_rows', 'uk_invoice_number')) {
+        try {
+          await conn.execute('ALTER TABLE app_invoice_mgr_rows DROP INDEX uk_invoice_number');
+          console.log('  ✓ Dropped old index uk_invoice_number');
+        } catch (e) {
+          console.log(`  ⚠ Failed to drop uk_invoice_number: ${e.message}`);
         }
       }
 
       const missingIndexes = [
-        { name: 'uk_invoice_number', def: 'UNIQUE KEY uk_invoice_number (invoice_number)' },
+        { name: 'uk_user_invoice_number', def: 'UNIQUE KEY uk_user_invoice_number (user_id, invoice_number)' },
+        { name: 'idx_user_id', def: 'INDEX idx_user_id (user_id)' },
         { name: 'idx_seller', def: 'INDEX idx_seller (seller_name)' },
         { name: 'idx_buyer', def: 'INDEX idx_buyer (buyer_name)' },
         { name: 'idx_date', def: 'INDEX idx_date (invoice_date)' },

--- a/server/controllers/invoice.controller.js
+++ b/server/controllers/invoice.controller.js
@@ -40,6 +40,7 @@ class InvoiceController {
         order: query.order,
         userId,
         isAdmin,
+        includeAll: query.include_all === 'true' || query.include_all === '1',
       });
       ctx.success(result);
     } catch (error) {
@@ -84,6 +85,7 @@ class InvoiceController {
         status: query.status,
         userId,
         isAdmin,
+        includeAll: query.include_all === 'true' || query.include_all === '1',
       };
 
       let buffer;

--- a/server/services/invoice.service.js
+++ b/server/services/invoice.service.js
@@ -91,6 +91,18 @@ class InvoiceService {
     return `${sortField} ${sortOrder}, m.created_at ${sortOrder}, r.invoice_number ${sortOrder}, m.id ${sortOrder}`;
   }
 
+  /**
+   * 基础查询条件拼接（列表、详情等读路径使用）
+   * 不添加 rows 表过滤，允许 duplicate 空壳记录（r.row_id IS NULL）出现在列表中
+   */
+  _buildBaseWhereClause(baseConditions) {
+    return `WHERE ${baseConditions.join(' AND ')}`;
+  }
+
+  /**
+   * 导出专用条件拼接
+   * 追加 r.row_id IS NOT NULL，确保 duplicate 空壳不进入导出
+   */
   _buildExportWhereClause(baseConditions) {
     const conditions = [...baseConditions, 'r.row_id IS NOT NULL'];
     return `WHERE ${conditions.join(' AND ')}`;
@@ -122,7 +134,7 @@ class InvoiceService {
       invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin,
     });
 
-    const where = this._buildExportWhereClause(conditions);
+    const where = this._buildBaseWhereClause(conditions);
     const orderClause = this._buildOrderClause(sort, order);
     const offset = (page - 1) * size;
 
@@ -338,7 +350,7 @@ class InvoiceService {
       startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status,
     });
 
-    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : 'WHERE 1=1';
+    const where = this._buildExportWhereClause(conditions);
     const orderClause = this._buildOrderClause(sort, order);
 
     // 查询所有符合条件的发票 header

--- a/server/services/invoice.service.js
+++ b/server/services/invoice.service.js
@@ -91,6 +91,27 @@ class InvoiceService {
     return `${sortField} ${sortOrder}, m.created_at ${sortOrder}, r.invoice_number ${sortOrder}, m.id ${sortOrder}`;
   }
 
+  _parseRecordData(data) {
+    if (!data) return {};
+    if (typeof data === 'string') {
+      try {
+        return JSON.parse(data);
+      } catch {
+        return {};
+      }
+    }
+    return typeof data === 'object' ? data : {};
+  }
+
+  _decorateDuplicateMeta(row) {
+    const recordData = this._parseRecordData(row?.data);
+    return {
+      ...row,
+      is_duplicate: Boolean(recordData.duplicate),
+      duplicate_source_row_id: recordData.existing_row_id || null,
+    };
+  }
+
   async list({ page = 1, size = 20, invoiceNumber, sellerName, buyerName, status, startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin }) {
     const { conditions, replacements } = this._buildConditions({
       invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin,
@@ -103,6 +124,7 @@ class InvoiceService {
     const [rows, countResult] = await Promise.all([
       this.sequelize.query(
         `SELECT m.id, m.status, m.created_at,
+                m.data,
                 r.invoice_number, r.invoice_date, r.invoice_type,
                 r.seller_name, r.seller_tax_id, r.buyer_name, r.buyer_tax_id,
                 r.total_amount, r.total_tax, r.total_with_tax,
@@ -125,7 +147,7 @@ class InvoiceService {
     ]);
 
     return {
-      list: rows,
+      list: rows.map(row => this._decorateDuplicateMeta(row)),
       total: countResult[0]?.total || 0,
       page,
       size,
@@ -146,6 +168,7 @@ class InvoiceService {
     const [rows, items] = await Promise.all([
       this.sequelize.query(
         `SELECT m.id, m.status, m.created_at,
+                m.data,
                 r.invoice_number, r.invoice_date, r.invoice_type,
                 r.seller_name, r.seller_tax_id, r.buyer_name, r.buyer_tax_id,
                 r.total_amount, r.total_tax, r.total_with_tax,
@@ -163,7 +186,7 @@ class InvoiceService {
     ]);
 
     return {
-      ...(rows[0] || {}),
+      ...this._decorateDuplicateMeta(rows[0] || {}),
       items: items || [],
     };
   }

--- a/server/services/invoice.service.js
+++ b/server/services/invoice.service.js
@@ -91,6 +91,11 @@ class InvoiceService {
     return `${sortField} ${sortOrder}, m.created_at ${sortOrder}, r.invoice_number ${sortOrder}, m.id ${sortOrder}`;
   }
 
+  _buildExportWhereClause(baseConditions) {
+    const conditions = [...baseConditions, 'r.row_id IS NOT NULL'];
+    return `WHERE ${conditions.join(' AND ')}`;
+  }
+
   _parseRecordData(data) {
     if (!data) return {};
     if (typeof data === 'string') {
@@ -117,7 +122,7 @@ class InvoiceService {
       invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin,
     });
 
-    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : 'WHERE 1=1';
+    const where = this._buildExportWhereClause(conditions);
     const orderClause = this._buildOrderClause(sort, order);
     const offset = (page - 1) * size;
 
@@ -201,7 +206,7 @@ class InvoiceService {
       startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status,
     });
 
-    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : 'WHERE 1=1';
+    const where = this._buildExportWhereClause(conditions);
     const orderClause = this._buildOrderClause(sort, order);
 
     // 查询所有符合条件的发票 header

--- a/server/services/invoice.service.js
+++ b/server/services/invoice.service.js
@@ -31,11 +31,11 @@ class InvoiceService {
     return matches[0][0];
   }
 
-  _buildConditions({ invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin }) {
+  _buildConditions({ invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin, includeAll = false }) {
     const conditions = ['m.status IS NOT NULL'];
     const replacements = [];
 
-    if (!isAdmin) {
+    if (!isAdmin || !includeAll) {
       conditions.push('m.user_id = ?');
       replacements.push(userId);
     }
@@ -129,9 +129,9 @@ class InvoiceService {
     };
   }
 
-  async list({ page = 1, size = 20, invoiceNumber, sellerName, buyerName, status, startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin }) {
+  async list({ page = 1, size = 20, invoiceNumber, sellerName, buyerName, status, startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin, includeAll = false }) {
     const { conditions, replacements } = this._buildConditions({
-      invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin,
+      invoiceNumber, sellerName, buyerName, status, startDate, endDate, userId, isAdmin, includeAll,
     });
 
     const where = this._buildBaseWhereClause(conditions);
@@ -213,9 +213,9 @@ class InvoiceService {
    * - Sheet1「发票信息」：所有发票的 header 字段
    * - Sheet2「商品明细」：所有明细行（含发票号码用于 VLOOKUP）
    */
-  async exportFull({ startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin, invoiceNumber, sellerName, buyerName, status }) {
+  async exportFull({ startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin, invoiceNumber, sellerName, buyerName, status, includeAll = false }) {
     const { conditions, replacements } = this._buildConditions({
-      startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status,
+      startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status, includeAll,
     });
 
     const where = this._buildExportWhereClause(conditions);
@@ -316,7 +316,7 @@ class InvoiceService {
   /**
    * 个性化导出：用户选择字段 + 可选商品明细
    */
-  async exportCustom({ startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin, invoiceNumber, sellerName, buyerName, status, fields, includeItems }) {
+  async exportCustom({ startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin, invoiceNumber, sellerName, buyerName, status, fields, includeItems, includeAll = false }) {
     // ⚠️ 字段定义需与前端 exportFieldGroups (InvoiceList.vue) 保持同步
     const ALL_HEADER_FIELDS = [
       { key: 'invoice_number', header: '发票号码', width: 22 },
@@ -347,7 +347,7 @@ class InvoiceService {
     }
 
     const { conditions, replacements } = this._buildConditions({
-      startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status,
+      startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status, includeAll,
     });
 
     const where = this._buildExportWhereClause(conditions);
@@ -439,9 +439,9 @@ class InvoiceService {
   /**
    * 负值导出：筛选金额为负的商品明细，每行带上发票 header 信息
    */
-  async exportNegative({ startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin, invoiceNumber, sellerName, buyerName, status }) {
+  async exportNegative({ startDate, endDate, sort = 'created_at', order = 'desc', userId, isAdmin, invoiceNumber, sellerName, buyerName, status, includeAll = false }) {
     const { conditions, replacements } = this._buildConditions({
-      startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status,
+      startDate, endDate, userId, isAdmin, invoiceNumber, sellerName, buyerName, status, includeAll,
     });
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : 'WHERE 1=1';


### PR DESCRIPTION
## 变更概述

本 PR 修复发票管理链路中的一组相关问题，覆盖：

1. duplicate 发票命中后持续重试并最终失败
2. duplicate 前端展示语义不正确
3. duplicate 空壳记录错误进入导出
4. duplicate 去重未按 `user_id` 隔离
5. 管理员默认列表范围不合理
6. 附件上传阶段因 `attachments.created_by` 长度不足导致 500

本次改动的目标是把上传、识别、duplicate、导出、多用户隔离、管理员视图范围这条主链路收口到一致语义。

---

## 主要改动

### 1. duplicate 状态机修复

- 修复 duplicate 命中后仍继续进入后续处理的问题
- duplicate 记录命中后不再持续重试
- duplicate 流程会正确落到终态，避免用户看到长时间“待处理”后失败

涉及文件：

- `apps/invoice-mgr/tick/index.js`
- `apps/invoice-mgr/handlers/invoice-extract/index.js`
- `apps/invoice-mgr/handlers/invoice-vl-extract/index.js`
- `apps/invoice-mgr/lib/check-duplicate.js`

---

### 2. duplicate 展示与跳转优化

- 前端对 duplicate 记录显示为“重复发票”
- duplicate 记录支持跳转到原始发票详情
- 列表和详情页的 duplicate 展示语义保持一致

涉及文件：

- `frontend/src/components/invoice/InvoiceList.vue`
- `frontend/src/components/invoice/InvoiceDetail.vue`
- `frontend/src/utils/invoice-status-labels.ts`

---

### 3. duplicate 导出语义修复

- duplicate 空壳记录继续保留在列表中可见
- duplicate 空壳记录不再进入导出
- `exportFull()` 与 `exportCustom()` 导出过滤语义统一

涉及文件：

- `server/services/invoice.service.js`

---

### 4. duplicate 去重按用户隔离

- duplicate 判断改为按 `user_id + invoice_number`
- 运行时 duplicate 查询收敛为公共逻辑
- 数据库唯一约束同步调整为按用户维度约束

涉及文件：

- `apps/invoice-mgr/lib/check-duplicate.js`
- `apps/invoice-mgr/handlers/invoice-extract/index.js`
- `apps/invoice-mgr/handlers/invoice-vl-extract/index.js`
- `apps/invoice-mgr/manifest.json`
- `models/app_invoice_mgr_row.js`
- `scripts/upgrade-database.js`

---

### 5. 管理员默认只看自己，支持手动切换全部

- 管理员进入发票列表时默认只看自己的记录
- 管理员可手动切换到“全部发票”视图
- 导出范围跟随当前视图范围
- 前后端均新增 `include_all` 语义支持

涉及文件：

- `server/services/invoice.service.js`
- `server/controllers/invoice.controller.js`
- `frontend/src/api/invoice.ts`
- `frontend/src/components/invoice/InvoiceList.vue`

说明：

- 列表与导出默认按个人范围
- 管理员可手动切换查看全部列表
- 管理员详情权限仍保持可查看全部记录

---

### 6. 附件上传 500 修复（单独补充说明）

本次还补充提交了两个与附件上传稳定性直接相关的文件：

- `scripts/upgrade-database.js`
- `models/attachment.js`

#### 改动原因

发票附件上传时会写入 `attachments.created_by = 当前用户ID`。在按用户隔离语义落地后，这里稳定写入了当前 32 位用户 ID，但历史表结构仍为 `VARCHAR(20)`，导致数据库报 `ER_DATA_TOO_LONG`，前端表现为附件上传 `500`。

#### 本次处理

- 在迁移脚本中将 `attachments.created_by` 从 `VARCHAR(20)` 扩为 `VARCHAR(32)`
- 迁移时显式处理外键：先删外键，再改列，再恢复外键
- 同步更新 `models/attachment.js`，确保 Sequelize 模型定义与数据库结构一致

#### 结果

- 附件上传不再因 `created_by` 长度不足而失败
- 数据库结构与模型定义保持一致，避免后续继续错位

---

## 风险与兼容性说明

### 已处理风险

1. duplicate 不再持续重试
2. duplicate 空壳不再进入导出
3. 多用户之间不再因发票号重复而互相影响
4. 管理员默认视图与业务心智更一致
5. 附件上传不再因 `created_by` 长度不足报错

### 已知非阻塞事项

1. duplicate 底层状态仍复用 `extract_failed`，后续统计/筛选语义仍可进一步治理
2. 后续若新增统计、搜索、汇总等读接口，需要继续沿用当前管理员范围语义

---

## 验证说明

本轮已完成的人工验证包括：

1. 管理员默认进入列表时可只看到自己的记录
2. 管理员切换到“全部发票”后可看到全量记录
3. 导出链路已同步支持当前视图范围
4. 附件上传链路已恢复，`created_by` 长度不再触发 500

---

## 建议评审重点

1. `include_all` 语义在列表与导出上的一致性
2. duplicate 列表可见但导出不可见的边界是否符合预期
3. `attachments.created_by` 扩容迁移的执行顺序是否满足现网升级要求
4. `models/attachment.js` 与数据库结构是否已保持一致

Closes #955 