### PR TITLE
refactor: 迁移专家文档召回优化并恢复基于原文的回答链路

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -2083,16 +2083,60 @@ class ExpertChatService {
       context += modeConstraints + '\n\n';
     }
 
+    // audit-round04 P1-1: evidence_capability 首次进入控制面
+    // 当 tool 只有 identity 证据但 query 被纠偏为 answer_question 时，
+    // 追加 identity-only 守卫，防止 LLM 把身份证据当内容证据使用
+    //
+    // audit-round07 P0: auto_content_chain 降级此守卫的必要性。
+    // 当 find_document 已自动追加内容检索（auto_content_chain.active === true），
+    // evidence_capability 已升级为 chunk_evidence，不再需要 identity-only 守卫。
+    const orch = toolResult?.orchestration || {};
+    if (orch.evidence_capability === 'identity_only'
+        && orch.goal_type_source === 'query_signal_override') {
+      context += `## ⚠️ 证据能力约束：身份信息仅用于定位
+
+**重要提示：** 当前工具仅返回文档身份信息（标题、类型、相关度），**未提供完整的原文内容**。
+用户的查询被识别为内容问答型，但你可用的证据仅限于文档身份和少量片段摘要。
+请参考上面的「单文档定位模式」约束，不要基于片段摘要编造完整的条款/参数/费用回答。
+如需完整回答，应引导用户进入文档内容检索流程。
+
+`;
+    }
+
+    // audit-round07 P0: auto content chain 合并
+    // 当 find_document 已自动追加内容检索时，优先使用 content_documents
+    // （含 chunk 级 top_evidence），同时保留 candidates 作为身份确认。
+    const autoChain = toolResult?.auto_content_chain;
+    let evidenceDocs;
+    if (autoChain?.active && toolResult.content_documents?.length > 0) {
+      // 将 content_documents 的 top_evidence 映射为 evidence-formatter 期望的 evidence 字段
+      evidenceDocs = toolResult.content_documents.map(doc => ({
+        document_id: doc.document_id,
+        document_title: doc.document_title,
+        doc_type: doc.doc_type,
+        collection_name: doc.collection_name,
+        relevance_score: doc.relevance_score,
+        candidate_confidence: doc.candidate_confidence || 'medium',
+        evidence: (doc.top_evidence || []).map(ev => ({
+          content: ev.content || '',
+          score: ev.score || 0,
+        })),
+      }));
+    }
+
     // 使用 evidence-formatter 格式化证据上下文
     // 兼容 answer_from_documents (documents) 和 find_document (candidates) 两种返回结构
+    // auto_content_chain 激活时：优先用 auto-chained 内容证据；否则用原始结构
     const packet = {
       strategy: toolResult.strategy,
       meta: {
-        evidence_sufficiency: toolResult.evidence_sufficiency,
+        evidence_sufficiency: autoChain?.active
+          ? (toolResult.content_documents?.[0]?.evidence_count ? 'medium' : toolResult.evidence_sufficiency)
+          : toolResult.evidence_sufficiency,
         suggested_response_mode: toolResult.suggested_response_mode,
         reason_codes: toolResult.reason_codes || [],
       },
-      documents: toolResult.documents || toolResult.candidates || [],
+      documents: evidenceDocs || toolResult.documents || toolResult.candidates || [],
     };
     context += buildEvidenceContextMessage(packet, { maxTokens });
     return context;
@@ -2148,6 +2192,7 @@ class ExpertChatService {
 2. **明确告知依据有限。** 使用"目前检索到的信息有限""未找到明确依据"等表述。
 3. **可以给出参考信息**，但必须注明证据强度较弱，仅供参考。
 4. **不要补充超出检索结果的内容。** 如果你不了解某事，直接说"根据当前文档资料，我无法确认这一点"。
+5. **如果证据中已经出现明确参数，就必须逐项照证据回答。** 禁止把“30min”改写成“通常至少1分钟”，禁止把“顶部以上0.15m、底面下1m”改成模糊说法。
 
 ## 输出模板（请严格按照以下结构输出）
 
@@ -2157,6 +2202,36 @@ class ExpertChatService {
 [基于检索到的证据片段，整理可提供的参考内容]
 
 **不确定性提示：** [明确指出哪些部分缺乏充分证据支撑，建议用户进一步核实]`;
+
+      case 'answer_with_citation':
+        return `## ⚠️ 强制回答约束：引用回答模式
+
+**你必须遵守以下规则，不得违反：**
+
+1. **优先回答证据中已经明确写出的事实。** 尤其是数值、时长、距离、流量、章节号、表格项。
+2. **禁止把原文参数改写成经验性表述。** 例如原文写“30min”，就不能说“通常至少1分钟”；原文写“顶部以上至少0.15m”，就不能说“在规定水深下”。
+3. **若问题询问“代表什么/做什么实验/条件是什么”这类标准参数问题，回答时应分点列出：含义、试验装置、关键参数、对应条款。**
+4. **如果证据没有覆盖某个细节，就明确说当前证据未显示该细节，不得脑补。**
+5. **回答后附来源指向。** 至少指出文档名及证据对应的表/章/条（若证据中可见）。`;
+
+      case 'single_document':
+        // audit-round04 P0-1: 单文档身份确认模式，不默认承接内容问答
+        // find_document 仅返回 identity 信息 (+ supporting_evidence snippets)，
+        // 不等价于 answer_from_documents 的 chunk 级证据包
+        //
+        // audit-round07 P0: 当系统已自动追加内容检索（下方文档检索结果含内容证据时），
+        // 应直接基于证据回答而非停止在身份确认。对纯定位问题仍保持身份确认行为。
+        return `## ⚠️ 强制回答约束：单文档定位模式
+
+**你必须遵守以下规则，不得违反：**
+
+1. **确认已定位到的文档身份。** 说明检索到的文档名称、类型、所属集合。
+2. **如果用户问的是"在哪里""有没有"这类定位问题**：直接告知文档已找到及其基本信息即可。
+3. **如果用户问的是具体内容（条款、参数、费用等）**：
+   - 若下方「文档检索结果」中包含该文档的内容证据（关键证据片段），请**直接基于证据回答用户问题**，并附引用来源，不要停留在身份确认阶段。
+   - 若下方仅有文档身份信息而无内容证据，先确认文档已定位，然后告知用户可继续检索该文档的完整内容，**不要仅凭片段摘要编造答案**。
+4. **禁止过度解读 supporting_evidence 片段。** supporting_evidence 仅用于帮助确认文档身份，不等价于全文内容。回答应优先使用「关键证据片段」中已检索到的原文内容。
+5. **回答中附文档名称和类型。**`;
 
       default:
         return '';
@@ -2207,7 +2282,23 @@ class ExpertChatService {
     }
 
     response += '---\n';
-    response += '请告诉我您最关心以上哪个文档，我会为您提供详细信息。';
+
+    // audit-round02 P0-1: mergeable_hint — 候选可合并消费提示
+    const mergeableHint = docRetrievalResult?.orchestration?.mergeable_hint;
+    if (mergeableHint) {
+      const reasonCodes = docRetrievalResult?.orchestration?.reason_codes || [];
+      const mergeSignals = docRetrievalResult?.orchestration?.merge_signals || {};
+      // 生成合并原因的可读描述
+      const signalMessages = [];
+      if (mergeSignals.same_collection) signalMessages.push('属于同一文档集合');
+      if (mergeSignals.complementary_types) signalMessages.push('类型互补，可协同回答');
+      if (mergeSignals.same_source) signalMessages.push('来源相关');
+      const reasonText = signalMessages.length > 0 ? `（${signalMessages.join('，')}）` : '';
+
+      response += `\n> 💡 以上文档可合并消费${reasonText}。您可以指定一个或多个文档，让我基于其内容为您回答。\n`;
+    } else {
+      response += '请告诉我您最关心以上哪个文档，我会为您提供详细信息。';
+    }
 
     return response;
   }
@@ -2252,6 +2343,12 @@ class ExpertChatService {
     //   - tool_only + candidate_list / conservative_answer / direct_answer / ...
     //   - auto_rag  + (无 response_mode，旧路径不经过此决策)
     //   - none      + (无 response_mode，无检索发生)
+    //
+    // audit-round01 P0-2: 编排感知日志 — 记录 goal_type / candidate_resolution
+    // audit-round02 P0-1: mergeable_hint / goal_type_source 增加观测维度
+    //  当 find_document 返回 mergeable 候选时，走 candidate_list 短路（保守方案）
+    //  mergeable_hint 提示用户候选可合并消费
+    const orchestration = docRetrievalResult?.orchestration || null;
     logger.info('[ExpertChatService._getResponseModeDecision] retrieval round result (tool path):', {
       retrieval_source: 'tool_only',
       response_mode: mode,
@@ -2259,6 +2356,14 @@ class ExpertChatService {
       evidence_sufficiency: docRetrievalResult.evidence_sufficiency,
       doc_count: (docRetrievalResult.documents || docRetrievalResult.candidates || []).length,
       strategy: docRetrievalResult.strategy,
+      // orchestration 字段（find_document 路径提供）
+      goal_type: orchestration?.goal_type || null,
+      goal_type_source: orchestration?.goal_type_source || null,
+      candidate_resolution: orchestration?.candidate_resolution || null,
+      orchestration_action: orchestration?.action || null,
+      merge_signals: orchestration?.merge_signals || null,
+      mergeable_hint: orchestration?.mergeable_hint || false,
+      evidence_capability: orchestration?.evidence_capability || null,
     });
 
     return decision;
@@ -2730,3 +2835,4 @@ class ExpertChatService {
 }
 
 export default ChatService;
+export { ExpertChatService };

--- a/lib/doc-recall-service.js
+++ b/lib/doc-recall-service.js
@@ -464,14 +464,17 @@ class DocRecallService {
    * - recall() 在全库范围内做 chunk 向量搜索（chunk-first）
    * - recallWithinDocuments() 在指定的候选文档/版本范围内做 chunk 向量搜索（document-first）
    *
-   * @param {string} query - 搜索查询
+   * audit-round01 P1-2: 支持 query_plan 对象输入，传递结构化 facets
+   *
+   * @param {string|Object} query - 搜索查询字符串，或 query_plan 对象
    * @param {string[]} documentIds - 候选文档ID列表
    * @param {Object} options - 检索选项
-   * @param {string[]} [options.revisionIds] - 可选，指定版本ID（不传则使用文档的 current_revision）
+   * @param {string[]} [options.revisionIds] - 可选，指定版本ID
    * @param {number} [options.top_k=5] - 返回数量
    * @param {number} [options.threshold=0.1] - 相似度阈值
    * @param {string} [options.userId] - 用户ID（权限验证）
    * @param {string} [options.embedding_model_id] - 指定 embedding 模型
+   * @param {boolean} [options.enable_rerank=true] - 是否启用 hybrid rerank
    * @returns {Promise<Object>} 检索结果 { success, items, total }
    */
   async recallWithinDocuments(query, documentIds, options = {}) {
@@ -481,28 +484,40 @@ class DocRecallService {
       threshold = 0.1,
       userId,
       embedding_model_id,
+      enable_rerank = true,
     } = options;
 
-    this.ensureModels();
+    // audit-round01 P1-2: 兼容 string 和 query_plan 双输入
+    const semanticQuery = typeof query === 'string' ? query : (query.semantic_query || query.raw_query || '');
+    // audit-round02 P0-2: 统一提取 query_plan，兼容 { query_plan: {...} } 嵌套和顶层平铺
+    // audit-round03 P1-3: { query_plan: {...} } 嵌套已废弃，主链改为扁平传递 { entity_terms, procedure_terms, ... }
+    //  保留此兼容提取以支持可能的旧调用方，新代码应直接使用顶层字段。
+    // audit-round04 P2-1: 兼容路径退场计划
+    //  - 保留原因：确保非主链调用方（如 tool/skill 直接调用 recallWithinDocuments）不会因扁平化而断裂
+    //  - 移除时机：下一轮 expert-retrieval 审计放行后，确认无其他 caller 传递 query_plan 嵌套格式
+    //  - 验证条件：grep 全仓 `query_plan` 无出现在构建 { semantic_query, query_plan } 对象处（主链已扁平）
+    //  - 移除方法：删除三元判断中的 query.query_plan 分支，queryPlan 直接取 query（已是扁平格式）
+    const queryPlan = typeof query === 'object'
+      ? (query.query_plan && typeof query.query_plan === 'object' ? query.query_plan : query)
+      : { raw_query: query, semantic_query: query };
 
-    if (!query || !query.trim()) {
-      return { success: false, message: 'Query is required', items: [] };
-    }
+    this.ensureModels();
 
     if (!documentIds || documentIds.length === 0) {
       return { success: true, items: [], total: 0, strategy: 'no_candidates' };
     }
 
     logger.info('[DocRecall] recallWithinDocuments:', {
-      query_length: query?.length || 0,
-      query_preview: typeof query === 'string' ? query.substring(0, 120) : null,
+      query_length: semanticQuery?.length || 0,
+      query_preview: typeof semanticQuery === 'string' ? semanticQuery.substring(0, 120) : null,
       candidate_count: documentIds.length,
       top_k,
+      enable_rerank,
     });
 
     try {
       const resolvedModelId = await this._resolveEmbeddingModelId(embedding_model_id);
-      const queryEmbedding = await this.generateQueryEmbedding(query, resolvedModelId);
+      const queryEmbedding = await this.generateQueryEmbedding(semanticQuery, resolvedModelId);
       if (!queryEmbedding) {
         return { success: false, message: 'Failed to generate embedding', items: [] };
       }
@@ -541,7 +556,9 @@ class DocRecallService {
         params.push(...accessibleCollectionIds);
       }
 
-      params.push(top_k);
+      // audit-round01 P0-1: 取 wider candidate set 供 hybrid rerank
+      const rerankPoolSize = enable_rerank ? Math.max(top_k * 4, 20) : top_k;
+      params.push(rerankPoolSize);
 
       const results = await this.db.sequelize.query(`
         SELECT *
@@ -603,6 +620,7 @@ class DocRecallService {
       const items = results
         .filter(r => (1 - r.distance) >= threshold)
         .map(r => ({
+          _raw: { distance: r.distance, chunk_title: r.chunk_title, content: r.content },
           score: 1 - r.distance,
           chunk: {
             id: r.chunk_id,
@@ -626,16 +644,35 @@ class DocRecallService {
           source: 'evidence_recall',
         }));
 
+      // audit-round01 P0-1: Hybrid rerank
+      let finalItems = items;
+      const rerankDebug = [];
+      if (enable_rerank && items.length > 0) {
+        const rerankResult = this._hybridRerank(items, queryPlan);
+        finalItems = rerankResult.items.slice(0, top_k);
+        for (const entry of rerankResult.debug.slice(0, 5)) {
+          rerankDebug.push(entry);
+        }
+      } else {
+        finalItems = items.slice(0, top_k);
+      }
+
+      // 清理内部 _raw 字段
+      finalItems = finalItems.map(({ _raw, ...rest }) => rest);
+
       logger.info('[DocRecall] recallWithinDocuments completed:', {
         candidate_count: documentIds.length,
-        evidence_count: items.length,
-        top_score: items[0]?.score || 0,
+        evidence_count: finalItems.length,
+        raw_count: items.length,
+        top_score: finalItems[0]?.score || 0,
+        rerank_applied: enable_rerank && items.length > 0,
+        rerank_debug: rerankDebug,
       });
 
       return {
         success: true,
-        items,
-        total: items.length,
+        items: finalItems,
+        total: finalItems.length,
         strategy: 'document_scoped',
         searched_document_ids: documentIds,
       };
@@ -644,6 +681,116 @@ class DocRecallService {
       logger.error('[DocRecall] recallWithinDocuments error:', error);
       return { success: false, message: error.message, items: [] };
     }
+  }
+
+  /**
+   * Hybrid Rerank（audit-round01 P0-1）
+   *
+   * 在纯向量相似度之上，叠加实体命中、程序词、结构锚点的综合打分。
+   * 权重可配置、打分可审计——每个证据 item 产出 rerank_debug 子分数。
+   *
+   * @param {Object[]} items - 原始向量召回结果（已映射）
+   * @param {Object} queryPlan - 查询计划（含 entity_terms, procedure_terms）
+   * @returns {{ items: Object[], debug: Object[] }}
+   */
+  _hybridRerank(items, queryPlan) {
+    const entityTerms = queryPlan.entity_terms || [];
+    const procedureTerms = queryPlan.procedure_terms || [];
+    const WEIGHTS = {
+      semantic: 0.45,
+      entity: 0.30,
+      procedure: 0.15,
+      structural: 0.10,
+    };
+
+    const debug = [];
+
+    const reranked = items.map((item, idx) => {
+      const content = (item._raw?.content || item.chunk?.content || '').toLowerCase();
+      const title = (item._raw?.chunk_title || item.chunk?.title || '').toLowerCase();
+      const combinedText = title + ' ' + content;
+      const seq = item.chunk?.seq || 0;
+
+      // entity_exact_match_score
+      let entityScore = 0;
+      const matchedEntities = [];
+      if (entityTerms.length > 0) {
+        let hits = 0;
+        for (const et of entityTerms) {
+          const etLower = et.toLowerCase();
+          if (combinedText.includes(etLower)) {
+            hits++;
+            matchedEntities.push(et);
+          }
+        }
+        entityScore = Math.min(hits / entityTerms.length, 1.0);
+      }
+
+      // procedure_term_match_score
+      let procedureScore = 0;
+      const matchedProcedures = [];
+      if (procedureTerms.length > 0) {
+        let hits = 0;
+        for (const pt of procedureTerms) {
+          if (combinedText.includes(pt.toLowerCase())) {
+            hits++;
+            matchedProcedures.push(pt);
+          }
+        }
+        procedureScore = Math.min(hits / Math.max(procedureTerms.length, 1), 1.0);
+      }
+
+      // structural_anchor_score — chapter/section proximity heuristics
+      let structuralScore = 0.5; // neutral default
+      // 章节锚点检测：内容中的章节编号（如 14.2.5）
+      const sectionPattern = /\b\d+\.\d+(?:\.\d+)?\b/;
+      if (sectionPattern.test(combinedText)) {
+        // 如果 entity 也匹配了数字编码（如 14.2.5、IPX5），则大幅加分
+        if (entityTerms.some(et => /\d/.test(et) && combinedText.includes(et.toLowerCase()))) {
+          structuralScore = 1.0;
+        } else {
+          structuralScore = 0.8;
+        }
+      }
+      // 表格标题/条款关键词加分
+      if (/\b(?:表|表格|条款|附录|附图)\b/.test(combinedText)) {
+        structuralScore = Math.max(structuralScore, 0.7);
+      }
+      // seq 信息：低 seq 的概述性 chunk 略降权
+      if (seq <= 2 && !sectionPattern.test(combinedText)) {
+        structuralScore = Math.min(structuralScore, 0.4);
+      }
+
+      const semanticScore = item.score || 0;
+      const finalScore =
+        WEIGHTS.semantic * semanticScore +
+        WEIGHTS.entity * entityScore +
+        WEIGHTS.procedure * procedureScore +
+        WEIGHTS.structural * structuralScore;
+
+      const rankDebug = {
+        chunk_id: item.chunk?.id,
+        semantic: Math.round(semanticScore * 100) / 100,
+        entity: Math.round(entityScore * 100) / 100,
+        procedure: Math.round(procedureScore * 100) / 100,
+        structural: Math.round(structuralScore * 100) / 100,
+        final: Math.round(finalScore * 100) / 100,
+        matched_entities: matchedEntities,
+        matched_procedures: matchedProcedures,
+      };
+      debug.push(rankDebug);
+
+      return {
+        ...item,
+        score: finalScore,
+        _rerank: rankDebug,
+      };
+    });
+
+    // 按 finalScore 降序重排
+    reranked.sort((a, b) => b.score - a.score);
+
+    return { items: reranked, debug };
   }
 }
 

--- a/lib/document-evidence-packer.js
+++ b/lib/document-evidence-packer.js
@@ -73,6 +73,7 @@ class DocumentEvidencePacker {
    * @param {Object} [options={}] - 打包选项
    * @param {number} [options.maxEvidencePerDoc=5] - 每个文档最多保留的 evidence 条数
    * @param {number} [options.minEvidenceScore=0] - evidence 最低分数阈值
+   * @param {Object} [options.queryFacets] - audit-round01 P0-2: 查询切面，用于 coverage 评估
    * @returns {Object} evidence packet
    */
   pack(candidates, evidenceItems, decision, traceId, options = {}) {
@@ -80,6 +81,7 @@ class DocumentEvidencePacker {
       maxEvidencePerDoc = 5,
       minEvidenceScore = 0,
       strategy = 'document_first',
+      queryFacets = null,
     } = options;
 
     const packet = {
@@ -121,10 +123,9 @@ class DocumentEvidencePacker {
     }
 
     // 3. 合并候选文档和 evidence
-    const allDocIds = new Set([
-      ...candidateMap.keys(),
-      ...evidenceByDoc.keys(),
-    ]);
+    const allDocIds = candidateMap.size > 0
+      ? new Set([...candidateMap.keys()])
+      : new Set([...evidenceByDoc.keys()]);
 
     for (const docId of allDocIds) {
       const candidate = candidateMap.get(docId) || {};
@@ -168,6 +169,8 @@ class DocumentEvidencePacker {
         identitySource = 'evidence_backfill';
       }
 
+      const resolvedCandidateConfidence = this._resolveCandidateConfidence(candidate, filteredEvidence, identityBackfilled);
+
       const docEntry = {
         document_id: docId,
         document_title: candidate.document_title || evDoc?.document_title || '',
@@ -176,7 +179,7 @@ class DocumentEvidencePacker {
         collection_name: candidate.collection_name || '',
         revision_no: candidate.revision_no || evDoc?.revision_no || null,
         relevance_score: candidate.relevance_score || 0,
-        candidate_confidence: candidate.candidate_confidence || (candidate.is_heuristic_fallback ? 'low' : 'high'),
+        candidate_confidence: resolvedCandidateConfidence,
         is_heuristic_fallback: candidate.is_heuristic_fallback || false,
         identity_confidence: identityConfidence,
         identity_source: identitySource,
@@ -211,6 +214,18 @@ class DocumentEvidencePacker {
     // 6. 评估证据充分性
     packet.meta.evidence_sufficiency = this._assessSufficiency(packet);
 
+    // 6.5 audit-round01 P0-2: 评估证据覆盖度
+    const coverage = this._assessCoverage(packet, queryFacets);
+    packet.meta.coverage_status = coverage.status;
+    packet.meta.coverage_reason_codes = coverage.reason_codes;
+
+    const parameterClosure = this._detectParameterEvidenceClosure(packet, queryFacets);
+    packet.meta.parameter_evidence_closure = parameterClosure.matched;
+    packet.meta.parameter_evidence_closure_reason_codes = parameterClosure.reasons;
+    if (parameterClosure.matched) {
+      packet.meta.reason_codes.push(...parameterClosure.reasons);
+    }
+
     // 7. 推导回答模式建议
     const responseMode = this._deriveResponseMode(packet);
     packet.meta.should_clarify = responseMode.should_clarify;
@@ -223,6 +238,7 @@ class DocumentEvidencePacker {
       evidence_count: packet.meta.total_evidence,
       max_score: packet.meta.max_evidence_score,
       sufficiency: packet.meta.evidence_sufficiency,
+      coverage: packet.meta.coverage_status,
       response_mode: packet.meta.suggested_response_mode,
       backfill_triggered: packet.meta.backfill_triggered,
       backfill_doc_count: packet.meta.backfill_doc_count,
@@ -249,6 +265,8 @@ class DocumentEvidencePacker {
         backfill_doc_count: 0,
         reason_codes: [reasonCode],
         evidence_sufficiency: 'none',
+        coverage_status: 'not_covered',
+        coverage_reason_codes: ['no_evidence'],
         should_clarify: true,
         should_answer_conservatively: true,
         suggested_response_mode: 'conservative_answer',
@@ -266,6 +284,219 @@ class DocumentEvidencePacker {
     packet.meta.fallback_triggered = true;
     packet.meta.reason_codes.push('fallback_to_chunk_first');
     return packet;
+  }
+
+  /**
+   * audit-round01 P0-2 & audit-round02 P1-1: 评估证据覆盖度（chunk 级）
+   *
+   * 检查已命中的 evidence 是否真正覆盖用户问题的核心对象，
+   * 而不只是同章相邻内容。与 _assessSufficiency 正交：
+   * - sufficiency 回答"证据够不够多/够不够高"
+   * - coverage 回答"证据有没有覆盖到问题核心对象"
+   *
+   * audit-round02 P1-1: 从全文拼接升级为 chunk 级命中跟踪，
+   * 避免跨 chunk 误拼接导致的伪 covered。
+   *
+   * @param {Object} packet - evidence packet
+   * @param {Object|null} queryFacets - 查询切面 { entity_terms, procedure_terms }
+   * @returns {{ status: string, reason_codes: string[], entity_chunk_hits: Object, procedure_chunk_hits: Object }}
+   */
+  _assessCoverage(packet, queryFacets) {
+    const entityTerms = queryFacets?.entity_terms || [];
+    const procedureTerms = queryFacets?.procedure_terms || [];
+    const reasonCodes = [];
+
+    // 无 facets → 无法评估覆盖，默认 partial
+    if (entityTerms.length === 0 && procedureTerms.length === 0) {
+      return { status: 'not_evaluated', reason_codes: ['no_facets_available'], entity_chunk_hits: {}, procedure_chunk_hits: {} };
+    }
+
+    // 无证据 → 直接 not_covered
+    if (packet.meta.total_evidence === 0) {
+      return { status: 'not_covered', reason_codes: ['no_evidence'], entity_chunk_hits: {}, procedure_chunk_hits: {} };
+    }
+
+    // audit-round02 P1-1: chunk 级命中跟踪
+    // 收集每条 evidence 的 chunk_id 和 content
+    const evidenceEntries = packet.documents
+      .flatMap(d => (d.evidence || []).map(e => ({
+        chunk_id: e.chunk_id || `unknown_${d.document_id}`,
+        content: (e.content || '').toLowerCase(),
+        document_id: d.document_id,
+      })));
+
+    // entity_chunk_hits: { entity_term -> Set<chunk_id> }
+    const entityChunkHits = {};
+    for (const et of entityTerms) {
+      const etLower = et.toLowerCase();
+      const hitChunks = new Set();
+      for (const entry of evidenceEntries) {
+        if (entry.content.includes(etLower)) {
+          hitChunks.add(entry.chunk_id);
+        }
+      }
+      entityChunkHits[et] = [...hitChunks];
+    }
+
+    // procedure_chunk_hits: { procedure_term -> Set<chunk_id> }
+    const procedureChunkHits = {};
+    for (const pt of procedureTerms) {
+      const ptLower = pt.toLowerCase();
+      const hitChunks = new Set();
+      for (const entry of evidenceEntries) {
+        if (entry.content.includes(ptLower)) {
+          hitChunks.add(entry.chunk_id);
+        }
+      }
+      procedureChunkHits[pt] = [...hitChunks];
+    }
+
+    // 实体命中检查
+    let entityHitCount = 0;
+    const missedEntities = [];
+    for (const et of entityTerms) {
+      if (entityChunkHits[et]?.length > 0) {
+        entityHitCount++;
+      } else {
+        missedEntities.push(et);
+      }
+    }
+
+    // 程序词命中检查
+    let procedureHitCount = 0;
+    const missedProcedures = [];
+    for (const pt of procedureTerms) {
+      if (procedureChunkHits[pt]?.length > 0) {
+        procedureHitCount++;
+      } else {
+        missedProcedures.push(pt);
+      }
+    }
+
+    // audit-round02 P1-1: chunk 级 overlap 检查
+    // 若实体与程序词命中在不同 chunk 组，不得判为 covered
+    const allEntityChunkIds = new Set(
+      Object.values(entityChunkHits).flat()
+    );
+    const allProcedureChunkIds = new Set(
+      Object.values(procedureChunkHits).flat()
+    );
+
+    // chunk overlap: 实体命中 chunk ∩ 程序词命中 chunk
+    const overlapChunkIds = new Set(
+      [...allEntityChunkIds].filter(id => allProcedureChunkIds.has(id))
+    );
+
+    if (missedEntities.length > 0) {
+      reasonCodes.push('coverage_miss_core_entity');
+    }
+    if (entityHitCount > 0 && procedureTerms.length > 0 && procedureHitCount === 0) {
+      reasonCodes.push('coverage_miss_required_procedure');
+    }
+    if (entityHitCount > 0 && entityHitCount < entityTerms.length) {
+      reasonCodes.push('coverage_partial_entity_match');
+    }
+    // audit-round02 P1-1: entity 和 procedure 不在同一 chunk → 不可判为 covered
+    if (entityHitCount > 0 && procedureHitCount > 0 && overlapChunkIds.size === 0) {
+      reasonCodes.push('coverage_no_chunk_overlap');
+    }
+
+    // 判定覆盖状态
+    let status;
+    if (entityTerms.length > 0 && entityHitCount === 0) {
+      status = 'not_covered';
+      if (!reasonCodes.includes('coverage_miss_core_entity')) {
+        reasonCodes.push('coverage_miss_core_entity');
+      }
+    } else if (entityTerms.length > 0 && entityHitCount < entityTerms.length) {
+      status = 'partial';
+    } else if (entityTerms.length > 0 && entityHitCount === entityTerms.length) {
+      // audit-round02 P1-1: 即使所有实体命中，chunk overlap 不足时降为 partial
+      if (procedureTerms.length > 0 && overlapChunkIds.size === 0) {
+        status = 'partial';
+      } else {
+        status = 'covered';
+      }
+    } else if (procedureTerms.length > 0 && procedureHitCount > 0) {
+      status = 'partial'; // 只有程序词命中（无实体 facet）
+    } else {
+      status = 'not_evaluated';
+    }
+
+    return {
+      status,
+      reason_codes: reasonCodes,
+      entity_chunk_hits: entityChunkHits,
+      procedure_chunk_hits: procedureChunkHits,
+    };
+  }
+
+  /**
+   * 检测参数证据闭环：同一证据片段内同时出现核心实体、参数值、条款/表格锚点
+   * 或明显参数问答语境。用于防止“证据已命中明确参数”却仍被误降级。
+   *
+   * @param {Object} packet
+   * @param {Object|null} queryFacets
+   * @returns {{ matched: boolean, reasons: string[], matched_document_id: string|null, matched_chunk_id: string|null }}
+   */
+  _detectParameterEvidenceClosure(packet, queryFacets) {
+    const entityTerms = (queryFacets?.entity_terms || []).filter(Boolean);
+    const attributeTerms = (queryFacets?.attribute_terms || []).filter(Boolean);
+    const procedureTerms = (queryFacets?.procedure_terms || []).filter(Boolean);
+
+    if (packet?.meta?.total_evidence === 0 || entityTerms.length === 0) {
+      return { matched: false, reasons: [], matched_document_id: null, matched_chunk_id: null };
+    }
+
+    const parameterValuePattern = /(?:\b\d+(?:\.\d+)?\s*(?:min|mm|cm|m|km|g|kg|mg|℃|°C|K|V|A|W|Hz|L\/min|m3\/h|%|‰)\b|\b\d+(?:\.\d+)?\b)/i;
+    const anchorPattern = /(?:表\s*\d+|第\s*\d+(?:\.\d+)+\s*[章节条款项]?|\b\d+(?:\.\d+)+\b)/i;
+
+    const matchesEntityConcept = (contentLower, term) => {
+      const normalizedTerm = String(term || '').trim().toLowerCase();
+      if (!normalizedTerm) return false;
+      if (contentLower.includes(normalizedTerm)) return true;
+
+      const ipxMatch = normalizedTerm.match(/^ipx(\d+)$/i);
+      if (ipxMatch) {
+        const n = ipxMatch[1];
+        const aliases = [
+          `第二位特征数字${n}`,
+          `第二位特征数字为${n}`,
+          `特征数字${n}`,
+          `数字${n}`,
+        ];
+        return aliases.some(alias => contentLower.includes(alias.toLowerCase()));
+      }
+
+      return false;
+    };
+
+    for (const doc of packet.documents || []) {
+      for (const ev of doc.evidence || []) {
+        const content = ev.content || '';
+        const lower = content.toLowerCase();
+        const entityHit = entityTerms.some(term => matchesEntityConcept(lower, term));
+        if (!entityHit) continue;
+
+        const hasParameterValue = parameterValuePattern.test(content);
+        const hasAnchor = anchorPattern.test(content);
+        const hasProcedureSignal = procedureTerms.length > 0
+          ? procedureTerms.some(term => lower.includes(String(term).toLowerCase()))
+          : false;
+        const hasAttributeIntent = attributeTerms.length > 0;
+
+        if (hasParameterValue && (hasAnchor || hasProcedureSignal || hasAttributeIntent)) {
+          return {
+            matched: true,
+            reasons: ['parameter_evidence_closure'],
+            matched_document_id: doc.document_id || null,
+            matched_chunk_id: ev.chunk_id || null,
+          };
+        }
+      }
+    }
+
+    return { matched: false, reasons: [], matched_document_id: null, matched_chunk_id: null };
   }
 
   /**
@@ -289,8 +520,10 @@ class DocumentEvidencePacker {
    */
   _deriveResponseMode(packet) {
     const sufficiency = packet.meta.evidence_sufficiency;
+    const coverage = packet.meta.coverage_status;
     const docCount = packet.documents.length;
     const decision = packet.decision;
+    const hasParameterClosure = packet.meta.parameter_evidence_closure === true;
 
     // 意图不明确 → 澄清
     if (decision?.recommended_strategy === 'clarify') {
@@ -310,8 +543,43 @@ class DocumentEvidencePacker {
       };
     }
 
+    // 参数证据闭环优先：同一证据片段已形成“实体 + 参数值 + 锚点/语境”闭环时，
+    // 即使 coverage 因 facet/措辞差异被打低，也应优先进入引用回答模式。
+    if (hasParameterClosure && (sufficiency === 'medium' || sufficiency === 'strong')) {
+      return {
+        mode: 'answer_with_citation',
+        should_clarify: false,
+        should_answer_conservatively: false,
+      };
+    }
+
+    // audit-round01 P0-2: 覆盖不足 → 保守回答（先止错答）
+    if (coverage === 'not_covered') {
+      return {
+        mode: 'conservative_answer',
+        should_clarify: sufficiency === 'weak' || sufficiency === 'none',
+        should_answer_conservatively: true,
+      };
+    }
+
     // 弱证据 → 保守回答
     if (sufficiency === 'weak') {
+      return {
+        mode: 'conservative_answer',
+        should_clarify: false,
+        should_answer_conservatively: true,
+      };
+    }
+
+    // audit-round01 P0-2: partial 覆盖 + 弱/中等充分性 → 保守
+    if (coverage === 'partial' && (sufficiency === 'weak' || sufficiency === 'medium')) {
+      if (hasParameterClosure) {
+        return {
+          mode: 'answer_with_citation',
+          should_clarify: false,
+          should_answer_conservatively: false,
+        };
+      }
       return {
         mode: 'conservative_answer',
         should_clarify: false,
@@ -322,7 +590,7 @@ class DocumentEvidencePacker {
     // 多候选文档且置信度分散 → 列候选
     if (docCount >= 3) {
       const highConfDocs = packet.documents.filter(
-        d => d.candidate_confidence === 'high' && d.evidence?.length > 0
+        d => (d.candidate_confidence === 'high' || d.candidate_confidence === 'medium') && d.evidence?.length > 0
       );
       // 多个高置信度文档 → 可能存在冲突，列出候选
       if (highConfDocs.length >= 2) {
@@ -334,7 +602,7 @@ class DocumentEvidencePacker {
       }
     }
 
-    // 有明确文档来源 → 引用回答
+    // 有明确文档来源 → 引用回答（覆盖已确认 covered 或 sufficient）
     if (sufficiency === 'strong' || sufficiency === 'medium') {
       return {
         mode: 'answer_with_citation',
@@ -349,6 +617,25 @@ class DocumentEvidencePacker {
       should_clarify: false,
       should_answer_conservatively: false,
     };
+  }
+
+  _resolveCandidateConfidence(candidate = {}, filteredEvidence = [], identityBackfilled = false) {
+    const relevanceScore = candidate.relevance_score || 0;
+    const maxEvidenceScore = filteredEvidence[0]?.score || 0;
+    const evidenceCount = filteredEvidence.length;
+
+    if (candidate.candidate_confidence) {
+      return candidate.candidate_confidence;
+    }
+
+    if (candidate.is_heuristic_fallback || identityBackfilled) {
+      if (evidenceCount >= 2 && maxEvidenceScore >= 0.7) return 'medium';
+      return 'low';
+    }
+
+    if (relevanceScore >= 80 && evidenceCount >= 1) return 'high';
+    if (relevanceScore >= 55 || maxEvidenceScore >= 0.65) return 'medium';
+    return 'low';
   }
 
   /**

--- a/lib/document-orchestration-service.js
+++ b/lib/document-orchestration-service.js
@@ -1,0 +1,449 @@
+/**
+ * Document Orchestration Service — 多文档协同问答编排层
+ *
+ * audit-round01 (multi-doc-orchestration) P0-1:
+ * 引入统一编排层，解决当前"单文档定位 / 单文档回答优先"的架构缺陷。
+ *
+ * 核心职责：
+ * 1. 判定用户目标 goal_type（定位文档 vs 获得答案）
+ * 2. 判定候选收敛状态 candidate_resolution（single/mergeable/ambiguous/conflicting）
+ * 3. 产出统一动作 action（answer/clarify/candidate_list/conservative_answer）
+ *
+ * 不替代现有检索链（DocumentRetrievalService / DocRecallService / DocumentEvidencePacker），
+ * 而是在它们之上提供任务编排。现有检索模块作为"检索与证据引擎"保持稳定。
+ *
+ * audit-round02 P0-1: find_document + mergeable 不再直接放行为 answer，
+ *  改为 candidate_list + mergeable_hint（find_document 不返回 chunk 级证据，
+ *  过早放行会导致 LLM 仅凭候选标题做"伪引用回答"）。
+ *
+ * 决策表（audit-round02修订）：
+ *
+ * | goal_type         | candidate_resolution | action             |
+ * |-------------------|----------------------|--------------------|
+ * | locate_document   | single               | answer             |
+ * | locate_document   | mergeable            | candidate_list (*) |
+ * | locate_document   | ambiguous            | candidate_list     |
+ * | locate_document   | conflicting          | candidate_list     |
+ * | answer_question   | single               | answer             |
+ * | answer_question   | mergeable            | answer             |
+ * | answer_question   | ambiguous            | candidate_list     |
+ * | answer_question   | conflicting          | conservative_answer|
+ * | (any)             | none (0 candidates)  | clarify            |
+ *
+ * (*) locate_document + mergeable 走 candidate_list 而非 answer，
+ *    因为 find_document 不返回 chunk 级证据。mergeable 信号通过
+ *    mergeable_hint 注入到候选列表提示中，供用户/LLM 做多文档消费决策。
+ */
+
+import logger from './logger.js';
+
+/**
+ * @typedef {Object} OrchestrationInput
+ * @property {string} toolName - 工具名 'find_document' | 'answer_from_documents' | 'verify_fact'
+ * @property {string} query - 用户原始查询
+ * @property {Array<Object>} candidates - 候选文档列表
+ * @property {Object} [packetMeta] - retrieval packet meta
+ */
+
+/**
+ * @typedef {Object} OrchestrationResult
+ * @property {'locate_document'|'answer_question'} goal_type
+ * @property {'single'|'mergeable'|'ambiguous'|'conflicting'|'none'} candidate_resolution
+ * @property {'answer'|'clarify'|'candidate_list'|'conservative_answer'} action
+ * @property {string[]} reason_codes
+ * @property {Object} [merge_signals] - mergeable 判定信号
+ * @property {boolean} mergeable_hint - 是否应提示用户候选可合并消费（仅 candidate_list + mergeable时）
+ * @property {string} [goal_type_source] - goal_type 判定来源 'tool_name' | 'query_signal'
+ * @property {'identity_only'|'chunk_evidence'} evidence_capability - 当前 tool 的证据能力
+ * @property {boolean} [identity_resolved] - 是否已确认文档身份（audit-round08 P1）
+ * @property {boolean} [evidence_resolved] - 是否已具备正文证据（audit-round08 P1）
+ */
+
+class DocumentOrchestrationService {
+
+  /**
+   * 主编排入口
+   * @param {OrchestrationInput} input
+   * @returns {OrchestrationResult}
+   */
+  orchestrate({ toolName, query, candidates, packetMeta }) {
+    const goalTypeResult = this._determineGoalType(toolName, query);
+    const candidateResolution = this._determineCandidateResolution(candidates, packetMeta);
+    let action = this._decideAction(goalTypeResult.goal_type, candidateResolution.resolution, candidates.length);
+
+    const anchoredBridgeEligible = (
+      toolName === 'find_document'
+      && goalTypeResult.source === 'anchored_document_answer_intent'
+      && candidateResolution.resolution === 'mergeable'
+    );
+
+    // audit-round09 P0: 显式文档锚点 + 同集合可桥接多候选
+    // 典型场景：用户明确点名“文件A”，而 A 正文又把关键参数指向同集合中的文件B。
+    // 此时多候选并非真正歧义，而是“已锁定主文档 + 关联答案载体”的桥接关系。
+    // 允许继续进入回答链，后续由 auto/broad content chain 获取 chunk 级证据。
+    if (anchoredBridgeEligible && action === 'candidate_list') {
+      action = 'answer';
+    }
+
+    // audit-round03 P0-1: tool-level guard — find_document 无 chunk 级证据，
+    // 无论 goal_type 是否被 query 纠偏为 answer_question，
+    // 多候选场景下不得直接进入 answer_with_citation 路径。
+    // 这封死了 round02 遗留的旁路：
+    //   find_document + query_signal_override + mergeable → answer → answer_with_citation
+    const reasonCodes = [...candidateResolution.reason_codes];
+    let toolGuardActive = false;
+    if (toolName === 'find_document' && candidates.length > 1 && action === 'answer' && !anchoredBridgeEligible) {
+      action = 'candidate_list';
+      toolGuardActive = true;
+      reasonCodes.push('tool_guard_find_document_multi_candidate');
+    }
+
+    // audit-round03 P1-1: 显式证据能力维度
+    const evidenceCapability = (toolName === 'find_document') ? 'identity_only' : 'chunk_evidence';
+
+    // audit-round02 P0-1: locate_document + mergeable → candidate_list（保守方案）
+    // 但因候选可合并，提示用户可多文档消费
+    const mergeableHint = (
+      goalTypeResult.goal_type === 'locate_document' &&
+      candidateResolution.resolution === 'mergeable' &&
+      action === 'candidate_list'
+    );
+
+    const result = {
+      goal_type: goalTypeResult.goal_type,
+      candidate_resolution: candidateResolution.resolution,
+      action,
+      reason_codes: reasonCodes,
+      merge_signals: candidateResolution.merge_signals,
+      mergeable_hint: mergeableHint,
+      goal_type_source: goalTypeResult.source,
+      evidence_capability: evidenceCapability,
+    };
+
+    logger.info('[DocOrchestration] Orchestration result:', {
+      goal_type: result.goal_type,
+      goal_type_source: result.goal_type_source,
+      candidate_resolution: result.candidate_resolution,
+      action: result.action,
+      candidate_count: candidates.length,
+      reason_codes: result.reason_codes,
+      mergeable_hint: result.mergeable_hint,
+      evidence_capability: result.evidence_capability,
+      tool_guard_active: toolGuardActive,
+    });
+
+    return result;
+  }
+
+  /**
+   * 判定用户目标类型
+   *
+   * audit-round02 P1-1: 增加 query 语义纠偏
+   * - toolName 作为强先验（find_document → locate_document）
+   * - query 语义信号可覆盖 tool 选择偏差
+   *
+   * query 语义信号（最小覆盖）：
+   * - 问答型：怎么/如何/什么/多少/几/吗/呢/是否/能不能
+   * - 计算/条款型：成本/费用/价格/多少钱/计算/条款/规定/要求/责任/承担
+   * - 纯定位型：找/在哪/有哪些/列表/列出/搜索/查
+   *
+   * @param {string} toolName
+   * @param {string} query
+   * @returns {{ goal_type: string, source: string }}
+   */
+  _determineGoalType(toolName, query) {
+    const q = (query || '').toLowerCase();
+
+    // 问答信号（强信号，可覆盖 find_document 的定位默认）
+    const answerPatterns = [
+      /怎么|如何|什么|多少|几[个项条]|[多几]少钱|是不是|能否|能不能|是否/,
+      /成本|费用|价格|计算|公式|标准值|参数|要求|规定|条款|责任|承担|赔偿|违约/,
+      /比例|基数|系数|每天|每日|延[期迟]交付|告诉我/,
+      /吗[？?\s]*$|呢[？?\s]*$/,
+    ];
+    const hasAnswerSignal = answerPatterns.some(p => p.test(q));
+
+    // 显式文档锚点：用户已指出具体文件/文档对象，后续更可能是在问该文档内容
+    // 例如：
+    // - 帮我看一下审稿人回信2里的回复都做了什么修改
+    // - 文件A里延期违约金怎么规定
+    // - 那个合同补充协议里面写了什么
+    const anchoredDocumentPatterns = [
+      /[《“"]?[^《》“”"\s]{1,40}(文件|文档|回信|回复|合同|协议|标准|报告|说明书)[0-9一二三四五六七八九十甲乙丙丁]*[》”"]?(里|中|内|里面)/,
+      /(文件|文档|回信|回复|合同|协议|标准|报告|说明书)[a-z0-9一二三四五六七八九十甲乙丙丁]+(里|中|内|里面)/,
+      /(文件|文档|回信|回复|合同|协议|标准|报告|说明书)[a-z0-9一二三四五六七八九十甲乙丙丁]+这份(文件|文档|合同|协议|标准|报告|说明书)/,
+      /(这个|该)(文件|文档|回信|回复|合同|协议|标准|报告|说明书)/,
+      /审稿人回信[0-9一二三四五六七八九十]+(里|中|内|里面)?/,
+    ];
+    const hasAnchoredDocumentSignal = anchoredDocumentPatterns.some(p => p.test(q));
+
+    // 定位信号
+    const locatePatterns = [
+      /找|在哪|有哪些|列表|列出|搜索|查[询看找]|定位/,
+      /^(GB\/T|ISO|GB|JT|DL|NB|SH|SY|HG)\s*[\d.-]+/,  // 纯编号开头
+    ];
+    const hasLocateSignal = locatePatterns.some(p => p.test(q));
+
+    if (toolName === 'find_document') {
+      // find_document + 显式文档锚点 + 问答信号 → answer_question（优先读该文档内容）
+      // 这类 query 的核心不是“帮我确认这份文件是谁”，而是“基于这份文件回答内容问题”。
+      // 即使句子里混有“看一下/找一下/查一下”等定位措辞，也应优先视作 anchored answer intent。
+      if (hasAnchoredDocumentSignal && hasAnswerSignal) {
+        return { goal_type: 'answer_question', source: 'anchored_document_answer_intent' };
+      }
+
+      // find_document + 明显问答信号 → answer_question（纠偏）
+      if (hasAnswerSignal && !hasLocateSignal) {
+        return { goal_type: 'answer_question', source: 'query_signal_override' };
+      }
+      // find_document + 同时有问答和定位信号 → locate_document_with_answer_intent
+      if (hasAnswerSignal && hasLocateSignal) {
+        return { goal_type: 'locate_document', source: 'tool_name_with_answer_intent' };
+      }
+      return { goal_type: 'locate_document', source: 'tool_name' };
+    }
+
+    // answer_from_documents, verify_fact → answer_question（默认正确）
+    return { goal_type: 'answer_question', source: 'tool_name' };
+  }
+
+  /**
+   * 判定候选收敛状态
+   *
+   * 启发式规则（第一阶段，先做可测可审的骨架）：
+   * - 0 candidates → 无候选
+   * - 1 candidate → single
+   * - 2+ candidates → 检查 mergeable 信号，否则 ambiguous
+   *
+   * mergeable 信号（按优先级）：
+   * 1. 同集合（same collection）：候选来自同一标准库/合同库 → mergeable
+   *    不同章节/条款常分布在同集合的不同文档中
+   * 2. 互补类型（complementary types）：如 standard + price_list → mergeable
+   *    费用计算常需"规则文档 + 价格文档"
+   * 3. 来源连续性（same source）：同上传批次 / 同附件来源 → mergeable
+   * 4. 默认：ambiguous
+   *
+   * @param {Array<Object>} candidates
+   * @param {Object} [packetMeta]
+   * @returns {{ resolution: string, reason_codes: string[], merge_signals: Object }}
+   */
+  _determineCandidateResolution(candidates, packetMeta) {
+    const n = candidates.length;
+
+    if (n === 0) {
+      return {
+        resolution: 'none',
+        reason_codes: ['no_candidates'],
+        merge_signals: null,
+      };
+    }
+
+    if (n === 1) {
+      return {
+        resolution: 'single',
+        reason_codes: ['single_candidate'],
+        merge_signals: null,
+      };
+    }
+
+    // n >= 2: 先检查 conflicting，再检查 mergeable
+    const conflict = this._detectConflicting(candidates);
+    if (conflict.isConflicting) {
+      return {
+        resolution: 'conflicting',
+        reason_codes: conflict.reasons,
+        merge_signals: null,
+      };
+    }
+
+    // 检查 mergeable 信号
+    const signals = this._detectMergeSignals(candidates);
+
+    if (signals.mergeable) {
+      return {
+        resolution: 'mergeable',
+        reason_codes: signals.reasons,
+        merge_signals: signals,
+      };
+    }
+
+    // 无法判定 → ambiguous
+    return {
+      resolution: 'ambiguous',
+      reason_codes: ['ambiguous_candidates_no_merge_signal'],
+      merge_signals: signals,
+    };
+  }
+
+  /**
+   * 检测多候选是否可合并消费
+   *
+   * @param {Array<Object>} candidates
+   * @returns {{ mergeable: boolean, reasons: string[], signals: Object }}
+   */
+  _detectMergeSignals(candidates) {
+    const reasons = [];
+    const signals = { same_collection: false, complementary_types: false, same_source: false };
+
+    // 信号 1：同集合
+    const collections = new Set(candidates.map(c => c.collection_name).filter(Boolean));
+    if (collections.size === 1 && candidates.length >= 2) {
+      signals.same_collection = true;
+      reasons.push('same_collection');
+    }
+
+    // 信号 2：互补类型（至少 2 种不同类型，且类型组合为已知互补对）
+    const docTypes = new Set(candidates.map(c => c.doc_type).filter(Boolean));
+    const complementaryPairs = [
+      new Set(['standard', 'price_list']),
+      new Set(['standard', 'attachment']),
+      new Set(['contract', 'attachment']),
+      new Set(['contract', 'price_list']),
+      new Set(['standard', 'regulation']),
+    ];
+    const isComplementary = complementaryPairs.some(pair => {
+      const intersection = [...docTypes].filter(t => pair.has(t));
+      return intersection.length >= 2;
+    });
+    if (isComplementary) {
+      signals.complementary_types = true;
+      reasons.push('complementary_types');
+    }
+
+    // 信号 3：来源连续性（暂用 collection_name 相同 + relevance_score 相近）
+    // 后续可扩展为 attachment 来源 / 上传批次
+    if (signals.same_collection) {
+      const scores = candidates.map(c => c.relevance_score || 0).filter(s => s > 0);
+      if (scores.length >= 2) {
+        const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
+        const allClose = scores.every(s => Math.abs(s - avg) < 0.3);
+        if (allClose) {
+          signals.same_source = true;
+          reasons.push('same_source_affinity');
+        }
+      }
+    }
+
+    const mergeable = reasons.length > 0;
+
+    return { mergeable, reasons, signals };
+  }
+
+  /**
+   * 检测候选间冲突（P1-2: 最小冲突启发式）
+   *
+   * 第一阶段不做复杂冲突图谱，仅检测明显互斥信号：
+   * 1. 类型互斥：同集合内有不同类型且非互补对（如 standard + contract 同集合竞争）
+   * 2. 来源分散：3+ 不同集合的高置信候选
+   *
+   * @param {Array<Object>} candidates
+   * @returns {{ isConflicting: boolean, reasons: string[] }}
+   */
+  _detectConflicting(candidates) {
+    const reasons = [];
+    const collections = new Set(candidates.map(c => c.collection_name).filter(Boolean));
+    const docTypes = new Set(candidates.map(c => c.doc_type).filter(Boolean));
+    const highConf = candidates.filter(c => c.candidate_confidence === 'high');
+
+    // 信号 1：同集合内类型分散（排除 mergeable 的 complementary 对）
+    if (collections.size === 1 && candidates.length >= 2) {
+      const complementaryPairs = [
+        new Set(['standard', 'price_list']),
+        new Set(['standard', 'attachment']),
+        new Set(['contract', 'attachment']),
+        new Set(['contract', 'price_list']),
+        new Set(['standard', 'regulation']),
+      ];
+      const isComplementary = complementaryPairs.some(pair => {
+        const intersection = [...docTypes].filter(t => pair.has(t));
+        return intersection.length >= 2;
+      });
+      if (!isComplementary && docTypes.size >= 2) {
+        reasons.push('conflicting_types_in_same_collection');
+      }
+    }
+
+    // 信号 2：来源高度分散（3+ 不同集合，高置信候选）
+    if (collections.size >= 3 && highConf.length >= 2) {
+      reasons.push('dispersed_high_confidence_sources');
+    }
+
+    return {
+      isConflicting: reasons.length > 0,
+      reasons,
+    };
+  }
+
+  /**
+   * 决策动作
+   *
+   * 基于 goal_type × candidate_resolution 决策表映射到 action。
+   *
+   * @param {'locate_document'|'answer_question'} goalType
+   * @param {'single'|'mergeable'|'ambiguous'|'conflicting'} candidateResolution
+   * @param {number} candidateCount
+   * @returns {'answer'|'clarify'|'candidate_list'|'conservative_answer'}
+   */
+  _decideAction(goalType, candidateResolution, candidateCount) {
+    // 0 候选 → clarify
+    if (candidateCount === 0) {
+      return 'clarify';
+    }
+
+    // locate_document 路径
+    if (goalType === 'locate_document') {
+      switch (candidateResolution) {
+        case 'single':
+          return 'answer';
+        case 'mergeable':
+          // audit-round02 P0-1: locate_document + mergeable 走 candidate_list（保守方案）
+          // find_document 不返回 chunk 级证据，过早 answer_with_citation 有风险
+          // mergeable_hint 由 orchestrate() 方法注入，供候选列表提示合并消费可能性
+          return 'candidate_list';
+        case 'ambiguous':
+          return 'candidate_list';
+        case 'conflicting':
+          return 'candidate_list';
+        default:
+          return 'candidate_list';
+      }
+    }
+
+    // answer_question 路径
+    switch (candidateResolution) {
+      case 'single':
+        return 'answer';
+      case 'mergeable':
+        return 'answer';
+      case 'ambiguous':
+        return 'candidate_list';
+      case 'conflicting':
+        return 'conservative_answer';
+      default:
+        return 'clarify';
+    }
+  }
+}
+
+// 单例
+const instance = new DocumentOrchestrationService();
+
+export default instance;
+export { DocumentOrchestrationService };
+
+/**
+ * audit-round07 P0: 判定是否需要在 find_document 单候选收敛后
+ * 自动追加 scoped answer_from_documents 内容检索。
+ *
+ * 纯函数，无副作用，可在单元测试中直接验证决策逻辑。
+ *
+ * @param {Object} orchestration - 编排结果 { evidence_capability, goal_type_source }
+ * @param {number} candidatesLength - 候选文档数量
+ * @returns {boolean}
+ */
+export function shouldAutoChainContent(orchestration, candidatesLength) {
+  return orchestration.evidence_capability === 'identity_only'
+    && candidatesLength === 1
+    && (orchestration.goal_type_source === 'tool_name_with_answer_intent'
+        || orchestration.goal_type_source === 'query_signal_override');
+}

--- a/lib/document-query-decision-service.js
+++ b/lib/document-query-decision-service.js
@@ -51,6 +51,11 @@ const ANCHOR_PATTERNS = {
     /(?:那[份个]|哪[份个]|这[份个]|关于|有关)?.*(?:手册|指南|说明书|操作指引)/,
     // 明确的文档标题引用
     /《[^》]+》/,
+    // 文件A / 文件B / 文档A / 文档B / 回信2 / 标准A 这类编号化锚点
+    /(?:文件|文档|回信|回复|合同|协议|标准|报告|说明书)[a-z0-9一二三四五六七八九十甲乙丙丁]+/i,
+    // “文件A这份文件 / 该文件 / 这个文件”
+    /(?:文件|文档|回信|回复|合同|协议|标准|报告|说明书)[a-z0-9一二三四五六七八九十甲乙丙丁]+这份(?:文件|文档|合同|协议|标准|报告|说明书)/i,
+    /(?:这个|该)(?:文件|文档|回信|回复|合同|协议|标准|报告|说明书)/,
   ],
 
   // 弱锚点：模糊的文档指代
@@ -61,6 +66,10 @@ const ANCHOR_PATTERNS = {
     /(?:文档|文件|资料)(?:里|中|里面|里边|上).*(?:怎么|如何|什么|哪些|有没有)/,
     // 提到collection/知识库
     /(?:知识库|文档库|资料库|归档)/,
+    // 口语型找文档：那个/哪份/叫什么/是哪个
+    /(?:那个|那份|哪份|这份).*(?:是哪个|叫什么|叫啥|哪一个)/,
+    /(?:帮我|给我)?(?:翻一下|找一下|看一下).*(?:那个|那份|哪份)/,
+    /(?:帮我|给我)?(?:翻一下|找一下|看一下).*(?:文件|文档|合同|协议|标准|报告)/,
   ],
 };
 
@@ -154,6 +163,21 @@ class DocumentQueryDecisionService {
       }
     }
 
+    const colloquialLookupSignals = [
+      /(?:那个|那份|哪份|这份).*(?:是哪个|叫什么|叫啥|哪一个)/,
+      /(?:帮我|给我)?(?:翻一下|找一下|看一下).*(?:那个|那份|哪份)/,
+    ];
+    const hasColloquialLookupSignal = colloquialLookupSignals.some(p => p.test(trimmedQuery));
+    const parsedTopicTerms = Array.isArray(context?.parsed_query?.topic_terms) ? context.parsed_query.topic_terms : [];
+    const cleanedQuery = typeof context?.parsed_query?.cleaned_query === 'string' ? context.parsed_query.cleaned_query.trim() : '';
+    const hasRecoverableTopic = parsedTopicTerms.length > 0 || cleanedQuery.length >= 4;
+
+    if (hasColloquialLookupSignal && hasRecoverableTopic && anchorStrength === ANCHOR_STRENGTH.NONE) {
+      anchorStrength = ANCHOR_STRENGTH.WEAK;
+      confidence = Math.max(confidence, 0.35);
+      matchedPatterns.push('colloquial_lookup_signal');
+    }
+
     // 5. 确定意图和推荐策略
     let intent;
     let recommendedStrategy;
@@ -184,7 +208,7 @@ class DocumentQueryDecisionService {
     ];
 
     const hasContentSignal = contentExplorationSignals.some(p => p.test(trimmedQuery));
-    if (hasContentSignal && anchorStrength === ANCHOR_STRENGTH.WEAK) {
+    if (hasContentSignal && anchorStrength === ANCHOR_STRENGTH.WEAK && !hasColloquialLookupSignal) {
       // 弱锚点 + 内容探索信号 → 降级为内容探索
       intent = QUERY_INTENT.CONTENT_EXPLORATION;
       recommendedStrategy = 'chunk_first';

--- a/lib/document-query-parser.js
+++ b/lib/document-query-parser.js
@@ -1,0 +1,634 @@
+/**
+ * Document Query Parser - 文档查询轻量结构化解析器
+ *
+ * 在 find_document 检索链路中作为第一层，对用户 query 进行轻量结构化解析：
+ * - 抽取检索真正需要的槽位（主题词、类型偏好、编号线索）
+ * - 生成清洗后的检索 query 与主题扩召 query
+ * - 判断用户是否在"找文档身份"（lookup_intent）
+ *
+ * 设计原则：
+ * - 纯规则驱动，不依赖 LLM 调用，零延迟
+ * - 输出可审计、可观测、可增量维护
+ * - query 生成主权归本模块，recall 层原则上只消费不隐式改写
+ *
+ * 使用方式：
+ *   import { parseDocumentQuery } from './document-query-parser.js';
+ *   const parsed = parseDocumentQuery(rawQuery);
+ *
+ * 输出契约（DocumentQueryParseResult）：
+ *   lookup_intent:       boolean   - 是否在找文档身份
+ *   topic_terms:         string[]  - 主题词列表
+ *   doc_type_hints:      string[]  - 文档类型偏好（国家标准/合同/制度等）
+ *   identifier_hints:    string[]  - 标准号/合同号/文号等
+ *   cleaned_query:       string    - 清洗后的主检索 query（仅含主题词）
+ *   expanded_topic_queries: string[] - 主题放宽扩召 query 列表
+ *   noise_terms:         string[]  - 被剔除的口语化噪音词
+ */
+
+import logger from './logger.js';
+
+// ============================================================
+// 噪音词模式：口语化表达，检索时应当剔除
+// ============================================================
+const NOISE_PATTERNS = [
+  // 口语化指代
+  /有一个/g, /有一份/g, /有一篇/g, /有一个叫/g,
+  /规定了/g, /规定了什么/g, /说的是/g, /讲的是/g,
+  /主要讲的是什么/g, /主要讲什么/g, /主要讲的是/g,
+  /主要内容是什么/g, /主要内容/g,
+  /是啥来着/g, /是什么来着/g, /叫什么来着/g,
+  /文件/g, /那个文件/g, /那份文件/g, /那份文档/g,
+  /帮我找/g, /帮我查/g, /帮我看看/g, /帮我看一下/g,
+  /找一下/g, /查一下/g, /看一下/g, /搜一下/g,
+  /请问/g, /我想问/g, /我想知道/g, /我想了解/g,
+  /能不能/g, /可不可以/g, /可以吗/g,
+  /在哪里/g, /在哪/g, /哪里找/g, /怎么找/g,
+  /来着/g, /对吧/g, /对不/g, /是不是/g,
+  // 口语动词补语碎片（audit-round04 P1-1）
+  /一下/g,
+  // 疑问词（audit-round03 P1-2）
+  /哪些/g, /哪个/g, /哪里/g, /什么/g, /怎么/g,
+  /有没有/g, /有没有关于/g, /有没有一个/g,
+  // 口语后缀（audit-round03 P1-2）
+  /那份/g, /那个/g, /那[份个]/g, /这[份个]/g,
+  // 语气/疑问词
+  /吗[\?？]*$/g, /呢[\?？]*$/g, /吧[\?？]*$/g, /啊[\?？]*$/g, /[\?？]/g,
+];
+
+// ============================================================
+// 文档类型提示词 → 标准类型 → 用于剥离的关键词集合
+// ============================================================
+const DOC_TYPE_HINT_MAP = [
+  // 国家标准
+  { patterns: [/国家标准/, /国标/, /国家规范/, /强制性标准/, /推荐性标准/, /^标准$/, /标准号/, /标准名称/], type: '国家标准' },
+  // 行业标准
+  { patterns: [/行业标准/, /行标/, /团体标准/, /企业标准/, /企标/], type: '行业标准' },
+  // 合同/协议
+  { patterns: [/合同/, /协议/, /契约/, /合约/], type: '合同协议' },
+  // 制度/办法/规定 — 注意：不使用裸 /规定/，避免把"规定了"动词误判为文档类型
+  { patterns: [/(?:管理制度|管理规定|暂行规定|试行规定|实施办法|管理办法|暂行条例)/, /制度/, /办法/, /条例/, /章程/, /细则/, /规程/], type: '制度规章' },
+  // 手册/指南
+  { patterns: [/手册/, /指南/, /说明书/, /操作指引/, /作业指导/], type: '手册指南' },
+  // 报告
+  { patterns: [/报告/, /报表/, /分析报告/, /评估报告/], type: '报告' },
+  // 法律文件
+  { patterns: [/法律/, /法规/, /法令/, /司法解释/], type: '法律法规' },
+  // 技术文档
+  { patterns: [/技术文档/, /技术规范/, /技术方案/, /技术规格书/], type: '技术文档' },
+];
+
+// ============================================================
+// 类型关键词剥离模式（从 cleaned_query 中剔除已识别的类型词）
+// 基于 DOC_TYPE_HINT_MAP 的 patterns，提取可剥离的关键词片段
+// ============================================================
+const TYPE_STRIP_PATTERNS = [
+  /国家标准/g, /国标/g, /国家规范/g, /强制性标准/g, /推荐性标准/g,
+  /行业标准/g, /行标/g, /团体标准/g, /企业标准/g, /企标/g,
+  /合同/g, /协议/g, /契约/g, /合约/g,
+  /管理制度/g, /管理规定/g, /暂行规定/g, /试行规定/g, /实施办法/g, /管理办法/g, /暂行条例/g,
+  /制度/g, /办法/g, /条例/g, /章程/g, /细则/g, /规程/g,
+  /手册/g, /指南/g, /说明书/g, /操作指引/g, /作业指导/g,
+  /报告/g, /报表/g, /分析报告/g, /评估报告/g,
+  /法律/g, /法规/g, /法令/g, /司法解释/g,
+  /技术文档/g, /技术规范/g, /技术方案/g, /技术规格书/g,
+];
+
+// ============================================================
+// 结构助词：用于拆分主题词时清理的虚词/连接词
+// ============================================================
+const STRUCTURAL_PARTICLES = /[的之与和及或关于有关涉及对]+/g;
+
+// ============================================================
+// 标准号/编号模式
+// ============================================================
+const IDENTIFIER_PATTERNS = [
+  // GB/T 12345-2020, GB 12345
+  /\bGB[\/\sT]*\d[\d.]*(-\d{2,4})?\b/gi,
+  // ISO 9001:2015
+  /\bISO[\/\s]*\d[\d.:]+\b/gi,
+  // 行业标准号：YY/T, HJ, DB, QB 等
+  /\b(?:YY\/T|HJ|DB\d|\bQB)\s*\d[\d.]*\b/gi,
+  // 合同编号：HT-2024-001
+  /\b(?:HT|CONT|CONTRACT)[-\s]*\d{2,4}[-\s]*\d+\b/gi,
+  // 文件号/文号：国发〔2024〕1号
+  /[〔\[]?\d{4}[〕\]]?\d+\s*号/gi,
+];
+
+// ============================================================
+// 文档定位信号：用户明确在找"文档身份"
+// ============================================================
+const LOOKUP_INTENT_PATTERNS = [
+  /找.*(?:文档|文件|资料|合同|标准|制度|手册|指南|报告)/,
+  /(?:文档|文件|资料|合同|标准|制度|手册|指南|报告).*(?:在哪|叫啥|叫什么|是啥|是什么)/,
+  /有没有.*(?:文档|文件|资料|合同|标准|制度)/,
+  /哪个.*(?:文档|文件|合同|标准|制度)/,
+  /《[^》]+》/,
+  // 编号查询
+  /\bGB[\/\sT]*\d/,
+  /\bISO[\/\s]*\d/,
+  /[〔\[]?\d{4}[〕\]]?\d+\s*号/,
+];
+
+// ============================================================
+// 同义词归一表（主题词扩展用）
+// ============================================================
+const SYNONYM_MAP = {
+  '汽车': ['车辆', '机动车'],
+  '车身': ['车体'],
+  '术语': ['词汇', '用语', '名词'],
+  '定义': ['释义', '含义'],
+  '标准': ['规范', '准则'],
+  '合同': ['协议'],
+  '制度': ['规章', '规定'],
+  '指南': ['手册', '指引'],
+};
+
+// ============================================================
+// Query Facet 抽取 — audit-round01 P1-1
+// 供 evidence rerank / coverage 校验消费，避免各模块重复拆词
+// ============================================================
+const PROCEDURE_TERM_PATTERNS = [
+  /试验/g, /实验/g, /测试/g, /检测/g, /检验/g,
+  /条件/g, /方法/g, /步骤/g, /流程/g, /要求/g, /规定/g, /规范/g,
+  /怎么做/g, /如何做/g, /怎么测/g, /如何测/g,
+];
+
+const ATTRIBUTE_TERM_PATTERNS = [
+  /是什么/g, /什么是/g, /代表什么/g, /含义/g, /定义/g,
+  /等级/g, /级别/g, /分类/g, /类型/g,
+  /多少/g, /多大/g, /多长/g, /多重/g,
+];
+
+/**
+ * 从原始 query 提取结构化 facets（轻量规则驱动）
+ * @param {string} rawQuery
+ * @param {string[]} identifierHints
+ * @returns {Object} facets
+ */
+function _extractQueryFacets(rawQuery, identifierHints) {
+  const trimmed = rawQuery.trim();
+
+  // entity_terms：标识符 + 数字编码 + 专有名词型实体
+  const entityTerms = [];
+
+  // 标识符直接作为实体
+  for (const id of identifierHints) {
+    entityTerms.push(id);
+  }
+
+  // 数字编码型实体（如 IPX5、IPX7、14.2.5、第二位数字为5）
+  const codePatterns = [
+    /\b[A-Z]{2,}[\s-]*\d[\d.]*\b/gi,      // IPX5, GB/T 12345
+    /\b\d+(?:\.\d+)+\b/g,                    // 14.2.5
+    /第[一二三四五六七八九十\d]+位数字为\d+/g,  // 第二位数字为5
+    /第[一二三四五六七八九十\d]+[章节条款项]/g, // 第二章、第3条
+  ];
+  for (const pattern of codePatterns) {
+    const matches = trimmed.match(pattern);
+    if (matches) {
+      for (const m of matches) {
+        const clean = m.replace(/\s+/g, ' ').trim();
+        if (!entityTerms.some(e => e === clean)) {
+          entityTerms.push(clean);
+        }
+      }
+    }
+  }
+
+  // 专有名词型实体（由大写字母起头的中英混合词，如 "IP 防护"）
+  const properNounPattern = /\b[A-Z]{2,}(?:[\s/-]*[^\s,，。；;、]{1,6}){0,3}/g;
+  const properMatches = trimmed.match(properNounPattern);
+  if (properMatches) {
+    for (const m of properMatches) {
+      const clean = m.replace(/\s+/g, ' ').trim();
+      if (clean.length >= 2 && !entityTerms.some(e => e === clean) && !/^[A-Z]+$/.test(clean)) {
+        entityTerms.push(clean);
+      }
+    }
+  }
+
+  // procedure_terms
+  const procedureTerms = [];
+  for (const pattern of PROCEDURE_TERM_PATTERNS) {
+    const matches = trimmed.match(new RegExp(pattern.source, 'g'));
+    if (matches) {
+      for (const m of matches) {
+        if (!procedureTerms.includes(m)) procedureTerms.push(m);
+      }
+    }
+  }
+
+  // attribute_terms
+  const attributeTerms = [];
+  for (const pattern of ATTRIBUTE_TERM_PATTERNS) {
+    const matches = trimmed.match(new RegExp(pattern.source, 'g'));
+    if (matches) {
+      for (const m of matches) {
+        if (!attributeTerms.includes(m)) attributeTerms.push(m);
+      }
+    }
+  }
+
+  // normalized_lookup_query：实体 + 程序词拼接
+  const normalizedParts = [...new Set([...entityTerms, ...procedureTerms])];
+  const normalizedLookupQuery = normalizedParts.join(' ') || trimmed;
+
+  return {
+    entity_terms: [...new Set(entityTerms)],
+    procedure_terms: [...new Set(procedureTerms)],
+    attribute_terms: [...new Set(attributeTerms)],
+    normalized_lookup_query: normalizedLookupQuery,
+  };
+}
+
+/**
+ * @typedef {Object} DocumentQueryParseResult
+ * @property {boolean} lookup_intent - 是否在找文档身份
+ * @property {string[]} topic_terms - 主题词列表
+ * @property {string[]} doc_type_hints - 文档类型偏好
+ * @property {string[]} identifier_hints - 标准号/合同号/文号
+ * @property {string} cleaned_query - 清洗后的主检索 query（仅主题词）
+ * @property {string[]} expanded_topic_queries - 主题放宽扩召 query
+ * @property {string[]} noise_terms - 被剔除的口语化噪音词
+ * @property {string} raw_query - 原始 query
+ * @property {Object} facets - 查询结构化切面（audit-round01 P1-1）
+ * @property {string[]} facets.entity_terms - 核心实体词
+ * @property {string[]} facets.procedure_terms - 程序/方法词
+ * @property {string[]} facets.attribute_terms - 属性/问法词
+ * @property {string} facets.normalized_lookup_query - 归一化查找 query
+ */
+
+/**
+ * 解析文档查询，提取结构化槽位
+ *
+ * 处理顺序（关键）：
+ *   原 query → 剔除噪音词 → 提取文档类型偏好 → 剔除类型关键词 → 提取主题词
+ * 必须先剔除噪音再检测类型，避免"规定了"等噪音词被误判为制度规章。
+ * 必须在提取类型后再剔除类型关键词，保证 cleaned_query 不受类型词污染。
+ *
+ * @param {string} rawQuery - 原始用户查询
+ * @returns {DocumentQueryParseResult}
+ */
+export function parseDocumentQuery(rawQuery) {
+  if (!rawQuery || typeof rawQuery !== 'string' || !rawQuery.trim()) {
+    return _emptyResult(rawQuery || '');
+  }
+
+  const trimmed = rawQuery
+    .replace(/[？]/g, '?')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // 1. 检测文档定位意图（使用原始 query）
+  const lookupIntent = LOOKUP_INTENT_PATTERNS.some(p => p.test(trimmed));
+
+  // 2. 提取编号线索（使用原始 query，编号是精确信号）
+  const identifierHints = [];
+  for (const pattern of IDENTIFIER_PATTERNS) {
+    const matches = trimmed.match(pattern);
+    if (matches) {
+      identifierHints.push(...matches.map(m => m.trim()));
+    }
+  }
+
+  // 3. 【关键顺序变更】先剔除噪音词，再检测类型偏好
+  //    避免"规定了"等口语噪音词被 DOC_TYPE_HINT_MAP 误判为制度规章
+  let cleaned = trimmed;
+  const noiseTerms = [];
+
+  cleaned = cleaned
+    .replace(/主要讲的是什么/g, ' ')
+    .replace(/主要讲什么/g, ' ')
+    .replace(/主要讲的是/g, ' ')
+    .replace(/主要内容是什么/g, ' ')
+    .replace(/主要内容/g, ' ')
+    .replace(/什么标准/g, ' 标准 ')
+    .replace(/什么文件/g, ' 文件 ')
+    .replace(/什么文档/g, ' 文档 ')
+    .replace(/是什么标准/g, ' 标准 ')
+    .replace(/是什么文件/g, ' 文件 ')
+    .replace(/是什么文档/g, ' 文档 ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  for (const pattern of NOISE_PATTERNS) {
+    const matches = cleaned.match(new RegExp(pattern.source, 'g'));
+    if (matches) {
+      noiseTerms.push(...matches);
+    }
+    cleaned = cleaned.replace(pattern, ' ').replace(/\s+/g, ' ').trim();
+  }
+
+  // 4. 在噪音已剔除的文本上检测文档类型偏好
+  //    注意：DOC_TYPE_HINT_MAP 的 patterns 不使用 /g，避免 lastIndex 状态泄漏
+  const docTypeHints = [];
+  for (const entry of DOC_TYPE_HINT_MAP) {
+    for (const p of entry.patterns) {
+      if (p.test(cleaned)) {
+        const trimmedType = entry.type.trim();
+        if (!docTypeHints.includes(trimmedType)) {
+          docTypeHints.push(trimmedType);
+        }
+        break;
+      }
+    }
+  }
+
+  // 5. 【新增】类型关键词剥离：从 cleaned 文本中剔除已识别的类型词
+  //    确保 cleaned_query 不受"国标""合同""制度"等类型词污染
+  let topicText = cleaned;
+  for (const typePattern of TYPE_STRIP_PATTERNS) {
+    topicText = topicText.replace(typePattern, ' ').replace(/\s+/g, ' ').trim();
+  }
+
+  // 6. 清理结构助词（的、之、与、和、及、或、关于、有关、涉及、对）
+  topicText = topicText.replace(STRUCTURAL_PARTICLES, ' ').replace(/\s+/g, ' ').trim();
+
+  // 6.5: 标识符剥离（audit-round04 P1-1）—— 在分词前将已捕获的完整编号从主题文本中移除
+  //     防止编号片段（如"一下HT""GB/T"残片）污染 topic_terms
+  let topicTextForSegmentation = topicText;
+  if (identifierHints.length > 0) {
+    for (const id of identifierHints) {
+      // 转义标识符中的正则特殊字符
+      const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      topicTextForSegmentation = topicTextForSegmentation
+        .replace(new RegExp(escaped, 'gi'), ' ')
+        .replace(/\s+/g, ' ').trim();
+    }
+    // 同时剥离常见标识符前缀碎片（如 "GB/T"、"HT" 等孤立残片）
+    topicTextForSegmentation = topicTextForSegmentation
+      .replace(/\b(?:GB\/T|GB|ISO|HT|CONT|CONTRACT|YY\/T|HJ|DB\d+|QB)\b\s*/gi, ' ')
+      .replace(/\s+/g, ' ').trim();
+  }
+
+  // 7. 从剥离后的纯主题文本中提取主题词
+  const topicTerms = _extractTopicTerms(topicTextForSegmentation || topicText, docTypeHints, identifierHints)
+    .map(t => t.trim())
+    .filter(Boolean)
+    .filter(t => !['标准', '文件', '文档', '规范', '资料'].includes(t));
+
+  // 8. 构造 cleaned_query（兼容 merge 前稳定语义）：
+  //    - 有编号时：编号优先 + 主题词随后
+  //    - 无编号时：优先保留连续主题文本，不强制用空格重组
+  let cleanedQuery;
+  const dedupedIds = [...new Set(identifierHints)];
+  const idPart = dedupedIds.join(' ');
+  const cleanTopicTerms = topicTerms.filter(t => {
+    // 过滤掉标识符残片（如 "GB/T"、"一下HT"）
+    if (/^(?:GB\/T|GB\d*|ISO\d*|HT[-\s]?\d*|CONT[-\s]?\d*|CONTRACT[-\s]?\d*|[A-Z]{2,}\/?\d*)$/i.test(t)) return false;
+    // 过滤已在 identifier_hints 中的片段
+    if (dedupedIds.some(id => t.includes(id) || id.includes(t))) return false;
+    return true;
+  });
+
+  const contiguousTopicText = (topicTextForSegmentation || topicText || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const topicPart = cleanTopicTerms.join(' ');
+
+  if (idPart && topicPart) {
+    cleanedQuery = idPart + ' ' + topicPart;
+  } else if (idPart) {
+    cleanedQuery = idPart;
+  } else if (contiguousTopicText) {
+    cleanedQuery = contiguousTopicText.replace(/\s+/g, '');
+  } else if (topicPart) {
+    cleanedQuery = topicPart;
+  } else {
+    cleanedQuery = topicText || cleaned;
+  }
+  // 最终去重空格
+  cleanedQuery = cleanedQuery.replace(/\s+/g, ' ').trim();
+
+  // 9. 生成主题扩召 query 列表
+  const expandedTopicQueries = _generateExpandedQueries(topicTerms);
+
+  // 10. 提取 query facets（audit-round01 P1-1）
+  const facets = _extractQueryFacets(trimmed, identifierHints);
+
+  const result = {
+    lookup_intent: lookupIntent || identifierHints.length > 0 || docTypeHints.length > 0,
+    topic_terms: topicTerms,
+    doc_type_hints: docTypeHints.map(t => t.trim()).filter(Boolean),
+    identifier_hints: [...new Set(identifierHints)],
+    cleaned_query: cleanedQuery,
+    expanded_topic_queries: expandedTopicQueries,
+    noise_terms: [...new Set(noiseTerms)],
+    raw_query: trimmed,
+    facets,
+  };
+
+  logger.info('[DocQueryParser] Parsed:', {
+    raw_query: trimmed.substring(0, 100),
+    lookup_intent: result.lookup_intent,
+    topic_terms: result.topic_terms,
+    doc_type_hints: result.doc_type_hints,
+    cleaned_query: result.cleaned_query,
+    expanded_count: result.expanded_topic_queries.length,
+  });
+
+  return result;
+}
+
+/**
+ * 从剥离类型词后的纯主题文本中提取主题词
+ *
+ * 注意：调用方已通过 TYPE_STRIP_PATTERNS 剥离了类型关键词，
+ * 因此本函数不再需要基于 doc_type_hints 做字符级过滤。
+ */
+function _extractTopicTerms(topicText, _docTypeHints, identifierHints) {
+  if (!topicText) return [];
+
+  // 1. 优先按标点/空格分割
+  let segments = topicText
+    .split(/[,，。；;、\s]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  // 2. 中文无空格长文本 → 启发式切分
+  if (segments.length <= 1 && topicText.length > 3) {
+    segments = _segmentChineseText(topicText);
+  }
+
+  // 3. 基础过滤 + 标识符碎片过滤（audit-round04 P1-1）
+  return segments.filter(seg => {
+    if (seg.length <= 1) return false;
+    if (/^[\d.,+\-×÷=<>()（）【】\[\]{}]+$/.test(seg)) return false;
+    // 过滤掉纯编号片段
+    if (identifierHints.some(id => seg.includes(id))) return false;
+    // 过滤标识符残片（如 "一下HT" 中的 "一下HT"、"GB/T" 残片）
+    if (/^(?:GB\/T|GB\d*|ISO\d*|HT[-\s]?\d*|CONT[-\s]?\d*|CONTRACT[-\s]?\d*|[A-Z]{2,}\/?\d*)$/i.test(seg)) return false;
+    return true;
+  });
+}
+
+/**
+ * 对中文无空格文本做启发式切分
+ *
+ * 策略（audit-round02 P1 改进）：
+ * - 优先用已知类型关键词作为切分边界（"标准""合同""制度""手册"等）
+ * - 边界内按 2-4 字滑窗切分
+ */
+function _segmentChineseText(text) {
+  // 先用常见类型关键词作为分割锚点
+  const SPLIT_ANCHORS = [
+    '国家标准', '行业标准', '团体标准', '企业标准', '强制性标准', '推荐性标准',
+    '管理制度', '管理规定', '实施办法', '管理办法', '暂行规定', '暂行条例',
+    '技术文档', '技术规范', '技术方案', '技术规格书',
+    '操作指引', '作业指导', '分析报告', '评估报告', '司法解释',
+  ];
+
+  let working = text;
+  const anchorPieces = [];
+
+  for (const anchor of SPLIT_ANCHORS) {
+    if (working.includes(anchor)) {
+      anchorPieces.push(anchor);
+      working = working.replace(anchor, '\n');
+    }
+  }
+
+  // 对剩余文本做滑窗切分
+  const rawSegments = working
+    .split(/[\n]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  const segments = [];
+  for (const raw of rawSegments) {
+    // 尝试 4→3→2 字滑窗
+    let i = 0;
+    while (i < raw.length) {
+      let matched = false;
+      for (const len of [4, 3, 2]) {
+        if (i + len <= raw.length) {
+          const candidate = raw.substring(i, i + len);
+          if (!/^[\d.,+\-×÷=<>()（）\s]+$/.test(candidate)) {
+            segments.push(candidate);
+            i += len;
+            matched = true;
+            break;
+          }
+        }
+      }
+      if (!matched) {
+        i++;
+      }
+    }
+  }
+
+  // 把锚点关键词插回合适位置
+  segments.push(...anchorPieces);
+
+  return segments;
+}
+
+/**
+ * 主题词常见边界表 —— 用于长主题词的放宽拆分（audit-round03 P2-1）
+ * 键：常见尾词/后缀；值：null 表示仅作拆分锚点
+ */
+const TOPIC_SPLIT_SUFFIXES = [
+  '术语', '定义', '标准', '规范', '指南', '手册', '办法', '规定',
+  '制度', '条例', '流程', '方案', '报告', '说明', '要求', '条件',
+  '指标', '参数', '方法', '技术', '系统', '管理', '安全', '质量',
+  '性能', '设计', '测试', '评估', '分析', '计算', '操作', '维护',
+];
+
+/**
+ * 生成主题扩召 query 列表
+ *
+ * 策略：
+ * - A) 多词主题，生成部分组合（去尾部修饰）
+ * - B) 单词主题，查找同义词表生成替换 query
+ * - C) 长单主题词（4+字），按已知词边界拆分放宽（audit-round03 P2-1）
+ * - 不做类型收窄（不追加"标准""国标"等类型词）
+ *
+ * @param {string[]} topicTerms - 主题词列表
+ * @returns {string[]} 扩召 query 列表
+ */
+function _generateExpandedQueries(topicTerms) {
+  if (!topicTerms || topicTerms.length === 0) return [];
+
+  const queries = [];
+
+  // 策略 A：多词主题 → 去尾部修饰，逐步放宽
+  if (topicTerms.length >= 2) {
+    // 去掉最后一个词
+    const droppedLast = topicTerms.slice(0, -1).join(' ');
+    if (droppedLast.length >= 2) {
+      queries.push(droppedLast);
+    }
+    // 去掉第一个词（常用于剥离泛领域前缀，如“汽车 外壳防护等级” → “外壳防护等级”）
+    const droppedFirst = topicTerms.slice(1).join(' ');
+    if (droppedFirst.length >= 2) {
+      queries.push(droppedFirst);
+    }
+    // 去掉前两个词之后的部分（保留核心前两词）
+    if (topicTerms.length >= 3) {
+      const coreTwo = topicTerms.slice(0, 2).join(' ');
+      if (coreTwo.length >= 2 && coreTwo !== droppedLast) {
+        queries.push(coreTwo);
+      }
+    }
+  }
+
+  // 策略 B：单主题词 → 查找同义词
+  for (const term of topicTerms) {
+    const synonyms = SYNONYM_MAP[term];
+    if (synonyms && synonyms.length > 0) {
+      for (const syn of synonyms) {
+        const expandedQuery = topicTerms.map(t => t === term ? syn : t).join(' ');
+        if (expandedQuery !== topicTerms.join(' ') && !queries.includes(expandedQuery)) {
+          queries.push(expandedQuery);
+        }
+      }
+    }
+  }
+
+  // 策略 C：长单主题词（4+ 字）→ 按已知词边界拆分放宽（audit-round03 P2-1）
+  if (topicTerms.length === 1) {
+    const singleTerm = topicTerms[0];
+    if (singleTerm.length >= 4) {
+      for (const suffix of TOPIC_SPLIT_SUFFIXES) {
+        if (singleTerm.endsWith(suffix) && singleTerm.length > suffix.length) {
+          const prefix = singleTerm.slice(0, -suffix.length);
+          if (prefix.length >= 2) {
+            // 拆分：前缀 + 尾词（如 汽车车身 + 术语）
+            queries.push(prefix + ' ' + suffix);
+            // 进一步放宽：仅前缀（如 汽车车身）
+            queries.push(prefix);
+          }
+          break; // 只取第一个匹配的尾词（最长匹配优先）
+        }
+      }
+    }
+  }
+
+  // 去重，限制数量
+  return [...new Set(queries)].slice(0, 5);
+}
+
+/**
+ * 返回空解析结果
+ */
+function _emptyResult(rawQuery) {
+  return {
+    lookup_intent: false,
+    topic_terms: [],
+    doc_type_hints: [],
+    identifier_hints: [],
+    cleaned_query: rawQuery || '',
+    expanded_topic_queries: [],
+    noise_terms: [],
+    raw_query: rawQuery || '',
+    facets: {
+      entity_terms: [],
+      procedure_terms: [],
+      attribute_terms: [],
+      normalized_lookup_query: rawQuery || '',
+    },
+  };
+}
+
+export default { parseDocumentQuery };

--- a/lib/document-retrieval-service.js
+++ b/lib/document-retrieval-service.js
@@ -41,6 +41,18 @@ import queryDecisionService from './document-query-decision-service.js';
 import DocumentSearchService from './document-search-service.js';
 import DocRecallService from './doc-recall-service.js';
 import DocumentEvidencePacker from './document-evidence-packer.js';
+import { parseDocumentQuery } from './document-query-parser.js';
+
+const DOC_TYPE_RERANK_SIGNALS = {
+  国家标准: [/\bGB\/?T?\b/i, /国家标准/, /标准/, /GB-T/i, /GB_T/i],
+  行业标准: [/行业标准/, /行标/, /YY\/T/i, /HJ\s*\d/i, /DB\d/i, /QB\s*\d/i],
+  合同协议: [/合同/, /协议/, /契约/, /合约/],
+  制度规章: [/制度/, /办法/, /条例/, /章程/, /细则/, /规程/, /规定/],
+  手册指南: [/手册/, /指南/, /说明书/, /操作指引/, /作业指导/],
+  报告: [/报告/, /报表/, /分析报告/, /评估报告/],
+  法律法规: [/法律/, /法规/, /法令/, /司法解释/],
+  技术文档: [/技术文档/, /技术规范/, /技术方案/, /技术规格书/],
+};
 
 /**
  * 检索策略常量
@@ -129,12 +141,24 @@ class DocumentRetrievalService {
       // ==========================================
       // 阶段 1：查询意图决策
       // ==========================================
+      const parsedQuery = parseDocumentQuery(query);
       const decision = this.decisionService.analyze(query, context);
       logger.info('[DocRetrieval] Decision:', { trace_id: traceId, ...decision });
 
-      // 如果决策建议走 chunk_first（纯内容探索），直接走回退路径
-      if (decision.recommended_strategy === 'chunk_first') {
+      const shouldForceDocumentFirst = this._shouldForceDocumentFirst(decision, parsedQuery);
+
+      if (!shouldForceDocumentFirst && decision.recommended_strategy === 'chunk_first' && allow_fallback) {
         return await this._handleChunkFirstFallback(query, options, decision, traceId, startTime);
+      }
+
+      if (shouldForceDocumentFirst && decision.recommended_strategy === 'chunk_first') {
+        logger.info('[DocRetrieval] chunk-first overridden by find_document document-first policy:', {
+          trace_id: traceId,
+          lookup_intent: parsedQuery.lookup_intent,
+          topic_terms: parsedQuery.topic_terms,
+          doc_type_hints: parsedQuery.doc_type_hints,
+          identifier_hints: parsedQuery.identifier_hints,
+        });
       }
 
       // 如果决策建议澄清（ambiguous + 无锚点），降级回答
@@ -145,26 +169,84 @@ class DocumentRetrievalService {
       // ==========================================
       // 阶段 2：文档级候选检索
       // ==========================================
-      const searchResult = await this.searchService.search(query, {
-        userId,
-        doc_types,
-        collection_id,
-        tag_ids,
-        top_k: top_k_candidates,
-      });
+      let searchResult = await this.searchService.search(
+        parsedQuery.cleaned_query || query,
+        {
+          userId,
+          doc_types,
+          collection_id,
+          tag_ids,
+          top_k: top_k_candidates,
+        }
+      );
+
+      searchResult = this._applyDocTypePreferenceRerank(searchResult, parsedQuery);
+
+      if ((!searchResult.candidates || searchResult.candidates.length === 0) && parsedQuery.identifier_hints?.length > 0) {
+        searchResult = await this.searchService.search(query, {
+          userId,
+          doc_types,
+          collection_id,
+          tag_ids,
+          top_k: top_k_candidates,
+        });
+        searchResult = this._applyDocTypePreferenceRerank(searchResult, parsedQuery);
+      }
+
+      let documentRecallRound = 1;
+      let candidateQuality = this._assessCandidateQuality(searchResult.candidates || []);
+      let round2Attempted = false;
+
+      if (this._shouldTriggerRound2(searchResult.candidates || [], decision, parsedQuery)) {
+        const round2Queries = this._buildRound2Queries(query, parsedQuery);
+        for (const round2Query of round2Queries) {
+          round2Attempted = true;
+          const round2Result = await this.searchService.search(round2Query, {
+            userId,
+            doc_types,
+            collection_id,
+            tag_ids,
+            top_k: top_k_candidates,
+          });
+
+          const rerankedRound2Result = this._applyDocTypePreferenceRerank(round2Result, parsedQuery);
+
+          const round2Quality = this._assessCandidateQuality(rerankedRound2Result.candidates || []);
+          if ((rerankedRound2Result.candidates?.length || 0) > 0 && this._isRound2Better(rerankedRound2Result.candidates || [], searchResult.candidates || [])) {
+            searchResult = rerankedRound2Result;
+            documentRecallRound = 2;
+            candidateQuality = round2Quality;
+            break;
+          }
+        }
+      }
 
       logger.info('[DocRetrieval] Document search result:', {
         trace_id: traceId,
         candidate_count: searchResult.candidates?.length || 0,
         strategy: searchResult.strategy,
+        document_recall_round: documentRecallRound,
+        candidate_quality: candidateQuality,
+        parser_lookup_intent: parsedQuery.lookup_intent,
+        parser_topic_terms: parsedQuery.topic_terms,
+        parser_doc_type_hints: parsedQuery.doc_type_hints,
+        parser_identifier_hints: parsedQuery.identifier_hints,
       });
 
       // 无候选文档 → 回退或降级
       if (!searchResult.success || !searchResult.candidates || searchResult.candidates.length === 0) {
         if (allow_fallback && decision.anchor_strength !== 'strong') {
+          logger.info('[DocRetrieval] No document candidates after document-first rounds:', {
+            trace_id: traceId,
+            round2_attempted: round2Attempted,
+            expanded_topic_queries: parsedQuery.expanded_topic_queries || [],
+          });
           return await this._handleChunkFirstFallback(query, options, decision, traceId, startTime);
         }
-        return this._handleDegrade(decision, traceId, startTime, 'no_candidates');
+        return this._handleDegrade(decision, traceId, startTime, 'no_candidates', {
+          document_recall_round: 0,
+          candidate_quality: 'not_applicable',
+        });
       }
 
       // ==========================================
@@ -174,7 +256,16 @@ class DocumentRetrievalService {
       const candidateDocIds = searchResult.candidates.map(c => c.document_id);
       const candidateRevIds = searchResult.candidates.map(c => c.revision_id).filter(Boolean);
 
-      const evidenceResult = await this.recallService.recallWithinDocuments(query, candidateDocIds, {
+      const evidenceResult = await this.recallService.recallWithinDocuments(
+        {
+          semantic_query: query,
+          entity_terms: parsedQuery.facets?.entity_terms || [],
+          procedure_terms: parsedQuery.facets?.procedure_terms || [],
+          attribute_terms: parsedQuery.facets?.attribute_terms || [],
+          normalized_lookup_query: parsedQuery.facets?.normalized_lookup_query || query,
+        },
+        candidateDocIds,
+        {
         revisionIds: candidateRevIds.length > 0 ? candidateRevIds : undefined,
         top_k: top_k_evidence,
         threshold: evidence_threshold,
@@ -197,7 +288,7 @@ class DocumentRetrievalService {
           evidenceResult.items,
           decision,
           traceId,
-          { maxEvidencePerDoc: top_k_evidence, minEvidenceScore: evidence_threshold }
+          { maxEvidencePerDoc: top_k_evidence, minEvidenceScore: evidence_threshold, queryFacets: parsedQuery.facets || null }
         );
       } else {
         // 有候选文档但没有证据 → 返回文档列表，标记证据不足
@@ -205,10 +296,14 @@ class DocumentRetrievalService {
           searchResult.candidates,
           [],
           decision,
-          traceId
+          traceId,
+          { queryFacets: parsedQuery.facets || null }
         );
         packet.meta.reason_codes.push('no_evidence_in_candidates');
       }
+
+      packet.meta.document_recall_round = documentRecallRound;
+      packet.meta.candidate_quality = candidateQuality;
 
       // ==========================================
       // 阶段 4.5：Scoped Identity Enrichment（Round 05 P0-2）
@@ -257,12 +352,17 @@ class DocumentRetrievalService {
       // 阶段 5：证据充分性判断 → 回退/降级
       // ==========================================
       const sufficiency = packet.meta.evidence_sufficiency;
+      const coverage = packet.meta.coverage_status;
 
       if (sufficiency === 'none' || sufficiency === 'weak') {
-        if (allow_fallback && decision.anchor_strength !== 'strong') {
-          // 弱证据 + 非强锚点 → 尝试 chunk-first 回退作为补充
+        // audit-round02 P0-3: coverage 不足时禁止 fallback supplement
+        // "先止错答，再追求补召回"——当核心实体未命中时，补检大概率也无效
+        const coverageAllowsFallback = coverage === 'covered' || coverage === 'not_evaluated';
+
+        if (allow_fallback && decision.anchor_strength !== 'strong' && coverageAllowsFallback) {
+          // 弱证据 + 非强锚点 + 覆盖可接受 → 尝试 chunk-first 回退作为补充
           const fallbackPacket = await this._tryFallbackSupplement(
-            query, options, decision, traceId, packet
+            query, options, decision, traceId, packet, parsedQuery?.facets || null
           );
           if (fallbackPacket) {
             this._logMetrics(traceId, RETRIEVAL_STRATEGY.DOCUMENT_FIRST, startTime, fallbackPacket, { fallback_supplemented: true });
@@ -272,6 +372,9 @@ class DocumentRetrievalService {
 
         // 有文档候选但证据弱 → 仍返回文档列表，标记降级
         packet.meta.reason_codes.push('weak_evidence_degrade');
+        if (!coverageAllowsFallback) {
+          packet.meta.reason_codes.push('fallback_blocked_by_coverage');
+        }
         this.metrics.degrade_count++;
         this._logMetrics(traceId, RETRIEVAL_STRATEGY.DEGRADE, startTime, packet);
         return { packet, strategy: RETRIEVAL_STRATEGY.DEGRADE, metrics: this.metrics };
@@ -367,16 +470,18 @@ class DocumentRetrievalService {
       }
     }
 
+    const filteredBackfillCandidates = this._filterFallbackCandidates(backfillCandidates, items, scopedIdentityConfirmed, scopedDocId);
+
     const packet = this.packer.packFallback(
       items,
       decision,
       traceId,
-      backfillCandidates,
+      filteredBackfillCandidates,
     );
 
     // Round 05 P0-2: 注入 scoped identity 信号到 packet meta
     if (scopedIdentityConfirmed && scopedDocId) {
-      const scopedDoc = backfillCandidates.find(c => c.document_id === scopedDocId);
+      const scopedDoc = filteredBackfillCandidates.find(c => c.document_id === scopedDocId) || backfillCandidates.find(c => c.document_id === scopedDocId);
       packet.meta.scoped_identity_confirmed = true;
       packet.meta.scoped_document_id = scopedDocId;
       packet.meta.scoped_identity_label = scopedDoc?.best_identity_label || scopedDoc?.document_title || '';
@@ -402,13 +507,54 @@ class DocumentRetrievalService {
     return { packet, strategy: RETRIEVAL_STRATEGY.CHUNK_FIRST_FALLBACK, metrics: this.metrics };
   }
 
+  _filterFallbackCandidates(candidates = [], items = [], scopedIdentityConfirmed = false, scopedDocId = null) {
+    if (!Array.isArray(candidates) || candidates.length === 0) return [];
+
+    const evidenceCountByDoc = new Map();
+    let maxEvidenceScoreByDoc = new Map();
+
+    for (const item of items || []) {
+      const docId = item.document?.id;
+      if (!docId) continue;
+      evidenceCountByDoc.set(docId, (evidenceCountByDoc.get(docId) || 0) + 1);
+      maxEvidenceScoreByDoc.set(docId, Math.max(maxEvidenceScoreByDoc.get(docId) || 0, item.score || 0));
+    }
+
+    const enriched = candidates.map(candidate => {
+      const docId = candidate.document_id;
+      const evidenceCount = evidenceCountByDoc.get(docId) || 0;
+      const maxEvidenceScore = maxEvidenceScoreByDoc.get(docId) || 0;
+      const relevanceScore = candidate.relevance_score || 0;
+      const fallbackScore = evidenceCount * 20 + maxEvidenceScore * 100 + relevanceScore * 0.1;
+      return {
+        ...candidate,
+        fallback_evidence_count: evidenceCount,
+        fallback_max_evidence_score: maxEvidenceScore,
+        fallback_rank_score: fallbackScore,
+      };
+    }).filter(candidate => candidate.fallback_evidence_count > 0);
+
+    if (scopedIdentityConfirmed && scopedDocId) {
+      return enriched
+        .filter(candidate => candidate.document_id === scopedDocId)
+        .sort((a, b) => (b.fallback_rank_score || 0) - (a.fallback_rank_score || 0));
+    }
+
+    return enriched
+      .filter(candidate => candidate.fallback_max_evidence_score >= 0.35 || candidate.fallback_evidence_count >= 2)
+      .sort((a, b) => (b.fallback_rank_score || 0) - (a.fallback_rank_score || 0))
+      .slice(0, 3);
+  }
+
   /**
    * 处理降级（无结果、无法回答）
    */
-  _handleDegrade(decision, traceId, startTime, reasonCode) {
+  _handleDegrade(decision, traceId, startTime, reasonCode, metaOverrides = {}) {
     logger.info('[DocRetrieval] Degrading:', { trace_id: traceId, reason: reasonCode });
 
     const packet = this.packer.packEmpty(decision, traceId, reasonCode, RETRIEVAL_STRATEGY.DEGRADE);
+    packet.meta.document_recall_round = metaOverrides.document_recall_round ?? 0;
+    packet.meta.candidate_quality = metaOverrides.candidate_quality ?? 'not_applicable';
     this.metrics.degrade_count++;
     this._logMetrics(traceId, RETRIEVAL_STRATEGY.DEGRADE, startTime, packet);
     return { packet, strategy: RETRIEVAL_STRATEGY.DEGRADE, metrics: this.metrics };
@@ -418,7 +564,7 @@ class DocumentRetrievalService {
    * 尝试用 chunk-first 回退补充 document-first 的结果
    * 仅在 document-first 证据不足时作为补充
    */
-  async _tryFallbackSupplement(query, options, decision, traceId, existingPacket) {
+  async _tryFallbackSupplement(query, options, decision, traceId, existingPacket, queryFacets = null) {
     try {
       this._ensureRecallService();
       const result = await this.recallService.recall(query, {
@@ -448,12 +594,13 @@ class DocumentRetrievalService {
         fallbackCandidates = await this.searchService.getDocumentInfo(newDocIds);
       }
 
-      // 将新发现的文档追加到 packet
+      // audit-round02 P0-4: 传入 queryFacets 以在 fallback packet 上计算 coverage
       const mergedPacket = this.packer.pack(
         fallbackCandidates,
         newItems,
         decision,
-        traceId
+        traceId,
+        { queryFacets }
       );
 
       // 合并原 packet 的文档
@@ -468,6 +615,19 @@ class DocumentRetrievalService {
       mergedPacket.meta.backfill_doc_count = existingPacket.meta.backfill_doc_count + mergedPacket.meta.backfill_doc_count;
       mergedPacket.meta.reason_codes.push('fallback_supplement');
       mergedPacket.meta.evidence_sufficiency = this.packer._assessSufficiency(mergedPacket);
+
+      // audit-round02 P0-4: merge 后重新评估 coverage 与 response mode
+      if (queryFacets) {
+        const mergedCoverage = this.packer._assessCoverage(mergedPacket, queryFacets);
+        mergedPacket.meta.coverage_status = mergedCoverage.status;
+        mergedPacket.meta.coverage_reason_codes = [
+          ...new Set([...mergedPacket.meta.coverage_reason_codes, ...mergedCoverage.reason_codes]),
+        ];
+        const mergedMode = this.packer._deriveResponseMode(mergedPacket);
+        mergedPacket.meta.suggested_response_mode = mergedMode.mode;
+        mergedPacket.meta.should_clarify = mergedMode.should_clarify;
+        mergedPacket.meta.should_answer_conservatively = mergedMode.should_answer_conservatively;
+      }
 
       return mergedPacket;
     } catch (error) {
@@ -517,6 +677,8 @@ class DocumentRetrievalService {
       // P0-5: identity 可观测性
       logEntry.backfill_triggered = packet.meta?.backfill_triggered || false;
       logEntry.backfill_doc_count = packet.meta?.backfill_doc_count ?? 0;
+      logEntry.document_recall_round = packet.meta?.document_recall_round ?? 0;
+      logEntry.candidate_quality = packet.meta?.candidate_quality ?? 'not_applicable';
       logEntry.identity_distribution = packet.documents
         ? packet.documents.map(d => ({ id: d.document_id, confidence: d.identity_confidence, source: d.identity_source }))
         : [];
@@ -529,6 +691,135 @@ class DocumentRetrievalService {
     const ts = Date.now().toString(36);
     const rand = Math.random().toString(36).substring(2, 8);
     return `drs_${ts}_${rand}`;
+  }
+
+  _assessCandidateQuality(candidates = []) {
+    if (!candidates.length) return 'not_applicable';
+    const top1 = candidates[0]?.relevance_score || 0;
+    const top2 = candidates[1]?.relevance_score || 0;
+    if (top1 >= 80) return 'good';
+    if (top1 >= 50 && (top1 - top2) >= 10) return 'good';
+    if (top1 >= 50) return 'marginal';
+    return 'weak';
+  }
+
+  _shouldTriggerRound2(candidates = [], decision, parsedQuery = null) {
+    if (!candidates.length) {
+      return Boolean(parsedQuery?.expanded_topic_queries?.length);
+    }
+    if (decision?.anchor_strength === 'strong') return false;
+    const top1 = candidates[0]?.relevance_score || 0;
+    if (top1 < 50) return true;
+    if (parsedQuery?.doc_type_hints?.length) {
+      const hasTypeMatch = candidates.some(candidate => this._docMatchesAnyTypeHint(candidate, parsedQuery.doc_type_hints));
+      if (!hasTypeMatch) return true;
+    }
+    return false;
+  }
+
+  _isRound2Better(round2Candidates = [], round1Candidates = []) {
+    if ((round1Candidates?.length || 0) === 0 && (round2Candidates?.length || 0) > 0) {
+      return true;
+    }
+    const top1Round2 = round2Candidates[0]?.relevance_score || 0;
+    const top1Round1 = round1Candidates[0]?.relevance_score || 0;
+    return top1Round2 > top1Round1;
+  }
+
+  _buildRound2Queries(query, parsedQuery = null) {
+    const queries = [];
+    const normalizedRaw = String(query || '').trim();
+    const stripped = normalizedRaw.replace(/国标|标准|文件|文档/g, ' ').replace(/\s+/g, ' ').trim();
+    if (stripped && stripped !== normalizedRaw) queries.push(stripped);
+
+    if (parsedQuery?.cleaned_query && !queries.includes(parsedQuery.cleaned_query) && parsedQuery.cleaned_query !== normalizedRaw) {
+      queries.push(parsedQuery.cleaned_query);
+    }
+
+    const compactCleaned = parsedQuery?.cleaned_query?.replace(/\s+/g, '').trim();
+    if (compactCleaned && !queries.includes(compactCleaned) && compactCleaned !== normalizedRaw) {
+      queries.push(compactCleaned);
+    }
+
+    for (const q of (parsedQuery?.expanded_topic_queries || [])) {
+      if (q && !queries.includes(q) && q !== normalizedRaw) {
+        queries.push(q);
+      }
+    }
+
+    const topicTerms = parsedQuery?.topic_terms || [];
+    if (topicTerms.length >= 2) {
+      for (let i = 1; i < topicTerms.length; i++) {
+        const suffix = topicTerms.slice(i).join(' ').trim();
+        if (suffix && !queries.includes(suffix) && suffix !== normalizedRaw) {
+          queries.push(suffix);
+        }
+      }
+    }
+
+    return queries.length > 0 ? queries : [normalizedRaw];
+  }
+
+  _shouldForceDocumentFirst(decision, parsedQuery) {
+    if (decision?.recommended_strategy === 'document_first' || decision?.recommended_strategy === 'document_first_with_fallback') {
+      return true;
+    }
+
+    if (parsedQuery?.lookup_intent) return true;
+    if ((parsedQuery?.identifier_hints?.length || 0) > 0) return true;
+    if ((parsedQuery?.topic_terms?.length || 0) > 0 && (parsedQuery?.doc_type_hints?.length || 0) > 0) return true;
+    return false;
+  }
+
+  _applyDocTypePreferenceRerank(searchResult, parsedQuery) {
+    if (!searchResult?.candidates?.length || !(parsedQuery?.doc_type_hints?.length)) {
+      return searchResult;
+    }
+
+    const rerankedCandidates = [...searchResult.candidates]
+      .map(candidate => {
+        const typeBoost = this._calculateDocTypeBoost(candidate, parsedQuery.doc_type_hints);
+        return {
+          ...candidate,
+          doc_type_preference_boost: typeBoost,
+          relevance_score: (candidate.relevance_score || 0) + typeBoost,
+        };
+      })
+      .sort((a, b) => (b.relevance_score || 0) - (a.relevance_score || 0));
+
+    return {
+      ...searchResult,
+      candidates: rerankedCandidates,
+      strategy: `${searchResult.strategy || 'relevance_match'}+doc_type_rerank`,
+    };
+  }
+
+  _calculateDocTypeBoost(candidate, docTypeHints = []) {
+    let boost = 0;
+    for (const hint of docTypeHints) {
+      if (this._docMatchesTypeHint(candidate, hint)) {
+        boost = Math.max(boost, 18);
+      }
+    }
+    return boost;
+  }
+
+  _docMatchesAnyTypeHint(candidate, docTypeHints = []) {
+    return docTypeHints.some(hint => this._docMatchesTypeHint(candidate, hint));
+  }
+
+  _docMatchesTypeHint(candidate, hint) {
+    const patterns = DOC_TYPE_RERANK_SIGNALS[hint] || [];
+    if (!patterns.length) return false;
+
+    const haystacks = [
+      candidate?.document_title,
+      candidate?.best_identity_label,
+      candidate?.doc_type,
+      ...(candidate?.attachment_filenames || []),
+    ].filter(Boolean);
+
+    return haystacks.some(text => patterns.some(pattern => pattern.test(String(text))));
   }
 }
 

--- a/lib/document-search-service.js
+++ b/lib/document-search-service.js
@@ -19,6 +19,13 @@
 import logger from './logger.js';
 import DocAccessService from './doc-access-service.js';
 
+const TOPIC_SUFFIX_HINTS = [
+  '术语', '定义', '标准', '规范', '指南', '手册', '办法', '规定',
+  '制度', '条例', '流程', '方案', '报告', '说明', '要求', '条件',
+  '指标', '参数', '方法', '技术', '系统', '管理', '安全', '质量',
+  '性能', '设计', '测试', '评估', '分析', '计算', '操作', '维护',
+];
+
 class DocumentSearchService {
   constructor(db) {
     this.db = db;
@@ -109,26 +116,36 @@ class DocumentSearchService {
         whereParams.push(...tag_ids);
       }
 
-      // 4. 构建相关性评分：标题匹配 + 类型匹配
+      // 4. 构建相关性评分：优先围绕主题主词做 document-level recall
       // 注意：评分表达式的 ? 在 SQL SELECT 中出现在 WHERE ? 之前，
       // 因此 scoreParams 必须在 whereParams 之前
       const trimmedQuery = query.trim();
-      const queryWords = trimmedQuery.split(/\s+/).filter(w => w.length > 0);
+      const normalizedQuery = this._normalizeSearchQuery(trimmedQuery);
+      const queryWords = this._extractQueryTerms(normalizedQuery);
       const scoreParams = [];
 
       // 标题精确匹配得分最高
       const titleExactScore = `CASE WHEN d.title = ? THEN 100 ELSE 0 END`;
-      scoreParams.push(trimmedQuery);
+      scoreParams.push(normalizedQuery);
 
       // 标题包含查询得分
       const titleContainsScore = `CASE WHEN d.title LIKE ? THEN 50 ELSE 0 END`;
-      scoreParams.push(`%${trimmedQuery}%`);
+      scoreParams.push(`%${normalizedQuery}%`);
 
-      // 关键词部分匹配得分
+      // 紧凑主题查询（去空格）命中，适配“汽车车身 术语” vs “汽车车身术语”
+      const compactQuery = normalizedQuery.replace(/\s+/g, '').trim();
+      const compactTitleContainsScore = compactQuery && compactQuery !== normalizedQuery
+        ? `CASE WHEN d.title LIKE ? THEN 40 ELSE 0 END`
+        : '0';
+      if (compactQuery && compactQuery !== normalizedQuery) {
+        scoreParams.push(`%${compactQuery}%`);
+      }
+
+      // 主题短语拆分匹配得分
       let keywordScoreParts = [];
       for (const word of queryWords) {
         if (word.length >= 2) {
-          keywordScoreParts.push(`CASE WHEN d.title LIKE ? THEN 10 ELSE 0 END`);
+          keywordScoreParts.push(`CASE WHEN d.title LIKE ? THEN 12 ELSE 0 END`);
           scoreParams.push(`%${word}%`);
         }
       }
@@ -136,11 +153,22 @@ class DocumentSearchService {
         ? `(${keywordScoreParts.join(' + ')})`
         : '0';
 
+      // 有序主题词同时命中时额外加分，鼓励“主题相关性先收敛”
+      let phraseComboScore = '0';
+      if (queryWords.length >= 2) {
+        const comboParts = [];
+        for (const word of queryWords.slice(0, 3)) {
+          comboParts.push('d.title LIKE ?');
+          scoreParams.push(`%${word}%`);
+        }
+        phraseComboScore = `CASE WHEN (${comboParts.join(' AND ')}) THEN 25 ELSE 0 END`;
+      }
+
       // metadata JSON 中包含查询词（适配 metadata 为 JSON 字符串的场景）
       const metadataScore = `CASE WHEN d.metadata LIKE ? THEN 5 ELSE 0 END`;
-      scoreParams.push(`%${trimmedQuery}%`);
+      scoreParams.push(`%${compactQuery || normalizedQuery}%`);
 
-      const relevanceScoreExpr = `(${titleExactScore} + ${titleContainsScore} + ${keywordScore} + ${metadataScore})`;
+      const relevanceScoreExpr = `(${titleExactScore} + ${titleContainsScore} + ${compactTitleContainsScore} + ${keywordScore} + ${phraseComboScore} + ${metadataScore})`;
 
       // 5. 执行查询
       const selectFields = [
@@ -190,28 +218,38 @@ class DocumentSearchService {
           revision_no: r.revision_no,
           revision_label: r.revision_label,
           relevance_score: r.relevance_score,
+          topic_match_terms: queryWords.filter(word => r.document_title?.includes(word)),
           ...(include_metadata && r.metadata ? { metadata: r.metadata } : {}),
         }));
 
+      const rerankedCandidates = this._rerankTopicCandidates(candidates, {
+        normalizedQuery,
+        compactQuery,
+        queryWords,
+      });
+
       // 7. 如果基于相关性的结果不足，补充同类型的最新文档作为候选
       let strategy = 'relevance_match';
-      if (candidates.length === 0 && doc_types && doc_types.length > 0) {
+      if (rerankedCandidates.length === 0 && doc_types && doc_types.length > 0) {
         // 回退：返回指定类型的最新文档
         const fallbackRows = await this._fallbackLatestByType(effectiveCollectionIds, doc_types, top_k);
-        candidates.push(...fallbackRows);
+        rerankedCandidates.push(...fallbackRows);
         strategy = 'fallback_latest_by_type';
       }
 
       logger.info('[DocSearch] Search completed:', {
-        candidate_count: candidates.length,
+        candidate_count: rerankedCandidates.length,
         strategy,
-        top_score: candidates[0]?.relevance_score || 0,
+        top_score: rerankedCandidates[0]?.relevance_score || 0,
+        normalized_query: normalizedQuery,
+        compact_query: compactQuery,
+        query_terms: queryWords,
       });
 
       return {
         success: true,
-        candidates,
-        total: candidates.length,
+        candidates: rerankedCandidates,
+        total: rerankedCandidates.length,
         strategy,
       };
 
@@ -219,6 +257,71 @@ class DocumentSearchService {
       logger.error('[DocSearch] Search error:', error);
       return { success: false, message: error.message, candidates: [], total: 0 };
     }
+  }
+
+  _normalizeSearchQuery(query) {
+    return String(query || '')
+      .replace(/[，。；、“”‘’：:（）()【】\[\],.!?？]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  _extractQueryTerms(query) {
+    const rawTerms = String(query || '').split(/\s+/).map(t => t.trim()).filter(Boolean);
+    const expandedTerms = [];
+
+    for (const term of rawTerms) {
+      expandedTerms.push(term);
+      if (term.length >= 4) {
+        for (const suffix of TOPIC_SUFFIX_HINTS) {
+          if (term.endsWith(suffix) && term.length > suffix.length) {
+            const prefix = term.slice(0, -suffix.length).trim();
+            if (prefix.length >= 2) {
+              expandedTerms.push(prefix);
+              expandedTerms.push(suffix);
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    return [...new Set(expandedTerms)].filter(term => term.length >= 2).slice(0, 8);
+  }
+
+  _rerankTopicCandidates(candidates, { normalizedQuery, compactQuery, queryWords }) {
+    return [...candidates]
+      .map(candidate => {
+        const title = String(candidate.document_title || '');
+        let boost = 0;
+
+        if (compactQuery && title.includes(compactQuery)) {
+          boost += 20;
+        }
+
+        if (normalizedQuery && title.includes(normalizedQuery)) {
+          boost += 15;
+        }
+
+        const matchedTerms = queryWords.filter(word => title.includes(word));
+        boost += matchedTerms.length * 6;
+
+        if (matchedTerms.length >= 2) {
+          boost += 10;
+        }
+
+        return {
+          ...candidate,
+          topic_match_terms: matchedTerms,
+          topic_recall_boost: boost,
+          relevance_score: (candidate.relevance_score || 0) + boost,
+        };
+      })
+      .sort((a, b) => {
+        const scoreDiff = (b.relevance_score || 0) - (a.relevance_score || 0);
+        if (scoreDiff !== 0) return scoreDiff;
+        return (b.topic_match_terms?.length || 0) - (a.topic_match_terms?.length || 0);
+      });
   }
 
   /**

--- a/lib/evidence-formatter.js
+++ b/lib/evidence-formatter.js
@@ -6,6 +6,11 @@
  *
  * 迁出时间：2026-07-07（旧自动预检索路径退场任务 Round 01）
  * 原位置：lib/rag-service.js buildEvidenceContextMessage()
+ *
+ * audit-round03 P2-1: reason_codes 消费边界
+ * - reason_codes: 流程级原因（no_evidence_in_candidates, fallback_supplement, weak_evidence_degrade 等）
+ * - coverage_reason_codes: 覆盖级原因（coverage_miss_core_entity, coverage_no_chunk_overlap 等）
+ * - 格式化时分别展示，避免混淆
  */
 
 import logger from './logger.js';
@@ -17,8 +22,10 @@ import logger from './logger.js';
  * @param {Object} packet.strategy - 检索策略标识
  * @param {Object} packet.meta - 元信息
  * @param {string} packet.meta.evidence_sufficiency - 证据充分性
+ * @param {string} packet.meta.coverage_status - 证据覆盖状态（audit-round03 P1-1）
+ * @param {string[]} packet.meta.coverage_reason_codes - 覆盖原因标记（audit-round03 P1-1）
  * @param {string} packet.meta.suggested_response_mode - 建议回答模式
- * @param {string[]} packet.meta.reason_codes - 原因标记
+ * @param {string[]} packet.meta.reason_codes - 流程级原因标记
  * @param {Array} packet.documents - 候选文档列表
  * @param {Object} options - 选项
  * @param {number} options.maxTokens - 最大 token 数（默认 3000）
@@ -34,6 +41,8 @@ export function buildEvidenceContextMessage(packet, options = {}) {
   const sufficiency = packet.meta?.evidence_sufficiency || 'unknown';
   const responseMode = packet.meta?.suggested_response_mode || 'direct_answer';
   const reasonCodes = packet.meta?.reason_codes || [];
+  const coverageStatus = packet.meta?.coverage_status || 'not_evaluated';
+  const coverageReasonCodes = packet.meta?.coverage_reason_codes || [];
 
   let context = '';
 
@@ -41,6 +50,11 @@ export function buildEvidenceContextMessage(packet, options = {}) {
   context += `## 文档检索结果\n`;
   context += `- 检索策略: ${packet.strategy || 'unknown'}\n`;
   context += `- 证据充分性: ${sufficiency}\n`;
+  context += `- 覆盖状态: ${coverageStatus}\n`;
+  if (coverageReasonCodes.length > 0) {
+    context += `- 覆盖原因: ${coverageReasonCodes.join(', ')}\n`;
+  }
+  context += `- 回答原则: 若证据中出现明确数值、时间、距离、章节号、表格参数，回答时必须优先逐项引用这些原文参数；禁止用常识或泛化表述替换。\n`;
 
   if (responseMode === 'conservative_answer') {
     context += `- ⚠️ 建议回答模式: 保守回答（证据不足，请明确告知用户依据有限）\n`;
@@ -53,7 +67,7 @@ export function buildEvidenceContextMessage(packet, options = {}) {
   }
 
   if (reasonCodes.length > 0) {
-    context += `- 原因标记: ${reasonCodes.join(', ')}\n`;
+    context += `- 流程原因: ${reasonCodes.join(', ')}\n`;
   }
   context += '\n';
 
@@ -66,6 +80,7 @@ export function buildEvidenceContextMessage(packet, options = {}) {
     context += `- 类型: ${doc.doc_type || 'unknown'} | 集合: ${doc.collection_name || 'unknown'}\n`;
     context += `- 相关度: ${Math.round((doc.relevance_score || 0) * 100)}% | 置信度: ${doc.candidate_confidence || 'unknown'}\n`;
     context += `- 证据条数: ${evidenceCount}\n`;
+    context += `- 回答要求: 若该文档证据已包含试验条件/判定条件/表格参数，必须直接依据下方证据作答，不得补写证据中未出现的试验时长、深度、流量、步骤。\n`;
 
     if (doc.evidence && doc.evidence.length > 0) {
       context += `\n**关键证据片段：**\n`;

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -13,6 +13,7 @@
 
 import SkillLoader from './skill-loader.js';
 import logger from './logger.js';
+import documentOrchestration, { shouldAutoChainContent } from './document-orchestration-service.js';
 import { getAssistantManager } from '../server/services/assistant/index.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -22,6 +23,7 @@ import { getDataBasePath } from './paths.js';
 import ConfigLoader from './config-loader.js';
 import DocumentRetrievalService from './document-retrieval-service.js';
 import DocAccessService from './doc-access-service.js';
+import { parseDocumentQuery } from './document-query-parser.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -279,7 +281,7 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
 
 权限说明：
 - 检索范围自动限定为用户有权访问的文档集合
-- 不回退到 chunk-first 全库搜索`,
+- 优先走 document-first；当标题/主题线索不足时，允许在受控范围内回退到 chunk-first，通过正文命中反锁文档身份`,
       parameters: {
         type: 'object',
         properties: {
@@ -2414,7 +2416,7 @@ class ToolManager {
           tool_name: effectiveToolName,
           skill_namespace: 'document_retrieval',
           strategy: 'collection_not_accessible',
-          query: query.trim(),
+          query: effectiveQuery,
           evidence_sufficiency: 'none',
           reason_codes: ['collection_not_accessible'],
           should_clarify: true,
@@ -2566,6 +2568,7 @@ class ToolManager {
     try {
       const retrievalService = this._getDocRetrievalService();
       const accessService = this._getDocAccessService();
+      const queryPlan = this._buildFindDocumentQueryPlan(query.trim());
 
       const accessibleIds = await accessService.getAccessibleCollectionIds(userId);
       if (collection_id && !accessibleIds.includes(collection_id)) {
@@ -2589,16 +2592,24 @@ class ToolManager {
       }
       const effectiveCollectionId = collection_id;
 
-      // find_document：走 document-first 检索，单候选高置信时补最小 supporting evidence
-      const result = await retrievalService.retrieve(query.trim(), {
+      // find_document：优先走 document-first；当标题/主题线索不足时，
+      // 顺序尝试原始问句、normalized_lookup_query、cleaned_query 等更宽入口。
+      // 若文档级检索仍无候选或无法锁定，再受控回退到 chunk-first，用正文命中反锁文档身份。
+      const baseRetrieveOptions = {
         userId,
         doc_types: doc_types?.length > 0 ? doc_types : undefined,
         collection_id: effectiveCollectionId || undefined,
         top_k_candidates: 10,
         top_k_evidence: 3,  // P0-3: 补最小证据用于身份验证
         evidence_threshold: 0.1,
-        allow_fallback: false,  // find_document 不回退到 chunk-first
-      });
+        allow_fallback: true,
+      };
+
+      const { result, effectiveQuery } = await this._retrieveWithFindDocumentQueryPlan(
+        retrievalService,
+        queryPlan,
+        baseRetrieveOptions,
+      );
 
       const packet = result.packet;
       const duration = Date.now() - startTime;
@@ -2609,12 +2620,12 @@ class ToolManager {
       if (docs.length === 0) {
         try {
           const attachmentCandidates = await retrievalService.searchService.searchByAttachmentFilenames(
-            query.trim(), { userId, doc_types, top_k: 5, collection_id: effectiveCollectionId || undefined }
+            effectiveQuery, { userId, doc_types, top_k: 5, collection_id: effectiveCollectionId || undefined }
           );
           if (attachmentCandidates && attachmentCandidates.length > 0) {
             logger.info('[ToolManager] find_document attachment fallback 命中:', {
               count: attachmentCandidates.length,
-              query: query.trim(),
+              query: effectiveQuery,
             });
             // 将 attachment fallback 结果转换为标准 docs 格式
             docs = attachmentCandidates.map(c => ({
@@ -2661,29 +2672,189 @@ class ToolManager {
           : undefined),
       }));
 
-      // find_document 的 response_mode 语义：
-      // - candidate_list: 多候选，需用户确认（共享 mode，chat-service 统一处理）
-      // - single_document: 单候选，可直接展示文档信息
-      // - clarify: 无候选，需澄清
+      // audit-round01 P0-1/P0-2: 使用编排层替代硬编码 candidate_list
+      // 旧行为：candidates.length > 1 → candidate_list（短路）
+      // 新行为：由 DocumentOrchestrationService 判定候选是否可合并消费
+      const orchestration = documentOrchestration.orchestrate({
+        toolName: effectiveToolName,
+        query: effectiveQuery,
+        candidates,
+        packetMeta: packet?.meta || {},
+      });
+
+      // 将 orchestration action 映射为 suggested_response_mode
+      const modeByAction = {
+        // answer: only for single candidate find_document (chunk-level evidence not included)
+        answer: candidates.length === 1 ? 'single_document' : 'answer_with_citation',
+        candidate_list: 'candidate_list',
+        clarify: 'clarify',
+        conservative_answer: 'conservative_answer',
+      };
+
       const response = {
         success: true,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
         strategy: result.strategy,
-        query: query.trim(),
+        query: effectiveQuery,
         evidence_sufficiency: packet?.meta?.evidence_sufficiency || 'none',
         reason_codes: packet?.meta?.reason_codes || [],
         should_clarify: packet?.meta?.should_clarify || candidates.length === 0,
-        should_answer_conservatively: false,
-        suggested_response_mode: candidates.length > 1 ? 'candidate_list'
-          : candidates.length === 1 ? 'single_document'
-          : 'clarify',
+        should_answer_conservatively: orchestration.action === 'conservative_answer',
+        suggested_response_mode: modeByAction[orchestration.action] || 'clarify',
+        // 编排元信息：供 chat-service 消费以决定是否短路
+        orchestration: {
+          goal_type: orchestration.goal_type,
+          candidate_resolution: orchestration.candidate_resolution,
+          action: orchestration.action,
+          reason_codes: orchestration.reason_codes,
+          merge_signals: orchestration.merge_signals,
+          mergeable_hint: orchestration.mergeable_hint,
+          goal_type_source: orchestration.goal_type_source,
+          evidence_capability: orchestration.evidence_capability,
+          // audit-round08 P1: 显式阶段字段，消除 single_document 语义混叠
+          identity_resolved: candidates.length > 0,
+          evidence_resolved: false,  // find_document 默认仅有 identity
+        },
         candidates,
         total_candidates: candidates.length,
         toolId: effectiveToolName,
         toolName: display,
         duration,
       };
+
+      // ============================================================
+      // audit-round07 P0: auto content chain
+      // 当 find_document 收敛到单候选且仅有 identity_only 证据、
+      // 但用户 query 包含内容意图时，系统不应停在身份确认阶段，
+      // 而应自动执行 scoped answer_from_documents 获取内容证据。
+      //
+      // 触发条件：
+      //   1. single_document 模式（单候选身份确认）
+      //   2. evidence_capability === 'identity_only'（当前仅有身份信息）
+      //   3. 内容意图信号：query_signal_override（纯内容问答）
+      //      或 tool_name_with_answer_intent（定位+问答混合）
+      //
+      // 不触发条件：
+      //   - tool_name（纯定位意图：用户只是想找文档在哪，不需要内容）
+      //   - 多候选场景（需要先收敛候选才能做内容检索）
+      // ============================================================
+      if (response.suggested_response_mode === 'single_document'
+          && response.candidates.length === 1
+          && shouldAutoChainContent(orchestration, candidates.length)) {
+
+        const candidate = response.candidates[0];
+        try {
+          // 以相同 query 自动执行 scoped answer_from_documents
+          // doc_type 从 candidate 提取以缩小检索范围
+          const contentResult = await this._handleAnswerFromDocuments(
+            {
+              query: effectiveQuery,
+              doc_types: candidate.doc_type ? [candidate.doc_type] : undefined,
+            },
+            context,
+            display,
+          );
+
+          if (contentResult.success && contentResult.documents?.length > 0) {
+            response.auto_content_chain = {
+              active: true,
+              content_document_count: contentResult.documents.length,
+            };
+            // 合并内容证据到响应
+            response.content_documents = contentResult.documents;
+            // 证据能力从 identity_only 升级为 chunk_evidence
+            response.orchestration.evidence_capability = 'chunk_evidence';
+            response.orchestration.evidence_resolved = true;
+            // 维持 single_document 模式（身份确认阶段已完成），
+            // 但 chat-service 端将感知 auto_content_chain 并调整约束强度
+            response.reason_codes = [...(response.reason_codes || []), 'auto_content_chain'];
+
+            logger.info('[ToolManager] find_document auto content chain 完成:', {
+              doc_count: contentResult.documents.length,
+              evidence_sufficiency: contentResult.evidence_sufficiency,
+              strategy: contentResult.strategy,
+              duration_ms: contentResult.duration,
+            });
+          } else {
+            logger.info('[ToolManager] find_document auto content chain: 无内容证据返回, 尝试 broader 搜索', {
+              success: contentResult.success,
+              doc_count: contentResult.documents?.length || 0,
+            });
+
+            // ============================================================
+            // audit-round08 P0: A → B 跨文档桥接
+            // scoped 搜索（同 doc_type）在 A 内无内容证据时，
+            // 尝试 broader 搜索（无 doc_type 过滤），以发现承载答案的关联文档 B。
+            //
+            // 触发条件：auto content chain 的 scoped 搜索失败
+            // 策略：同 query、同 collection（如果已知）、无 doc_type 限制
+            // ============================================================
+            try {
+              const broadResult = await this._handleAnswerFromDocuments(
+                {
+                  query: effectiveQuery,
+                  // 不传 doc_types = 全类型搜索（跨文档桥接的关键）
+                  // 传原始 collection_id 以保持范围可控
+                  collection_id: effectiveCollectionId || undefined,
+                },
+                context,
+                display,
+              );
+
+              if (broadResult.success && broadResult.documents?.length > 0) {
+                // 检查是否找到了不同于 A 的文档（跨文档桥接）
+                const newDocs = broadResult.documents.filter(
+                  d => d.document_id !== candidate.document_id
+                );
+                const bridgeActive = newDocs.length > 0;
+
+                response.auto_content_chain = {
+                  active: true,
+                  content_document_count: broadResult.documents.length,
+                  cross_document_bridge: bridgeActive,
+                  bridge_document_count: newDocs.length,
+                };
+                // 使用 broader 搜索结果（可能含 A + B）
+                response.content_documents = broadResult.documents;
+                response.orchestration.evidence_capability = 'chunk_evidence';
+                response.orchestration.evidence_resolved = true;
+                response.reason_codes = [
+                  ...(response.reason_codes || []),
+                  bridgeActive ? 'cross_document_bridge' : 'broad_content_chain',
+                ];
+
+                logger.info('[ToolManager] find_document broad content chain 完成:', {
+                  total_doc_count: broadResult.documents.length,
+                  bridge_active: bridgeActive,
+                  bridge_doc_count: newDocs.length,
+                  bridge_doc_ids: newDocs.map(d => d.document_id),
+                  evidence_sufficiency: broadResult.evidence_sufficiency,
+                  strategy: broadResult.strategy,
+                  duration_ms: broadResult.duration,
+                });
+              } else {
+                logger.info('[ToolManager] find_document broad content chain: 无内容证据返回', {
+                  success: broadResult.success,
+                  doc_count: broadResult.documents?.length || 0,
+                });
+              }
+            } catch (broadErr) {
+              // 非致命：broad 搜索失败时保持原始 identity_only 响应
+              logger.warn('[ToolManager] find_document broad content chain 异常:', {
+                error: broadErr.message,
+                candidate_id: candidate.document_id,
+              });
+            }
+          }
+        } catch (chainErr) {
+          // 非致命：auto-chain 失败时保持原始 identity_only 响应
+          logger.warn('[ToolManager] find_document auto content chain 异常:', {
+            error: chainErr.message,
+            candidate_id: candidate.document_id,
+          });
+        }
+      }
 
       logger.info('[ToolManager] find_document 完成:', {
         tool_name: effectiveToolName,
@@ -2817,6 +2988,28 @@ class ToolManager {
         }
       }
 
+      const documents = (packet?.documents || []).map(doc => ({
+        document_id: doc.document_id,
+        document_title: doc.document_title,
+        doc_type: doc.doc_type,
+        collection_name: doc.collection_name,
+        relevance_score: doc.relevance_score,
+        candidate_confidence: doc.candidate_confidence,
+        evidence: (doc.evidence || []).slice(0, 3).map(ev => ({
+          content: ev.content || '',
+          score: ev.score || 0,
+          chunk_id: ev.chunk_id || null,
+        })),
+        top_evidence: (doc.evidence || []).slice(0, 3).map(ev => ({
+          content: ev.content || '',
+          score: ev.score || 0,
+          chunk_id: ev.chunk_id || null,
+        })),
+      }));
+
+      const suggestedResponseMode = packet?.meta?.suggested_response_mode
+        || (verdict === 'supported' ? 'answer_with_citation' : 'conservative_answer');
+
       // verify_fact 能力诚实性：
       // - contradicted 判定需要独立的反驳证据链路（当前未实现）
       // - 当前仅稳定支持 supported / insufficient_evidence
@@ -2831,6 +3024,10 @@ class ToolManager {
         query: query.trim(),
         evidence_sufficiency: sufficiency,
         reason_codes: packet?.meta?.reason_codes || [],
+        suggested_response_mode: suggestedResponseMode,
+        should_clarify: packet?.meta?.should_clarify || verdict !== 'supported',
+        should_answer_conservatively: packet?.meta?.should_answer_conservatively || verdict !== 'supported',
+        documents,
         supporting_evidence: verdict === 'supported' ? allEvidence.slice(0, 5) : [],
         contradicting_evidence: [],
         related_documents: (packet?.documents || []).map(d => ({
@@ -2849,6 +3046,7 @@ class ToolManager {
         evidence_sufficiency: sufficiency,
         duration_ms: duration,
         reason_codes: response.reason_codes,
+        suggested_response_mode: response.suggested_response_mode,
         document_count: response.related_documents.length,
       });
 
@@ -2877,6 +3075,76 @@ class ToolManager {
         duration,
       };
     }
+  }
+
+  _buildFindDocumentQueryPlan(rawQuery) {
+    const trimmed = String(rawQuery || '').trim();
+    const parsed = parseDocumentQuery(trimmed);
+    const queries = [];
+    const maxExpandedQueries = 2;
+
+    const pushQuery = (role, value) => {
+      const normalized = String(value || '').trim();
+      if (!normalized || queries.some(entry => entry.query === normalized)) return;
+      queries.push({ role, query: normalized });
+    };
+
+    // 1) raw_query: 保留原问句任务语义
+    pushQuery('raw_query', trimmed);
+
+    // 2) lookup_query: 适合“找哪份文件”
+    pushQuery('lookup_query', parsed.facets?.normalized_lookup_query);
+
+    // 3) topic_query: 适合标题/主题召回
+    pushQuery('topic_query', parsed.cleaned_query);
+
+    // 4) expanded_query: 仅保留少量放宽变体，避免无限扩召
+    for (const q of (parsed.expanded_topic_queries || []).slice(0, maxExpandedQueries)) {
+      pushQuery('expanded_query', q);
+    }
+
+    logger.info('[ToolManager] find_document query plan:', {
+      raw_query: trimmed,
+      planned_queries: queries,
+      normalized_lookup_query: parsed.facets?.normalized_lookup_query || null,
+      cleaned_query: parsed.cleaned_query || null,
+      expanded_count: parsed.expanded_topic_queries?.length || 0,
+    });
+
+    return {
+      parsed,
+      queries: queries.length > 0 ? queries : [{ role: 'raw_query', query: trimmed }],
+    };
+  }
+
+  async _retrieveWithFindDocumentQueryPlan(retrievalService, queryPlan, baseOptions) {
+    let lastResult = null;
+    let lastQuery = queryPlan.queries[0]?.query || '';
+
+    for (const plannedEntry of queryPlan.queries) {
+      const plannedQuery = plannedEntry.query;
+      const currentResult = await retrievalService.retrieve(plannedQuery, baseOptions);
+      lastResult = currentResult;
+      lastQuery = plannedQuery;
+
+      const docCount = currentResult?.packet?.documents?.length || 0;
+      const strategy = currentResult?.strategy;
+      const sufficiency = currentResult?.packet?.meta?.evidence_sufficiency || 'none';
+
+      logger.info('[ToolManager] find_document query attempt:', {
+        role: plannedEntry.role,
+        query: plannedQuery,
+        strategy,
+        doc_count: docCount,
+        evidence_sufficiency: sufficiency,
+      });
+
+      if (docCount > 0 || strategy === 'chunk_first_fallback') {
+        return { result: currentResult, effectiveQuery: plannedQuery };
+      }
+    }
+
+    return { result: lastResult, effectiveQuery: lastQuery };
   }
 
   /**

--- a/tests/chat-service-prompt-injection.test.js
+++ b/tests/chat-service-prompt-injection.test.js
@@ -1,0 +1,469 @@
+/**
+ * ChatService prompt 注入测试 — 真实方法回归保护
+ *
+ * audit-round06: 从 static 副本测试升级为真实 ExpertChatService 方法调用。
+ * 使用 Object.create(prototype) 绕过构造函数重依赖，调用的仍是源文件中的真实方法。
+ *
+// audit-round07: auto_content_chain 场景 (G-J)
+ *
+ * audit-round08: 新增 cross_document_bridge 桥接场景 + identity_resolved 阶段字段场景
+ *
+ * 运行：node tests/chat-service-prompt-injection.test.js
+ */
+
+import { ExpertChatService } from '../lib/chat-service.js';
+import { buildEvidenceContextMessage } from '../lib/evidence-formatter.js';
+import { shouldAutoChainContent } from '../lib/document-orchestration-service.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+  }
+}
+
+function assertContains(text, substring, label) {
+  if (text.includes(substring)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label} | 预期包含: "${substring}"`);
+    console.error(`    实际文本前 300 字符: ${text.substring(0, 300)}`);
+  }
+}
+
+function assertNotContains(text, substring, label) {
+  if (!text.includes(substring)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label} | 不应包含: "${substring}"`);
+  }
+}
+
+// ============================================================
+// 构造最小实例：绕过构造函数重依赖，调用真实原型方法
+// 审计建议 5.2: Object.create(ExpertChatService.prototype)
+// ============================================================
+const service = Object.create(ExpertChatService.prototype);
+
+// ============================================================
+// 场景 A（必补）: 真实 _buildResponseModeConstraint('single_document')
+// audit-round06 §4.1
+// ============================================================
+function testCaseA_RealSingleDocumentConstraint() {
+  console.log('\n📋 场景A: 真实 _buildResponseModeConstraint("single_document")');
+
+  const output = service._buildResponseModeConstraint('single_document');
+
+  assertContains(output, '强制回答约束：单文档定位模式', 'A.1 含 single_document 约束标题');
+  assertContains(output, '确认已定位到的文档身份', 'A.2 含身份确认规则');
+  assertContains(output, '不要仅凭片段摘要编造答案', 'A.3 含禁止编造规则（无内容证据分支）');
+  assertContains(output, '禁止过度解读 supporting_evidence 片段', 'A.4 含禁止过度解读规则');
+  // audit-round07: 新约束文本含内容证据分支
+  assertContains(output, '直接基于证据回答用户问题', 'A.5 含内容证据分支（直接回答）');
+}
+
+// ============================================================
+// 场景 B（必补）: 真实 buildEvidenceInjection() identity_only + query_signal_override
+// audit-round06 §4.2
+// ============================================================
+function testCaseB_RealIdentityOnlyGuardInjection() {
+  console.log('\n📋 场景B: 真实 buildEvidenceInjection() identity_only + query_signal_override');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'single_document',
+    strategy: 'document_first',
+    evidence_sufficiency: 'low',
+    reason_codes: ['single_candidate'],
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库' },
+    ],
+    orchestration: {
+      evidence_capability: 'identity_only',
+      goal_type_source: 'query_signal_override',
+      goal_type: 'answer_question',
+      candidate_resolution: 'single',
+      action: 'answer',
+    },
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '强制回答约束：单文档定位模式', 'B.1 含 single_document 约束');
+  assertContains(output, '证据能力约束：身份信息仅用于定位', 'B.2 含 identity_only 守卫标题');
+  assertContains(output, '未提供完整的原文内容', 'B.3 含「未提供完整原文」声明');
+  assertContains(output, '不要基于片段摘要编造完整的条款', 'B.4 含禁止编造条款规则');
+}
+
+// ============================================================
+// 场景 C（建议）: identity_only + tool_name → 不触发守卫
+// audit-round06 §4.3
+// ============================================================
+function testCaseC_RealPureLocateNoGuard() {
+  console.log('\n📋 场景C: identity_only + tool_name → 不注入守卫');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'single_document',
+    strategy: 'document_first',
+    evidence_sufficiency: 'high',
+    reason_codes: ['single_candidate'],
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库' },
+    ],
+    orchestration: {
+      evidence_capability: 'identity_only',
+      goal_type_source: 'tool_name',
+      goal_type: 'locate_document',
+      candidate_resolution: 'single',
+      action: 'answer',
+    },
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '强制回答约束：单文档定位模式', 'C.1 含 single_document 约束');
+  assertNotContains(output, '证据能力约束：身份信息仅用于定位', 'C.2 不含 identity-only 守卫');
+}
+
+// ============================================================
+// 场景 D（建议）: chunk_evidence → 不触发 identity-only 守卫
+// audit-round06 §4.4
+// ============================================================
+function testCaseD_RealChunkEvidenceNoGuard() {
+  console.log('\n📋 场景D: chunk_evidence → 不含 identity-only 守卫');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'answer_with_citation',
+    strategy: 'semantic_first',
+    evidence_sufficiency: 'high',
+    reason_codes: ['sufficient_evidence'],
+    documents: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库' },
+    ],
+    orchestration: {
+      evidence_capability: 'chunk_evidence',
+      goal_type_source: 'tool_name',
+      goal_type: 'answer_question',
+      candidate_resolution: 'single',
+      action: 'answer',
+    },
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '强制回答约束：引用回答模式', 'D.1 含 answer_with_citation 约束');
+  assertNotContains(output, '证据能力约束：身份信息仅用于定位', 'D.2 不含 identity-only 守卫');
+  assertNotContains(output, '强制回答约束：单文档定位模式', 'D.3 不含 single_document 约束');
+}
+
+// ============================================================
+// 场景 E: 失败 toolResult → 空字符串（真实方法）
+// ============================================================
+function testCaseE_RealFailedToolResultEmptyOutput() {
+  console.log('\n📋 场景E: 失败 toolResult → 空字符串');
+
+  const output1 = service.buildEvidenceInjection(null, { maxTokens: 4000 });
+  assert(output1 === '', 'E.1 null → 空字符串');
+
+  const output2 = service.buildEvidenceInjection({ success: false }, { maxTokens: 4000 });
+  assert(output2 === '', 'E.2 { success: false } → 空字符串');
+}
+
+// ============================================================
+// 场景 F: single_document 完整路径（无 orchestration 的正常路径）
+// ============================================================
+function testCaseF_RealSingleDocumentFullPath() {
+  console.log('\n📋 场景F: single_document 完整路径（无 orchestration）');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'single_document',
+    strategy: 'document_first',
+    evidence_sufficiency: 'medium',
+    reason_codes: ['single_candidate'],
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库' },
+    ],
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '强制回答约束：单文档定位模式', 'F.1 含 single_document 约束');
+  assertContains(output, '确认已定位到的文档身份', 'F.2 含身份确认规则');
+  assertContains(output, '禁止过度解读 supporting_evidence 片段', 'F.3 含禁止过度解读规则');
+  assertContains(output, 'GB/T 4208-2017', 'F.4 含文档证据内容');
+  assertNotContains(output, '证据能力约束：身份信息仅用于定位', 'F.5 无 orchestration 不注入守卫');
+}
+
+// ============================================================
+// audit-round07 新增场景
+// ============================================================
+
+// 场景 G: shouldAutoChainContent 决策逻辑 — query_signal_override
+function testCaseG_ShouldAutoChainQuerySignalOverride() {
+  console.log('\n📋 场景G: shouldAutoChainContent query_signal_override → true');
+
+  assert(shouldAutoChainContent(
+    { evidence_capability: 'identity_only', goal_type_source: 'query_signal_override' },
+    1
+  ), 'G.1 identity_only + query_signal_override + 1 candidate → true');
+
+  assert(!shouldAutoChainContent(
+    { evidence_capability: 'identity_only', goal_type_source: 'query_signal_override' },
+    2
+  ), 'G.2 identity_only + query_signal_override + 2 candidates → false');
+
+  assert(!shouldAutoChainContent(
+    { evidence_capability: 'chunk_evidence', goal_type_source: 'query_signal_override' },
+    1
+  ), 'G.3 chunk_evidence + query_signal_override → false（已有内容证据）');
+}
+
+// 场景 H: shouldAutoChainContent 决策逻辑 — tool_name_with_answer_intent
+function testCaseH_ShouldAutoChainMixedIntent() {
+  console.log('\n📋 场景H: shouldAutoChainContent tool_name_with_answer_intent → true');
+
+  assert(shouldAutoChainContent(
+    { evidence_capability: 'identity_only', goal_type_source: 'tool_name_with_answer_intent' },
+    1
+  ), 'H.1 identity_only + mixed_intent + 1 candidate → true');
+
+  assert(!shouldAutoChainContent(
+    { evidence_capability: 'identity_only', goal_type_source: 'tool_name' },
+    1
+  ), 'H.2 identity_only + tool_name(pure locate) → false');
+}
+
+// 场景 I: buildEvidenceInjection 含 auto_content_chain
+function testCaseI_AutoContentChainInjection() {
+  console.log('\n📋 场景I: buildEvidenceInjection auto_content_chain → 含内容证据');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'single_document',
+    strategy: 'document_first',
+    evidence_sufficiency: 'medium',
+    reason_codes: ['single_candidate', 'auto_content_chain'],
+    candidates: [
+      { document_id: 'd1', document_title: '施工合同附件A', doc_type: 'contract', collection_name: '合同库' },
+    ],
+    auto_content_chain: { active: true, content_document_count: 1 },
+    content_documents: [
+      {
+        document_id: 'd1',
+        document_title: '施工合同附件A',
+        doc_type: 'contract',
+        collection_name: '合同库',
+        relevance_score: 0.95,
+        candidate_confidence: 'high',
+        top_evidence: [
+          { content: '每逾期一日，按合同总价的千分之三支付违约金。计算基数：合同总价（不含暂列金）。', score: 0.92 },
+        ],
+      },
+    ],
+    orchestration: {
+      evidence_capability: 'chunk_evidence',
+      goal_type_source: 'tool_name_with_answer_intent',
+      goal_type: 'locate_document',
+      candidate_resolution: 'single',
+      action: 'answer',
+    },
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '强制回答约束：单文档定位模式', 'I.1 含 single_document 约束');
+  assertContains(output, '直接基于证据回答用户问题', 'I.2 含内容证据分支（直接回答）');
+  assertContains(output, '千分之三', 'I.3 含内容证据文本');
+  assertContains(output, '施工合同附件A', 'I.4 含文档名称');
+  assertNotContains(output, '证据能力约束：身份信息仅用于定位', 'I.5 不含 identity-only 守卫（已升级 chunk_evidence）');
+}
+
+// 场景 J: auto_content_chain 但 content_documents 为空 → 回退到 candidates
+function testCaseJ_AutoContentChainEmptyFallback() {
+  console.log('\n📋 场景J: auto_content_chain 但 content_documents 为空 → 回退 candidates');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'single_document',
+    strategy: 'document_first',
+    evidence_sufficiency: 'low',
+    reason_codes: ['single_candidate', 'auto_content_chain'],
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库' },
+    ],
+    auto_content_chain: { active: true, content_document_count: 0 },
+    content_documents: [],
+    orchestration: {
+      evidence_capability: 'chunk_evidence',
+      goal_type_source: 'tool_name_with_answer_intent',
+      goal_type: 'locate_document',
+      candidate_resolution: 'single',
+      action: 'answer',
+    },
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '强制回答约束：单文档定位模式', 'J.1 含 single_document 约束');
+  assertContains(output, 'GB/T 4208-2017', 'J.2 含候选文档（回退）');
+}
+
+// ============================================================
+// audit-round08: 跨文档桥接 + 阶段字段
+// ============================================================
+
+// 场景 K: cross_document_bridge — 跨文档桥接包含新文档的内容证据
+function testCaseK_CrossDocumentBridge() {
+  console.log('\n📋 场景K: cross_document_bridge auto_content_chain → 注入跨文档证据');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'single_document',
+    strategy: 'document_first',
+    evidence_sufficiency: 'medium',
+    reason_codes: ['single_candidate', 'auto_content_chain', 'cross_document_bridge'],
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库' },
+    ],
+    auto_content_chain: { active: true, content_document_count: 2 },
+    content_documents: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', top_evidence: [{ content: 'IPX5试验条件：喷嘴内径6.3mm，水流量12.5L/min', score: 0.92 }] },
+      { document_id: 'd2', document_title: 'GB/T 4208-2017 关联解读', top_evidence: [{ content: 'IPX5试验需持续至少3分钟，距离2.5-3m', score: 0.88 }] },
+    ],
+    orchestration: {
+      evidence_capability: 'chunk_evidence',
+      goal_type_source: 'tool_name_with_answer_intent',
+      goal_type: 'locate_document',
+      candidate_resolution: 'single',
+      action: 'answer',
+      identity_resolved: true,
+      evidence_resolved: true,
+    },
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '单文档定位模式', 'K.1 含 single_document 约束');
+  assertContains(output, '直接基于证据回答', 'K.2 含内容证据分支（直接回答）');
+  assertContains(output, 'GB/T 4208-2017', 'K.3 含主候选文档');
+  assertContains(output, '关联解读', 'K.4 含跨文档桥接文档名称');
+  assertContains(output, '12.5L/min', 'K.5 含桥接内容证据');
+  assertContains(output, '2.5-3m', 'K.6 含桥接内容证据');
+  assertNotContains(output, '身份信息仅用于定位', 'K.7 不含 identity-only 守卫（已桥接到 chunk_evidence）');
+}
+
+// 场景 L: orchestration 含 identity_resolved/evidence_resolved → 不影响注入但字段存在
+function testCaseL_StageFieldsPropagation() {
+  console.log('\n📋 场景L: identity_resolved/evidence_resolved 阶段字段传播');
+
+  const toolResult = {
+    success: true,
+    suggested_response_mode: 'single_document',
+    strategy: 'document_first',
+    evidence_sufficiency: 'low',
+    reason_codes: ['single_candidate', 'auto_content_chain'],
+    candidates: [
+      { document_id: 'd3', document_title: '内部操作手册 v3', doc_type: 'manual', collection_name: '内部知识库' },
+    ],
+    auto_content_chain: { active: true, content_document_count: 1 },
+    content_documents: [
+      { document_id: 'd3', document_title: '内部操作手册 v3', top_evidence: [{ content: '设备巡检周期为每周一次，记录表编号TM-0421', score: 0.91 }] },
+    ],
+    orchestration: {
+      evidence_capability: 'chunk_evidence',
+      goal_type_source: 'query_signal_override',
+      goal_type: 'answer_question',
+      candidate_resolution: 'single',
+      action: 'answer',
+      identity_resolved: true,
+      evidence_resolved: true,
+    },
+  };
+
+  const output = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assertContains(output, '单文档定位模式', 'L.1 含 single_document 约束');
+  assertContains(output, '直接基于证据回答', 'L.2 含内容证据分支');
+  assertContains(output, '内部操作手册 v3', 'L.3 含文档名称');
+  assertContains(output, 'TM-0421', 'L.4 含证据内容');
+}
+
+// 场景 M: verify_fact 返回 supported + documents → 进入 answer_with_citation
+function testCaseM_VerifyFactSupportedConsumesCitationMode() {
+  console.log('\n📋 场景M: verify_fact supported → 消费为 answer_with_citation');
+
+  const toolResult = {
+    success: true,
+    tool_name: 'verify_fact',
+    skill_namespace: 'document_retrieval',
+    verdict: 'supported',
+    strategy: 'document_first',
+    evidence_sufficiency: 'strong',
+    suggested_response_mode: 'answer_with_citation',
+    reason_codes: ['strong_anchor_detected', 'parameter_evidence_closure'],
+    documents: [
+      {
+        document_id: 'd1',
+        document_title: 'GB/T 4208-2017',
+        doc_type: 'standard',
+        collection_name: '标准库',
+        relevance_score: 0.98,
+        candidate_confidence: 'high',
+        evidence: [
+          { content: '对外壳顶部低于 0.85m 的，外壳最高点应低于水面 0.15m 以上；对外壳总高等于或高于 0.85m 的，外壳最低点应低于水面 1m 以下，且外壳最高点应低于水面 0.15m 以上，试验时间 30min。', score: 0.97 },
+        ],
+        top_evidence: [
+          { content: '对外壳顶部低于 0.85m 的，外壳最高点应低于水面 0.15m 以上；对外壳总高等于或高于 0.85m 的，外壳最低点应低于水面 1m 以下，且外壳最高点应低于水面 0.15m 以上，试验时间 30min。', score: 0.97 },
+        ],
+      },
+    ],
+  };
+
+  const decision = service._getResponseModeDecision(toolResult);
+  const injection = service.buildEvidenceInjection(toolResult, { maxTokens: 4000 });
+
+  assert(decision.mode === 'answer_with_citation', 'M.1 mode = answer_with_citation');
+  assert(!decision.isShortCircuit, 'M.2 非短路模式');
+  assertContains(decision.evidenceInjection || '', '强制回答约束：引用回答模式', 'M.3 决策注入含引用回答约束');
+  assertContains(injection, 'GB/T 4208-2017', 'M.4 注入含文档名');
+  assertContains(injection, '试验时间 30min', 'M.5 注入含关键参数原文');
+  assertContains(injection, 'parameter_evidence_closure', 'M.6 注入含 reason code');
+}
+
+// ============================================================
+// 运行
+// ============================================================
+
+console.log('╔══════════════════════════════════════╗');
+console.log('║  ChatService Prompt 注入测试 (真实) ║');
+console.log('╚══════════════════════════════════════╝');
+
+testCaseA_RealSingleDocumentConstraint();
+testCaseB_RealIdentityOnlyGuardInjection();
+testCaseC_RealPureLocateNoGuard();
+testCaseD_RealChunkEvidenceNoGuard();
+testCaseE_RealFailedToolResultEmptyOutput();
+testCaseF_RealSingleDocumentFullPath();
+testCaseG_ShouldAutoChainQuerySignalOverride();
+testCaseH_ShouldAutoChainMixedIntent();
+testCaseI_AutoContentChainInjection();
+testCaseJ_AutoContentChainEmptyFallback();
+testCaseK_CrossDocumentBridge();
+testCaseL_StageFieldsPropagation();
+testCaseM_VerifyFactSupportedConsumesCitationMode();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) process.exit(1);

--- a/tests/document-answer-guardrails.test.js
+++ b/tests/document-answer-guardrails.test.js
@@ -1,0 +1,306 @@
+/**
+ * 文档回答护栏测试
+ *
+ * 目标：确保标准参数类问答必须依据原文参数回答，
+ * 不允许把证据中的明确数值改写成经验性描述。
+ *
+ * 运行：node tests/document-answer-guardrails.test.js
+ */
+
+import { buildEvidenceContextMessage } from '../lib/evidence-formatter.js';
+import DocumentEvidencePacker from '../lib/document-evidence-packer.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+  }
+}
+
+function assertIncludes(text, expected, label) {
+  assert(text.includes(expected), `${label} | 缺少: ${expected}`);
+}
+
+class ChatServiceLike {
+  _buildResponseModeConstraint(mode) {
+    switch (mode) {
+      case 'clarify':
+        return `## ⚠️ 强制回答约束：澄清模式`;
+
+      case 'candidate_list':
+        return `## ⚠️ 强制回答约束：候选列表模式（fallback）`;
+
+      case 'conservative_answer':
+        return `## ⚠️ 强制回答约束：保守回答模式
+
+**你必须遵守以下规则，不得违反：**
+
+1. **禁止给确定性的结论。** 证据不足时，不要用"根据文档..."开头来伪装确定性。
+2. **明确告知依据有限。** 使用"目前检索到的信息有限""未找到明确依据"等表述。
+3. **可以给出参考信息**，但必须注明证据强度较弱，仅供参考。
+4. **不要补充超出检索结果的内容。** 如果你不了解某事，直接说"根据当前文档资料，我无法确认这一点"。
+5. **如果证据中已经出现明确参数，就必须逐项照证据回答。** 禁止把“30min”改写成“通常至少1分钟”，禁止把“顶部以上0.15m、底面下1m”改成模糊说法。
+
+## 输出模板（请严格按照以下结构输出）
+
+**⚠️ 依据有限声明：** 目前从文档平台检索到的信息有限，以下回答仅供参考，可能存在不完整之处。
+
+**参考信息：**
+[基于检索到的证据片段，整理可提供的参考内容]
+
+**不确定性提示：** [明确指出哪些部分缺乏充分证据支撑，建议用户进一步核实]`;
+
+      case 'answer_with_citation':
+        return `## ⚠️ 强制回答约束：引用回答模式
+
+**你必须遵守以下规则，不得违反：**
+
+1. **优先回答证据中已经明确写出的事实。** 尤其是数值、时长、距离、流量、章节号、表格项。
+2. **禁止把原文参数改写成经验性表述。** 例如原文写“30min”，就不能说“通常至少1分钟”；原文写“顶部以上至少0.15m”，就不能说“在规定水深下”。
+3. **若问题询问“代表什么/做什么实验/条件是什么”这类标准参数问题，回答时应分点列出：含义、试验装置、关键参数、对应条款。**
+4. **如果证据没有覆盖某个细节，就明确说当前证据未显示该细节，不得脑补。**
+5. **回答后附来源指向。** 至少指出文档名及证据对应的表/章/条（若证据中可见）。`;
+
+      default:
+        return '';
+    }
+  }
+}
+
+function testCase1_AnswerWithCitationConstraintContainsNoRewriteRule() {
+  console.log('\n📋 场景1: answer_with_citation 约束禁止改写原文参数');
+  const svc = new ChatServiceLike();
+  const text = svc._buildResponseModeConstraint('answer_with_citation');
+
+  assertIncludes(text, '禁止把原文参数改写成经验性表述', '1.1 应明确禁止经验性改写');
+  assertIncludes(text, '30min', '1.2 应包含 30min 反例');
+  assertIncludes(text, '顶部以上至少0.15m', '1.3 应包含 0.15m 反例');
+  assertIncludes(text, '含义、试验装置、关键参数、对应条款', '1.4 应要求参数类问题按结构回答');
+}
+
+function testCase2_ConservativeConstraintContainsNoHallucinationRule() {
+  console.log('\n📋 场景2: conservative_answer 约束禁止把参数说模糊');
+  const svc = new ChatServiceLike();
+  const text = svc._buildResponseModeConstraint('conservative_answer');
+
+  assertIncludes(text, '如果证据中已经出现明确参数，就必须逐项照证据回答', '2.1 应要求逐项照证据回答');
+  assertIncludes(text, '通常至少1分钟', '2.2 应覆盖错误示例');
+  assertIncludes(text, '顶部以上0.15m、底面下1m', '2.3 应覆盖深度示例');
+}
+
+function testCase3_EvidenceContextContainsVerbatimAnswerRule() {
+  console.log('\n📋 场景3: 证据注入文本应强调按原文参数作答');
+  const packet = {
+    strategy: 'document_first',
+    meta: {
+      evidence_sufficiency: 'medium',
+      suggested_response_mode: 'answer_with_citation',
+      reason_codes: ['medium_anchor_detected'],
+    },
+    documents: [
+      {
+        document_id: 'd-ip',
+        document_title: 'GB/T 4208-2017 外壳防护等级(IP代码)',
+        doc_type: 'standard',
+        collection_name: '标准库',
+        relevance_score: 0.88,
+        candidate_confidence: 'high',
+        evidence: [
+          {
+            score: 0.91,
+            content: '表8 防水试验法和主要试验条件：第二位特征数字7，使用潜水箱，水面在外壳顶部以上至少0.15m，外壳底面在水面下至少1m，30min，14.2.7。',
+          },
+        ],
+      },
+    ],
+  };
+
+  const text = buildEvidenceContextMessage(packet, { maxTokens: 3000 });
+
+  assertIncludes(text, '回答原则: 若证据中出现明确数值、时间、距离、章节号、表格参数，回答时必须优先逐项引用这些原文参数', '3.1 应有总则');
+  assertIncludes(text, '不得补写证据中未出现的试验时长、深度、流量、步骤', '3.2 应禁止补写');
+  assertIncludes(text, '30min', '3.3 证据应带出原文时长');
+  assertIncludes(text, '0.15m', '3.4 证据应带出原文水深参数');
+  assertIncludes(text, '14.2.7', '3.5 证据应带出条款');
+}
+
+function testCase4_CoverageNotCoveredOutput() {
+  console.log('\n📋 场景4: not_covered 时输出 coverage 状态与原因');
+
+  const packet = {
+    strategy: 'degrade',
+    meta: {
+      evidence_sufficiency: 'weak',
+      coverage_status: 'not_covered',
+      coverage_reason_codes: ['coverage_miss_core_entity', 'no_evidence'],
+      suggested_response_mode: 'conservative_answer',
+      reason_codes: ['weak_evidence_degrade', 'fallback_blocked_by_coverage'],
+    },
+    documents: [
+      {
+        document_id: 'd1',
+        document_title: '前言文档',
+        doc_type: 'standard',
+        collection_name: '标准库',
+        relevance_score: 0.3,
+        candidate_confidence: 'low',
+        evidence: [
+          { score: 0.3, content: '前言内容...' },
+        ],
+      },
+    ],
+  };
+
+  const text = buildEvidenceContextMessage(packet, { maxTokens: 3000 });
+
+  assertIncludes(text, '覆盖状态: not_covered', '4.1 应输出 coverage_status');
+  assertIncludes(text, '覆盖原因: coverage_miss_core_entity', '4.2 应输出 coverage_reason_codes');
+  assertIncludes(text, 'no_evidence', '4.3 应包含所有 coverage reason');
+  assertIncludes(text, '流程原因: weak_evidence_degrade', '4.4 流程原因单独列出');
+  assertIncludes(text, 'fallback_blocked_by_coverage', '4.5 fallback 被阻止的原因可见');
+}
+
+function testCase5_CoveragePartialOutput() {
+  console.log('\n📋 场景5: partial 时输出覆盖原因');
+
+  const packet = {
+    strategy: 'document_first',
+    meta: {
+      evidence_sufficiency: 'medium',
+      coverage_status: 'partial',
+      coverage_reason_codes: ['coverage_partial_entity_match', 'coverage_no_chunk_overlap'],
+      suggested_response_mode: 'conservative_answer',
+      reason_codes: ['medium_anchor_detected'],
+    },
+    documents: [
+      {
+        document_id: 'd1',
+        document_title: 'GB/T 4208',
+        doc_type: 'standard',
+        collection_name: '标准库',
+        relevance_score: 0.7,
+        candidate_confidence: 'medium',
+        evidence: [
+          { score: 0.6, content: '试验方法...' },
+          { score: 0.5, content: 'IPX5 等级...' },
+        ],
+      },
+    ],
+  };
+
+  const text = buildEvidenceContextMessage(packet, { maxTokens: 3000 });
+
+  assertIncludes(text, '覆盖状态: partial', '5.1 partial 覆盖');
+  assertIncludes(text, 'coverage_no_chunk_overlap', '5.2 chunk overlap 原因');
+  assertIncludes(text, 'coverage_partial_entity_match', '5.3 partial entity 原因');
+}
+
+function testCase6_ParameterClosurePromotesCitationMode() {
+  console.log('\n📋 场景6: 参数证据闭环命中时，不应被 partial+medium 降级');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = packer.pack(
+    [
+      {
+        document_id: 'd-ipx7',
+        document_title: 'GB/T 4208-2017 外壳防护等级(IP代码)',
+        doc_type: 'standard',
+        collection_name: '标准库',
+        relevance_score: 0.95,
+        candidate_confidence: 'high',
+      },
+    ],
+    [
+      {
+        score: 0.91,
+        chunk: {
+          id: 'c-ipx7',
+          seq: 12,
+          content: '表8 防水试验法和主要试验条件：第二位特征数字7，使用潜水箱，水面在外壳顶部以上至少0.15m，外壳底面在水面下至少1m，30min，14.2.7。',
+        },
+        document: { id: 'd-ipx7' },
+      },
+    ],
+    { recommended_strategy: 'document_first', reason_codes: ['medium_anchor_detected'] },
+    'trace-ipx7',
+    {
+      strategy: 'document_first',
+      queryFacets: {
+        entity_terms: ['IPX7'],
+        procedure_terms: ['试验'],
+        attribute_terms: ['是不是', '多少'],
+      },
+    }
+  );
+
+  assert(packet.meta.parameter_evidence_closure === true, '6.1 应识别参数证据闭环');
+  assertIncludes(packet.meta.reason_codes.join(','), 'parameter_evidence_closure', '6.2 应记录闭环原因');
+  assert(packet.meta.suggested_response_mode === 'answer_with_citation', '6.3 partial/medium 下应提升为 answer_with_citation');
+}
+
+function testCase7_ParameterClosureIsGenericForRatioQuestion() {
+  console.log('\n📋 场景7: 比例参数问答同样适用闭环提升');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = packer.pack(
+    [
+      {
+        document_id: 'd-contract',
+        document_title: '施工合同附件A',
+        doc_type: 'contract',
+        collection_name: '合同库',
+        relevance_score: 0.93,
+        candidate_confidence: 'high',
+      },
+    ],
+    [
+      {
+        score: 0.89,
+        chunk: {
+          id: 'c-delay',
+          seq: 5,
+          content: '第12.3条：每逾期一日，按合同总价的0.3%支付违约金。',
+        },
+        document: { id: 'd-contract' },
+      },
+    ],
+    { recommended_strategy: 'document_first', reason_codes: ['medium_anchor_detected'] },
+    'trace-contract',
+    {
+      strategy: 'document_first',
+      queryFacets: {
+        entity_terms: ['违约金'],
+        procedure_terms: [],
+        attribute_terms: ['多少', '比例'],
+      },
+    }
+  );
+
+  assert(packet.meta.parameter_evidence_closure === true, '7.1 比例参数也应识别闭环');
+  assert(packet.meta.suggested_response_mode === 'answer_with_citation', '7.2 比例参数问答应进入引用回答模式');
+}
+
+console.log('╔══════════════════════════════════════╗');
+console.log('║  Document Answer Guardrails 测试    ║');
+console.log('╚══════════════════════════════════════╝');
+
+testCase1_AnswerWithCitationConstraintContainsNoRewriteRule();
+testCase2_ConservativeConstraintContainsNoHallucinationRule();
+testCase3_EvidenceContextContainsVerbatimAnswerRule();
+testCase4_CoverageNotCoveredOutput();
+testCase5_CoveragePartialOutput();
+testCase6_ParameterClosurePromotesCitationMode();
+testCase7_ParameterClosureIsGenericForRatioQuestion();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/document-evidence-rerank-coverage.test.js
+++ b/tests/document-evidence-rerank-coverage.test.js
@@ -1,0 +1,210 @@
+/**
+ * Document Evidence Rerank & Coverage 单元测试
+ *
+ * 覆盖审计标准：
+ * - audit-round01 P0-1: _hybridRerank 混合重排
+ * - audit-round01 P0-2: _assessCoverage 覆盖度评估
+ *
+ * 运行：node tests/document-evidence-rerank-coverage.test.js
+ */
+
+import DocRecallService from '../lib/doc-recall-service.js';
+import DocumentEvidencePacker from '../lib/document-evidence-packer.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEq(actual, expected, label) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) { passed++; }
+  else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+    console.error(`     expected: ${JSON.stringify(expected)}`);
+    console.error(`     actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// ==========================================
+// P0-1: _hybridRerank 测试
+// ==========================================
+
+function testRerank_Basic() {
+  console.log('\n📋 Rerank 用例1: 基础重排');
+
+  const service = new DocRecallService();
+  const items = [
+    { _raw: { content: '第14.2.5条规定防水等级为IPX5', chunk_title: '防水等级', distance: 0.15 }, score: 0.85, chunk: { id: 'c1', title: '防水等级', content: '第14.2.5条规定防水等级为IPX5', seq: 5 } },
+    { _raw: { content: '前言概述...', chunk_title: '前言', distance: 0.10 }, score: 0.90, chunk: { id: 'c2', title: '前言', content: '前言概述...', seq: 0 } },
+  ];
+  const queryPlan = { entity_terms: ['IPX5', '14.2.5'], procedure_terms: ['试验', '方法'] };
+
+  const result = service._hybridRerank(items, queryPlan);
+
+  assert(result.items.length === 2, 'R1.1: 返回同数量 items');
+  assert(result.debug.length === 2, 'R1.2: 返回 debug 信息');
+  assert(typeof result.items[0]._rerank === 'object', 'R1.3: item 含 _rerank 子分数');
+  assert(result.items[0]._rerank.entity > 0, 'R1.4: 实体命中分 > 0');
+
+  // c1 含实体 + 章节锚点，应该排第一
+  assert(result.items[0].chunk.id === 'c1', 'R1.5: 含实体+锚点的 chunk 排第一');
+  assert(result.items[0].score > result.items[1].score, 'R1.6: 第一的 final 分高于第二');
+
+  // 前言 seq=0 且无 section pattern → structural 低
+  const c2Debug = result.debug.find(d => d.chunk_id === 'c2');
+  assert(c2Debug.structural <= 0.5, 'R1.7: 前言 overview chunk structural 偏低');
+}
+
+function testRerank_EmptyFacets() {
+  console.log('\n📋 Rerank 用例2: 空 facets');
+
+  const service = new DocRecallService();
+  const items = [
+    { _raw: { content: 'content a', chunk_title: 'title a' }, score: 0.80, chunk: { id: 'c1', title: 'title a', content: 'content a', seq: 1 } },
+    { _raw: { content: 'content b', chunk_title: 'title b' }, score: 0.75, chunk: { id: 'c2', title: 'title b', content: 'content b', seq: 1 } },
+  ];
+  const queryPlan = { entity_terms: [], procedure_terms: [] };
+
+  const result = service._hybridRerank(items, queryPlan);
+
+  assert(result.items.length === 2, 'R2.1: 空 facets 正常返回');
+  // 纯语义排序：保持原顺序（按 semantic 降序）
+  assert(result.items[0].chunk.id === 'c1', 'R2.2: 无 facets 保持语义排序');
+  assert(result.items[0]._rerank.entity === 0, 'R2.3: 空实体时 entity=0');
+  assert(result.items[0]._rerank.procedure === 0, 'R2.4: 空程序词时 procedure=0');
+}
+
+function testRerank_WeightsSumToOne() {
+  console.log('\n📋 Rerank 用例3: 权重校验');
+
+  const service = new DocRecallService();
+  const items = [
+    { _raw: { content: 'anything', chunk_title: 'title' }, score: 1.0, chunk: { id: 'c1', title: 'title', content: 'anything', seq: 3 } },
+  ];
+  const queryPlan = { entity_terms: [], procedure_terms: [] };
+
+  const result = service._hybridRerank(items, queryPlan);
+
+  // semantic=1.0, entity=0, procedure=0, structural=0.5(default)
+  // final = 0.45*1.0 + 0*0.30 + 0*0.15 + 0.5*0.10 = 0.50
+  const d = result.debug[0];
+  assert(d.semantic === 1, 'R3.1: semantic=1.0');
+  assert(d.final <= 1.0, 'R3.2: 总分不超过 1.0');
+  assert(d.final >= 0.0, 'R3.3: 总分不低于 0.0');
+}
+
+// ==========================================
+// P0-2: _assessCoverage 测试
+// ==========================================
+
+function testCoverage_Covered() {
+  console.log('\n📋 Coverage 用例1: 完全覆盖');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = {
+    meta: { total_evidence: 3, max_evidence_score: 0.85 },
+    documents: [
+      { evidence: [{ content: 'IPX5 防水等级要求 第14.2.5条' }, { content: '试验方法说明' }] },
+      { evidence: [{ content: '附录A 详细参数' }] },
+    ],
+  };
+  const facets = { entity_terms: ['IPX5', '14.2.5'], procedure_terms: ['试验'] };
+
+  const coverage = packer._assessCoverage(packet, facets);
+  assert(coverage.status === 'covered', 'C1.1: 所有实体+程序词命中 → covered');
+  assert(coverage.reason_codes.length === 0, 'C1.2: 无 warning code');
+}
+
+function testCoverage_Partial() {
+  console.log('\n📋 Coverage 用例2: 部分覆盖');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = {
+    meta: { total_evidence: 2 },
+    documents: [
+      { evidence: [{ content: 'IPX5 等级说明' }] },
+    ],
+  };
+  const facets = { entity_terms: ['IPX5', 'IPX7'], procedure_terms: [] };
+
+  const coverage = packer._assessCoverage(packet, facets);
+  assert(coverage.status === 'partial', 'C2.1: 部分实体未命中 → partial');
+  assert(coverage.reason_codes.includes('coverage_miss_core_entity'), 'C2.2: miss_core_entity');
+}
+
+function testCoverage_NotCovered() {
+  console.log('\n📋 Coverage 用例3: 未覆盖');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = {
+    meta: { total_evidence: 2 },
+    documents: [
+      { evidence: [{ content: '前言概述' }, { content: '术语定义' }] },
+    ],
+  };
+  const facets = { entity_terms: ['IPX5', '14.2.5'], procedure_terms: ['试验'] };
+
+  const coverage = packer._assessCoverage(packet, facets);
+  assert(coverage.status === 'not_covered', 'C3.1: 实体完全未命中 → not_covered');
+  assert(coverage.reason_codes.includes('coverage_miss_core_entity'), 'C3.2: miss_core_entity');
+}
+
+function testCoverage_NoEvidence() {
+  console.log('\n📋 Coverage 用例4: 无证据');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = {
+    meta: { total_evidence: 0 },
+    documents: [],
+  };
+  const facets = { entity_terms: ['IPX5'], procedure_terms: [] };
+
+  const coverage = packer._assessCoverage(packet, facets);
+  assert(coverage.status === 'not_covered', 'C4.1: 无证据 → not_covered');
+  assert(coverage.reason_codes.includes('no_evidence'), 'C4.2: no_evidence');
+}
+
+function testCoverage_NoFacets() {
+  console.log('\n📋 Coverage 用例5: 无 facets');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = {
+    meta: { total_evidence: 1 },
+    documents: [{ evidence: [{ content: 'anything' }] }],
+  };
+  const facets = { entity_terms: [], procedure_terms: [] };
+
+  const coverage = packer._assessCoverage(packet, facets);
+  assert(coverage.status === 'not_evaluated', 'C5.1: 无 facets → not_evaluated');
+}
+
+// ==========================================
+// 运行
+// ==========================================
+
+console.log('\n╔══════════════════════════════════════╗');
+console.log('║  Evidence Rerank & Coverage 单元测试 ║');
+console.log('╚══════════════════════════════════════╝');
+
+testRerank_Basic();
+testRerank_EmptyFacets();
+testRerank_WeightsSumToOne();
+
+testCoverage_Covered();
+testCoverage_Partial();
+testCoverage_NotCovered();
+testCoverage_NoEvidence();
+testCoverage_NoFacets();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/document-orchestration-service.test.js
+++ b/tests/document-orchestration-service.test.js
@@ -1,0 +1,849 @@
+/**
+ * Document Orchestration Service 测试
+ *
+ * audit-round01 P0-1: 验证编排状态机的正确性
+ *
+ * 运行：node tests/document-orchestration-service.test.js
+ */
+
+import orchestrationService, { shouldAutoChainContent } from '../lib/document-orchestration-service.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual === expected) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label} | expected: ${expected}, got: ${actual}`);
+  }
+}
+
+// ============================================================
+// 场景 1: find_document + single → answer
+// ============================================================
+function testCase1_FindDocumentSingle() {
+  console.log('\n📋 场景1: find_document + 单候选 → answer');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'GB/T 4208 在哪里',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '1.1 goal_type=locate_document');
+  assertEqual(result.candidate_resolution, 'single', '1.2 candidate_resolution=single');
+  assertEqual(result.action, 'answer', '1.3 action=answer');
+}
+
+// ============================================================
+// 场景 2: find_document + mergeable (同集合) → candidate_list + mergeable_hint
+// audit-round02 P0-1: find_document 不返回 chunk 证据，走保守方案
+// ============================================================
+function testCase2_FindDocumentMergeableSameCollection() {
+  console.log('\n📋 场景2: find_document + 同集合多候选 → candidate_list (mergeable_hint)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'IP防护等级试验条件',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017 第1部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.88 },
+      { document_id: 'd2', document_title: 'GB/T 4208-2017 第2部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.85 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '2.1 goal_type=locate_document');
+  assertEqual(result.candidate_resolution, 'mergeable', '2.2 candidate_resolution=mergeable');
+  assertEqual(result.action, 'candidate_list', '2.3 action=candidate_list (保守!)');
+  assert(result.reason_codes.includes('same_collection'), '2.4 含 same_collection 信号');
+  assertEqual(result.mergeable_hint, true, '2.5 mergeable_hint=true');
+}
+
+// ============================================================
+// 场景 3: find_document + complementary types → candidate_list + mergeable_hint
+// audit-round02 P0-1: find_document 不返回 chunk 证据，走保守方案
+// 注意：query 不含问答信号词（如"成本"），避免 P1-1 query纠偏覆盖
+// ============================================================
+function testCase3_FindDocumentComplementaryTypes() {
+  console.log('\n📋 场景3: find_document + 互补类型 → candidate_list (mergeable_hint)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'X物品分类与参考文档',
+    candidates: [
+      { document_id: 'd1', document_title: '物品分类标准', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.9 },
+      { document_id: 'd2', document_title: '航运价格表', doc_type: 'price_list', collection_name: '价格库', relevance_score: 0.85 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '3.1 goal_type=locate_document');
+  assertEqual(result.candidate_resolution, 'mergeable', '3.2 candidate_resolution=mergeable');
+  assertEqual(result.action, 'candidate_list', '3.3 action=candidate_list (保守!)');
+  assert(result.reason_codes.includes('complementary_types'), '3.4 含 complementary_types 信号');
+  assertEqual(result.mergeable_hint, true, '3.5 mergeable_hint=true');
+}
+
+// ============================================================
+// 场景 4: find_document + ambiguous → candidate_list
+// ============================================================
+function testCase4_FindDocumentAmbiguous() {
+  console.log('\n📋 场景4: find_document + 模糊多候选 → candidate_list');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '合同',
+    candidates: [
+      { document_id: 'd1', document_title: '采购合同A', doc_type: 'contract', collection_name: '合同库A', relevance_score: 0.75 },
+      { document_id: 'd2', document_title: '销售合同B', doc_type: 'contract', collection_name: '合同库B', relevance_score: 0.72 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '4.1 goal_type=locate_document');
+  assertEqual(result.candidate_resolution, 'ambiguous', '4.2 candidate_resolution=ambiguous');
+  assertEqual(result.action, 'candidate_list', '4.3 action=candidate_list');
+}
+
+// ============================================================
+// 场景 5: find_document + 0 候选 → clarify, resolution=none
+// audit-round02 P2-1: 0候选 resolution 应为 'none' 而非 'single'
+// ============================================================
+function testCase5_FindDocumentZero() {
+  console.log('\n📋 场景5: find_document + 0 候选 → clarify (resolution=none)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '不存在的文档xyz',
+    candidates: [],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '5.1 goal_type=locate_document');
+  assertEqual(result.candidate_resolution, 'none', '5.2 candidate_resolution=none');
+  assertEqual(result.action, 'clarify', '5.3 action=clarify');
+}
+
+// ============================================================
+// 场景 6: answer_from_documents + mergeable → answer
+// ============================================================
+function testCase6_AnswerFromDocumentsMergeable() {
+  console.log('\n📋 场景6: answer_from_documents + mergeable → answer');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'answer_from_documents',
+    query: 'X物品物流成本怎么算',
+    candidates: [
+      { document_id: 'd1', document_title: '物品分类标准', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.9 },
+      { document_id: 'd2', document_title: '航运价格表', doc_type: 'price_list', collection_name: '价格库', relevance_score: 0.85 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '6.1 goal_type=answer_question');
+  assertEqual(result.candidate_resolution, 'mergeable', '6.2 candidate_resolution=mergeable');
+  assertEqual(result.action, 'answer', '6.3 action=answer');
+}
+
+// ============================================================
+// 场景 7: answer_from_documents + ambiguous → candidate_list
+// ============================================================
+function testCase7_AnswerFromDocumentsAmbiguous() {
+  console.log('\n📋 场景7: answer_from_documents + 模糊 → candidate_list');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'answer_from_documents',
+    query: '那个标准怎么说',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_name: '标准库A', relevance_score: 0.7 },
+      { document_id: 'd2', document_title: 'GB/T 12345', doc_type: 'standard', collection_name: '标准库B', relevance_score: 0.68 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '7.1 goal_type=answer_question');
+  assertEqual(result.candidate_resolution, 'ambiguous', '7.2 candidate_resolution=ambiguous');
+  assertEqual(result.action, 'candidate_list', '7.3 action=candidate_list');
+}
+
+// ============================================================
+// 场景 8: P1-1 — find_document + 纯文档查询 → locate_document
+// ============================================================
+function testCase8_GoalTypePureLocate() {
+  console.log('\n📋 场景8: find_document + 纯定位query → locate_document (tool_name)');
+
+  // 纯编号查询：无问答信号词，只有定位意图
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'GB/T 4208',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '8.1 goal_type=locate_document');
+  assertEqual(result.goal_type_source, 'tool_name', '8.2 source: 纯编号，无问答信号');
+}
+
+// ============================================================
+// 场景 8b: P1-1 — find_document + 同时有定位和问答信号 → tool_name_with_answer_intent
+// ============================================================
+function testCase8b_GoalTypeLocateWithAnswerIntent() {
+  console.log('\n📋 场景8b: find_document + 定位+问答混合同义 → tool_name_with_answer_intent');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '找一下GB/T 4208标准，里面规定了什么要求',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '8b.1 goal_type=locate_document');
+  assertEqual(result.goal_type_source, 'tool_name_with_answer_intent', '8b.2 source: 同时有定位+问答信号');
+}
+
+// ============================================================
+// 场景 9: P1-1 — find_document + 文档名+条款问题 → answer_question (query纠偏)
+// ============================================================
+function testCase9_GoalTypeDocNameWithClause() {
+  console.log('\n📋 场景9: find_document + 文档名+条款问题 → answer_question (query纠偏)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'GB/T 4208 里规定IPX5试验要求是什么',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '9.1 goal_type=answer_question');
+  assertEqual(result.goal_type_source, 'query_signal_override', '9.2 source: query覆盖tool先验');
+  assertEqual(result.action, 'answer', '9.3 action=answer (单候选 answer_question)');
+}
+
+// ============================================================
+// 场景 10: P1-1 — find_document + 文档名+计算问题 → answer_question (query纠偏)
+// ============================================================
+function testCase10_GoalTypeDocNameWithCalc() {
+  console.log('\n📋 场景10: find_document + 文档名+费用计算 → answer_question (query纠偏)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '航运价格表里X物品的运费多少钱',
+    candidates: [
+      { document_id: 'd1', document_title: '航运价格表2025', doc_type: 'price_list', collection_name: '价格库', relevance_score: 0.92 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '10.1 goal_type=answer_question');
+  assertEqual(result.goal_type_source, 'query_signal_override', '10.2 source: query覆盖');
+  assertEqual(result.action, 'answer', '10.3 action=answer (单候选)');
+}
+
+// ============================================================
+// 场景 10b: find_document + 显式文档锚点 + 内容问答 → anchored_document_answer_intent
+// ============================================================
+function testCase10b_AnchoredDocumentAnswerIntent() {
+  console.log('\n📋 场景10b: 显式文档锚点 + 内容问答 → anchored_document_answer_intent');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '在文档集合里，帮我看一下审稿人回信2里的回复都做了什么修改',
+    candidates: [
+      { document_id: 'd1', document_title: '审稿人回信2', doc_type: 'reply_letter', collection_name: '投稿文档', relevance_score: 0.96 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '10b.1 goal_type=answer_question');
+  assertEqual(result.goal_type_source, 'anchored_document_answer_intent', '10b.2 source=anchored_document_answer_intent');
+  assertEqual(result.action, 'answer', '10b.3 action=answer');
+}
+
+// ============================================================
+// 场景 10c: 文件A里...怎么规定 → anchored_document_answer_intent
+// ============================================================
+function testCase10c_FileAAnswerIntent() {
+  console.log('\n📋 场景10c: 文件A里内容提问 → anchored_document_answer_intent');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '文件A里延期违约金怎么规定',
+    candidates: [
+      { document_id: 'd1', document_title: '文件A', doc_type: 'contract', collection_name: '合同库', relevance_score: 0.94 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '10c.1 goal_type=answer_question');
+  assertEqual(result.goal_type_source, 'anchored_document_answer_intent', '10c.2 source=anchored_document_answer_intent');
+  assertEqual(result.action, 'answer', '10c.3 action=answer');
+}
+
+// ============================================================
+// 场景 10d: 文件A这份文件，如果... → anchored_document_answer_intent
+// ============================================================
+function testCase10d_FileAThisDocumentAnswerIntent() {
+  console.log('\n📋 场景10d: 文件A这份文件，如果项目延期了... → anchored_document_answer_intent');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '帮我看一下文档平台里文件A这份文件，如果项目延期了，每天具体要扣多少比例的违约金？请把计算基数也一并告诉我。',
+    candidates: [
+      { document_id: 'd1', document_title: '文件A', doc_type: 'contract', collection_name: '合同库', relevance_score: 0.94 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '10d.1 goal_type=answer_question');
+  assertEqual(result.goal_type_source, 'anchored_document_answer_intent', '10d.2 source=anchored_document_answer_intent');
+  assertEqual(result.action, 'answer', '10d.3 action=answer');
+}
+
+// ============================================================
+// 场景 11: P1-2 — 同集合内类型互斥 → conflicting
+// ============================================================
+function testCase11_ConflictingTypesInSameCollection() {
+  console.log('\n📋 场景11: 同集合不同类型(非互补) → conflicting');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'answer_from_documents',
+    query: '合同条款是否合规',
+    candidates: [
+      { document_id: 'd1', document_title: '采购合同A', doc_type: 'contract', collection_name: '合同库', relevance_score: 0.82, candidate_confidence: 'high' },
+      { document_id: 'd2', document_title: '相关标准', doc_type: 'standard', collection_name: '合同库', relevance_score: 0.78, candidate_confidence: 'medium' },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '11.1 goal_type=answer_question');
+  assertEqual(result.candidate_resolution, 'conflicting', '11.2 candidate_resolution=conflicting');
+  assertEqual(result.action, 'conservative_answer', '11.3 action=conservative_answer');
+  assert(result.reason_codes.includes('conflicting_types_in_same_collection'), '11.4 含conflicting类型理由');
+}
+
+// ============================================================
+// 场景 12: P1-2 — 高分散多来源 → conflicting
+// ============================================================
+function testCase12_ConflictingDispersedSources() {
+  console.log('\n📋 场景12: 3+不同集合高置信候选 → conflicting');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'answer_from_documents',
+    query: '这个规定有没有依据',
+    candidates: [
+      { document_id: 'd1', document_title: '法规A', doc_type: 'regulation', collection_name: '法规库', relevance_score: 0.9, candidate_confidence: 'high' },
+      { document_id: 'd2', document_title: '标准B', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.85, candidate_confidence: 'high' },
+      { document_id: 'd3', document_title: '合同C', doc_type: 'contract', collection_name: '合同库', relevance_score: 0.8, candidate_confidence: 'high' },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '12.1 goal_type=answer_question');
+  assertEqual(result.candidate_resolution, 'conflicting', '12.2 candidate_resolution=conflicting');
+  assertEqual(result.action, 'conservative_answer', '12.3 action=conservative_answer');
+  assert(result.reason_codes.includes('dispersed_high_confidence_sources'), '12.4 含dispersed信号');
+}
+
+// ============================================================
+// 场景 13-16: P1-3 集成路径 — tool-manager response 映射校验
+//  模拟 _handleFindDocument 中 orchestration → response 的映射逻辑
+// ============================================================
+
+/**
+ * 模拟 tool-manager._handleFindDocument 中的 orchestration→mode 映射
+ * audit-round08 P1: 增加 identity_resolved / evidence_resolved 阶段字段
+ */
+function simulateResponseMapping(orchestrationResult, candidates) {
+  const modeByAction = {
+    answer: candidates.length === 1 ? 'single_document' : 'answer_with_citation',
+    candidate_list: 'candidate_list',
+    clarify: 'clarify',
+    conservative_answer: 'conservative_answer',
+  };
+
+  return {
+    suggested_response_mode: modeByAction[orchestrationResult.action] || 'clarify',
+    short_circuit: orchestrationResult.action === 'candidate_list' || orchestrationResult.action === 'clarify',
+    mergeable_hint: orchestrationResult.mergeable_hint || false,
+    // audit-round08 P1: 阶段字段
+    identity_resolved: candidates.length > 0,
+    evidence_resolved: orchestrationResult.evidence_capability === 'chunk_evidence',
+  };
+}
+
+// 场景 13: find_document + single → single_document (不短路)
+function testCase13_IntegrationSingleDocument() {
+  console.log('\n📋 场景13: find_document+single → single_document (不短路)');
+
+  const orch = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'GB/T 4208',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  const mapped = simulateResponseMapping(orch, [{ document_id: 'd1' }]);
+
+  assertEqual(mapped.suggested_response_mode, 'single_document', '13.1 mode=single_document');
+  assertEqual(mapped.short_circuit, false, '13.2 不短路 (LLM继续处理)');
+  assertEqual(mapped.mergeable_hint, false, '13.3 不触发mergeable_hint');
+}
+
+// 场景 14: find_document + mergeable → candidate_list (短路, mergeable_hint)
+function testCase14_IntegrationMergeableShortCircuit() {
+  console.log('\n📋 场景14: find_document+mergeable → candidate_list (短路, mergeable_hint)');
+
+  const orch = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'IP防护等级试验条件',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017 第1部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.88 },
+      { document_id: 'd2', document_title: 'GB/T 4208-2017 第2部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.85 },
+    ],
+  });
+
+  const mapped = simulateResponseMapping(orch, [{ document_id: 'd1' }, { document_id: 'd2' }]);
+
+  assertEqual(mapped.suggested_response_mode, 'candidate_list', '14.1 mode=candidate_list (短路)');
+  assertEqual(mapped.short_circuit, true, '14.2 短路 (展示候选列表)');
+  assertEqual(mapped.mergeable_hint, true, '14.3 mergeable_hint=true (提示可合并消费)');
+}
+
+// 场景 15: find_document + ambiguous → candidate_list (短路, 无mergeable_hint)
+function testCase15_IntegrationAmbiguousShortCircuit() {
+  console.log('\n📋 场景15: find_document+ambiguous → candidate_list (短路, 无mergeable_hint)');
+
+  const orch = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '合同',
+    candidates: [
+      { document_id: 'd1', document_title: '采购合同A', doc_type: 'contract', collection_name: '合同库A', relevance_score: 0.75 },
+      { document_id: 'd2', document_title: '销售合同B', doc_type: 'contract', collection_name: '合同库B', relevance_score: 0.72 },
+    ],
+  });
+
+  const mapped = simulateResponseMapping(orch, [{ document_id: 'd1' }, { document_id: 'd2' }]);
+
+  assertEqual(mapped.suggested_response_mode, 'candidate_list', '15.1 mode=candidate_list');
+  assertEqual(mapped.short_circuit, true, '15.2 短路');
+  assertEqual(mapped.mergeable_hint, false, '15.3 无mergeable_hint');
+}
+
+// 场景 16: find_document + 0 → clarify (短路)
+function testCase16_IntegrationZeroClarify() {
+  console.log('\n📋 场景16: find_document+0 → clarify (短路)');
+
+  const orch = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '不存在的文档xyz',
+    candidates: [],
+  });
+
+  const mapped = simulateResponseMapping(orch, []);
+
+  assertEqual(mapped.suggested_response_mode, 'clarify', '16.1 mode=clarify (短路)');
+  assertEqual(mapped.short_circuit, true, '16.2 短路');
+  assertEqual(mapped.mergeable_hint, false, '16.3 无mergeable_hint');
+}
+
+// ============================================================
+// 场景 17-19: P1-2 — 关键组合路径：query override × mergeable × find_document
+// audit-round03: 封死旁路：find_document + answer_question + mergeable → answer_with_citation
+// ============================================================
+
+// 场景 17: find_document + query_signal_override + mergeable + 多候选
+// 这是 round02 遗留的最危险旁路 — tool guard 必须降级为 candidate_list
+function testCase17_QueryOverrideMergeableMultiCandidate() {
+  console.log('\n📋 场景17: find_document+query_override+mergeable+多候选 → candidate_list (tool guard)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'GB/T 4208 里规定IPX5试验要求是什么',  // 触发 query_signal_override
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017 第1部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.88 },
+      { document_id: 'd2', document_title: 'GB/T 4208-2017 第2部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.85 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '17.1 goal_type=answer_question (query覆盖)');
+  assertEqual(result.goal_type_source, 'query_signal_override', '17.2 source=query_signal_override');
+  assertEqual(result.candidate_resolution, 'mergeable', '17.3 candidate_resolution=mergeable');
+  // 关键断言：tool guard 强制降级为 candidate_list
+  assertEqual(result.action, 'candidate_list', '17.4 action=candidate_list (tool guard 降级!)');
+  assert(result.reason_codes.includes('tool_guard_find_document_multi_candidate'), '17.5 含 tool_guard 标记');
+  assertEqual(result.evidence_capability, 'identity_only', '17.6 evidence_capability=identity_only');
+
+  // 映射验证：不会走到 answer_with_citation
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }, { document_id: 'd2' }]);
+  assert(mapped.suggested_response_mode !== 'answer_with_citation', '17.7 不是 answer_with_citation!');
+  assertEqual(mapped.suggested_response_mode, 'candidate_list', '17.8 mode=candidate_list');
+}
+
+// 场景 18: find_document + tool_name_with_answer_intent + mergeable + 多候选
+// 同时有定位和问答信号时仍为 locate_document，但也必须被 tool guard 保护
+function testCase18_AnswerIntentMergeableMultiCandidate() {
+  console.log('\n📋 场景18: find_document+answer_intent+mergeable+多候选 → candidate_list (tool guard)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '找一下GB/T 4208标准，里面规定了什么要求',  // 同时有定位+问答信号
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017 第1部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.88 },
+      { document_id: 'd2', document_title: 'GB/T 4208-2017 第2部分', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.85 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '18.1 goal_type=locate_document');
+  assertEqual(result.goal_type_source, 'tool_name_with_answer_intent', '18.2 source=tool_name_with_answer_intent');
+  assertEqual(result.candidate_resolution, 'mergeable', '18.3 candidate_resolution=mergeable');
+  // round02 已经修正的路径：locate_document + mergeable → candidate_list
+  assertEqual(result.action, 'candidate_list', '18.4 action=candidate_list');
+  assert(result.reason_codes.includes('same_collection'), '18.5 含 mergeable 信号');
+  assertEqual(result.evidence_capability, 'identity_only', '18.6 evidence_capability=identity_only');
+  assertEqual(result.mergeable_hint, true, '18.7 mergeable_hint=true');
+
+  // 映射验证
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }, { document_id: 'd2' }]);
+  assert(mapped.suggested_response_mode !== 'answer_with_citation', '18.8 不是 answer_with_citation!');
+}
+
+// 场景 19: answer_from_documents + mergeable → answer（正例：有 chunk 证据，可以放行）
+// 验证 tool guard 不影响 answer_from_documents 的正常行为
+function testCase19_AnswerFromDocsMergeableWithEvidence() {
+  console.log('\n📋 场景19: answer_from_documents+mergeable → answer (正例：有chunk证据)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'answer_from_documents',
+    query: 'X物品物流成本怎么算',
+    candidates: [
+      { document_id: 'd1', document_title: '物品分类标准', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.9 },
+      { document_id: 'd2', document_title: '航运价格表', doc_type: 'price_list', collection_name: '价格库', relevance_score: 0.85 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '19.1 goal_type=answer_question');
+  assertEqual(result.candidate_resolution, 'mergeable', '19.2 candidate_resolution=mergeable');
+  // answer_from_documents 有 chunk 证据，tool guard 不触发
+  assertEqual(result.action, 'answer', '19.3 action=answer (有chunk证据，可以放行)');
+  assertEqual(result.evidence_capability, 'chunk_evidence', '19.4 evidence_capability=chunk_evidence');
+  // 确认 reason_codes 不含 tool_guard
+  const hasToolGuard = result.reason_codes.some(c => c.startsWith('tool_guard'));
+  assert(!hasToolGuard, '19.5 不含 tool_guard (answer_from_documents 有 chunk 证据)');
+
+  // 映射验证：多候选 answer → answer_with_citation（有 chunk 证据，正确）
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }, { document_id: 'd2' }]);
+  assertEqual(mapped.suggested_response_mode, 'answer_with_citation', '19.6 mode=answer_with_citation (正确)');
+}
+
+// 场景 19b: find_document + anchored_document_answer_intent + same_collection mergeable → answer
+function testCase19b_AnchoredBridgeMergeableAnswer() {
+  console.log('\n📋 场景19b: 文件A点名 + 同集合文件B承载答案 → answer (桥接放行)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '帮我看一下文档平台里文件A这份文件，如果项目延期了，每天具体要扣多少比例的违约金？请把计算基数也一并告诉我。',
+    candidates: [
+      { document_id: 'd1', document_title: '文件A', doc_type: 'contract', collection_name: 'test0701', relevance_score: 0.82, candidate_confidence: 'medium' },
+      { document_id: 'd2', document_title: '文件B', doc_type: 'contract', collection_name: 'test0701', relevance_score: 0.79, candidate_confidence: 'medium' },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '19b.1 goal_type=answer_question');
+  assertEqual(result.goal_type_source, 'anchored_document_answer_intent', '19b.2 source=anchored_document_answer_intent');
+  assertEqual(result.candidate_resolution, 'mergeable', '19b.3 candidate_resolution=mergeable');
+  assertEqual(result.action, 'answer', '19b.4 action=answer (桥接放行)');
+  assert(result.reason_codes.includes('same_collection'), '19b.5 含 same_collection');
+  assertEqual(result.evidence_capability, 'identity_only', '19b.6 evidence_capability=identity_only');
+
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }, { document_id: 'd2' }]);
+  assertEqual(mapped.suggested_response_mode, 'answer_with_citation', '19b.7 mode=answer_with_citation');
+  assertEqual(mapped.short_circuit, false, '19b.8 不短路');
+}
+
+// ============================================================
+// 场景 20-22: P1-2 单候选 answer-intent 边界测试
+// audit-round04: 单候选 + answer_intent + identity_only 仍需走 single_document，
+// 但 chat-service 应注入 identity-only 守卫约束，防止 LLM 过度回答
+// ============================================================
+
+// 场景 20: find_document + query_signal_override + single_candidate
+// 最危险的单候选边界：query 明显是问答型，但 tool 只有 identity 证据
+function testCase20_SingleCandidateQueryOverride() {
+  console.log('\n📋 场景20: find_document+query_override+single → single_document (identity_only)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'GB/T 4208 里规定IPX5试验要求是什么',  // 触发 query_signal_override
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '20.1 goal_type=answer_question (query覆盖)');
+  assertEqual(result.goal_type_source, 'query_signal_override', '20.2 source=query_signal_override');
+  assertEqual(result.candidate_resolution, 'single', '20.3 single candidate');
+  // 单候选不触发 tool guard（guard 只保护多候选）
+  assertEqual(result.action, 'answer', '20.4 action=answer (单候选，tool guard 不触发)');
+  assertEqual(result.evidence_capability, 'identity_only', '20.5 evidence_capability=identity_only');
+
+  // 映射验证：单候选 answer → single_document
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }]);
+  assertEqual(mapped.suggested_response_mode, 'single_document', '20.6 mode=single_document');
+
+  // 关键：evidence_capability=identity_only 且 goal_type_source=query_signal_override
+  // 这个组合应触发 chat-service 的 identity-only 守卫约束
+  // （守卫逻辑在 buildEvidenceInjection 中，此处只验证编排信号正确传递）
+  const needsIdentityGuard = (
+    result.evidence_capability === 'identity_only' &&
+    result.goal_type_source === 'query_signal_override'
+  );
+  assert(needsIdentityGuard, '20.7 此组合需 identity-only 守卫约束');
+}
+
+// 场景 21: find_document + tool_name_with_answer_intent + single_candidate
+// 混合意图 + 单候选 — 同样需要约束但不能阻断
+function testCase21_SingleCandidateAnswerIntent() {
+  console.log('\n📋 场景21: find_document+answer_intent+single → single_document (约束但不阻断)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '找一下GB/T 4208标准，里面规定了什么要求',  // 同时有定位+问答信号
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'locate_document', '21.1 goal_type=locate_document');
+  assertEqual(result.goal_type_source, 'tool_name_with_answer_intent', '21.2 answer_intent');
+  assertEqual(result.candidate_resolution, 'single', '21.3 single candidate');
+  assertEqual(result.action, 'answer', '21.4 action=answer');
+  assertEqual(result.evidence_capability, 'identity_only', '21.5 identity_only');
+
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }]);
+  assertEqual(mapped.suggested_response_mode, 'single_document', '21.6 mode=single_document');
+
+  // tool_name_with_answer_intent 也表示存在问答意图，约束应生效
+  const hasAnswerIntent = (
+    result.evidence_capability === 'identity_only' &&
+    (result.goal_type_source === 'query_signal_override' ||
+     result.goal_type_source === 'tool_name_with_answer_intent')
+  );
+  assert(hasAnswerIntent, '21.7 answer_intent + identity_only 应触发约束');
+}
+
+// 场景 22: answer_from_documents + single_candidate + answer_question → answer（正例）
+// 有 chunk 证据的单候选回答 — 不需要 identity 守卫
+function testCase22_AnswerFromDocsSingleWithEvidence() {
+  console.log('\n📋 场景22: answer_from_docs+single → answer (正例：chunk_evidence，不受限)');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'answer_from_documents',
+    query: 'IPX5试验条件是什么',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  assertEqual(result.goal_type, 'answer_question', '22.1 goal_type=answer_question');
+  assertEqual(result.candidate_resolution, 'single', '22.2 single');
+  assertEqual(result.action, 'answer', '22.3 action=answer');
+  assertEqual(result.evidence_capability, 'chunk_evidence', '22.4 chunk_evidence');
+
+  // chunk_evidence 不应触发 identity-only 守卫
+  const needsIdentityGuard = (
+    result.evidence_capability === 'identity_only' &&
+    result.goal_type_source === 'query_signal_override'
+  );
+  assert(!needsIdentityGuard, '22.5 chunk_evidence 不需要 identity 守卫');
+
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }]);
+  assertEqual(mapped.suggested_response_mode, 'single_document', '22.6 mode=single_document');
+}
+
+// ============================================================
+// audit-round07 P0: shouldAutoChainContent 决策逻辑
+// ============================================================
+
+function testCase23_ShouldAutoChainQueryOverride() {
+  console.log('\n📋 场景23: shouldAutoChainContent — query_signal_override + 单候选 → 应触发');
+
+  assert(
+    shouldAutoChainContent(
+      { evidence_capability: 'identity_only', goal_type_source: 'query_signal_override' },
+      1
+    ),
+    '23.1 identity_only + query_signal_override + 1 candidate → true'
+  );
+
+  assert(
+    !shouldAutoChainContent(
+      { evidence_capability: 'identity_only', goal_type_source: 'query_signal_override' },
+      2
+    ),
+    '23.2 identity_only + query_signal_override + 2 candidates → false'
+  );
+
+  assert(
+    !shouldAutoChainContent(
+      { evidence_capability: 'chunk_evidence', goal_type_source: 'query_signal_override' },
+      1
+    ),
+    '23.3 chunk_evidence 不需要 auto-chain（已有内容证据）'
+  );
+}
+
+function testCase24_ShouldAutoChainMixedIntent() {
+  console.log('\n📋 场景24: shouldAutoChainContent — tool_name_with_answer_intent + 单候选 → 应触发');
+
+  assert(
+    shouldAutoChainContent(
+      { evidence_capability: 'identity_only', goal_type_source: 'tool_name_with_answer_intent' },
+      1
+    ),
+    '24.1 identity_only + mixed_intent + 1 candidate → true'
+  );
+}
+
+function testCase25_ShouldAutoChainPureLocate() {
+  console.log('\n📋 场景25: shouldAutoChainContent — tool_name(纯定位) → 不触发');
+
+  assert(
+    !shouldAutoChainContent(
+      { evidence_capability: 'identity_only', goal_type_source: 'tool_name' },
+      1
+    ),
+    '25.1 identity_only + tool_name + 1 candidate → false（纯定位不触发）'
+  );
+}
+
+function testCase26_ShouldAutoChainMultiCandidate() {
+  console.log('\n📋 场景26: shouldAutoChainContent — 多候选 → 不触发');
+
+  assert(
+    !shouldAutoChainContent(
+      { evidence_capability: 'identity_only', goal_type_source: 'tool_name_with_answer_intent' },
+      3
+    ),
+    '26.1 identity_only + mixed_intent + 3 candidates → false'
+  );
+}
+
+function testCase27_ShouldAutoChainChunkEvidence() {
+  console.log('\n📋 场景27: shouldAutoChainContent — chunk_evidence → 不触发');
+
+  assert(
+    !shouldAutoChainContent(
+      { evidence_capability: 'chunk_evidence', goal_type_source: 'tool_name_with_answer_intent' },
+      1
+    ),
+    '27.1 chunk_evidence + mixed_intent + 1 candidate → false（已有证据）'
+  );
+}
+
+// ============================================================
+// audit-round08 P1: identity_resolved / evidence_resolved 阶段字段
+// ============================================================
+
+function testCase28_StageFieldsFindDocumentSingle() {
+  console.log('\n📋 场景28: find_document 单候选 → identity_resolved=true, evidence_resolved=false');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: 'GB/T 4208',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }]);
+  assert(mapped.identity_resolved, '28.1 identity_resolved=true');
+  assert(!mapped.evidence_resolved, '28.2 evidence_resolved=false（identity_only）');
+}
+
+function testCase29_StageFieldsAnswerFromDocsWithEvidence() {
+  console.log('\n📋 场景29: answer_from_documents 单候选 → identity_resolved=true, evidence_resolved=true');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'answer_from_documents',
+    query: 'IPX5试验条件',
+    candidates: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 0.95 },
+    ],
+  });
+
+  const mapped = simulateResponseMapping(result, [{ document_id: 'd1' }]);
+  assert(mapped.identity_resolved, '29.1 identity_resolved=true');
+  assert(mapped.evidence_resolved, '29.2 evidence_resolved=true（chunk_evidence）');
+}
+
+function testCase30_StageFieldsFindDocumentZero() {
+  console.log('\n📋 场景30: find_document 0 候选 → identity_resolved=false, evidence_resolved=false');
+
+  const result = orchestrationService.orchestrate({
+    toolName: 'find_document',
+    query: '不存在的文档',
+    candidates: [],
+  });
+
+  const mapped = simulateResponseMapping(result, []);
+  assert(!mapped.identity_resolved, '30.1 identity_resolved=false');
+  assert(!mapped.evidence_resolved, '30.2 evidence_resolved=false');
+  assertEqual(mapped.suggested_response_mode, 'clarify', '30.3 mode=clarify');
+}
+
+// audit-round08 P1: identity_resolved / evidence_resolved 阶段字段
+testCase28_StageFieldsFindDocumentSingle();
+testCase29_StageFieldsAnswerFromDocsWithEvidence();
+testCase30_StageFieldsFindDocumentZero();
+
+console.log('╔══════════════════════════════════════╗');
+console.log('║  Document Orchestration 测试        ║');
+console.log('╚══════════════════════════════════════╝');
+
+testCase1_FindDocumentSingle();
+testCase2_FindDocumentMergeableSameCollection();
+testCase3_FindDocumentComplementaryTypes();
+testCase4_FindDocumentAmbiguous();
+testCase5_FindDocumentZero();
+testCase6_AnswerFromDocumentsMergeable();
+testCase7_AnswerFromDocumentsAmbiguous();
+// audit-round02 新增
+testCase8_GoalTypePureLocate();
+testCase8b_GoalTypeLocateWithAnswerIntent();
+testCase9_GoalTypeDocNameWithClause();
+testCase10_GoalTypeDocNameWithCalc();
+testCase10b_AnchoredDocumentAnswerIntent();
+testCase10c_FileAAnswerIntent();
+testCase10d_FileAThisDocumentAnswerIntent();
+testCase11_ConflictingTypesInSameCollection();
+testCase12_ConflictingDispersedSources();
+testCase13_IntegrationSingleDocument();
+testCase14_IntegrationMergeableShortCircuit();
+testCase15_IntegrationAmbiguousShortCircuit();
+testCase16_IntegrationZeroClarify();
+// audit-round03 P1-2: 关键组合路径
+testCase17_QueryOverrideMergeableMultiCandidate();
+testCase18_AnswerIntentMergeableMultiCandidate();
+testCase19_AnswerFromDocsMergeableWithEvidence();
+testCase19b_AnchoredBridgeMergeableAnswer();
+// audit-round04 P1-2: 单候选 answer-intent 边界
+testCase20_SingleCandidateQueryOverride();
+testCase21_SingleCandidateAnswerIntent();
+testCase22_AnswerFromDocsSingleWithEvidence();
+// audit-round07 P0: auto content chain 决策逻辑
+testCase23_ShouldAutoChainQueryOverride();
+testCase24_ShouldAutoChainMixedIntent();
+testCase25_ShouldAutoChainPureLocate();
+testCase26_ShouldAutoChainMultiCandidate();
+testCase27_ShouldAutoChainChunkEvidence();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) process.exit(1);

--- a/tests/document-query-parser.test.js
+++ b/tests/document-query-parser.test.js
@@ -1,0 +1,333 @@
+/**
+ * Document Query Parser 单元测试
+ *
+ * 覆盖审计标准：
+ * - audit-round02 P0-1: 主题/类型分离
+ * - audit-round03 P1-2 & P2-1: 疑问词清理、编号保护、长主题扩召
+ * - audit-round04 P0-1: 幂等性（消除全局正则 lastIndex 状态污染）
+ * - audit-round04 P1-1: 编号不重复、无残片、无口语残留
+ * - audit-round04 P1-2: 精确输出断言（不再仅用 includes()）
+ *
+ * 运行：node tests/document-query-parser.test.js
+ */
+
+import { parseDocumentQuery } from '../lib/document-query-parser.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEq(actual, expected, label) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) { passed++; }
+  else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+    console.error(`     expected: ${JSON.stringify(expected)}`);
+    console.error(`     actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertContains(arr, item, label) {
+  if (arr.includes(item)) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label} — array: ${JSON.stringify(arr)}`); }
+}
+
+// ============================================================
+// 用例 1："国标文件" — 类型词从主题中剥离
+// ============================================================
+function testCase1_GuoBiao() {
+  console.log('\n📋 用例1: 国标文件查询');
+  const r = parseDocumentQuery('有一个规定了汽车车身术语的国标文件是啥来着？');
+
+  assert(r.lookup_intent === true, '1.1 lookup_intent');
+  assertEq(r.cleaned_query, '汽车车身术语', '1.2 cleaned_query 精确值');
+  assertEq(r.doc_type_hints, ['国家标准'], '1.3 doc_type_hints 精确值');
+  assert(r.topic_terms.length > 0, '1.4 topic_terms 非空');
+  assert(!r.topic_terms.some(t => t.includes('国标')), '1.5 topic_terms 不含国标');
+  assert(!r.cleaned_query.includes('国标'), '1.6 cleaned_query 不含国标');
+  assert(!r.cleaned_query.includes('规定了'), '1.7 cleaned_query 不含"规定了"');
+}
+
+// ============================================================
+// 用例 2："制度办法" — 制度类正确识别，不带噪音
+// ============================================================
+function testCase2_ZhiDu() {
+  console.log('\n📋 用例2: 制度办法查询');
+  const r = parseDocumentQuery('公司管理制度有哪些？');
+
+  assert(r.lookup_intent === true, '2.1 lookup_intent');
+  assertEq(r.doc_type_hints, ['制度规章'], '2.2 doc_type_hints 精确值（无空格污染）');
+  assert(!r.cleaned_query.includes('管理制度'), '2.3 cleaned_query 不含管理制度');
+  assert(!r.cleaned_query.includes('哪些'), '2.4 cleaned_query 不含疑问词');
+  assert(!r.cleaned_query.includes('？'), '2.5 cleaned_query 不含问号');
+}
+
+// ============================================================
+// 用例 3："合同编号" — 编号优先，无口语残片（audit-round04 P1-1）
+// ============================================================
+function testCase3_HeTong() {
+  console.log('\n📋 用例3: 合同查询（编号优先）');
+  const r = parseDocumentQuery('帮我找一下HT-2024-001那份合同');
+
+  assert(r.lookup_intent === true, '3.1 lookup_intent');
+  assertContains(r.doc_type_hints, '合同协议', '3.2 doc_type_hints');
+  assertEq(r.identifier_hints, ['HT-2024-001'], '3.3 identifier_hints 精确值');
+  assertEq(r.cleaned_query, 'HT-2024-001', '3.4 cleaned_query=纯编号，无口语残片');
+  assert(!r.cleaned_query.includes('一下'), '3.5 不含"一下"');
+  assert(!r.cleaned_query.includes('那份'), '3.6 不含"那份"');
+  // 编号只出现一次
+  assert((r.cleaned_query.match(/HT-2024-001/g) || []).length === 1, '3.7 编号不重复');
+}
+
+// ============================================================
+// 用例 4："纯主题查找" — 无类型提示
+// ============================================================
+function testCase4_PureTopic() {
+  console.log('\n📋 用例4: 纯主题查找');
+  const r = parseDocumentQuery('汽车安全性能评测');
+
+  assertEq(r.doc_type_hints, [], '4.1 doc_type_hints 为空');
+  assert(r.topic_terms.length >= 1, '4.2 topic_terms 有内容');
+  assert(r.cleaned_query.length > 0, '4.3 cleaned_query 非空');
+  assert(r.lookup_intent === false, '4.4 lookup_intent=false');
+}
+
+// ============================================================
+// 用例 5："模糊口语问法" — 噪音剔除
+// ============================================================
+function testCase5_FuzzyColloquial() {
+  console.log('\n📋 用例5: 模糊口语问法');
+  const r = parseDocumentQuery('有没有关于环保方面的规定文件来着？');
+
+  assert(r.noise_terms.some(t => t.includes('有没有') || t.includes('来着') || t.includes('文件')),
+    '5.1 noise_terms 含口语词');
+  assert(!r.cleaned_query.includes('有没有'), '5.2 不含"有没有"');
+  assert(!r.cleaned_query.includes('来着'), '5.3 不含"来着"');
+  assert(!r.cleaned_query.includes('文件'), '5.4 不含"文件"');
+}
+
+// ============================================================
+// 用例 6：空 query
+// ============================================================
+function testCase6_EmptyQuery() {
+  console.log('\n📋 用例6: 空 query');
+  const r = parseDocumentQuery('');
+  assert(!r.lookup_intent, '6.1 lookup_intent=false');
+  assertEq(r.topic_terms, [], '6.2 topic_terms 空');
+}
+
+// ============================================================
+// 用例 7：标准号精确查询 — 编号优先，无GB/T残片重复
+// ============================================================
+function testCase7_StandardNumber() {
+  console.log('\n📋 用例7: 标准号查询（编号优先）');
+  const r = parseDocumentQuery('GB/T 12345-2020 在哪里');
+
+  assert(r.lookup_intent === true, '7.1 lookup_intent');
+  assertEq(r.identifier_hints, ['GB/T 12345-2020'], '7.2 identifier_hints 精确值');
+  assertEq(r.cleaned_query, 'GB/T 12345-2020', '7.3 cleaned_query=纯编号，无GB/T残片');
+  // GB/T 只出现一次
+  assert((r.cleaned_query.match(/GB\/T/g) || []).length <= 1, '7.4 GB/T 不重复');
+  // topic_terms 不应含 GB/T 残片
+  assert(!r.topic_terms.some(t => t === 'GB/T' || t === 'GB'), '7.5 topic_terms 无 GB 残片');
+}
+
+// ============================================================
+// 用例 8：疑问词清理
+// ============================================================
+function testCase8_QuestionWordCleanup() {
+  console.log('\n📋 用例8: 疑问词清理');
+  const r = parseDocumentQuery('公司管理制度有哪些？');
+  assert(!r.cleaned_query.includes('哪些'), '8.1 不含"哪些"');
+  assert(!r.cleaned_query.includes('？'), '8.2 不含问号');
+  assertContains(r.doc_type_hints, '制度规章', '8.3 类型仍正确');
+}
+
+// ============================================================
+// 用例 9：长主题词扩召
+// ============================================================
+function testCase9_TopicExpansion() {
+  console.log('\n📋 用例9: 长主题词扩召');
+  const r = parseDocumentQuery('汽车车身术语');
+  assert(r.expanded_topic_queries.length >= 1, '9.1 至少 1 个扩召 query');
+  const hasSplit = r.expanded_topic_queries.some(q => q.includes('汽车车身'));
+  assert(hasSplit, '9.2 扩召含主题拆分');
+}
+
+// ============================================================
+// 用例 10：制度+疑问词复合
+// ============================================================
+function testCase10_Supplementary() {
+  console.log('\n📋 用例10: 制度+疑问词复合');
+  const r = parseDocumentQuery('有没有关于安全生产的管理规定？');
+  assert(r.lookup_intent === true, '10.1 lookup_intent');
+  assertContains(r.doc_type_hints, '制度规章', '10.2 制度规章');
+  assert(!r.cleaned_query.includes('有没有'), '10.3 不含口语');
+  assert(!r.cleaned_query.includes('？'), '10.4 不含问号');
+}
+
+// ============================================================
+// 用例 11：ISO 标准号（audit-round04 新增编号类型覆盖）
+// ============================================================
+function testCase11_ISO() {
+  console.log('\n📋 用例11: ISO 标准号');
+  const r = parseDocumentQuery('找一下ISO 9001:2015标准');
+  assert(r.identifier_hints.length >= 1, '11.1 identifier_hints 非空');
+  assert(r.identifier_hints.some(id => /ISO/i.test(id)), '11.2 含 ISO');
+  assert(!r.cleaned_query.includes('找一下'), '11.3 不含口语');
+  assert(r.cleaned_query.length > 0, '11.4 cleaned_query 非空');
+}
+
+// ============================================================
+// 用例 12：文号查询（audit-round04 新增编号类型覆盖）
+// ============================================================
+function testCase12_DocumentNumber() {
+  console.log('\n📋 用例12: 文号查询');
+  const r = parseDocumentQuery('国发〔2024〕1号文件');
+  assert(r.identifier_hints.length >= 1, '12.1 捕获文号');
+  assert(r.lookup_intent === true, '12.2 lookup_intent');
+  assert(!r.cleaned_query.includes('文件'), '12.3 不含"文件"噪音');
+}
+
+// ============================================================
+// 用例 13：标准号 + 内容问法 —— 不应把“主要/标准”误留为主题词
+// ============================================================
+function testCase13_StandardNumberContentQuestion() {
+  console.log('\n📋 用例13: 标准号 + 内容问法');
+  const r = parseDocumentQuery('GB28046.5-2013主要讲的是什么标准？');
+  assertEq(r.identifier_hints, ['GB28046.5-2013'], '13.1 identifier_hints 精确值');
+  assertEq(r.doc_type_hints, [], '13.2 doc_type_hints 不应从内容问法硬推断类型');
+  assertEq(r.cleaned_query, 'GB28046.5-2013', '13.3 cleaned_query 应仅保留标准号');
+  assertEq(r.topic_terms, [], '13.4 topic_terms 应为空');
+}
+
+// ============================================================
+// P0-1: 幂等性测试（audit-round04 核心验收标准）
+// ============================================================
+function testCase_Idempotence_SameQuery() {
+  console.log('\n📋 幂等性1: 同一 query 100 次解析结果一致');
+  const q = '有一个规定了汽车车身术语的国标文件是啥来着？';
+  const results = [];
+  for (let i = 0; i < 100; i++) {
+    results.push(JSON.stringify(parseDocumentQuery(q)));
+  }
+  const allSame = results.every(r => r === results[0]);
+  assert(allSame, 'Idem1: 100 次相同 query 结果完全一致');
+}
+
+function testCase_Idempotence_Alternating() {
+  console.log('\n📋 幂等性2: 两个不同 query 交替 100 轮结果一致');
+  const q1 = '公司管理制度有哪些？';
+  const q2 = 'GB/T 12345-2020 在哪里';
+  const even = [];
+  const odd = [];
+  for (let i = 0; i < 100; i++) {
+    const r = JSON.stringify(parseDocumentQuery(i % 2 === 0 ? q1 : q2));
+    if (i % 2 === 0) even.push(r);
+    else odd.push(r);
+  }
+  assert(even.every(r => r === even[0]), 'Idem2a: 偶数轮（制度查询）全部一致');
+  assert(odd.every(r => r === odd[0]), 'Idem2b: 奇数轮（标准号查询）全部一致');
+}
+
+// ============================================================
+// 执行
+// ============================================================
+console.log('╔══════════════════════════════════════╗');
+console.log('║  Document Query Parser 单元测试     ║');
+console.log('╚══════════════════════════════════════╝');
+
+testCase1_GuoBiao();
+testCase2_ZhiDu();
+testCase3_HeTong();
+testCase4_PureTopic();
+testCase5_FuzzyColloquial();
+testCase6_EmptyQuery();
+testCase7_StandardNumber();
+testCase8_QuestionWordCleanup();
+testCase9_TopicExpansion();
+testCase10_Supplementary();
+testCase11_ISO();
+testCase12_DocumentNumber();
+testCase13_StandardNumberContentQuestion();
+testCase_Idempotence_SameQuery();
+testCase_Idempotence_Alternating();
+
+// ==========================================
+// audit-round01 P1-1: Query Facets 测试
+// ==========================================
+
+function testCase_Facets_EntityTerms() {
+  console.log('\n📋 用例F1: 实体词提取');
+
+  // 国家标准编号
+  const r1 = parseDocumentQuery('GB/T 12345-2020 的防水等级怎么规定');
+  assert(r1.facets.entity_terms.includes('GB/T 12345-2020'), 'F1.1: 标准编号');
+  // 编号后面的年份可能也被提取
+  assert(r1.facets.entity_terms.some(e => e.includes('12345')), 'F1.2: 含数字编号');
+
+  // 合同编号
+  const r2 = parseDocumentQuery('合同 HT-2024-001 的付款条款');
+  assert(r2.facets.entity_terms.includes('HT-2024-001'), 'F1.3: 合同编号');
+
+  // ISO 编号
+  const r3 = parseDocumentQuery('ISO 9001 质量体系');
+  assert(r3.facets.entity_terms.some(e => e.includes('ISO')), 'F1.4: ISO编号');
+
+  // 无实体的自然语言问题
+  const r4 = parseDocumentQuery('合同违约金怎么算');
+  assert(r4.facets.entity_terms.length === 0, 'F1.6: 无编号查询无实体词');
+
+  console.log(`  entity_terms cases: passed`);
+}
+
+function testCase_Facets_ProcedureTerms() {
+  console.log('\n📋 用例F2: 程序词提取');
+
+  const r1 = parseDocumentQuery('这个试验怎么做');
+  assert(r1.facets.procedure_terms.includes('试验'), 'F2.1: 试验');
+  assert(r1.facets.procedure_terms.includes('怎么做'), 'F2.2: 怎么做');
+
+  const r2 = parseDocumentQuery('验收条件和测试方法');
+  assert(r2.facets.procedure_terms.includes('条件'), 'F2.2: 条件');
+  assert(r2.facets.procedure_terms.includes('方法'), 'F2.3: 方法');
+  assert(r2.facets.procedure_terms.includes('测试'), 'F2.4: 测试');
+
+  const r3 = parseDocumentQuery('GB/T 12345 在哪里');
+  assert(r3.facets.procedure_terms.length === 0, 'F2.5: 纯查找无程序词');
+
+  console.log(`  procedure_terms cases: passed`);
+}
+
+function testCase_Facets_NormalizedLookup() {
+  console.log('\n📋 用例F3: 归一化查找 query');
+
+  const r1 = parseDocumentQuery('GB/T 12345-2020 的防水等级怎么规定');
+  assert(r1.facets.normalized_lookup_query.length > 0, 'F3.1: 有 normalized query');
+  assert(r1.facets.normalized_lookup_query.includes('GB/T 12345-2020'), 'F3.2: 包含标准编号');
+  assert(r1.facets.normalized_lookup_query.includes('规定'), 'F3.3: 包含程序词');
+  assert(!r1.facets.normalized_lookup_query.includes('怎么'), 'F3.4: 无口语词');
+
+  // 纯编号查询（无主题词）
+  const r2 = parseDocumentQuery('GB/T 12345-2020');
+  assert(r2.facets.normalized_lookup_query === 'GB/T 12345-2020', 'F3.5: 纯编号保留');
+
+  console.log(`  normalized_lookup_query cases: passed`);
+}
+
+testCase_Facets_EntityTerms();
+testCase_Facets_ProcedureTerms();
+testCase_Facets_NormalizedLookup();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/document-retrieval-orchestration.test.js
+++ b/tests/document-retrieval-orchestration.test.js
@@ -1,0 +1,261 @@
+/**
+ * Document Retrieval Orchestration 行为测试
+ *
+ * 覆盖 audit-round02 P0-3 验收标准：
+ * - 零候选扩召
+ * - 低分扩召
+ * - 类型信号不足扩召
+ * - Round 2 成功后的质量重评与重排
+ *
+ * 注意：本测试聚焦于单元级的质量评估与扩召决策逻辑，
+ * 不启动真实数据库。需要端到端验证时请在集成环境运行。
+ *
+ * 运行：node tests/document-retrieval-orchestration.test.js
+ */
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+  }
+}
+
+function assertEq(actual, expected, label) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+    console.error(`     expected: ${JSON.stringify(expected)}`);
+    console.error(`     actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// ============================================================
+// 从 document-retrieval-service.js 复制的候选质量评估函数
+// （与生产代码保持同步）
+// ============================================================
+const FALLBACK_REASON = {
+  NO_CANDIDATE: 'no_candidate',
+  WEAK_CANDIDATE_QUALITY: 'weak_candidate_quality',
+  DOC_TYPE_SIGNAL_MISSING: 'doc_type_signal_missing',
+  PARSER_TOPIC_INSUFFICIENT: 'parser_topic_insufficient',
+};
+
+const CANDIDATE_QUALITY_THRESHOLDS = {
+  MIN_CANDIDATE_COUNT: 1,
+  MIN_TOP1_SCORE: 50,
+  TOP1_TOP2_MIN_MARGIN: 15,
+};
+
+function _assessCandidateQuality(candidates, docTypeHints = []) {
+  if (!candidates || candidates.length === 0) {
+    return {
+      quality: 'poor',
+      reason: FALLBACK_REASON.NO_CANDIDATE,
+      needs_expansion: true,
+    };
+  }
+
+  const top1Score = candidates[0]?.relevance_score || 0;
+
+  if (top1Score < CANDIDATE_QUALITY_THRESHOLDS.MIN_TOP1_SCORE) {
+    return {
+      quality: 'poor',
+      reason: FALLBACK_REASON.WEAK_CANDIDATE_QUALITY,
+      needs_expansion: true,
+    };
+  }
+
+  if (candidates.length >= 2) {
+    const top2Score = candidates[1]?.relevance_score || 0;
+    const margin = top1Score - top2Score;
+    if (margin < CANDIDATE_QUALITY_THRESHOLDS.TOP1_TOP2_MIN_MARGIN) {
+      return {
+        quality: 'marginal',
+        reason: 'low_top1_top2_margin',
+        needs_expansion: false,
+      };
+    }
+  }
+
+  if (docTypeHints.length > 0) {
+    const hasTypeMatch = candidates.some(c =>
+      _docMatchesTypeHint(c, docTypeHints)
+    );
+    if (!hasTypeMatch) {
+      return {
+        quality: 'marginal',
+        reason: FALLBACK_REASON.DOC_TYPE_SIGNAL_MISSING,
+        needs_expansion: candidates.length < CANDIDATE_QUALITY_THRESHOLDS.MIN_CANDIDATE_COUNT,
+      };
+    }
+  }
+
+  return {
+    quality: 'good',
+    reason: 'sufficient',
+    needs_expansion: false,
+  };
+}
+
+function _docMatchesTypeHint(candidate, docTypeHints) {
+  const searchText = [
+    candidate.document_title || '',
+    candidate.best_identity_label || '',
+    candidate.doc_type || '',
+    (candidate.attachment_filenames || []).join(' '),
+  ].join(' ').toLowerCase();
+
+  const docTypeKeywordMap = {
+    '国家标准': ['gb', '国家标准', '国标'],
+    '行业标准': ['行业标准', '行标', '团体标准'],
+    '合同协议': ['合同', '协议'],
+    '制度规章': ['制度', '办法', '规定', '条例', '章程'],
+    '手册指南': ['手册', '指南', '说明书'],
+    '报告': ['报告', '报表'],
+    '法律法规': ['法律', '法规'],
+    '技术文档': ['技术文档', '技术规范'],
+  };
+
+  for (const hint of docTypeHints) {
+    const keywords = docTypeKeywordMap[hint] || [hint.toLowerCase()];
+    if (keywords.some(k => searchText.includes(k))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ============================================================
+// 辅助：构造 mock candidate
+// ============================================================
+function makeCandidate(id, title, score, docType, attachments = []) {
+  return {
+    document_id: id,
+    document_title: title,
+    relevance_score: score,
+    doc_type: docType,
+    best_identity_label: title,
+    attachment_filenames: attachments,
+  };
+}
+
+// ============================================================
+// 场景 1：零候选 → needs_expansion = true
+// ============================================================
+function testCase1_ZeroCandidates() {
+  console.log('\n📋 场景1: 零候选 → 触发扩召');
+  const r = _assessCandidateQuality([], []);
+  assertEq(r.quality, 'poor', '1.1 quality 应为 poor');
+  assertEq(r.reason, FALLBACK_REASON.NO_CANDIDATE, '1.2 reason 应为 no_candidate');
+  assert(r.needs_expansion === true, '1.3 needs_expansion 应为 true');
+}
+
+// ============================================================
+// 场景 2：低分候选 → needs_expansion = true
+// ============================================================
+function testCase2_LowScoreCandidate() {
+  console.log('\n📋 场景2: 低分候选（top1=30 < 50）→ 触发扩召');
+  const candidates = [
+    makeCandidate('d1', '汽车通用手册', 30, 'manual'),
+  ];
+  const r = _assessCandidateQuality(candidates, ['国家标准']);
+  assertEq(r.quality, 'poor', '2.1 quality 应为 poor');
+  assertEq(r.reason, FALLBACK_REASON.WEAK_CANDIDATE_QUALITY, '2.2 reason 应为 weak_candidate_quality');
+  assert(r.needs_expansion === true, '2.3 needs_expansion 应为 true');
+}
+
+// ============================================================
+// 场景 3：有候选但类型信号缺失 → needs_expansion 取决于候选数
+// ============================================================
+function testCase3_TypeSignalMissing() {
+  console.log('\n📋 场景3: 类型信号缺失（有高分候选但不匹配目标类型）');
+  // 只有一个候选且不匹配"国家标准"类型
+  const candidates = [
+    makeCandidate('d1', '汽车安全培训材料', 80, 'training'),
+  ];
+  const r = _assessCandidateQuality(candidates, ['国家标准']);
+  assertEq(r.quality, 'marginal', '3.1 quality 应为 marginal');
+  assertEq(r.reason, FALLBACK_REASON.DOC_TYPE_SIGNAL_MISSING, '3.2 reason 应为 doc_type_signal_missing');
+  // 候选数 = 1 < MIN_CANDIDATE_COUNT(1) ？不，>= 但只有1个且没匹配，所以 needs_expansion
+  // 注意：needs_expansion = candidates.length < MIN_CANDIDATE_COUNT = 1 < 1 = false
+  // 所以 needs_expansion = false。这其实是正确的——有高分候选，只是类型不匹配，
+  // 扩召不是最好的策略，应该让类型重排去处理。
+  assert(r.needs_expansion === false, '3.3 单候选+类型不匹配时不应扩召（应交由重排）');
+}
+
+// ============================================================
+// 场景 4：多候选高质量 → needs_expansion = false
+// ============================================================
+function testCase4_GoodQuality() {
+  console.log('\n📋 场景4: 高质量候选 → 不扩召');
+  const candidates = [
+    makeCandidate('d1', 'GB/T 汽车车身术语标准', 100, 'standard', ['GB-T-12345.pdf']),
+    makeCandidate('d2', '汽车零部件术语', 60, 'standard'),
+  ];
+  const r = _assessCandidateQuality(candidates, ['国家标准']);
+  assertEq(r.quality, 'good', '4.1 quality 应为 good');
+  assert(r.needs_expansion === false, '4.2 needs_expansion 应为 false');
+}
+
+// ============================================================
+// 场景 5：top1/top2 分数差距太小 → marginal
+// ============================================================
+function testCase5_LowMargin() {
+  console.log('\n📋 场景5: top1/top2 差距太小（55 vs 50，margin=5 < 15）');
+  const candidates = [
+    makeCandidate('d1', '汽车术语手册', 55, 'manual'),
+    makeCandidate('d2', '汽车术语标准', 50, 'standard'),
+  ];
+  const r = _assessCandidateQuality(candidates, []);
+  assertEq(r.quality, 'marginal', '5.1 quality 应为 marginal');
+  assertEq(r.reason, 'low_top1_top2_margin', '5.2 reason 应为 low_top1_top2_margin');
+  assert(r.needs_expansion === false, '5.3 差距小但不扩召（仍有两个候选可用）');
+}
+
+// ============================================================
+// 场景 6：类型匹配 — 验证 _docMatchesTypeHint
+// ============================================================
+function testCase6_TypeMatching() {
+  console.log('\n📋 场景6: 类型匹配函数');
+
+  const stdDoc = makeCandidate('d1', '汽车车身术语', 80, '', ['GB-T-12345-2020.pdf']);
+  const match = _docMatchesTypeHint(stdDoc, ['国家标准']);
+  assert(match === true, '6.1 含 GB 附件的文档应匹配 国家标准');
+
+  const contractDoc = makeCandidate('d2', '劳动合同模板', 70, 'contract');
+  const matchC = _docMatchesTypeHint(contractDoc, ['合同协议']);
+  assert(matchC === true, '6.2 doc_type=contract 应匹配 合同协议');
+
+  const noMatch = _docMatchesTypeHint(makeCandidate('d3', '通用培训材料', 60, 'training'), ['国家标准']);
+  assert(noMatch === false, '6.3 培训材料不应匹配 国家标准');
+}
+
+// ============================================================
+// 执行
+// ============================================================
+console.log('╔══════════════════════════════════════╗');
+console.log('║  Retrieval Orchestration 行为测试   ║');
+console.log('╚══════════════════════════════════════╝');
+
+testCase1_ZeroCandidates();
+testCase2_LowScoreCandidate();
+testCase3_TypeSignalMissing();
+testCase4_GoodQuality();
+testCase5_LowMargin();
+testCase6_TypeMatching();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/document-retrieval-service.test.js
+++ b/tests/document-retrieval-service.test.js
@@ -1,0 +1,893 @@
+/**
+ * DocumentRetrievalService 真实编排层测试
+ *
+ * audit-round03 P1-1: 真实编排验证
+ * audit-round04 P1-3: 类型偏好重排 + Round 2 组合场景
+ *
+ * 运行：node tests/document-retrieval-service.test.js
+ */
+
+import DocumentRetrievalService from '../lib/document-retrieval-service.js';
+import logger from '../lib/logger.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+// ============================================================
+// Mock helpers
+// ============================================================
+function makeDbMock() {
+  return { query: () => [], execute: () => {}, getModel: () => ({}) };
+}
+
+function makeConfigLoaderMock() {
+  return { get: () => ({}), getModel: () => ({}) };
+}
+
+function makeCandidate(id, title, score, docType = 'standard') {
+  return { document_id: id, document_title: title, relevance_score: score, doc_type: docType, revision_id: id + '-rev' };
+}
+
+// ============================================================
+// 场景 1：allow_fallback=false + chunk_first 建议 → 不被抢占
+// ============================================================
+async function testCase1_NoChunkFirstBypass() {
+  console.log('\n📋 场景1: find_document 不被 chunk-first 抢占');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  // Stub DecisionService: 返回 chunk_first 建议
+  svc.decisionService.analyze = () => ({
+    intent: 'content_exploration',
+    anchor_strength: 'none',
+    confidence: 0.3,
+    matched_patterns: [],
+    reason_codes: ['no_document_anchor'],
+    recommended_strategy: 'chunk_first',
+  });
+
+  // Stub SearchService: 返回零候选（触发降级路径）
+  // 注意：当 decision 建议 chunk_first 但 allow_fallback=false 时，应绕过 bypass，
+  // 继续走 document-first（搜索返回零候选 → 尝试扩召 → 降级）
+  svc.searchService.search = async () => ({
+    success: true, candidates: [], total: 0, strategy: 'empty',
+  });
+
+  const result = await svc.retrieve('纯内容探索问题', {
+    userId: 'u1',
+    allow_fallback: false,  // find_document 场景
+  });
+
+  // 不应该走 chunk_first_fallback 策略
+  assert(result.strategy !== 'chunk_first_fallback',
+    '1.1 allow_fallback=false 时不应被 chunk_first 抢占');
+  // 零候选应降级
+  assert(result.strategy === 'degrade',
+    '1.2 零候选应降级 (degrade)');
+  assert(result.packet.meta.reason_codes.includes('no_candidates'),
+    '1.3 reason_codes 应包含 no_candidates');
+}
+
+// ============================================================
+// 场景 2：Round 1 低质量 → Round 2 触发 + 最终 meta 使用 R2 质量
+// ============================================================
+async function testCase2_Round2QualityWriteback() {
+  console.log('\n📋 场景2: Round 1 低分 → Round 2 命中 → meta 反映 R2 质量');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'medium',
+    confidence: 0.6,
+    matched_patterns: ['标准'],
+    reason_codes: ['medium_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  let searchCallCount = 0;
+
+  svc.searchService.search = async (query) => {
+    searchCallCount++;
+    if (searchCallCount === 1) {
+      // Round 1: 返回低分候选（score=30 < 50）
+      return {
+        success: true,
+        candidates: [makeCandidate('d1', '低分文档', 30)],
+        total: 1,
+        strategy: 'title_match',
+      };
+    }
+    // Round 2: 扩召命中高分候选
+    return {
+      success: true,
+      candidates: [makeCandidate('d2', '高分目标文档', 85)],
+      total: 1,
+      strategy: 'title_match',
+    };
+  };
+
+  // Stub: recall 返回最小有效证据
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [{ score: 0.8, content: 'test chunk', document: { id: 'd2' } }],
+    }),
+  };
+
+  const result = await svc.retrieve('汽车车身术语', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  // Round 2 应被触发（因为 top1 分数 30 < 50）
+  assert(searchCallCount >= 2, '2.1 Round 2 应被触发（search 被调用 >= 2 次）');
+
+  // 最终 meta 的 candidate_quality 应反映 Round 2 结果
+  assert(result.packet.meta.candidate_quality === 'good',
+    '2.2 最终 candidate_quality 应为 good（Round 2 高分）');
+  assert(result.packet.meta.document_recall_round === 2,
+    '2.3 document_recall_round 应为 2');
+}
+
+// ============================================================
+// 场景 3：Round 1 高分 → 不触发 Round 2
+// ============================================================
+async function testCase3_NoExpansionNeeded() {
+  console.log('\n📋 场景3: Round 1 高分 → 不触发 Round 2');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'strong',
+    confidence: 0.9,
+    matched_patterns: ['GB/T'],
+    reason_codes: ['strong_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  let searchCallCount = 0;
+
+  svc.searchService.search = async () => {
+    searchCallCount++;
+    return {
+      success: true,
+      candidates: [makeCandidate('d1', 'GB/T 汽车术语标准', 100)],
+      total: 1,
+      strategy: 'title_match',
+    };
+  };
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [{ score: 0.9, content: 'test', document: { id: 'd1' } }],
+    }),
+  };
+
+  const result = await svc.retrieve('GB/T 12345-2020', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  // Round 2 不应触发（高分候选）
+  assert(searchCallCount === 1, '3.1 search 只应被调用 1 次（无 Round 2）');
+  assert(result.packet.meta.document_recall_round === 1,
+    '3.2 document_recall_round 应为 1');
+  assert(result.packet.meta.candidate_quality === 'good',
+    '3.3 candidate_quality 应为 good');
+  assert(result.strategy === 'document_first',
+    '3.4 strategy 应为 document_first');
+}
+
+// ============================================================
+// 场景 4（audit-round04 P1-3）：Round 2 命中后类型偏好重排
+// ============================================================
+async function testCase4_TypePreferenceRankingAfterRound2() {
+  console.log('\n📋 场景4: Round 2 → 类型偏好重排不丢失主题相关性');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  // 模拟"国标文件"查询
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'medium',
+    confidence: 0.7,
+    matched_patterns: ['国标', '标准'],
+    reason_codes: ['medium_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  let searchCallCount = 0;
+  svc.searchService.search = async (query) => {
+    searchCallCount++;
+    if (searchCallCount === 1) {
+      // Round 1: 返回主题相关但非国标类型的文档（score=40 < 50）
+      return {
+        success: true,
+        candidates: [
+          makeCandidate('d1', '汽车行业技术报告', 40, '报告'),
+        ],
+        total: 1,
+        strategy: 'title_match',
+      };
+    }
+    // Round 2: 扩召命中两个候选，其中 d2 是国标
+    return {
+      success: true,
+      candidates: [
+        makeCandidate('d2', 'GB/T 汽车术语标准', 80, 'standard'),
+        makeCandidate('d3', '汽车行业技术报告 v2', 75, '报告'),
+      ],
+      total: 2,
+      strategy: 'title_match',
+    };
+  };
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [
+        { score: 0.9, content: 'test chunk', document: { id: 'd2' } },
+        { score: 0.7, content: 'test chunk', document: { id: 'd3' } },
+      ],
+    }),
+  };
+
+  const result = await svc.retrieve('汽车车身术语国标', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  // Round 2 应被触发
+  assert(searchCallCount >= 2, '4.1 Round 2 被触发');
+  // 最终质量反映 Round 2（top1=80/top2=75 margin 小 → marginal，非错误）
+  assert(result.packet.meta.document_recall_round === 2, '4.2 document_recall_round=2');
+  // 候选文档至少 2 个，且 top1 为 d2（GB/T 标准）
+  const docCount = result.packet.documents?.length || 0;
+  assert(docCount >= 2, '4.3 至少 2 个文档候选');
+  const top1Id = result.packet.documents?.[0]?.document_id;
+  assert(top1Id === 'd2', '4.4 top1 是 d2（GB/T 标准，类型匹配）');
+}
+
+// ============================================================
+// 场景 5：chunk-first fallback 日志保留 document_recall_round=0
+// ============================================================
+async function testCase5_FallbackLogKeepsZeroRound() {
+  console.log('\n📋 场景5: chunk-first fallback 日志保留 round=0');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  const originalInfo = logger.info;
+  const completedLogs = [];
+  logger.info = (message, payload) => {
+    if (message === '[DocRetrieval] Completed:') {
+      completedLogs.push(payload);
+    }
+  };
+
+  try {
+    svc.decisionService.analyze = () => ({
+      intent: 'content_exploration',
+      anchor_strength: 'none',
+      confidence: 0.2,
+      matched_patterns: [],
+      reason_codes: ['no_document_anchor'],
+      recommended_strategy: 'chunk_first',
+    });
+
+    svc._ensureRecallService = () => {};
+    svc.recallService = {
+      recall: async () => ({
+        success: true,
+        items: [{ score: 0.6, content: 'fallback chunk', document: { id: 'd1' } }],
+      }),
+    };
+
+    svc.searchService.getDocumentInfo = async () => ([{
+      document_id: 'd1',
+      document_title: '回退命中文档',
+      doc_type: 'standard',
+      relevance_score: 70,
+      revision_id: 'd1-rev',
+    }]);
+
+    const result = await svc.retrieve('随便问个内容问题', {
+      userId: 'u1',
+      allow_fallback: true,
+    });
+
+    assert(result.strategy === 'chunk_first_fallback', '5.1 应走 chunk_first_fallback');
+    assert(completedLogs.length > 0, '5.2 应产出 Completed 日志');
+    const lastLog = completedLogs[completedLogs.length - 1] || {};
+    assert(lastLog.document_recall_round === 0, '5.3 fallback Completed 日志应保留 round=0');
+    assert(lastLog.candidate_quality === 'not_applicable', '5.4 fallback Completed 日志应记录 not_applicable');
+  } finally {
+    logger.info = originalInfo;
+  }
+}
+
+// ============================================================
+// 场景 6：degrade 日志显式记录 round/quality
+// ============================================================
+async function testCase6_DegradeLogHasStructuredFields() {
+  console.log('\n📋 场景6: degrade 日志显式记录 round/quality');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  const originalInfo = logger.info;
+  const completedLogs = [];
+  logger.info = (message, payload) => {
+    if (message === '[DocRetrieval] Completed:') {
+      completedLogs.push(payload);
+    }
+  };
+
+  try {
+    svc.decisionService.analyze = () => ({
+      intent: 'content_exploration',
+      anchor_strength: 'none',
+      confidence: 0.3,
+      matched_patterns: [],
+      reason_codes: ['no_document_anchor'],
+      recommended_strategy: 'chunk_first',
+    });
+
+    svc.searchService.search = async () => ({
+      success: true,
+      candidates: [],
+      total: 0,
+      strategy: 'empty',
+    });
+
+    const result = await svc.retrieve('纯内容探索问题', {
+      userId: 'u1',
+      allow_fallback: false,
+    });
+
+    assert(result.strategy === 'degrade', '6.1 应走 degrade');
+    assert(completedLogs.length > 0, '6.2 应产出 Completed 日志');
+    const lastLog = completedLogs[completedLogs.length - 1] || {};
+    assert(lastLog.document_recall_round === 0, '6.3 degrade Completed 日志应显式记录 round=0');
+    assert(lastLog.candidate_quality === 'not_applicable', '6.4 degrade Completed 日志应显式记录 not_applicable');
+  } finally {
+    logger.info = originalInfo;
+  }
+}
+
+// ============================================================
+// 场景 7：真实主题扩召 —— 汽车外壳防护等级 → 外壳防护等级(IP代码)
+// ============================================================
+async function testCase7_TopicExpansionFindsIPDocument() {
+  console.log('\n📋 场景7: 主题扩召命中外壳防护等级(IP代码)');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'medium',
+    confidence: 0.6,
+    matched_patterns: ['标准'],
+    reason_codes: ['medium_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  const seenQueries = [];
+  svc.searchService.search = async (query) => {
+    seenQueries.push(query);
+    if (query.includes('汽车外壳防护等级')) {
+      return {
+        success: true,
+        candidates: [],
+        total: 0,
+        strategy: 'title_match',
+      };
+    }
+    if (query.includes('防护等级')) {
+      return {
+        success: true,
+        candidates: [makeCandidate('d-ip', 'GB/T 4208-2017 外壳防护等级（IP代码）', 88, 'standard')],
+        total: 1,
+        strategy: 'title_match',
+      };
+    }
+    return {
+      success: true,
+      candidates: [],
+      total: 0,
+      strategy: 'title_match',
+    };
+  };
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [{ score: 0.86, content: 'IP代码与外壳防护等级', document: { id: 'd-ip' } }],
+    }),
+  };
+
+  const result = await svc.retrieve('汽车外壳防护等级', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(seenQueries.some(q => q.includes('防护等级')),
+    '7.1 应尝试主题放宽扩召并命中“防护等级”相关查询');
+  assert(result.strategy === 'document_first',
+    '7.2 应命中文档级检索，不应直接降级');
+  assert(result.packet.documents?.[0]?.document_id === 'd-ip',
+    '7.3 top1 应为外壳防护等级(IP代码)文档');
+}
+
+// ============================================================
+// 场景 8：README 主线 —— parser 表明在找文档时，不允许 decision 抢去 chunk_first
+// ============================================================
+async function testCase8_ForceDocumentFirstForLookupIntent() {
+  console.log('\n📋 场景8: lookup_intent 命中时强制 document-first');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'content_exploration',
+    anchor_strength: 'none',
+    confidence: 0.25,
+    matched_patterns: [],
+    reason_codes: ['no_document_anchor'],
+    recommended_strategy: 'chunk_first',
+  });
+
+  let fallbackCalled = false;
+  svc._handleChunkFirstFallback = async () => {
+    fallbackCalled = true;
+    throw new Error('should not fallback first');
+  };
+
+  svc.searchService.search = async (query) => ({
+    success: true,
+    candidates: [makeCandidate('d-std', `GB/T 4780-2020 ${query}`, 72, 'standard')],
+    total: 1,
+    strategy: 'title_match',
+  });
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [{ score: 0.82, content: '汽车车身术语', document: { id: 'd-std' } }],
+    }),
+  };
+
+  const result = await svc.retrieve('有一个规定了汽车车身术语的国标文件是啥来着？', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(fallbackCalled === false, '8.1 parser 识别为找文档时不应先走 fallback');
+  assert(result.strategy === 'document_first', '8.2 应优先走 document_first');
+  assert(result.packet.documents?.[0]?.document_id === 'd-std', '8.3 应返回 document-first 候选');
+}
+
+// ============================================================
+// 场景 9：README 主线 —— 第一轮主题召回后类型偏好不匹配，应触发第二轮而不是直接结束
+// ============================================================
+async function testCase9_DocTypeHintTriggersRound2() {
+  console.log('\n📋 场景9: 缺少类型匹配时触发第二轮主题扩召');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'medium',
+    confidence: 0.66,
+    matched_patterns: ['标准'],
+    reason_codes: ['medium_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  const queries = [];
+  svc.searchService.search = async (query) => {
+    queries.push(query);
+    if (queries.length === 1) {
+      return {
+        success: true,
+        candidates: [makeCandidate('d-report', '汽车车身术语研究报告', 62, '报告')],
+        total: 1,
+        strategy: 'title_match',
+      };
+    }
+
+    return {
+      success: true,
+      candidates: [
+        makeCandidate('d-std', 'GB/T 4780-2020 汽车车身术语', 61, 'standard'),
+        makeCandidate('d-report', '汽车车身术语研究报告', 62, '报告'),
+      ],
+      total: 2,
+      strategy: 'title_match',
+    };
+  };
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [{ score: 0.84, content: '汽车车身术语正文', document: { id: 'd-std' } }],
+    }),
+  };
+
+  const result = await svc.retrieve('汽车车身术语国标', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(queries.length >= 2, '9.1 第一轮无类型匹配时应触发第二轮扩召');
+  assert(result.packet.meta.document_recall_round === 2, '9.2 应记录第二轮召回');
+  assert(result.packet.documents?.[0]?.document_id === 'd-std', '9.3 第二轮后应由标准文档排到 top1');
+}
+
+// ============================================================
+// 执行
+// ============================================================
+console.log('╔══════════════════════════════════════╗');
+console.log('║  DocumentRetrievalService 编排测试  ║');
+console.log('╚══════════════════════════════════════╝');
+
+await testCase1_NoChunkFirstBypass();
+await testCase2_Round2QualityWriteback();
+await testCase3_NoExpansionNeeded();
+await testCase4_TypePreferenceRankingAfterRound2();
+await testCase5_FallbackLogKeepsZeroRound();
+await testCase6_DegradeLogHasStructuredFields();
+await testCase7_TopicExpansionFindsIPDocument();
+await testCase8_ForceDocumentFirstForLookupIntent();
+await testCase9_DocTypeHintTriggersRound2();
+
+// ============================================================
+// 场景 10：口语型“那个…是哪个”应视为文档定位，不应直接 chunk-first
+// ============================================================
+async function testCase10_ColloquialLookupAvoidsBlindFallback() {
+  console.log('\n📋 场景10: 口语型找文档问法不应盲目 chunk-first');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  let fallbackCalled = false;
+  const originalAnalyze = svc.decisionService.analyze.bind(svc.decisionService);
+  svc._handleChunkFirstFallback = async () => {
+    fallbackCalled = true;
+    throw new Error('should not fallback first');
+  };
+
+  svc.searchService.search = async (query) => ({
+    success: true,
+    candidates: [makeCandidate('lab1', `可信实验室算法考核 ${query}`, 78, 'contract')],
+    total: 1,
+    strategy: 'title_match',
+  });
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [{ score: 0.76, content: '可信实验室算法考核', document: { id: 'lab1' } }],
+    }),
+  };
+
+  try {
+    const result = await svc.retrieve('那个实验室算法考核你帮我翻一下是哪个', {
+      userId: 'u1',
+      allow_fallback: true,
+      context: {
+        parsed_query: {
+          topic_terms: ['实验室算法考核'],
+          cleaned_query: '实验室算法考核',
+        },
+      },
+    });
+
+    assert(fallbackCalled === false, '10.1 不应先走 chunk-first fallback');
+    assert(result.strategy === 'document_first', '10.2 应优先走 document_first');
+    assert(result.packet.documents?.[0]?.document_id === 'lab1', '10.3 应返回目标文档');
+  } finally {
+    svc.decisionService.analyze = originalAnalyze;
+  }
+}
+
+// ============================================================
+// 场景 11：fallback 候选不应出现 0 分 high 置信度混入
+// ============================================================
+async function testCase11_FallbackCandidateConfidenceAndFiltering() {
+  console.log('\n📋 场景11: fallback 候选筛选与置信度收紧');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'content_exploration',
+    anchor_strength: 'none',
+    confidence: 0.2,
+    matched_patterns: [],
+    reason_codes: ['no_document_anchor'],
+    recommended_strategy: 'chunk_first',
+  });
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recall: async () => ({
+      success: true,
+      items: [
+        { score: 0.82, chunk: { content: '可信实验室算法考核' }, document: { id: 'd-good' } },
+        { score: 0.12, chunk: { content: '无关片段' }, document: { id: 'd-bad' } },
+      ],
+    }),
+  };
+
+  svc.searchService.getDocumentInfo = async () => ([
+    { document_id: 'd-good', document_title: '可信实验室算法考核', doc_type: 'contract', relevance_score: 0, revision_id: 'd-good-rev' },
+    { document_id: 'd-bad', document_title: 'GB 28046.5-2013', doc_type: 'contract', relevance_score: 0, revision_id: 'd-bad-rev' },
+  ]);
+
+  const result = await svc.retrieve('实验室算法考核', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(result.strategy === 'chunk_first_fallback', '11.1 应走 fallback');
+  assert(result.packet.documents.length === 1, '11.2 应过滤掉弱相关 fallback 候选');
+  assert(result.packet.documents[0].document_id === 'd-good', '11.3 仅保留高集中候选');
+  assert(result.packet.documents[0].candidate_confidence !== 'high', '11.4 fallback 候选不应默认 high');
+}
+
+await testCase10_ColloquialLookupAvoidsBlindFallback();
+await testCase11_FallbackCandidateConfidenceAndFiltering();
+
+// ============================================================
+// 场景 12：find_document 应允许 document-first 失败后回退到 chunk-first 锁文档
+// ============================================================
+async function testCase12_FindDocumentCanFallbackAfterDocumentFirstMiss() {
+  console.log('\n📋 场景12: find_document 允许两轮 document-first 后回退 chunk-first 锁文档');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.searchService.search = async () => ({
+    success: true,
+    candidates: [],
+    total: 0,
+    strategy: 'title_match',
+  });
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recall: async () => ({
+      success: true,
+      items: [
+        { score: 0.88, chunk: { content: 'IPX5 试验应使用直径 6.3 mm 喷嘴进行喷水试验' }, document: { id: 'd-ipx5' } },
+        { score: 0.74, chunk: { content: '外壳防护等级（IP代码）规定了 IPX5 的试验方法' }, document: { id: 'd-ipx5' } },
+      ],
+    }),
+  };
+
+  svc.searchService.getDocumentInfo = async () => ([{
+    document_id: 'd-ipx5',
+    document_title: 'GB/T 4208-2017 外壳防护等级（IP代码）',
+    doc_type: 'standard',
+    relevance_score: 0,
+    revision_id: 'd-ipx5-rev',
+    best_identity_label: 'GB/T 4208-2017 外壳防护等级（IP代码）',
+    identity_label_source: 'document_title',
+  }]);
+
+  const result = await svc.retrieve('IPX5 外壳防护等级 标准', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(result.strategy === 'chunk_first_fallback', '12.1 无标题候选时应允许 fallback 锁文档');
+  assert(result.packet.meta.scoped_identity_confirmed === true, '12.2 chunk 命中同一文档时应确认 scoped identity');
+  assert(result.packet.documents?.[0]?.document_id === 'd-ipx5', '12.3 应反锁到正确标准文档');
+}
+
+// ============================================================
+// 场景 13：IPX5 类问题的主题扩召失败后，仍应可由 fallback 反锁标准文档
+// ============================================================
+async function testCase13_IPX5FallbackRecoversOriginalStrategy() {
+  console.log('\n📋 场景13: IPX5 标准标题想不起来时，fallback 仍应可反锁文档');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  const seenQueries = [];
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'medium',
+    confidence: 0.6,
+    matched_patterns: ['标准'],
+    reason_codes: ['medium_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  svc.searchService.search = async (query) => {
+    seenQueries.push(query);
+    return {
+      success: true,
+      candidates: [],
+      total: 0,
+      strategy: 'title_match',
+    };
+  };
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recall: async () => ({
+      success: true,
+      items: [
+        { score: 0.81, chunk: { content: 'IPX5 防护等级要求进行喷水试验' }, document: { id: 'd-4208' } },
+        { score: 0.77, chunk: { content: '本标准规定外壳防护等级 IPX5 的试验装置与判定' }, document: { id: 'd-4208' } },
+      ],
+    }),
+  };
+  svc.searchService.getDocumentInfo = async () => ([{
+    document_id: 'd-4208',
+    document_title: 'GB/T 4208-2017 外壳防护等级（IP代码）',
+    doc_type: 'standard',
+    relevance_score: 0,
+    revision_id: 'd-4208-rev',
+  }]);
+
+  const result = await svc.retrieve('IPX5 外壳防护等级 标准', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(seenQueries.length >= 1, '13.1 仍应先尝试 document-first');
+  assert(result.strategy === 'chunk_first_fallback', '13.2 document-first 无结果后应走 fallback');
+  assert(result.packet.documents?.[0]?.document_title === 'GB/T 4208-2017 外壳防护等级（IP代码）', '13.3 fallback 应反锁到 GB/T 4208 文档');
+}
+
+// ============================================================
+// 场景 14：find_document query plan 应保留原问句 + normalized_lookup_query
+// ============================================================
+async function testCase14_FindDocumentQueryPlanKeepsNaturalQuestion() {
+  console.log('\n📋 场景14: find_document query 入口保留原问句与 normalized_lookup_query');
+
+  const { default: ToolManager } = await import('../lib/tool-manager.js');
+  const tm = new ToolManager(makeDbMock(), 'expert-test', {});
+
+  const plan = tm._buildFindDocumentQueryPlan('我想找那个关于IPX5的标准，是哪份文件？顺便告诉我要做什么实验。');
+
+  assert(plan.queries[0].role === 'raw_query', '14.1 第一入口应为 raw_query');
+  assert(plan.queries[0].query.includes('我想找那个关于IPX5的标准'), '14.2 第一入口应保留原始自然语言问句');
+  assert(plan.queries.some(q => q.query.includes('IPX5')), '14.3 query plan 应保留 IPX5 核心实体');
+  assert(plan.queries.some(q => q.role === 'lookup_query' || q.role === 'topic_query'), '14.4 query plan 应包含 lookup/topic 归一化入口');
+}
+
+// ============================================================
+// 场景 15：find_document 应优先接受原问句命中，而不是只依赖压缩 query
+// ============================================================
+async function testCase15_FindDocumentPrefersNaturalQuestionHit() {
+  console.log('\n📋 场景15: find_document 优先尝试原问句命中');
+
+  const { default: ToolManager } = await import('../lib/tool-manager.js');
+  const tm = new ToolManager(makeDbMock(), 'expert-test', {});
+
+  const queries = [];
+  const retrievalService = {
+    retrieve: async (q) => {
+      queries.push(q);
+      if (q.includes('顺便告诉我要做什么实验')) {
+        return {
+          strategy: 'document_first',
+          packet: { documents: [{ document_id: 'd1' }], meta: { evidence_sufficiency: 'medium' } },
+        };
+      }
+      return {
+        strategy: 'degrade',
+        packet: { documents: [], meta: { evidence_sufficiency: 'none' } },
+      };
+    },
+  };
+
+  const plan = tm._buildFindDocumentQueryPlan('我想找那个关于IPX5的标准，是哪份文件？顺便告诉我要做什么实验。');
+  const { effectiveQuery, result } = await tm._retrieveWithFindDocumentQueryPlan(retrievalService, plan, {});
+
+  assert(queries.length >= 1, '15.1 应至少尝试一次 query');
+  assert(effectiveQuery.includes('顺便告诉我要做什么实验'), '15.2 命中时应保留原问句作为 effectiveQuery');
+  assert(result.packet.documents?.length === 1, '15.3 原问句命中时应直接返回结果');
+}
+
+// ============================================================
+// 场景 16：文件A这份文件类问句应识别为文档锚点，而非 no_document_anchor
+// ============================================================
+async function testCase16_AnchoredFileQuestionUsesDocumentFirst() {
+  console.log('\n📋 场景16: 文件A这份文件 + 内容问题 → document_first');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigLoaderMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  let capturedDecision = null;
+  const originalAnalyze = svc.decisionService.analyze.bind(svc.decisionService);
+  svc.decisionService.analyze = (query, context) => {
+    const decision = originalAnalyze(query, context);
+    capturedDecision = decision;
+    return decision;
+  };
+
+  svc.searchService.search = async () => ({
+    success: true,
+    candidates: [makeCandidate('file-a', '文件A', 88, '合同协议')],
+    total: 1,
+    strategy: 'title_match',
+  });
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [
+        {
+          score: 0.83,
+          chunk: { id: 'c1', content: '如项目延期，每日按合同金额的0.1%承担违约金。' },
+          document: { id: 'file-a', document_title: '文件A', doc_type: '合同协议' },
+        },
+      ],
+    }),
+  };
+
+  const result = await svc.retrieve('帮我看一下文档平台里文件A这份文件，如果项目延期了，每天具体要扣多少比例的违约金？', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(capturedDecision?.anchor_strength !== 'none', '16.1 anchor_strength 不应为 none');
+  assert(!capturedDecision?.reason_codes?.includes('no_document_anchor'), '16.2 不应包含 no_document_anchor');
+  assert(capturedDecision?.recommended_strategy !== 'chunk_first', '16.3 不应推荐 chunk_first');
+  assert(result.strategy === 'document_first', '16.4 应走 document_first');
+}
+
+await testCase12_FindDocumentCanFallbackAfterDocumentFirstMiss();
+await testCase13_IPX5FallbackRecoversOriginalStrategy();
+await testCase14_FindDocumentQueryPlanKeepsNaturalQuestion();
+await testCase15_FindDocumentPrefersNaturalQuestionHit();
+await testCase16_AnchoredFileQuestionUsesDocumentFirst();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/document-retrieval-system.test.js
+++ b/tests/document-retrieval-system.test.js
@@ -1,0 +1,385 @@
+/**
+ * Document Retrieval 系统闭环测试
+ *
+ * 覆盖 audit-round02 P1-3 验收标准：
+ * 1. rerank 后的结果确实传给上游
+ * 2. coverage=not_covered 时不触发 fallback supplement
+ * 3. fallback merge 后 coverage/response_mode 被重新计算
+ *
+ * 运行：node tests/document-retrieval-system.test.js
+ */
+
+import DocumentRetrievalService from '../lib/document-retrieval-service.js';
+import DocumentEvidencePacker from '../lib/document-evidence-packer.js';
+import DocRecallService from '../lib/doc-recall-service.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEq(actual, expected, label) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) { passed++; }
+  else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+    console.error(`     expected: ${JSON.stringify(expected)}`);
+    console.error(`     actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// ============================================================
+// 测试辅助
+// ============================================================
+
+function makeDbMock() {
+  return {
+    getModel: () => ({}),
+    sequelize: { QueryTypes: { SELECT: 'SELECT' }, query: async () => [] },
+    query: async () => [],
+  };
+}
+
+function makeConfigMock() {
+  return {
+    get: () => ({}),
+    db: {
+      getModelConfig: async () => ({}),
+      getDefaultEmbeddingModel: async () => 'em-default',
+    },
+  };
+}
+
+function makeCandidate(id, title, score, docType) {
+  return {
+    document_id: id, document_title: title, relevance_score: score,
+    doc_type: docType, revision_id: `${id}-rev`, collection_id: 'col-1',
+    collection_name: 'default', revision_no: 1, is_heuristic_fallback: false,
+    candidate_confidence: score >= 80 ? 'high' : 'medium',
+  };
+}
+
+// ============================================================
+// 场景 A: query_plan 正确提取 + rerank 结果传给上游
+// ============================================================
+function testCaseA_QueryPlanExtraction() {
+  console.log('\n📋 系统场景A: query_plan 嵌套提取 + rerank 返回验证');
+
+  const mockDb = makeDbMock();
+  const svc = new DocRecallService(mockDb);
+
+  // P0-2: 验证 query_plan 嵌套结构被正确提取
+  // 模拟 DocumentRetrievalService 传入的结构
+  const query = {
+    semantic_query: 'IPX5 防水等级怎么测',
+    query_plan: {
+      entity_terms: ['IPX5', '4208'],
+      procedure_terms: ['试验', '方法'],
+      attribute_terms: ['等级'],
+      normalized_lookup_query: 'IPX5 4208 试验 方法',
+    },
+  };
+
+  // 构造 items 模拟 rerank
+  const items = [
+    { _raw: { content: '前言概要...', chunk_title: '前言', distance: 0.10 }, score: 0.90, chunk: { id: 'c1', title: '前言', content: '前言概要...', seq: 0 } },
+    { _raw: { content: '第14.2.5条 IPX5 试验方法 喷水30min', chunk_title: '防水试验', distance: 0.15 }, score: 0.85, chunk: { id: 'c2', title: '防水试验', content: '第14.2.5条 IPX5 试验方法 喷水30min', seq: 5 } },
+  ];
+
+  const rerankResult = svc._hybridRerank(items, query.query_plan);
+  assert(rerankResult.items.length === 2, 'A1: rerank 后 items 数不变');
+  // c2 含 IPX5 + 试验 + 章节锚点 → 应排第一
+  assert(rerankResult.items[0].chunk.id === 'c2', 'A2: 含实体+程序词+锚点的 chunk 排第一');
+  // 验证子分数
+  const c2Debug = rerankResult.debug.find(d => d.chunk_id === 'c2');
+  assert(c2Debug.entity > 0, 'A3: c2 entity_score > 0');
+  assert(c2Debug.procedure > 0, 'A4: c2 procedure_score > 0');
+  assert(c2Debug.final > rerankResult.debug.find(d => d.chunk_id === 'c1').final, 'A5: c2 final > c1 final');
+  assert(c2Debug.matched_entities.length > 0, 'A6: matched_entities 不为空');
+}
+
+// ============================================================
+// 场景 A2: 直接验证 recallWithinDocuments 返回 finalItems
+// ============================================================
+function testCaseA2_ReturnFinalItems() {
+  console.log('\n📋 系统场景A2: recallWithinDocuments 返回 rerank 后结果');
+
+  // 不启动真实数据库，直接验证 rerank 与 return 路径一致性
+  const mockDb = makeDbMock();
+  const svc = new DocRecallService(mockDb);
+
+  const items = [
+    { _raw: { content: '前言...', chunk_title: '前言', distance: 0.10 }, score: 0.90, chunk: { id: 'c1', title: '前言', content: '前言...', seq: 0 } },
+    { _raw: { content: 'IPX5 试验条件', chunk_title: '试验方法', distance: 0.15 }, score: 0.85, chunk: { id: 'c2', title: '试验方法', content: 'IPX5 试验条件', seq: 5 } },
+  ];
+  const queryPlan = { entity_terms: ['IPX5'], procedure_terms: ['试验'] };
+
+  const rerankResult = svc._hybridRerank(items, queryPlan);
+  const finalItems = rerankResult.items.slice(0, 3).map(({ _raw, ...rest }) => rest);
+
+  // 模拟 recallWithinDocuments 中的 return 结构
+  assert(finalItems.length === 2, 'A2.1: finalItems 长度正确');
+  assert(finalItems[0].chunk.id === 'c2', 'A2.2: rerank 后 c2 排第一（含 IPX5）');
+  assert(finalItems[0].score > finalItems[1].score, 'A2.3: finalItems 按 rerank 分数排序');
+}
+
+// ============================================================
+// 场景 B: coverage=not_covered 时不触发 fallback supplement
+// ============================================================
+async function testCaseB_NoFallbackWhenNotCovered() {
+  console.log('\n📋 系统场景B: coverage=not_covered 时阻止 fallback');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'medium',
+    confidence: 0.6,
+    matched_patterns: ['标准'],
+    reason_codes: ['medium_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  svc.searchService.search = async () => ({
+    success: true,
+    candidates: [makeCandidate('d1', '前言概述文档', 50, 'standard')],
+    total: 1,
+    strategy: 'title_match',
+  });
+
+  let fallbackCalled = false;
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    recallWithinDocuments: async () => ({
+      success: true,
+      // 只返回与问题无关的前言内容 → coverage 将判定 not_covered
+      items: [
+        { score: 0.4, chunk: { id: 'c1', title: '前言', content: '本标准前言...', seq: 0 }, document: { id: 'd1' } },
+      ],
+      total: 1,
+    }),
+    recall: async () => {
+      fallbackCalled = true;
+      return { success: true, items: [], total: 0 };
+    },
+  };
+
+  const result = await svc.retrieve('IPX5 防水等级怎么测', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  // coverage 应该是 not_covered（entity=IPX5 未命中）
+  assert(result.packet.meta.coverage_status === 'not_covered', 'B1: coverage=not_covered');
+  // fallback 不应该被调用
+  assert(!fallbackCalled, 'B2: fallback supplement 未被调用');
+  // 应该降级而非通过
+  assert(result.packet.meta.suggested_response_mode === 'conservative_answer', 'B3: 降级为 conservative_answer');
+  assert(result.strategy === 'degrade' || result.packet.meta.reason_codes.includes('fallback_blocked_by_coverage'),
+    'B4: strategy 降级或日志标注 fallback 被阻止');
+}
+
+// ============================================================
+// 场景 C: fallback merge 后 coverage 被重新计算
+// ============================================================
+async function testCaseC_RecomputeCoverageAfterMerge() {
+  console.log('\n📋 系统场景C: fallback merge 后重算 coverage');
+
+  // 直接测试 packer 行为，不需要完整 orchestration
+  const packer = new DocumentEvidencePacker();
+
+  const existingPacket = packer.pack(
+    [makeCandidate('d1', '前言文档', 50, 'standard')],
+    [{ score: 0.4, chunk: { id: 'c1', title: '前言', content: '前言内容...' }, document: { id: 'd1' } }],
+    { intent: 'document_lookup', recommended_strategy: 'document_first' },
+    'trace-c',
+    { queryFacets: { entity_terms: ['IPX5'], procedure_terms: ['试验'] } }
+  );
+  assert(existingPacket.meta.coverage_status === 'not_covered', 'C1: 原始 packet coverage=not_covered');
+
+  // 模拟 fallback 合并：加入命中实体的证据
+  const newPacket = packer.pack(
+    [makeCandidate('d2', '外壳防护等级', 80, 'standard')],
+    [{ score: 0.85, chunk: { id: 'c2', title: 'IPX5 试验条件', content: 'IPX5 试验条件为...', seq: 5 }, document: { id: 'd2' } }],
+    { intent: 'document_lookup', recommended_strategy: 'document_first' },
+    'trace-c',
+    { queryFacets: { entity_terms: ['IPX5'], procedure_terms: ['试验'] } }
+  );
+
+  // 合并
+  newPacket.documents = [...existingPacket.documents, ...newPacket.documents];
+  newPacket.meta.total_candidates = existingPacket.meta.total_candidates + newPacket.meta.total_candidates;
+  newPacket.meta.total_evidence = existingPacket.meta.total_evidence + newPacket.meta.total_evidence;
+  newPacket.meta.max_evidence_score = Math.max(existingPacket.meta.max_evidence_score, newPacket.meta.max_evidence_score);
+
+  const mergedCoverage = packer._assessCoverage(newPacket, { entity_terms: ['IPX5'], procedure_terms: ['试验'] });
+  const mergedMode = packer._deriveResponseMode(newPacket);
+
+  assert(mergedCoverage.status === 'covered', 'C2: merge 后 coverage=covered');
+  assert(mergedMode.should_answer_conservatively === false, 'C3: merge 后不再保守回答');
+  assert(mergedMode.mode === 'answer_with_citation', 'C4: merge 后恢复引用回答');
+}
+
+// ============================================================
+// 场景 F: coverage=covered + sufficiency=weak → fallback 触发 → merge 后重算 coverage
+// ============================================================
+async function testCaseF_FallbackTriggeredWhenCovered() {
+  console.log('\n📋 系统场景F: covered+weak → fallback → merge 后 coverage 收敛为具体值');
+
+  const mockDb = makeDbMock();
+  const mockConfig = makeConfigMock();
+  const svc = new DocumentRetrievalService(mockDb, mockConfig);
+
+  svc.decisionService.analyze = () => ({
+    intent: 'document_lookup',
+    anchor_strength: 'medium',
+    confidence: 0.55,
+    matched_patterns: ['标准'],
+    reason_codes: ['medium_anchor_detected'],
+    recommended_strategy: 'document_first',
+  });
+
+  svc.searchService.search = async () => ({
+    success: true,
+    candidates: [makeCandidate('d1', 'IP测试标准', 60, 'standard')],
+    total: 1,
+    strategy: 'title_match',
+  });
+
+  let fallbackRecallCalled = false;
+  let getDocumentInfoCalled = false;
+
+  svc._ensureRecallService = () => {};
+  svc.recallService = {
+    // 主召回：低分但同 chunk 命中实体+程序词 → coverage=covered, sufficiency=weak
+    recallWithinDocuments: async () => ({
+      success: true,
+      items: [
+        { score: 0.5, chunk: { id: 'c1', title: 'IPX5 试验概述', content: 'IPX5 试验概述与基本流程...', seq: 0 }, document: { id: 'd1' } },
+      ],
+      total: 1,
+    }),
+    // fallback 召回：同 query 其他文档的高分证据
+    recall: async () => {
+      fallbackRecallCalled = true;
+      return {
+        success: true,
+        items: [
+          { score: 0.88, chunk: { id: 'c2', title: 'IPX5 试验条件', content: 'IPX5 试验条件：喷水30min，14.2.7...', seq: 5 }, document: { id: 'd2' } },
+        ],
+        total: 1,
+      };
+    },
+  };
+
+  svc.searchService.getDocumentInfo = async () => {
+    getDocumentInfoCalled = true;
+    return [makeCandidate('d2', '外壳防护等级 GB/T 4208', 85, 'standard')];
+  };
+
+  // "IPX5 试验" → parser 提取 entity_terms=['IPX5'], procedure_terms=['试验']
+  const result = await svc.retrieve('IPX5 试验', {
+    userId: 'u1',
+    allow_fallback: true,
+  });
+
+  assert(fallbackRecallCalled, 'F1: fallback recall() 被调用');
+  assert(getDocumentInfoCalled, 'F2: getDocumentInfo 补全了 fallback 文档身份');
+  assert(result.packet.documents.length >= 2, 'F3: 合并后包含至少 2 个文档');
+
+  // 核心：merge 后 coverage 必须被重算为具体值，不得停留在 not_evaluated
+  const finalCoverage = result.packet.meta.coverage_status;
+  assert(finalCoverage === 'covered' || finalCoverage === 'partial',
+    `F4: merge 后 coverage 收敛为具体值 (got: ${finalCoverage})`);
+  assert(finalCoverage !== 'not_evaluated',
+    `F4b: merge 后 coverage 不得仍为 not_evaluated`);
+
+  assert(result.packet.meta.evidence_sufficiency !== 'weak',
+    `F5: merge 后 sufficiency 不再为 weak (got: ${result.packet.meta.evidence_sufficiency})`);
+  assert(result.packet.meta.suggested_response_mode !== 'conservative_answer',
+    `F6: merge 后 response_mode 不是 conservative_answer (got: ${result.packet.meta.suggested_response_mode})`);
+  assert(result.packet.meta.reason_codes.includes('fallback_supplement'),
+    'F7: reason_codes 含 fallback_supplement');
+  assert(result.packet.meta.coverage_reason_codes !== undefined,
+    'F8: merge 后 coverage_reason_codes 存在');
+}
+function testCaseD_ChunkLevelCoverage_NoOverlap() {
+  console.log('\n📋 系统场景D: chunk 级覆盖 — 无 overlap 判 partial');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = {
+    meta: { total_evidence: 2, max_evidence_score: 0.7 },
+    documents: [
+      {
+        document_id: 'd1',
+        evidence: [
+          { chunk_id: 'c1', content: 'IPX5 防水等级要求' },
+          { chunk_id: 'c2', content: '试验方法为喷水30min' },
+        ],
+      },
+    ],
+  };
+  const facets = { entity_terms: ['IPX5'], procedure_terms: ['试验'] };
+
+  const coverage = packer._assessCoverage(packet, facets);
+  // IPX5 在 c1，试验 在 c2 → 有 overlap 因为它们在同一个 document 下
+  // 但不同 chunk，overlapChunkIds.size === 0
+  assert(coverage.entity_chunk_hits['IPX5']?.includes('c1'), 'D1: IPX5 命中 c1');
+  assert(coverage.procedure_chunk_hits['试验']?.includes('c2'), 'D2: 试验 命中 c2');
+  // 实体全中但 chunk 无 overlap → 应降为 partial
+  assert(coverage.status === 'partial', 'D3: 无 chunk overlap → partial');
+  assert(coverage.reason_codes.includes('coverage_no_chunk_overlap'), 'D4: no_chunk_overlap');
+}
+
+// ============================================================
+// 场景 E: chunk 级覆盖 — 同一 chunk 命中 → covered
+// ============================================================
+function testCaseE_ChunkLevelCoverage_SameChunk() {
+  console.log('\n📋 系统场景E: chunk 级覆盖 — 同一 chunk 命中 → covered');
+
+  const packer = new DocumentEvidencePacker();
+  const packet = {
+    meta: { total_evidence: 1, max_evidence_score: 0.85 },
+    documents: [
+      {
+        document_id: 'd1',
+        evidence: [
+          { chunk_id: 'c1', content: 'IPX5 防水等级 试验条件为喷水30min' },
+        ],
+      },
+    ],
+  };
+  const facets = { entity_terms: ['IPX5'], procedure_terms: ['试验'] };
+
+  const coverage = packer._assessCoverage(packet, facets);
+  assert(coverage.status === 'covered', 'E1: 同一 chunk 命中 → covered');
+  assert(coverage.reason_codes.length === 0, 'E2: 无 warning code');
+}
+
+// ============================================================
+// 运行
+// ============================================================
+
+console.log('\n╔══════════════════════════════════════╗');
+console.log('║  Retrieval System 闭环测试          ║');
+console.log('╚══════════════════════════════════════╝');
+
+testCaseA_QueryPlanExtraction();
+testCaseA2_ReturnFinalItems();
+await testCaseB_NoFallbackWhenNotCovered();
+await testCaseC_RecomputeCoverageAfterMerge();
+testCaseD_ChunkLevelCoverage_NoOverlap();
+testCaseE_ChunkLevelCoverage_SameChunk();
+await testCaseF_FallbackTriggeredWhenCovered();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) process.exit(1);

--- a/tests/document-search-service.test.js
+++ b/tests/document-search-service.test.js
@@ -1,0 +1,111 @@
+import DocumentSearchService from '../lib/document-search-service.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) passed++;
+  else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+  }
+}
+
+function makeDbMock(rows = []) {
+  return {
+    getModel: () => ({}),
+    sequelize: {
+      QueryTypes: { SELECT: 'SELECT' },
+      query: async (sql, options) => {
+        if (String(sql).includes('FROM documents d')) {
+          return rows;
+        }
+        return [];
+      },
+    },
+  };
+}
+
+function makeAccessService() {
+  return {
+    getAccessibleCollectionIds: async () => ['c1'],
+  };
+}
+
+async function testCase1_CompactTopicRecallRanksHigher() {
+  console.log('\n📋 场景1: 连续主题标题优先于零散命中');
+
+  const rows = [
+    {
+      document_id: 'd1',
+      document_title: 'GB/T 4780-2020 汽车车身术语',
+      doc_type: 'standard',
+      collection_id: 'c1',
+      collection_name: 'test',
+      revision_id: 'r1',
+      revision_no: 1,
+      revision_label: 'v1',
+      relevance_score: 60,
+    },
+    {
+      document_id: 'd2',
+      document_title: '汽车行业术语报告（车身部分）',
+      doc_type: 'report',
+      collection_id: 'c1',
+      collection_name: 'test',
+      revision_id: 'r2',
+      revision_no: 1,
+      revision_label: 'v1',
+      relevance_score: 62,
+    },
+  ];
+
+  const service = new DocumentSearchService(makeDbMock(rows));
+  service.accessService = makeAccessService();
+
+  const result = await service.search('汽车车身 术语', { userId: 'u1', top_k: 10 });
+
+  assert(result.candidates[0]?.document_id === 'd1', '1.1 连续主题标题应排到 top1');
+  assert((result.candidates[0]?.topic_recall_boost || 0) > (result.candidates[1]?.topic_recall_boost || 0), '1.2 连续主题标题应获得更高主题 boost');
+}
+
+async function testCase2_LongTopicSplitHelpsRecall() {
+  console.log('\n📋 场景2: 长主题词拆分后应识别核心词');
+
+  const rows = [
+    {
+      document_id: 'd-ip',
+      document_title: 'GB/T 4208-2017 外壳防护等级（IP代码）',
+      doc_type: 'standard',
+      collection_id: 'c1',
+      collection_name: 'test',
+      revision_id: 'r-ip',
+      revision_no: 1,
+      revision_label: 'v1',
+      relevance_score: 55,
+    },
+  ];
+
+  const service = new DocumentSearchService(makeDbMock(rows));
+  service.accessService = makeAccessService();
+
+  const result = await service.search('外壳防护等级', { userId: 'u1', top_k: 10 });
+
+  assert(result.candidates.length === 1, '2.1 应返回候选');
+  assert(result.candidates[0]?.topic_match_terms?.includes('防护等级') || result.candidates[0]?.topic_match_terms?.includes('外壳防护等级'), '2.2 应识别核心主题词命中');
+}
+
+console.log('╔══════════════════════════════════╗');
+console.log('║  DocumentSearchService 排序测试 ║');
+console.log('╚══════════════════════════════════╝');
+
+await testCase1_CompactTopicRecallRanksHigher();
+await testCase2_LongTopicSplitHelpsRecall();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## 变更摘要

本 PR 基于当前干净分支相对 `upstream/master` 的**实际生效代码**整理，目标是恢复并增强专家文档问答链路中的“基于原文回答”能力。

本次改动主要聚焦于：

- 文档优先检索链路增强
- 文档锚点识别增强
- 多候选 / 多文档编排优化
- `verify_fact` 证据消费链修复
- retrieval / evidence / chat consumption 联动增强
- 相关回归测试补齐

说明：本 PR 描述的是**当前最终生效版本**，不是中途多轮尝试的历史过程。


## 当前分支相对 upstream/master 的代码差异

### 核心实现文件

- `lib/chat-service.js`
- `lib/doc-recall-service.js`
- `lib/document-evidence-packer.js`
- `lib/document-orchestration-service.js`
- `lib/document-query-decision-service.js`
- `lib/document-query-parser.js`
- `lib/document-retrieval-service.js`
- `lib/document-search-service.js`
- `lib/evidence-formatter.js`
- `lib/tool-manager.js`

### 回归测试文件

- `tests/chat-service-prompt-injection.test.js`
- `tests/document-answer-guardrails.test.js`
- `tests/document-evidence-rerank-coverage.test.js`
- `tests/document-orchestration-service.test.js`
- `tests/document-query-parser.test.js`
- `tests/document-retrieval-orchestration.test.js`
- `tests/document-retrieval-service.test.js`
- `tests/document-retrieval-system.test.js`
- `tests/document-search-service.test.js`

### 差异规模

相对 `upstream/master`：

- 19 个文件发生变化
- 6221 行新增
- 80 行删除


## 主要生效改动

### 1. 文档检索主链增强

围绕 `DocumentRetrievalService` 补强了文档优先检索链路，联动：

- `document-query-parser`
- `document-query-decision-service`
- `document-search-service`
- `doc-recall-service`
- `document-evidence-packer`

使显式点名文档、带编号锚点、或包含“这份文件 / 这个文件 / 该文件”的真实问法，更稳定地进入文档级问答链路，而不是过早退化。


### 2. 文档锚点识别增强

增强了对以下表达的识别能力：

- `文件A这份文件`
- `这个文件`
- `该文件`
- `文件A / 文件B`
- `文档A`
- `回信2`
- `标准A`

并补强了“点名文档 + 内容提问”场景下的问答信号识别，避免其只停留在文档定位层。


### 3. 多候选 / 多文档编排优化

在 `document-orchestration-service` 和 `tool-manager` 中优化了多候选编排逻辑，主要包括：

- 减少过早回退到 `candidate_list`
- 在满足锚点和候选可合并条件时，继续进入回答链路
- 支持同集合内可桥接候选的进一步消费

这部分主要解决“已经点了文档，但一旦出现多个候选就立刻要求用户重选”的问题。


### 4. verify_fact 消费链修复

修复了 `verify_fact` 已检索到支持证据，但 `ChatService` 仍无法稳定按证据回答的问题。

本次补齐了消费层所需关键字段，包括：

- `suggested_response_mode`
- `documents`
- `evidence`
- `top_evidence`
- `should_clarify`
- `should_answer_conservatively`

使 `verify_fact` 的“检索成功 → 按证据回答”链路真正闭环。


### 5. 证据打包与回答消费增强

增强了以下模块之间的联动：

- `document-evidence-packer`
- `evidence-formatter`
- `chat-service`

使 retrieval 结果、证据充分性、覆盖状态和回答模式建议，能被回答层更稳定地消费。


### 6. 回归测试补齐

围绕 retrieval / orchestration / evidence / chat consumption 增补了回归测试，覆盖：

- 查询解析
- 文档优先判断
- 多候选编排
- 证据覆盖与重排
- `ChatService` 对文档工具结果的消费
- `verify_fact` 的 supported → answer 路径


## 验证情况

已重点验证通过：

- `node tests/document-retrieval-service.test.js`
- `node tests/document-orchestration-service.test.js`
- `node tests/chat-service-prompt-injection.test.js`

结果：

- `document-retrieval-service`：`55 passed, 0 failed`
- `document-orchestration-service`：`128 passed, 0 failed`
- `chat-service-prompt-injection`：`50 passed, 0 failed`

此外，当前分支后端已成功启动，可用于真实运行时验证。


## 评审建议

建议重点关注以下几个方面：

1. 文档锚点识别规则是否准确
2. 多候选放行条件是否足够稳妥
3. `verify_fact` 返回结构补齐是否对其他路径有副作用
4. retrieval → orchestration → evidence → chat consumption 的联动是否完整


Closes #962 