### PR TITLE
refactor: 文档检索原子工具外显、消费层收敛与 workflow 边界整理

### DIFF
--- a/docs/development/document-retrieval-skill-contract.md
+++ b/docs/development/document-retrieval-skill-contract.md
@@ -47,21 +47,21 @@
 | `strategy` | `string` | 检索策略：`document_first` / `chunk_first_fallback` / `degrade`。<br>区分推荐策略（`decision.recommended_strategy`）与实际执行策略（顶层 `strategy`）。 |
 | `evidence_sufficiency` | `string` | 证据充分性：`strong` / `medium` / `weak` / `none` |
 | `reason_codes` | `string[]` | 原因代码列表（如 `no_candidates`、`weak_evidence_degrade`） |
-| `should_clarify` | `boolean` | 是否应向用户澄清问题 |
-| `should_answer_conservatively` | `boolean` | 是否应保守回答 |
-| `suggested_response_mode` | `string` | 建议回答模式（见下方枚举） |
+| `workflow_action` | `string` | **主动作信号**（审计 round04 起为唯一主动作字段）。枚举见下方。此字段替代旧 `suggested_response_mode` / `should_clarify` / `should_answer_conservatively`（已删除）。 |
 | `duration` | `number` | 检索耗时（ms） |
 
-### `suggested_response_mode` 枚举
+### `workflow_action` 枚举
+
+`workflow_action` 是 chat-service / tool-manager 消费层的主决策信号，覆盖所有 tool 的标准化动作码：
 
 | 值 | 含义 | chat-service 行为 | 适用 tool |
 |----|------|-------------------|-----------|
-| `direct_answer` | 证据充分，可直接回答 | LLM + 证据注入 | answer_from_documents |
-| `answer_with_citation` | 有明确来源，回答时引用出处 | LLM + 证据注入 + 引用约束 | answer_from_documents |
-| `candidate_list` | 多候选，列出候选供用户确认 | **短路 LLM**，直接格式化候选列表 | answer_from_documents / find_document |
-| `single_document` | 单候选文档，直接展示文档信息 | LLM + 证据注入（find_document 语义） | find_document |
-| `clarify` | 意图模糊或信息不足，应澄清问题 | LLM + 澄清约束骨架 | 所有 tool |
-| `conservative_answer` | 证据不足，保守回答 | LLM + 保守回答约束骨架 | answer_from_documents |
+| `answer_with_ranked_chunks` | 证据充分，LLM + 证据注入回答 | LLM + 证据注入（强证据附加引用约束） | answer_from_documents / verify_fact |
+| `return_document_candidates` | 多候选冲突/弱证据多文档，列出候选供确认 | **短路 LLM**，直接格式化候选列表 | answer_from_documents / find_document |
+| `ask_for_clarification` | 意图模糊或信息不足，应澄清问题 | LLM + 澄清约束骨架 | 所有 tool |
+| `decline_due_to_insufficient_evidence` | 无任何可用证据，保守回答 | LLM + 保守回答约束骨架 | answer_from_documents / verify_fact |
+
+> **历史说明**：旧 `suggested_response_mode` 枚举（`direct_answer` / `candidate_list` / `clarify` / `conservative_answer` / `answer_with_citation` / `single_document`）与旧布尔字段 `should_clarify` / `should_answer_conservatively` 已于审计 round04 删除。下游统一以 `workflow_action` 为主动作信号。chat-service 内部通过 `_resolveConstraintMode()` 将 action 映射到约束模式名，该映射为内部实现细节不暴露到 tool 契约。|
 
 ### `strategy` 枚举
 
@@ -161,8 +161,7 @@
 | `evidence_sufficiency` | 返回结果 | 质量监控 |
 | `reason_codes` | 返回结果 | 失败原因分析 |
 | `document_count` | 返回结果 | 召回量监控 |
-| `should_clarify` | 返回结果 | 降级率监控 |
-| `suggested_response_mode` | 返回结果 | 回答模式分布 |
+| `workflow_action` | 返回结果 | 回答动作分布（round04 起替代旧 should_clarify / suggested_response_mode） |
 | `backfill_triggered` | 返回结果 | identity 回补触发率 |
 | `backfill_doc_count` | 返回结果 | identity 回补文档数 |
 | `identity_distribution` | 返回结果 | 各文档 identity_confidence / source 分布 |
@@ -185,4 +184,5 @@ Phase 3: compare_documents / search_within_document
 | `ragContext` | ✅ 已清除 | 无需处理 |
 | `knowledge_config` | ⚠️ 历史兼容读取 | expert.controller 保留读取，标注 `@deprecated` |
 | "知识策略开关" | ✅ 已清除 | 无需处理 |
+| `suggested_response_mode` / `should_clarify` / `should_answer_conservatively` | ✅ 已删除 (Round 04) | 统一由 `workflow_action` 替代 |
 | "builtin tool" | ⚠️ 过渡态 | 内部实现保留，文档统一用 "系统级 skill" |

--- a/docs/development/document-retrieval-skill-contract.md
+++ b/docs/development/document-retrieval-skill-contract.md
@@ -3,8 +3,9 @@
 > 本文档定义 `document_retrieval` 系统级 skill/workflow 的稳定协议。
 > 所有实现必须对齐本文档。
 >
-> **audit-round07 收口**：6 个原子 tool 对外暴露给 LLM，内部由 DocumentRetrievalWorkflow
+> **audit-round08 收口**：6 个原子 tool 对外暴露给 LLM，内部由 DocumentRetrievalWorkflow
 > 统一编排管线。`tool_name` 日志与前端展示均为 LLM 实际调用的原子 tool 名。
+> 关于"为何不让 6 tool 行为独立化"的架构决策，见 2.1 过渡实现说明。
 
 ---
 
@@ -15,7 +16,7 @@
 | Skill Name | `document_retrieval` |
 | 类型 | 系统级 skill/workflow（非专家私有） |
 | 权限模型 | 基于 DocAccessService 的用户集合访问权限 |
-| 当前阶段 | Phase 2（6 原子 tool 外显 + workflow 内编排 + atomic_steps 轨迹） |
+| 当前阶段 | Phase 2 过渡态（6 原子 tool 外显 + workflow 统一编排 + atomic_steps 轨迹，见 2.1） |
 
 ## 2. LLM 可见 Tool（6 个原子 tool）
 
@@ -37,6 +38,27 @@
 | `doc_types` | `string[]` | ❌ | 限定文档类型 |
 
 **`skill_namespace`** 统一为 `"document_retrieval"`，chat-service 按此聚合消费。
+
+### 2.1 过渡实现说明（audit-round08 诚实标注）
+
+> **当前实现状态**：6 个原子 tool 名对 LLM 是**语义化选择入口**，执行层统一路由到
+> `DocumentRetrievalWorkflow.runAnswerQuestion()` 完整管线，真实执行步骤通过
+> `atomic_steps` 字段对外暴露。
+>
+> **为什么不让每个 tool 独立执行**：
+> 1. 6 个原子 tool 内部存在硬依赖链（`rank_chunks_for_question` 需要上游 chunks，
+>    `read_document_content` 需要上游 document_id）。若强制独立执行，LLM 必须多步
+>    编排并传递中间结果——这正是 Phase 1 之前被淘汰的反模式（幻觉 ID、丢失中间态、
+>    延迟放大 3-5 倍）。
+> 2. 参数签名差异化（如要求 LLM 传 `chunks: object[]`）在当前 tool-calling 范式下
+>    不可靠。
+>
+> **接口分层定位**：tool 名是接口层（帮助 LLM 表达意图），workflow 是编排层（保证
+> 管线正确），`atomic_steps` 是可观测层（审计真实执行轨迹）。类比 REST 多 endpoint
+> 共享 service 层。
+>
+> **收敛方向**：Phase 3 计划正式化"意图路由层"，使各 tool 名可映射到差异化的管线
+> 裁剪（如 `search_documents_by_metadata` 跳过 chunk 精排），而非统一全管线。
 
 ## 3. 标准返回字段
 
@@ -88,8 +110,8 @@
 
 ```
 Phase 1（Round 03-04）: 3 复合 tool + 内部原子化 ✅
-Phase 2（Round 06-07）: 6 原子 tool 外显 + workflow 内编排 ✅
-Phase 3（下一迭代）: 反驳证据链路 + compare_documents / search_within_document
+Phase 2（Round 06-08）: 6 原子 tool 外显 + workflow 内编排 + atomic_steps 轨迹 ✅（过渡态，见 2.1）
+Phase 3（下一迭代）: 意图路由层（按 tool 名裁剪管线）+ 反驳证据链路 + compare_documents
 ```
 
 ## 7. 历史清理

--- a/docs/development/document-retrieval-skill-contract.md
+++ b/docs/development/document-retrieval-skill-contract.md
@@ -1,7 +1,10 @@
 # Document Retrieval Skill Contract
 
-> 本文档定义 `document_retrieval` 系统级 skill 的稳定协议。
+> 本文档定义 `document_retrieval` 系统级 skill/workflow 的稳定协议。
 > 所有实现必须对齐本文档。
+>
+> **audit-round06 收口**：外部接口原子化完成。LLM 仅看到 1 个 `document_retrieval` tool，
+> 内部由 DocumentRetrievalWorkflow 编排 6 个原子 tool，执行轨迹通过 `atomic_steps` 暴露。
 
 ---
 
@@ -10,58 +13,67 @@
 | 属性 | 值 |
 |------|-----|
 | Skill Name | `document_retrieval` |
-| 类型 | 系统级 skill（非专家私有） |
+| 类型 | 系统级 skill/workflow（非专家私有） |
 | 权限模型 | 基于 DocAccessService 的用户集合访问权限，不由 expert 配置控制 |
-| 当前阶段 | Phase 1（纯多 tool 模式，旧 document_retrieval 单入口已删除） |
+| 当前阶段 | Phase 2（单一 LLM 入口 + 6 原子 tool 内部编排 + steps[] 轨迹暴露） |
 
-## 2. Tool 列表（当前形态）
+## 2. LLM 可见 Tool
 
-### 当前 LLM 可见 Tool
+### 唯一入口：`document_retrieval`
 
-| Tool Name | 职责 | 用户任务 |
-|-----------|------|----------|
-| `answer_from_documents` | 基于文档证据回答问题 | "根据制度说明某个规定"、"文档里对某问题如何描述" |
-| `find_document` | 定位可能相关的文档 | "帮我找某份合同"、"哪个文档提到某项规则" |
-| `verify_fact` | 校验命题是否得到文档支持 | "文档里是不是这么写"、"某说法是否有依据" |
+| 属性 | 值 |
+|------|-----|
+| Tool Name | `document_retrieval` |
+| 职责 | 从文档平台检索与用户问题相关的证据并返回结构化结果 |
+| 覆盖场景 | 基于文档证据回答问题 / 定位可能相关文档 / 校验命题是否有文档依据 |
+| skill_namespace | `document_retrieval` |
 
-三个 tool 通过 `skill_namespace: 'document_retrieval'` 聚合，chat-service 消费层按命名空间统一消费。
+**参数**：
 
-### 后续 Tool
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `query` | `string` | ✅ | 检索查询文本 |
+| `collection_id` | `string` | ❌ | 限定文档集合ID（仅过滤，非授权） |
+| `doc_types` | `string[]` | ❌ | 限定文档类型，如 `["contract", "invoice"]` |
 
-| Tool Name | 职责 | 优先级 |
-|-----------|------|--------|
-| `compare_documents` | 比较多文档异同 | P2 |
-| `search_within_document` | 已知文档范围内定点检索 | P1/P2 |
+### 内部原子 Tool（不暴露给 LLM）
 
-### 历史说明
+以下 6 个原子 tool 仅由 DocumentRetrievalWorkflow 内部编排调用，LLM 不可见：
 
-旧 `document_retrieval` 单入口 tool（含 `goal` 参数做内部分流）已于 Round 04 删除。
-`executeDocumentRetrieval()` 兼容壳层同步删除。
+| Tool Name | 职责 |
+|-----------|------|
+| `search_documents_by_metadata` | 按标题/元数据检索文档候选 |
+| `read_document_content` | 读取文档完整内容 |
+| `search_chunks_in_document` | 在指定文档内搜索相关 chunk |
+| `search_chunks_globally` | 全库 chunk 全局搜索（fallback） |
+| `rank_chunks_for_question` | 对 chunk 按问题相关性重排序 |
+| `resolve_documents_from_chunks` | 从 chunk 命中的文档ID解析文档信息 |
 
-## 3. 共享返回字段（所有 tool 通用）
+## 3. 标准返回字段
 
-以下元数据字段在所有 tool 的返回中保持一致语义：
+### 共享字段
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `strategy` | `string` | 检索策略：`document_first` / `chunk_first_fallback` / `degrade`。<br>区分推荐策略（`decision.recommended_strategy`）与实际执行策略（顶层 `strategy`）。 |
+| `tool_name` | `string` | 固定为 `"document_retrieval"` |
+| `skill_namespace` | `string` | 固定为 `"document_retrieval"` |
+| `workflow_action` | `string` | **主动作信号**。枚举见下方 |
+| `strategy` | `string` | 实际检索策略：`document_first` / `chunk_first_fallback` / `degrade` |
 | `evidence_sufficiency` | `string` | 证据充分性：`strong` / `medium` / `weak` / `none` |
-| `reason_codes` | `string[]` | 原因代码列表（如 `no_candidates`、`weak_evidence_degrade`） |
-| `workflow_action` | `string` | **主动作信号**（审计 round04 起为唯一主动作字段）。枚举见下方。此字段替代旧 `suggested_response_mode` / `should_clarify` / `should_answer_conservatively`（已删除）。 |
+| `reason_codes` | `string[]` | 原因代码列表 |
+| `documents` | `object[]` | 候选文档列表（含 top_evidence） |
+| `scoped_identity` | `object` | 文档身份确认信息 |
+| `atomic_steps` | `string[]` | **原子 tool 执行轨迹**（audit-round06 新增），如 `["decision","search_documents_by_metadata","search_chunks_in_document","evidence_packing"]` |
 | `duration` | `number` | 检索耗时（ms） |
 
 ### `workflow_action` 枚举
 
-`workflow_action` 是 chat-service / tool-manager 消费层的主决策信号，覆盖所有 tool 的标准化动作码：
-
-| 值 | 含义 | chat-service 行为 | 适用 tool |
-|----|------|-------------------|-----------|
-| `answer_with_ranked_chunks` | 证据充分，LLM + 证据注入回答 | LLM + 证据注入（强证据附加引用约束） | answer_from_documents / verify_fact |
-| `return_document_candidates` | 多候选冲突/弱证据多文档，列出候选供确认 | **短路 LLM**，直接格式化候选列表 | answer_from_documents / find_document |
-| `ask_for_clarification` | 意图模糊或信息不足，应澄清问题 | LLM + 澄清约束骨架 | 所有 tool |
-| `decline_due_to_insufficient_evidence` | 无任何可用证据，保守回答 | LLM + 保守回答约束骨架 | answer_from_documents / verify_fact |
-
-> **历史说明**：旧 `suggested_response_mode` 枚举（`direct_answer` / `candidate_list` / `clarify` / `conservative_answer` / `answer_with_citation` / `single_document`）与旧布尔字段 `should_clarify` / `should_answer_conservatively` 已于审计 round04 删除。下游统一以 `workflow_action` 为主动作信号。chat-service 内部通过 `_resolveConstraintMode()` 将 action 映射到约束模式名，该映射为内部实现细节不暴露到 tool 契约。|
+| 值 | 含义 | chat-service 行为 |
+|----|------|-------------------|
+| `answer_with_ranked_chunks` | 证据充分，LLM + 证据注入回答 | LLM + 证据注入（强证据附加引用约束） |
+| `return_document_candidates` | 多候选冲突/弱证据多文档 | **短路 LLM**，直接格式化候选列表 |
+| `ask_for_clarification` | 意图模糊或信息不足 | LLM + 澄清约束骨架 |
+| `decline_due_to_insufficient_evidence` | 无任何可用证据 | LLM + 保守回答约束骨架 |
 
 ### `strategy` 枚举
 
@@ -71,112 +83,71 @@
 | `chunk_first_fallback` | document-first 无结果后回退到 chunk-first 全库搜索 |
 | `degrade` | 所有路径失败，返回空证据包 |
 
-## 4. 各 Tool 独立返回字段
-
-### `answer_from_documents`
+### `documents[]` 结构
 
 ```json
-{
-  // ...共享字段...
-  "documents": [{
-    "document_id": "string",
-    "document_title": "string",
-    "doc_type": "string",
-    "collection_name": "string",
-    "relevance_score": "number",
-    "candidate_confidence": "high|low",
-    "identity_confidence": "confirmed|probable|unknown",
-    "identity_source": "search_match|evidence_backfill|fallback|inferred",
-    "evidence_count": "number",
-    "top_evidence": [{
-      "content": "string (truncated 500 chars)",
-      "score": "number"
-    }]
+[{
+  "document_id": "string",
+  "document_title": "string",
+  "doc_type": "string",
+  "collection_name": "string",
+  "relevance_score": "number",
+  "candidate_confidence": "high|low",
+  "identity_confidence": "confirmed|probable|unknown",
+  "identity_source": "search_match|evidence_backfill|fallback|inferred",
+  "evidence_count": "number",
+  "top_evidence": [{
+    "content": "string (truncated 500 chars)",
+    "score": "number"
   }]
-}
+}]
 ```
 
-### `find_document`
-
-```json
-{
-  // ...共享字段...
-  "candidates": [{
-    "document_id": "string",
-    "document_title": "string",
-    "doc_type": "string",
-    "collection_name": "string",
-    "relevance_score": "number",
-    "candidate_confidence": "high|low",
-    "identity_confidence": "confirmed|probable|unknown",
-    "match_reason": "string",
-    "supporting_evidence": [{ "content": "string (truncated 300 chars)" }]
-  }],
-  "total_candidates": "number"
-}
-```
-
-注：单候选高置信时附带 1-3 条 supporting_evidence 供身份验证，多候选时不附带。
-
-### `verify_fact`
-
-```json
-{
-  // ...共享字段...
-  "verdict": "supported|insufficient_evidence",
-  "contradicted_available": false,
-  "supporting_evidence": [{ "content": "string", "document_id": "string", "score": "number" }],
-  "contradicting_evidence": [],
-  "related_documents": ["..."]
-}
-```
-
-**能力诚实性说明**：
-- 当前版本仅稳定支持 `supported` / `insufficient_evidence` 判定
-- `contradicted` 判定需要独立的"反驳证据检测"链路，目前尚未实现
-- `contradicted_available: false` 明确告知消费方当前不支持真正反驳判定
-- `contradicting_evidence` 字段保留但当前恒为空数组（schema 预留）
-
-## 5. 内部服务分层（不暴露给 LLM）
-
-以下服务是 skill 内部实现，不应作为 tool 直接暴露：
+## 4. 内部服务分层（不暴露给 LLM）
 
 | 服务 | 职责 | 文件 |
 |------|------|------|
+| `DocumentRetrievalWorkflow` | 显式编排 6 原子 tool 的检索管线 | `lib/document-retrieval-workflow.js` |
+| `DocumentAtomicTools` | 6 个原子 tool 的实现 | `lib/document-atomic-tools.js` |
 | `DocumentQueryDecisionService` | 查询意图决策（规则引擎） | `lib/document-query-decision-service.js` |
-| `DocumentSearchService` | 文档级候选检索 | `lib/document-search-service.js` |
-| `DocRecallService` | chunk 级证据召回 | `lib/doc-recall-service.js` |
 | `DocumentEvidencePacker` | 证据打包与元数据生成 | `lib/document-evidence-packer.js` |
 | `DocAccessService` | 统一权限判定 | `lib/doc-access-service.js` |
 
-## 6. 可观测性要求
+## 5. 可观测性要求
 
 每次 tool 调用必须记录以下观测字段：
 
 | 字段 | 来源 | 用途 |
 |------|------|------|
-| `tool_name` | 实际执行的 tool | 区分不同 tool 的调用分布 |
+| `tool_name` | 固定 `"document_retrieval"` | 调用分布 |
 | `strategy` | 返回结果 | 检索路径分布 |
 | `duration_ms` | 计时 | 性能监控 |
 | `evidence_sufficiency` | 返回结果 | 质量监控 |
 | `reason_codes` | 返回结果 | 失败原因分析 |
 | `document_count` | 返回结果 | 召回量监控 |
-| `workflow_action` | 返回结果 | 回答动作分布（round04 起替代旧 should_clarify / suggested_response_mode） |
-| `backfill_triggered` | 返回结果 | identity 回补触发率 |
-| `backfill_doc_count` | 返回结果 | identity 回补文档数 |
-| `identity_distribution` | 返回结果 | 各文档 identity_confidence / source 分布 |
+| `workflow_action` | 返回结果 | 回答动作分布 |
+| `atomic_steps` | 返回结果 | 原子工具调用轨迹（audit-round06 新增） |
 
-## 7. 演进路线图
+## 6. 演进路线图
 
 ```
-Phase 1（当前 Round 04）: 纯多 tool 外显 + 删除 document_retrieval 单入口 ✅
+Phase 1（Round 03-04）: 3 复合 tool 模式 + 内部原子化 ✅
     ↓
-Phase 2（下一迭代）: verify_fact 反驳链路设计 + single_document 产品形态评估
+Phase 2（Round 06 当前）: 外部接口原子化 — 单一 document_retrieval 入口 + 6 原子编排 ✅
     ↓
-Phase 3: compare_documents / search_within_document
+Phase 3（下一迭代）: 反驳证据链路 + compare_documents / search_within_document 新能力
 ```
 
-## 8. 历史命名清理清单
+## 7. 历史命名清理
+
+| 旧名称 | 状态 | 说明 |
+|--------|------|------|
+| `answer_from_documents` | ❌ 已删除（round06） | 合并为 `document_retrieval` |
+| `find_document` | ❌ 已删除（round06） | 合并为 `document_retrieval` |
+| `verify_fact` | ❌ 已删除（round06） | 合并为 `document_retrieval` |
+| `suggested_response_mode` | ❌ 已删除（round04） | 由 `workflow_action` 替代 |
+| `should_clarify` / `should_answer_conservatively` | ❌ 已删除（round04） | 由 `workflow_action` 替代 |
+| `document_retrieval`（旧单入口含 goal 参数） | ❌ 已删除（round04） | 已被纯多 tool 模式替代 |
 
 | 旧名称 | 状态 | 处理方式 |
 |--------|------|----------|

--- a/docs/development/document-retrieval-skill-contract.md
+++ b/docs/development/document-retrieval-skill-contract.md
@@ -3,8 +3,8 @@
 > 本文档定义 `document_retrieval` 系统级 skill/workflow 的稳定协议。
 > 所有实现必须对齐本文档。
 >
-> **audit-round06 收口**：外部接口原子化完成。LLM 仅看到 1 个 `document_retrieval` tool，
-> 内部由 DocumentRetrievalWorkflow 编排 6 个原子 tool，执行轨迹通过 `atomic_steps` 暴露。
+> **audit-round07 收口**：6 个原子 tool 对外暴露给 LLM，内部由 DocumentRetrievalWorkflow
+> 统一编排管线。`tool_name` 日志与前端展示均为 LLM 实际调用的原子 tool 名。
 
 ---
 
@@ -14,129 +14,94 @@
 |------|-----|
 | Skill Name | `document_retrieval` |
 | 类型 | 系统级 skill/workflow（非专家私有） |
-| 权限模型 | 基于 DocAccessService 的用户集合访问权限，不由 expert 配置控制 |
-| 当前阶段 | Phase 2（单一 LLM 入口 + 6 原子 tool 内部编排 + steps[] 轨迹暴露） |
+| 权限模型 | 基于 DocAccessService 的用户集合访问权限 |
+| 当前阶段 | Phase 2（6 原子 tool 外显 + workflow 内编排 + atomic_steps 轨迹） |
 
-## 2. LLM 可见 Tool
+## 2. LLM 可见 Tool（6 个原子 tool）
 
-### 唯一入口：`document_retrieval`
+| Tool Name | 职责 | 典型场景 |
+|-----------|------|----------|
+| `search_documents_by_metadata` | 按标题/文件名/元数据检索文档 | "帮我找XX合同"、"标准号是多少" |
+| `read_document_content` | 读取指定文档内容/章节 | "合同第三条怎么写的" |
+| `search_chunks_in_document` | 在已定位文档内搜索段落 | 已有候选文档，需找具体条款 |
+| `search_chunks_globally` | 全库内容级 chunk 搜索 | 不知道在哪个文档里，按内容搜 |
+| `rank_chunks_for_question` | 对 chunk 结果精排 | 多候选需选最相关的 |
+| `resolve_documents_from_chunks` | 从 chunk 命中反查文档信息 | 搜到内容片段但不知道属于哪个文档 |
 
-| 属性 | 值 |
-|------|-----|
-| Tool Name | `document_retrieval` |
-| 职责 | 从文档平台检索与用户问题相关的证据并返回结构化结果 |
-| 覆盖场景 | 基于文档证据回答问题 / 定位可能相关文档 / 校验命题是否有文档依据 |
-| skill_namespace | `document_retrieval` |
-
-**参数**：
+**所有 6 个 tool 共享相同参数签名**：
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | `query` | `string` | ✅ | 检索查询文本 |
 | `collection_id` | `string` | ❌ | 限定文档集合ID（仅过滤，非授权） |
-| `doc_types` | `string[]` | ❌ | 限定文档类型，如 `["contract", "invoice"]` |
+| `doc_types` | `string[]` | ❌ | 限定文档类型 |
 
-### 内部原子 Tool（不暴露给 LLM）
-
-以下 6 个原子 tool 仅由 DocumentRetrievalWorkflow 内部编排调用，LLM 不可见：
-
-| Tool Name | 职责 |
-|-----------|------|
-| `search_documents_by_metadata` | 按标题/元数据检索文档候选 |
-| `read_document_content` | 读取文档完整内容 |
-| `search_chunks_in_document` | 在指定文档内搜索相关 chunk |
-| `search_chunks_globally` | 全库 chunk 全局搜索（fallback） |
-| `rank_chunks_for_question` | 对 chunk 按问题相关性重排序 |
-| `resolve_documents_from_chunks` | 从 chunk 命中的文档ID解析文档信息 |
+**`skill_namespace`** 统一为 `"document_retrieval"`，chat-service 按此聚合消费。
 
 ## 3. 标准返回字段
 
-### 共享字段
+所有 6 个 tool 返回统一结构，`tool_name` 字段为 LLM 实际调用的原子 tool 名：
 
 | 字段 | 类型 | 说明 |
 |------|------|------|
-| `tool_name` | `string` | 固定为 `"document_retrieval"` |
-| `skill_namespace` | `string` | 固定为 `"document_retrieval"` |
-| `workflow_action` | `string` | **主动作信号**。枚举见下方 |
+| `tool_name` | `string` | LLM 实际调用的原子 tool 名（`search_documents_by_metadata` 等） |
+| `skill_namespace` | `string` | 固定 `"document_retrieval"` |
+| `workflow_action` | `string` | 主动作信号 |
 | `strategy` | `string` | 实际检索策略：`document_first` / `chunk_first_fallback` / `degrade` |
 | `evidence_sufficiency` | `string` | 证据充分性：`strong` / `medium` / `weak` / `none` |
-| `reason_codes` | `string[]` | 原因代码列表 |
+| `reason_codes` | `string[]` | 原因代码 |
 | `documents` | `object[]` | 候选文档列表（含 top_evidence） |
 | `scoped_identity` | `object` | 文档身份确认信息 |
-| `atomic_steps` | `string[]` | **原子 tool 执行轨迹**（audit-round06 新增），如 `["decision","search_documents_by_metadata","search_chunks_in_document","evidence_packing"]` |
-| `duration` | `number` | 检索耗时（ms） |
+| `atomic_steps` | `string[]` | 内部 workflow 编排的原子 tool 执行轨迹（审计可观测） |
+| `duration` | `number` | 耗时（ms） |
 
 ### `workflow_action` 枚举
 
 | 值 | 含义 | chat-service 行为 |
 |----|------|-------------------|
-| `answer_with_ranked_chunks` | 证据充分，LLM + 证据注入回答 | LLM + 证据注入（强证据附加引用约束） |
-| `return_document_candidates` | 多候选冲突/弱证据多文档 | **短路 LLM**，直接格式化候选列表 |
-| `ask_for_clarification` | 意图模糊或信息不足 | LLM + 澄清约束骨架 |
-| `decline_due_to_insufficient_evidence` | 无任何可用证据 | LLM + 保守回答约束骨架 |
-
-### `strategy` 枚举
-
-| 值 | 含义 |
-|----|------|
-| `document_first` | 标准 document-first 检索链路（文档候选 → chunk 证据） |
-| `chunk_first_fallback` | document-first 无结果后回退到 chunk-first 全库搜索 |
-| `degrade` | 所有路径失败，返回空证据包 |
-
-### `documents[]` 结构
-
-```json
-[{
-  "document_id": "string",
-  "document_title": "string",
-  "doc_type": "string",
-  "collection_name": "string",
-  "relevance_score": "number",
-  "candidate_confidence": "high|low",
-  "identity_confidence": "confirmed|probable|unknown",
-  "identity_source": "search_match|evidence_backfill|fallback|inferred",
-  "evidence_count": "number",
-  "top_evidence": [{
-    "content": "string (truncated 500 chars)",
-    "score": "number"
-  }]
-}]
-```
+| `answer_with_ranked_chunks` | 证据充分 | LLM + 证据注入 |
+| `return_document_candidates` | 多候选冲突 | 短路 LLM，直接格式化候选列表 |
+| `ask_for_clarification` | 意图模糊 | LLM + 澄清约束 |
+| `decline_due_to_insufficient_evidence` | 无可用证据 | LLM + 保守回答约束 |
 
 ## 4. 内部服务分层（不暴露给 LLM）
 
 | 服务 | 职责 | 文件 |
 |------|------|------|
-| `DocumentRetrievalWorkflow` | 显式编排 6 原子 tool 的检索管线 | `lib/document-retrieval-workflow.js` |
-| `DocumentAtomicTools` | 6 个原子 tool 的实现 | `lib/document-atomic-tools.js` |
-| `DocumentQueryDecisionService` | 查询意图决策（规则引擎） | `lib/document-query-decision-service.js` |
-| `DocumentEvidencePacker` | 证据打包与元数据生成 | `lib/document-evidence-packer.js` |
-| `DocAccessService` | 统一权限判定 | `lib/doc-access-service.js` |
+| `DocumentRetrievalWorkflow` | 编排 6 原子 tool 的检索管线 | `lib/document-retrieval-workflow.js` |
+| `DocumentAtomicTools` | 6 个原子 tool 的内部实现 | `lib/document-atomic-tools.js` |
+| `DocumentQueryDecisionService` | 查询意图决策 | `lib/document-query-decision-service.js` |
+| `DocumentEvidencePacker` | 证据打包 | `lib/document-evidence-packer.js` |
+| `DocAccessService` | 权限判定 | `lib/doc-access-service.js` |
 
-## 5. 可观测性要求
+## 5. 可观测性
 
-每次 tool 调用必须记录以下观测字段：
-
-| 字段 | 来源 | 用途 |
-|------|------|------|
-| `tool_name` | 固定 `"document_retrieval"` | 调用分布 |
-| `strategy` | 返回结果 | 检索路径分布 |
-| `duration_ms` | 计时 | 性能监控 |
-| `evidence_sufficiency` | 返回结果 | 质量监控 |
-| `reason_codes` | 返回结果 | 失败原因分析 |
-| `document_count` | 返回结果 | 召回量监控 |
-| `workflow_action` | 返回结果 | 回答动作分布 |
-| `atomic_steps` | 返回结果 | 原子工具调用轨迹（audit-round06 新增） |
+| 字段 | 说明 |
+|------|------|
+| `tool_name` | LLM 实际调用的原子 tool 名 |
+| `strategy` / `duration_ms` | 检索路径分布 / 性能 |
+| `evidence_sufficiency` / `reason_codes` | 质量监控 / 失败分析 |
+| `workflow_action` | 回答动作分布 |
+| `atomic_steps` | 内部编排轨迹 |
 
 ## 6. 演进路线图
 
 ```
-Phase 1（Round 03-04）: 3 复合 tool 模式 + 内部原子化 ✅
-    ↓
-Phase 2（Round 06 当前）: 外部接口原子化 — 单一 document_retrieval 入口 + 6 原子编排 ✅
-    ↓
-Phase 3（下一迭代）: 反驳证据链路 + compare_documents / search_within_document 新能力
+Phase 1（Round 03-04）: 3 复合 tool + 内部原子化 ✅
+Phase 2（Round 06-07）: 6 原子 tool 外显 + workflow 内编排 ✅
+Phase 3（下一迭代）: 反驳证据链路 + compare_documents / search_within_document
 ```
+
+## 7. 历史清理
+
+| 旧名称 | 状态 |
+|--------|------|
+| `answer_from_documents` | ❌ round06 删除 |
+| `find_document` | ❌ round06 删除 |
+| `verify_fact` | ❌ round06 删除 |
+| `document_retrieval`（单复合入口） | ❌ round07 撤销（改为 6 原子外显） |
+| `suggested_response_mode` | ❌ round04 删除 |
+| `should_clarify` / `should_answer_conservatively` | ❌ round04 删除 |
 
 ## 7. 历史命名清理
 

--- a/frontend/src/components/AssistantMessage.vue
+++ b/frontend/src/components/AssistantMessage.vue
@@ -16,6 +16,7 @@
         :result-formatted="toolParser.formatToolCallResult(toolCall)"
         :result-preview="toolCall.result_preview"
         :tool-message-id="toolCall.tool_message_id ? String(toolCall.tool_message_id) : undefined"
+        :atomic-steps="toolCall.atomic_steps"
         :embedded="true"
         @jump-to-message="$emit('jumpToMessage', $event)"
       />

--- a/frontend/src/components/ToolMessageCard.vue
+++ b/frontend/src/components/ToolMessageCard.vue
@@ -17,6 +17,14 @@
           </svg>
         </span>
       </div>
+      <div v-if="atomicSteps && atomicSteps.length > 0" class="tool-atomic-trail">
+        <span class="atomic-trail-label">⛓️</span>
+        <span
+          v-for="(step, si) in atomicSteps"
+          :key="`step-${si}`"
+          class="atomic-step-chip"
+        >{{ step }}<span v-if="si < atomicSteps.length - 1" class="atomic-sep">→</span></span>
+      </div>
       <div v-if="context" class="tool-context-line">
         <span class="tool-context-icon">💭</span>
         <span class="tool-context-text">{{ context }}</span>
@@ -60,6 +68,8 @@ defineProps<{
   resultPreview?: string
   toolMessageId?: string
   embedded?: boolean
+  /** audit-round06：原子工具执行步骤列表 */
+  atomicSteps?: string[]
 }>()
 
 defineEmits<{
@@ -188,6 +198,39 @@ const addLineNumbers = (code: string): string => {
   display: flex;
   gap: 8px;
   align-items: flex-start;
+}
+
+/* audit-round06：原子工具执行轨迹 */
+.tool-atomic-trail {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.atomic-trail-label {
+  flex-shrink: 0;
+  font-size: 11px;
+  opacity: 0.6;
+}
+
+.atomic-step-chip {
+  display: inline-flex;
+  align-items: center;
+  background: var(--code-bg, #2d2d2d);
+  color: #a0d9f7;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: 'Consolas', 'Monaco', monospace;
+  white-space: nowrap;
+}
+
+.atomic-sep {
+  color: var(--text-hint, #999);
+  margin-left: 4px;
+  font-size: 10px;
 }
 
 .tool-context-icon {

--- a/frontend/src/composables/useToolDataParser.ts
+++ b/frontend/src/composables/useToolDataParser.ts
@@ -13,6 +13,8 @@ export interface ToolCallData {
   result?: unknown
   result_preview?: string
   context?: string
+  /** audit-round06：原子工具执行轨迹（仅 document_retrieval skill） */
+  atomic_steps?: string[]
 }
 
 export interface NormalizedToolData {

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -1989,19 +1989,25 @@ class ExpertChatService {
     if (skills.length > 0) {
       const skillsDesc = skills.map(s => `- ${s.name}: ${s.description}`).join('\n');
       baseSystemPrompt += `\n\n【可用技能】\n${skillsDesc}`;
-      baseSystemPrompt += `\n\n【文档检索优先规则】\n当用户明确提到“文档库”“知识库”“资料库”“内部文档”“帮我找文档”“帮我看看在哪个文档里”“某企业是否有相关规定”“文档里怎么说”“请根据文档回答”等场景时，应调用 document_retrieval 工具。该工具覆盖以下所有意图：
-- 基于文档证据回答问题
-- 定位/查找特定文档
-- 核实某个说法是否有文档依据
-系统会在内部自动分析查询意图并选择合适的检索策略，你只需把用户的问题原样（或适度改写为检索友好形式）传入 query 参数。
+      baseSystemPrompt += `\n\n【文档检索优先规则】\n当用户明确提到“文档库”“知识库”“资料库”“内部文档”“帮我找文档”“帮我看看在哪个文档里”“某企业是否有相关规定”“文档里怎么说”“请根据文档回答”等场景时，应使用文档检索工具。6 个原子工具按意图选择：
+- 搜具体文档（按标题/文件名）→ search_documents_by_metadata
+- 读取文档内容/章节 → read_document_content
+- 在已定位文档内搜段落 → search_chunks_in_document
+- 全库内容级搜索（不知道哪个文档）→ search_chunks_globally
+- 对结果精排 → rank_chunks_for_question
+- 从片段反查所属文档 → resolve_documents_from_chunks
+
+典型调用流：search_documents_by_metadata（找文档）→ search_chunks_in_document（找段落）。
+如果第一步无结果，改用 search_chunks_globally → resolve_documents_from_chunks。
+一次调用只选一个工具，系统内部会自动完成后续检索编排。
 
 【已知文档ID后的行为约束（关键）】
-当 document_retrieval 已经返回了明确的 document_id 和 identity 信息（尤其是响应中包含 scoped_identity.confirmed=true 时），说明文档身份已被系统确认。此时：
-- 禁止再构造新的全局 document_retrieval 查询去"重新搜索"该文档
-- 如果仍需更多文档元信息，直接用已有的 document_id 信息告知用户
-- 不要因为 document_title 看起来像导入文件名就怀疑结果——系统已自动使用附件文件名等最佳身份来源
+当文档检索已返回 scoped_identity.confirmed=true 时，说明文档身份已被确认。此时：
+- 禁止再发起新的文档检索去"重新搜索"该文档
+- 如需更多元信息，直接用已有 document_id 告知用户
+- 不要因 document_title 看起来像导入文件名就怀疑结果
 
-优先使用 document_retrieval，而非直接调用 web_search。\n如果用户没有给出具体文档名，也不代表不能先查文档；只要问题明显是在让你帮助定位文档、核实文档内容、或基于内部文档回答，就应先尝试 document_retrieval。\n只有在文档检索返回证据不足、无法定位、或问题明显超出文档平台范围时，才再考虑使用 web_search 作为补充。`;
+优先使用文档检索工具，而非 web_search。`;
     }
 
     // 使用 MinimalContextOrganizer 组织上下文
@@ -2318,8 +2324,8 @@ class ExpertChatService {
   /**
    * 从 toolResults 中按 skill_namespace 查找 document retrieval 结果
    *
-   * audit-round06 变更项 A：LLM 可见 tool 已收敛为单一 document_retrieval，
-   * 通过 skill_namespace === 'document_retrieval' 聚合（toolName 匹配仅作兜底）。
+   * audit-round07 变更项 P0-A：LLM 可见 6 个原子 tool，
+   * 通过 skill_namespace === 'document_retrieval' 聚合匹配。
    *
    * @param {Array} toolResults - 工具执行结果数组
    * @returns {Object|null} document retrieval skill 的第一个成功结果，或 null
@@ -2327,7 +2333,7 @@ class ExpertChatService {
   _findDocRetrievalResult(toolResults) {
     if (!toolResults || toolResults.length === 0) return null;
     return toolResults.find(r =>
-      r?.skill_namespace === 'document_retrieval' || r?.toolName === 'document_retrieval'
+      r?.skill_namespace === 'document_retrieval'
     ) || null;
   }
 

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -2077,8 +2077,11 @@ class ExpertChatService {
 
     let context = '';
 
-    // P0-2: 显式回答模式约束（高优先级，必须放在最前面）
-    const modeConstraints = this._buildResponseModeConstraint(toolResult.suggested_response_mode);
+    // audit-round03 变更项 A：优先用 workflow_action 推导约束模式
+    const effectiveMode = this._resolveConstraintMode(toolResult);
+
+    // 显式回答模式约束（高优先级，必须放在最前面）
+    const modeConstraints = this._buildResponseModeConstraint(effectiveMode);
     if (modeConstraints) {
       context += modeConstraints + '\n\n';
     }
@@ -2099,12 +2102,46 @@ class ExpertChatService {
   }
 
   /**
-   * P0-2: 根据 suggested_response_mode 生成显式回答行为约束
+   * audit-round03 变更项 A：从 workflow_action + evidence_sufficiency 推导约束模式
    *
-   * 将"建议"推进为"约束"，为高风险模式（clarify/candidate_list/conservative_answer）
-   * 提供强制执行规则，减少对 LLM 自由发挥的依赖。
+   * 优先消费 workflow_action 作为主动作信号；仅在无 workflow_action 时
+   * fallback 到 suggested_response_mode。
    *
-   * @param {string} mode - suggested_response_mode 值
+   * @param {Object} toolResult
+   * @returns {string} 约束模式名（clarify | candidate_list | conservative_answer | answer_with_citation | direct_answer）
+   */
+  _resolveConstraintMode(toolResult) {
+    const action = toolResult?.workflow_action;
+    if (!action) {
+      // fallback：旧 suggested_response_mode
+      return toolResult?.suggested_response_mode || 'conservative_answer';
+    }
+
+    switch (action) {
+      case 'return_document_candidates':
+        return 'candidate_list';
+      case 'ask_for_clarification':
+        return 'clarify';
+      case 'decline_due_to_insufficient_evidence':
+        return 'conservative_answer';
+      case 'answer_with_ranked_chunks': {
+        const sufficiency = toolResult?.evidence_sufficiency;
+        return (sufficiency === 'strong' || sufficiency === 'medium')
+          ? 'answer_with_citation'
+          : 'direct_answer';
+      }
+      default:
+        return toolResult?.suggested_response_mode || 'conservative_answer';
+    }
+  }
+
+  /**
+   * 根据 response mode 生成显式回答行为约束
+   *
+   * audit-round03 变更项 A：由 _resolveConstraintMode() 统一推导模式，
+   * 本方法仅负责模式→约束文本的映射，不再关心模式来源。
+   *
+   * @param {string} mode - 约束模式值（来自 _resolveConstraintMode）
    * @returns {string} 显式行为约束文本，或空字符串
    */
   _buildResponseModeConstraint(mode) {
@@ -2215,22 +2252,25 @@ class ExpertChatService {
   /**
    * P0-2: 统一回答模式决策入口（流式与非流式共用）
    *
-   * 单一决策入口，根据文档检索 tool 返回的 suggested_response_mode
-   * 决定回答策略。消除流式/非流式路径的决策分叉。
+   * audit-round03 变更项 A：优先消费 workflow_action 作为主动作信号，
+   * suggested_response_mode 降级为兼容 fallback。
    *
-   * 决策规则：
-   * - candidate_list  → 直接格式化（短路 LLM，返回 isShortCircuit + directResponse）
-   * - clarify / conservative_answer / answer_with_citation / direct_answer →
-   *   LLM + 证据注入 + 输出骨架（返回 evidenceInjection）
+   * 决策规则（以 workflow_action 为主，mode 为 fallback）：
+   * - return_document_candidates → 直接格式化（短路 LLM）
+   * - ask_for_clarification → 短路 LLM，输出澄清追问
+   * - decline_due_to_insufficient_evidence → LLM + 保守回答约束
+   * - answer_with_ranked_chunks → LLM + 证据注入
+   * - 无 workflow_action 时 fallback 到 suggested_response_mode
    *
    * @param {Object|null} docRetrievalResult - 文档检索 tool 的返回结果
    * @returns {{ mode: string|null, isShortCircuit: boolean, directResponse: string|null, evidenceInjection: string|null }}
    */
   _getResponseModeDecision(docRetrievalResult) {
-    const mode = docRetrievalResult?.suggested_response_mode || null;
+    const workflowAction = docRetrievalResult?.workflow_action || null;
+    const legacyMode = docRetrievalResult?.suggested_response_mode || null;
 
     const decision = {
-      mode,
+      mode: legacyMode,
       isShortCircuit: false,
       directResponse: null,
       evidenceInjection: null,
@@ -2240,21 +2280,39 @@ class ExpertChatService {
       return decision;
     }
 
-    if (mode === 'candidate_list') {
+    // audit-round03 变更项 A：优先按 workflow_action 决策
+    if (workflowAction === 'return_document_candidates') {
       decision.directResponse = this._buildCandidateListResponse(docRetrievalResult);
       decision.isShortCircuit = true;
-    } else {
+      decision.mode = 'candidate_list'; // 兼容旧日志
+    } else if (workflowAction === 'ask_for_clarification') {
+      decision.evidenceInjection = this._buildResponseModeConstraint('clarify');
+      // clarify 也走 LLM 但带强制澄清约束（不短路，让 LLM 生成自然追问）
+      decision.mode = 'clarify';
+    } else if (workflowAction === 'decline_due_to_insufficient_evidence') {
+      decision.evidenceInjection = this._buildResponseModeConstraint('conservative_answer');
+      decision.mode = 'conservative_answer';
+    } else if (workflowAction === 'answer_with_ranked_chunks') {
       decision.evidenceInjection = this.buildEvidenceInjection(docRetrievalResult, { maxTokens: 4000 });
+      // mode 由 evidence_sufficiency 推断，而非固定值
+      decision.mode = docRetrievalResult?.evidence_sufficiency === 'strong'
+        ? 'answer_with_citation'
+        : 'direct_answer';
+    } else {
+      // fallback：无 workflow_action 时回退到旧 suggested_response_mode
+      if (legacyMode === 'candidate_list') {
+        decision.directResponse = this._buildCandidateListResponse(docRetrievalResult);
+        decision.isShortCircuit = true;
+      } else {
+        decision.evidenceInjection = this.buildEvidenceInjection(docRetrievalResult, { maxTokens: 4000 });
+      }
     }
 
-    // P2-1: 回答模式决策观测锚点（统一日志，便于 grep 统计各模式分布）
-    // 统一口径：retrieval_source + response_mode 可对齐两条检索路径的决策视图
-    //   - tool_only + candidate_list / conservative_answer / direct_answer / ...
-    //   - auto_rag  + (无 response_mode，旧路径不经过此决策)
-    //   - none      + (无 response_mode，无检索发生)
+    // 统一日志（新增 workflow_action 字段）
     logger.info('[ExpertChatService._getResponseModeDecision] retrieval round result (tool path):', {
       retrieval_source: 'tool_only',
-      response_mode: mode,
+      workflow_action: workflowAction,
+      response_mode: decision.mode,
       is_short_circuit: decision.isShortCircuit,
       evidence_sufficiency: docRetrievalResult.evidence_sufficiency,
       doc_count: (docRetrievalResult.documents || docRetrievalResult.candidates || []).length,
@@ -2302,11 +2360,12 @@ class ExpertChatService {
 
     const modeDecision = this._getResponseModeDecision(docRetrievalResult);
 
-    // 统一可观测性日志（替换两处分散的日志）
+    // 统一可观测性日志（audit-round03：新增 workflow_action 字段）
     logger.info(`[ChatService.${logContext.caller}] doc retrieval result consumed:`, {
       retrieval_source: 'tool_only',
       tool_name: docRetrievalResult.tool_name || docRetrievalResult.toolName || 'document_retrieval',
       skill_namespace: docRetrievalResult.skill_namespace || null,
+      workflow_action: docRetrievalResult.workflow_action || null,
       response_mode: modeDecision.mode,
       is_short_circuit: modeDecision.isShortCircuit,
       evidence_sufficiency: docRetrievalResult.evidence_sufficiency,
@@ -2730,3 +2789,5 @@ class ExpertChatService {
 }
 
 export default ChatService;
+// audit-round03 变更项 C：导出 ExpertChatService 用于消费层测试
+export { ExpertChatService };

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -892,7 +892,7 @@ class ChatService {
                 });
                 logger.info('[ChatService.chat] 已注入文档检索证据指引到 System Prompt:', {
                   sufficiency: docRetrievalResult?.evidence_sufficiency,
-                  response_mode: docRetrievalResult?.suggested_response_mode,
+                  workflow_action: docRetrievalResult?.workflow_action,
                   doc_count: docRetrievalResult?.documents?.length || docRetrievalResult?.candidates?.length || 0,
                 });
               }
@@ -2088,11 +2088,12 @@ class ExpertChatService {
 
     // 使用 evidence-formatter 格式化证据上下文
     // 兼容 answer_from_documents (documents) 和 find_document (candidates) 两种返回结构
+    // audit-round04 变更项 A：packet.meta.suggested_response_mode 已删除，
+    // mode 完全由 _resolveConstraintMode 根据 workflow_action 推导。
     const packet = {
       strategy: toolResult.strategy,
       meta: {
         evidence_sufficiency: toolResult.evidence_sufficiency,
-        suggested_response_mode: toolResult.suggested_response_mode,
         reason_codes: toolResult.reason_codes || [],
       },
       documents: toolResult.documents || toolResult.candidates || [],
@@ -2104,8 +2105,10 @@ class ExpertChatService {
   /**
    * audit-round03 变更项 A：从 workflow_action + evidence_sufficiency 推导约束模式
    *
-   * 优先消费 workflow_action 作为主动作信号；仅在无 workflow_action 时
-   * fallback 到 suggested_response_mode。
+   * 优先消费 workflow_action 作为主动作信号。
+   *
+   * audit-round04 变更项 A：suggested_response_mode 已从 tool-manager 输出面物理删除，
+   * 此方法不再保留任何兼容 fallback。无 workflow_action 时直接返回 conservative_answer。
    *
    * @param {Object} toolResult
    * @returns {string} 约束模式名（clarify | candidate_list | conservative_answer | answer_with_citation | direct_answer）
@@ -2113,8 +2116,8 @@ class ExpertChatService {
   _resolveConstraintMode(toolResult) {
     const action = toolResult?.workflow_action;
     if (!action) {
-      // fallback：旧 suggested_response_mode
-      return toolResult?.suggested_response_mode || 'conservative_answer';
+      // 防御性兜底：仅异常/旧数据路径触发，normal 链路 tool-manager 总是设置 workflow_action
+      return 'conservative_answer';
     }
 
     switch (action) {
@@ -2131,7 +2134,7 @@ class ExpertChatService {
           : 'direct_answer';
       }
       default:
-        return toolResult?.suggested_response_mode || 'conservative_answer';
+        return 'conservative_answer';
     }
   }
 
@@ -2201,11 +2204,7 @@ class ExpertChatService {
   }
 
   /**
-   * P0-2: 生成候选文档列表回复（显式编排，不调用 LLM）
-   *
-   * 当 suggested_response_mode === 'candidate_list' 时，
-   * 直接基于文档检索 tool 返回的结构化文档列表格式化输出，
-   * 不经过 LLM。这消除了 LLM 替用户选择单一文档的风险。
+   * 生成候选文档列表回复（显式编排，不调用 LLM）
    *
    * @param {Object} docRetrievalResult - 文档检索 tool 的返回结果（来自 answer_from_documents / find_document / verify_fact）
    * @returns {string} Markdown 格式的候选文档列表
@@ -2250,27 +2249,26 @@ class ExpertChatService {
   }
 
   /**
-   * P0-2: 统一回答模式决策入口（流式与非流式共用）
+   * 统一回答模式决策入口（流式与非流式共用）
    *
-   * audit-round03 变更项 A：优先消费 workflow_action 作为主动作信号，
-   * suggested_response_mode 降级为兼容 fallback。
+   * audit-round04 变更项 A：suggested_response_mode 兼容字段已物理删除，
+   * workflow_action 是唯一主动作信号。无 workflow_action 时仅做防御性兜底。
    *
-   * 决策规则（以 workflow_action 为主，mode 为 fallback）：
+   * 决策规则（以 workflow_action 为主）：
    * - return_document_candidates → 直接格式化（短路 LLM）
-   * - ask_for_clarification → 短路 LLM，输出澄清追问
+   * - ask_for_clarification → LLM + 澄清约束
    * - decline_due_to_insufficient_evidence → LLM + 保守回答约束
    * - answer_with_ranked_chunks → LLM + 证据注入
-   * - 无 workflow_action 时 fallback 到 suggested_response_mode
+   * - 无 workflow_action → 防御性 conservative_answer + 证据注入兜底
    *
    * @param {Object|null} docRetrievalResult - 文档检索 tool 的返回结果
    * @returns {{ mode: string|null, isShortCircuit: boolean, directResponse: string|null, evidenceInjection: string|null }}
    */
   _getResponseModeDecision(docRetrievalResult) {
     const workflowAction = docRetrievalResult?.workflow_action || null;
-    const legacyMode = docRetrievalResult?.suggested_response_mode || null;
 
     const decision = {
-      mode: legacyMode,
+      mode: null,
       isShortCircuit: false,
       directResponse: null,
       evidenceInjection: null,
@@ -2299,13 +2297,11 @@ class ExpertChatService {
         ? 'answer_with_citation'
         : 'direct_answer';
     } else {
-      // fallback：无 workflow_action 时回退到旧 suggested_response_mode
-      if (legacyMode === 'candidate_list') {
-        decision.directResponse = this._buildCandidateListResponse(docRetrievalResult);
-        decision.isShortCircuit = true;
-      } else {
-        decision.evidenceInjection = this.buildEvidenceInjection(docRetrievalResult, { maxTokens: 4000 });
-      }
+      // 防御性兜底：无 workflow_action（仅异常/旧数据路径触发）。
+      // audit-round04 变更项 A：不再读取 suggested_response_mode（已物理删除），
+      // 直接以 conservative_answer 作为安全兜底并注入证据。
+      decision.evidenceInjection = this.buildEvidenceInjection(docRetrievalResult, { maxTokens: 4000 });
+      decision.mode = 'conservative_answer';
     }
 
     // 统一日志（新增 workflow_action 字段）

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -1203,6 +1203,7 @@ class ChatService {
     const isSuccess = toolResult.success;
 
     // 构建 tool_calls 字段内容
+    // audit-round06 变更项 C：持久化 atomic_steps 供前端展示原子工具轨迹
     const toolCallsData = {
       tool_call_id: toolResult.toolCallId,
       name: toolResult.toolName,
@@ -1214,6 +1215,8 @@ class ChatService {
       result_length: resultLength,
       // 图片标记（用于上下文加载时识别）
       has_image: hasBase64Image || false,
+      // 原子工具执行轨迹（仅 document_retrieval skill 返回，展开在结果顶层）
+      atomic_steps: toolResult.atomic_steps || null,
     };
 
     // 根据阈值决定存储策略（图片已被清理，通常不会超阈值）
@@ -1986,25 +1989,19 @@ class ExpertChatService {
     if (skills.length > 0) {
       const skillsDesc = skills.map(s => `- ${s.name}: ${s.description}`).join('\n');
       baseSystemPrompt += `\n\n【可用技能】\n${skillsDesc}`;
-      baseSystemPrompt += `\n\n【文档检索优先规则】\n当用户明确提到“文档库”“知识库”“资料库”“内部文档”“帮我找文档”“帮我看看在哪个文档里”“某企业是否有相关规定”“文档里怎么说”“请根据文档回答”等场景时，应根据具体意图选择对应工具：
-- 需要基于文档证据回答问题 → 调用 answer_from_documents
-- 需要定位/查找特定文档 → 调用 find_document
-- 需要核实某个说法是否有文档依据 → 调用 verify_fact
-
-【文档身份识别优先规则（重要）】
-当用户的问题明显是"寻找某份文档的身份"或"确认某份文档是什么"时，应优先使用 find_document：
-- "是哪个文件/是哪份文档/那份标准是啥/叫什么来着/帮我找那份..."
-- "文档库里那个规定了[某内容]的文件是哪个"
-- "有没有一份关于[某主题]的制度/合同/标准"
-这类问题的首要目标是定位文档，然后才是获取其内容。不要将此类问题当做"内容探索"优先走 answer_from_documents。
+      baseSystemPrompt += `\n\n【文档检索优先规则】\n当用户明确提到“文档库”“知识库”“资料库”“内部文档”“帮我找文档”“帮我看看在哪个文档里”“某企业是否有相关规定”“文档里怎么说”“请根据文档回答”等场景时，应调用 document_retrieval 工具。该工具覆盖以下所有意图：
+- 基于文档证据回答问题
+- 定位/查找特定文档
+- 核实某个说法是否有文档依据
+系统会在内部自动分析查询意图并选择合适的检索策略，你只需把用户的问题原样（或适度改写为检索友好形式）传入 query 参数。
 
 【已知文档ID后的行为约束（关键）】
-当 answer_from_documents 或 find_document 已经返回了明确的 document_id 和 identity 信息（尤其是响应中包含 scoped_identity.confirmed=true 时），说明文档身份已被系统确认。此时：
-- 禁止再构造新的全局 find_document 查询去"重新搜索"该文档
+当 document_retrieval 已经返回了明确的 document_id 和 identity 信息（尤其是响应中包含 scoped_identity.confirmed=true 时），说明文档身份已被系统确认。此时：
+- 禁止再构造新的全局 document_retrieval 查询去"重新搜索"该文档
 - 如果仍需更多文档元信息，直接用已有的 document_id 信息告知用户
 - 不要因为 document_title 看起来像导入文件名就怀疑结果——系统已自动使用附件文件名等最佳身份来源
 
-优先使用上述文档检索工具，而非直接调用 web_search。\n如果用户没有给出具体文档名，也不代表不能先查文档；只要问题明显是在让你帮助定位文档、核实文档内容、或基于内部文档回答，就应先尝试文档检索工具。\n只有在文档检索工具返回证据不足、无法定位、或问题明显超出文档平台范围时，才再考虑使用 web_search 作为补充。`;
+优先使用 document_retrieval，而非直接调用 web_search。\n如果用户没有给出具体文档名，也不代表不能先查文档；只要问题明显是在让你帮助定位文档、核实文档内容、或基于内部文档回答，就应先尝试 document_retrieval。\n只有在文档检索返回证据不足、无法定位、或问题明显超出文档平台范围时，才再考虑使用 web_search 作为补充。`;
     }
 
     // 使用 MinimalContextOrganizer 组织上下文
@@ -2058,8 +2055,8 @@ class ExpertChatService {
   /**
    * 将文档检索 tool 结果格式化为可注入 System Prompt 的证据上下文
    *
-   * 这是"证据约束回答"的基础设施方法。当 LLM 调用了 answer_from_documents /
-   * find_document / verify_fact 任意一个文档检索工具后，
+   * 这是"证据约束回答"的基础设施方法。当 LLM 调用了 document_retrieval
+   * 文档检索工具后，
    * tool 返回的结构化 evidence 通过此方法转换为 LLM 可理解的上下文文本，
    * 包含证据充分性评估和建议的回答模式。
    *
@@ -2087,7 +2084,7 @@ class ExpertChatService {
     }
 
     // 使用 evidence-formatter 格式化证据上下文
-    // 兼容 answer_from_documents (documents) 和 find_document (candidates) 两种返回结构
+    // 兼容 documents / candidates 两种返回结构（历史数据兼容）
     // audit-round04 变更项 A：packet.meta.suggested_response_mode 已删除，
     // mode 完全由 _resolveConstraintMode 根据 workflow_action 推导。
     const packet = {
@@ -2206,11 +2203,11 @@ class ExpertChatService {
   /**
    * 生成候选文档列表回复（显式编排，不调用 LLM）
    *
-   * @param {Object} docRetrievalResult - 文档检索 tool 的返回结果（来自 answer_from_documents / find_document / verify_fact）
+   * @param {Object} docRetrievalResult - 文档检索 tool 的返回结果（来自 document_retrieval）
    * @returns {string} Markdown 格式的候选文档列表
    */
   _buildCandidateListResponse(docRetrievalResult) {
-    // 兼容 answer_from_documents (documents) 和 find_document (candidates) 两种返回结构
+    // 兼容 documents / candidates 两种返回结构（历史数据兼容）
     const documents = docRetrievalResult?.documents || docRetrievalResult?.candidates || [];
     const strategy = docRetrievalResult?.strategy || 'document_first';
 
@@ -2321,17 +2318,16 @@ class ExpertChatService {
   /**
    * 从 toolResults 中按 skill_namespace 查找 document retrieval 结果
    *
-   * 匹配 answer_from_documents / find_document / verify_fact 三 tool 的返回结果，
-   * 通过 skill_namespace === 'document_retrieval' 聚合。
+   * audit-round06 变更项 A：LLM 可见 tool 已收敛为单一 document_retrieval，
+   * 通过 skill_namespace === 'document_retrieval' 聚合（toolName 匹配仅作兜底）。
    *
    * @param {Array} toolResults - 工具执行结果数组
    * @returns {Object|null} document retrieval skill 的第一个成功结果，或 null
    */
   _findDocRetrievalResult(toolResults) {
     if (!toolResults || toolResults.length === 0) return null;
-    const docRetrievalToolIds = new Set(['answer_from_documents', 'find_document', 'verify_fact']);
     return toolResults.find(r =>
-      r?.skill_namespace === 'document_retrieval' || docRetrievalToolIds.has(r?.toolName)
+      r?.skill_namespace === 'document_retrieval' || r?.toolName === 'document_retrieval'
     ) || null;
   }
 

--- a/lib/document-atomic-tools.js
+++ b/lib/document-atomic-tools.js
@@ -356,14 +356,20 @@ class DocumentAtomicTools {
       const content = chunk.content || '';
       const vectorScore = Math.max(0, Math.min(1, chunk.score || 0));
 
+      // 加权覆盖率：短 CJK term（滑窗产物）权重较低
       let coverage = 0;
       if (terms.length > 0) {
-        const hits = terms.filter(t => content.includes(t)).length;
-        coverage = hits / terms.length;
+        let totalWeight = 0;
+        let hitWeight = 0;
+        for (const t of terms) {
+          totalWeight += t.weight;
+          if (content.includes(t.text)) hitWeight += t.weight;
+        }
+        coverage = totalWeight > 0 ? hitWeight / totalWeight : 0;
       }
 
       const titleText = `${chunk.document_title || ''} ${chunk.chunk_title || ''}`;
-      const titleHit = terms.some(t => titleText.includes(t)) ? 1 : 0;
+      const titleHit = terms.some(t => titleText.includes(t.text)) ? 1 : 0;
 
       const lockedBonus = lockedSet.has(chunk.document_id) ? 1 : 0;
 
@@ -460,30 +466,37 @@ class DocumentAtomicTools {
 
   /**
    * 简易关键词抽取（用于 rank 覆盖率信号）
+   *
+   * audit-round02 变更项 E：优化中文覆盖策略，减少 2 字滑窗噪声
    * - ASCII 词直接切分（长度>=2）
-   * - 中文连续串整体保留；长度>4 的串额外生成 2 字滑窗提高覆盖率召回
-   * 这是启发式实现，够用即可；重排的主信号仍是向量分。
+   * - 中文连续串整体保留
+   * - 中文串 > 6 字：额外做 3 字滑窗（原 2 字滑窗噪声过多）
+   * - 覆盖率计算时对短 CJK term（长度<=2）降权 0.5
    */
   _extractTerms(text) {
     if (!text) return [];
-    const terms = new Set();
+    const terms = [];
 
     const asciiWords = text.match(/[A-Za-z0-9][A-Za-z0-9./-]*/g) || [];
     for (const w of asciiWords) {
-      if (w.length >= 2) terms.add(w);
+      if (w.length >= 2) terms.push({ text: w, weight: 1.0 });
     }
 
     const cjkRuns = text.match(/[\u4e00-\u9fff]+/g) || [];
     for (const run of cjkRuns) {
-      if (run.length >= 2) terms.add(run);
-      if (run.length > 4) {
-        for (let i = 0; i + 2 <= run.length; i++) {
-          terms.add(run.substring(i, i + 2));
+      if (run.length >= 2) {
+        // 完整 run 保留（权重 1.0）
+        terms.push({ text: run, weight: 1.0 });
+      }
+      // > 6 字才做滑窗，滑窗大小 3（减少短词噪声）
+      if (run.length > 6) {
+        for (let i = 0; i + 3 <= run.length; i++) {
+          terms.push({ text: run.substring(i, i + 3), weight: 0.7 });
         }
       }
     }
 
-    return [...terms];
+    return terms;
   }
 }
 

--- a/lib/document-atomic-tools.js
+++ b/lib/document-atomic-tools.js
@@ -53,6 +53,8 @@ class DocumentAtomicTools {
    * @param {Object} [deps.searchService] - DocumentSearchService 实例
    * @param {Object} [deps.recallService] - DocRecallService 实例
    * @param {Object} [deps.accessService] - DocAccessService 实例
+   * @param {Object} [deps.reranker] - 可选 reranker（audit-round03 变更项 D）
+   *   传入 { computeScore(chunk, signals): number } 可替换默认启发式排序
    */
   constructor(db, configLoader, deps = {}) {
     this.db = db;
@@ -60,6 +62,8 @@ class DocumentAtomicTools {
     this.searchService = deps.searchService || (db ? new DocumentSearchService(db) : null);
     this.accessService = deps.accessService || (db ? new DocAccessService(db) : null);
     this.recallService = deps.recallService || null;
+    // audit-round03 变更项 D：可替换 reranker，null 时使用默认启发式排序
+    this.reranker = deps.reranker || null;
   }
 
   _ensureRecallService() {
@@ -352,11 +356,11 @@ class DocumentAtomicTools {
     const terms = this._extractTerms(question || '');
     const lockedSet = new Set(locked_document_ids);
 
-    const ranked = chunks.map(chunk => {
+    // audit-round03 变更项 D：信号计算与评分解耦，支持可替换 reranker
+    const computeSignals = (chunk) => {
       const content = chunk.content || '';
       const vectorScore = Math.max(0, Math.min(1, chunk.score || 0));
 
-      // 加权覆盖率：短 CJK term（滑窗产物）权重较低
       let coverage = 0;
       if (terms.length > 0) {
         let totalWeight = 0;
@@ -370,20 +374,23 @@ class DocumentAtomicTools {
 
       const titleText = `${chunk.document_title || ''} ${chunk.chunk_title || ''}`;
       const titleHit = terms.some(t => titleText.includes(t.text)) ? 1 : 0;
-
       const lockedBonus = lockedSet.has(chunk.document_id) ? 1 : 0;
 
-      const rankScore = 0.6 * vectorScore + 0.25 * coverage + 0.1 * titleHit + 0.05 * lockedBonus;
+      return { vector_score: vectorScore, keyword_coverage: Math.round(coverage * 100) / 100, title_hit: titleHit, locked_bonus: lockedBonus };
+    };
+
+    const ranked = chunks.map(chunk => {
+      const signals = computeSignals(chunk);
+
+      // 默认启发式公式（可被 reranker 替换）
+      const rankScore = this.reranker?.computeScore
+        ? this.reranker.computeScore(chunk, signals)
+        : (0.6 * signals.vector_score + 0.25 * signals.keyword_coverage + 0.1 * signals.title_hit + 0.05 * signals.locked_bonus);
 
       return {
         ...chunk,
         rank_score: Math.round(rankScore * 10000) / 10000,
-        rank_signals: {
-          vector_score: vectorScore,
-          keyword_coverage: Math.round(coverage * 100) / 100,
-          title_hit: titleHit,
-          locked_bonus: lockedBonus,
-        },
+        rank_signals: signals,
       };
     }).sort((a, b) => b.rank_score - a.rank_score);
 

--- a/lib/document-atomic-tools.js
+++ b/lib/document-atomic-tools.js
@@ -1,0 +1,490 @@
+/**
+ * Document Atomic Tools - 文档检索第一批原子能力层
+ *
+ * audit-round01 Phase 1（task-20260717-atomic-tooling-plan）：
+ * 把文档检索的"稳定一步能力"从胖 tool / 编排链路中拆出来，形成
+ * 输入语义清楚、输出结构稳定、不偷做多轮策略的原子层。
+ *
+ * 第一批 6 个原子能力：
+ *   1. searchDocumentsByMetadata   — 文档级 metadata 检索（标题/元数据 或 附件文件名，单轮，无 fallback）
+ *   2. readDocumentContent         — 读取文档基本信息 + 正文（短期聚合读取，按 chunk seq 拼装）
+ *   3. searchChunksInDocument      — 已知文档范围内的 chunk 向量检索
+ *   4. searchChunksGlobally        — 全库 chunk 向量检索（根据内容反找证据）
+ *   5. rankChunksForQuestion       — 多信号 chunk 重排（向量分 + 关键词覆盖 + 标题命中 + 锁定文档加权）
+ *   6. resolveDocumentsFromChunks  — chunk → document 身份反查与聚合
+ *
+ * 设计原则（对应审计 §3.2 / §8）：
+ * - 每个方法只做一件事，一次调用一轮检索，不在内部做 fallback / 多轮改写
+ * - 多步策略（先 metadata 后 chunk、附件名兜底等）一律上移到 DocumentRetrievalWorkflow
+ * - 输出统一 { success, ... } 结构，chunk 采用统一扁平契约（见 _normalizeChunkItem）
+ * - 权限：所有涉及库检索的方法都要求 user_id，底层服务自带 DocAccessService 硬边界
+ *
+ * 统一 chunk 契约：
+ *   { chunk_id, document_id, document_title, doc_type, collection_id,
+ *     revision_id, outline_id, seq, chunk_title, content, score }
+ *
+ * 使用方式：
+ *   const atomicTools = new DocumentAtomicTools(db, configLoader);
+ *   const r = await atomicTools.searchDocumentsByMetadata({ metadata_query, user_id });
+ */
+
+import logger from './logger.js';
+import DocumentSearchService from './document-search-service.js';
+import DocRecallService from './doc-recall-service.js';
+import DocAccessService from './doc-access-service.js';
+
+/**
+ * 第一批原子 tool 名称清单（供 workflow / 未来 tool 暴露引用）
+ */
+export const ATOMIC_TOOL_NAMES = [
+  'search_documents_by_metadata',
+  'read_document_content',
+  'search_chunks_in_document',
+  'search_chunks_globally',
+  'rank_chunks_for_question',
+  'resolve_documents_from_chunks',
+];
+
+class DocumentAtomicTools {
+  /**
+   * @param {Object} db - 数据库实例
+   * @param {Object} configLoader - 配置加载器
+   * @param {Object} [deps={}] - 依赖注入（测试用）
+   * @param {Object} [deps.searchService] - DocumentSearchService 实例
+   * @param {Object} [deps.recallService] - DocRecallService 实例
+   * @param {Object} [deps.accessService] - DocAccessService 实例
+   */
+  constructor(db, configLoader, deps = {}) {
+    this.db = db;
+    this.configLoader = configLoader;
+    this.searchService = deps.searchService || (db ? new DocumentSearchService(db) : null);
+    this.accessService = deps.accessService || (db ? new DocAccessService(db) : null);
+    this.recallService = deps.recallService || null;
+  }
+
+  _ensureRecallService() {
+    if (!this.recallService) {
+      this.recallService = new DocRecallService(this.db, this.configLoader);
+    }
+    return this.recallService;
+  }
+
+  // ============================================================
+  // 1. search_documents_by_metadata
+  // ============================================================
+
+  /**
+   * 文档级 metadata 检索（单轮，无内部 fallback）
+   *
+   * @param {Object} params
+   * @param {string} params.metadata_query - 文档级检索查询（标题片段、标准号、标签词等）
+   * @param {string} params.user_id - 用户ID（权限硬边界）
+   * @param {string} [params.collection_id] - 限定集合
+   * @param {string[]} [params.doc_types] - 限定文档类型
+   * @param {string[]} [params.tag_ids] - 标签过滤
+   * @param {number} [params.top_k=10]
+   * @param {string[]} [params.match_fields=['title','metadata']] - 匹配面：
+   *   - ['title','metadata']（默认）：标题 + 元数据 SQL 匹配
+   *   - ['attachment_filename']：附件文件名匹配（原 find_document 内嵌的 fallback，现由 workflow 显式编排）
+   * @returns {Promise<Object>} { success, matched_by, documents[], total }
+   */
+  async searchDocumentsByMetadata(params = {}) {
+    const {
+      metadata_query,
+      user_id,
+      collection_id,
+      doc_types,
+      tag_ids,
+      top_k = 10,
+      match_fields = ['title', 'metadata'],
+    } = params;
+
+    if (!metadata_query || !metadata_query.trim()) {
+      return { success: false, error: 'metadata_query is required', documents: [], total: 0 };
+    }
+
+    try {
+      if (match_fields.length === 1 && match_fields[0] === 'attachment_filename') {
+        const rows = await this.searchService.searchByAttachmentFilenames(metadata_query.trim(), {
+          userId: user_id,
+          doc_types,
+          top_k,
+          collection_id: collection_id || undefined,
+        });
+        return {
+          success: true,
+          matched_by: 'attachment_filename',
+          documents: rows || [],
+          total: rows?.length || 0,
+        };
+      }
+
+      const result = await this.searchService.search(metadata_query.trim(), {
+        userId: user_id,
+        doc_types,
+        collection_id: collection_id || undefined,
+        tag_ids,
+        top_k,
+      });
+
+      return {
+        success: result.success !== false,
+        matched_by: 'title_metadata',
+        documents: result.candidates || [],
+        total: result.total ?? (result.candidates?.length || 0),
+        strategy: result.strategy,
+      };
+    } catch (error) {
+      logger.error('[DocAtomicTools] searchDocumentsByMetadata error:', error.message);
+      return { success: false, error: error.message, documents: [], total: 0 };
+    }
+  }
+
+  // ============================================================
+  // 2. read_document_content
+  // ============================================================
+
+  /**
+   * 读取文档基本信息 + 正文内容（短期聚合读取职责，见审计 §8.3）
+   *
+   * 正文按当前版本 chunk seq 顺序拼装。暂不拆 get_document_by_id /
+   * list_document_sections / get_chunks_by_document，出现结构级需求后再细拆。
+   *
+   * @param {Object} params
+   * @param {string} params.document_id - 文档ID
+   * @param {string} params.user_id - 用户ID（权限硬边界）
+   * @param {boolean} [params.include_chunks=false] - 是否返回 chunk 列表
+   * @param {number} [params.max_chars=20000] - 正文最大字符数
+   * @returns {Promise<Object>} { success, document, content, content_truncated, total_chunks, chunks? }
+   */
+  async readDocumentContent(params = {}) {
+    const { document_id, user_id, include_chunks = false, max_chars = 20000 } = params;
+
+    if (!document_id) {
+      return { success: false, error: 'document_id is required' };
+    }
+
+    try {
+      const infoRows = await this.searchService.getDocumentInfo([document_id]);
+      if (!infoRows || infoRows.length === 0) {
+        return { success: false, error: 'document_not_found' };
+      }
+      const docInfo = infoRows[0];
+
+      // 权限硬边界：文档所在集合必须在用户可访问范围内
+      const accessibleIds = await this.accessService.getAccessibleCollectionIds(user_id);
+      if (!accessibleIds.includes(docInfo.collection_id)) {
+        return { success: false, error: 'access_denied' };
+      }
+
+      const chunkRows = await this.db.sequelize.query(`
+        SELECT c.id as chunk_id, c.outline_id, c.title as chunk_title, c.content, c.seq
+        FROM document_chunks c
+        JOIN document_revisions v ON c.revision_id = v.id
+        JOIN documents d ON v.document_id = d.id
+        WHERE d.id = ? AND d.current_revision_id = v.id
+        ORDER BY c.seq ASC
+      `, {
+        replacements: [document_id],
+        type: this.db.sequelize.QueryTypes.SELECT,
+      });
+
+      let content = '';
+      let truncated = false;
+      for (const row of chunkRows) {
+        if (!row.content) continue;
+        if (content.length + row.content.length + 1 > max_chars) {
+          content += row.content.substring(0, Math.max(0, max_chars - content.length));
+          truncated = true;
+          break;
+        }
+        content += (content ? '\n' : '') + row.content;
+      }
+
+      const response = {
+        success: true,
+        document: docInfo,
+        content,
+        content_truncated: truncated,
+        total_chunks: chunkRows.length,
+      };
+      if (include_chunks) {
+        response.chunks = chunkRows.map(r => ({
+          chunk_id: r.chunk_id,
+          outline_id: r.outline_id,
+          chunk_title: r.chunk_title,
+          content: r.content,
+          seq: r.seq,
+        }));
+      }
+      return response;
+    } catch (error) {
+      logger.error('[DocAtomicTools] readDocumentContent error:', error.message);
+      return { success: false, error: error.message };
+    }
+  }
+
+  // ============================================================
+  // 3. search_chunks_in_document
+  // ============================================================
+
+  /**
+   * 已知文档范围内的 chunk 向量检索（"根据文档找内容"的原子步骤）
+   *
+   * @param {Object} params
+   * @param {string} params.content_query - 内容检索查询
+   * @param {string[]} params.document_ids - 目标文档ID列表
+   * @param {string[]} [params.revision_ids] - 指定版本（不传用 current revision）
+   * @param {string} params.user_id - 用户ID
+   * @param {number} [params.top_k=5]
+   * @param {number} [params.threshold=0.1]
+   * @returns {Promise<Object>} { success, chunks[], total }
+   */
+  async searchChunksInDocument(params = {}) {
+    const { content_query, document_ids, revision_ids, user_id, top_k = 5, threshold = 0.1 } = params;
+
+    if (!content_query || !content_query.trim()) {
+      return { success: false, error: 'content_query is required', chunks: [], total: 0 };
+    }
+    if (!document_ids || document_ids.length === 0) {
+      return { success: true, chunks: [], total: 0, reason: 'no_target_documents' };
+    }
+
+    try {
+      const recall = this._ensureRecallService();
+      const result = await recall.recallWithinDocuments(content_query.trim(), document_ids, {
+        revisionIds: revision_ids?.length > 0 ? revision_ids : undefined,
+        top_k,
+        threshold,
+        userId: user_id,
+      });
+
+      if (!result.success) {
+        return { success: false, error: result.message || 'recall_failed', chunks: [], total: 0 };
+      }
+      const chunks = (result.items || []).map(item => this._normalizeChunkItem(item));
+      return { success: true, chunks, total: chunks.length };
+    } catch (error) {
+      logger.error('[DocAtomicTools] searchChunksInDocument error:', error.message);
+      return { success: false, error: error.message, chunks: [], total: 0 };
+    }
+  }
+
+  // ============================================================
+  // 4. search_chunks_globally
+  // ============================================================
+
+  /**
+   * 全库 chunk 向量检索（"根据内容找文档/找证据"的原子步骤）
+   *
+   * 与 searchChunksInDocument 语义完全不同，禁止合并（审计 §8.4）。
+   *
+   * @param {Object} params
+   * @param {string} params.content_query - 内容检索查询
+   * @param {string} params.user_id - 用户ID
+   * @param {string} [params.collection_id] - 限定集合
+   * @param {string[]} [params.doc_types] - 限定文档类型
+   * @param {number} [params.top_k=5]
+   * @param {number} [params.threshold=0.1]
+   * @returns {Promise<Object>} { success, chunks[], total }
+   */
+  async searchChunksGlobally(params = {}) {
+    const { content_query, user_id, collection_id, doc_types, top_k = 5, threshold = 0.1 } = params;
+
+    if (!content_query || !content_query.trim()) {
+      return { success: false, error: 'content_query is required', chunks: [], total: 0 };
+    }
+
+    try {
+      const recall = this._ensureRecallService();
+      const result = await recall.recall(content_query.trim(), {
+        scope: 'all',
+        doc_types,
+        top_k,
+        threshold,
+        userId: user_id,
+        collectionId: collection_id || undefined,
+      });
+
+      if (!result.success) {
+        return { success: false, error: result.message || 'recall_failed', chunks: [], total: 0 };
+      }
+      const chunks = (result.items || []).map(item => this._normalizeChunkItem(item));
+      return { success: true, chunks, total: chunks.length };
+    } catch (error) {
+      logger.error('[DocAtomicTools] searchChunksGlobally error:', error.message);
+      return { success: false, error: error.message, chunks: [], total: 0 };
+    }
+  }
+
+  // ============================================================
+  // 5. rank_chunks_for_question
+  // ============================================================
+
+  /**
+   * 多信号 chunk 重排（同步纯函数，不做 IO）
+   *
+   * 信号构成（审计 §8.5：不应只按原召回顺序透传）：
+   * - vector_score：召回向量相似度（0-1）
+   * - keyword_coverage：问题关键词在 chunk 内容中的覆盖率（0-1）
+   * - title_hit：chunk 所属文档标题 / chunk 标题是否命中问题关键词（0 或 1）
+   * - locked_bonus：chunk 是否来自已锁定文档（0 或 1）
+   *
+   * rank_score = 0.6*vector + 0.25*coverage + 0.1*title_hit + 0.05*locked_bonus
+   *
+   * @param {Object} params
+   * @param {string} params.question - 用户问题
+   * @param {Object[]} params.chunks - 统一 chunk 契约数组
+   * @param {string[]} [params.locked_document_ids=[]] - 已锁定文档（workflow 已确认目标文档时传入）
+   * @param {number} [params.top_k] - 截断数量（不传则全量返回）
+   * @returns {Object} { success, chunks[]（含 rank_score / rank_signals，降序）, total }
+   */
+  rankChunksForQuestion(params = {}) {
+    const { question, chunks, locked_document_ids = [], top_k } = params;
+
+    if (!Array.isArray(chunks)) {
+      return { success: false, error: 'chunks must be an array', chunks: [], total: 0 };
+    }
+    if (chunks.length === 0) {
+      return { success: true, chunks: [], total: 0 };
+    }
+
+    const terms = this._extractTerms(question || '');
+    const lockedSet = new Set(locked_document_ids);
+
+    const ranked = chunks.map(chunk => {
+      const content = chunk.content || '';
+      const vectorScore = Math.max(0, Math.min(1, chunk.score || 0));
+
+      let coverage = 0;
+      if (terms.length > 0) {
+        const hits = terms.filter(t => content.includes(t)).length;
+        coverage = hits / terms.length;
+      }
+
+      const titleText = `${chunk.document_title || ''} ${chunk.chunk_title || ''}`;
+      const titleHit = terms.some(t => titleText.includes(t)) ? 1 : 0;
+
+      const lockedBonus = lockedSet.has(chunk.document_id) ? 1 : 0;
+
+      const rankScore = 0.6 * vectorScore + 0.25 * coverage + 0.1 * titleHit + 0.05 * lockedBonus;
+
+      return {
+        ...chunk,
+        rank_score: Math.round(rankScore * 10000) / 10000,
+        rank_signals: {
+          vector_score: vectorScore,
+          keyword_coverage: Math.round(coverage * 100) / 100,
+          title_hit: titleHit,
+          locked_bonus: lockedBonus,
+        },
+      };
+    }).sort((a, b) => b.rank_score - a.rank_score);
+
+    const finalChunks = typeof top_k === 'number' && top_k > 0 ? ranked.slice(0, top_k) : ranked;
+    return { success: true, chunks: finalChunks, total: finalChunks.length };
+  }
+
+  // ============================================================
+  // 6. resolve_documents_from_chunks
+  // ============================================================
+
+  /**
+   * chunk → document 身份反查与聚合（连接两类检索面的关键步骤，审计 §8.6）
+   *
+   * @param {Object} params
+   * @param {Object[]} params.chunks - 统一 chunk 契约数组（须含 document_id）
+   * @param {boolean} [params.aggregate=true] - 是否输出按文档聚合视图（chunk_count / max_score / top_chunk）
+   * @returns {Promise<Object>} { success, documents[], total }
+   */
+  async resolveDocumentsFromChunks(params = {}) {
+    const { chunks, aggregate = true } = params;
+
+    if (!Array.isArray(chunks)) {
+      return { success: false, error: 'chunks must be an array', documents: [], total: 0 };
+    }
+
+    const docIds = [...new Set(chunks.map(c => c.document_id).filter(Boolean))];
+    if (docIds.length === 0) {
+      return { success: true, documents: [], total: 0 };
+    }
+
+    try {
+      const infoRows = await this.searchService.getDocumentInfo(docIds);
+      const infoById = new Map(infoRows.map(r => [r.document_id, r]));
+
+      const documents = docIds.map(docId => {
+        const info = infoById.get(docId) || { document_id: docId };
+        const docChunks = chunks.filter(c => c.document_id === docId);
+        const entry = { ...info };
+        if (aggregate) {
+          const sorted = [...docChunks].sort((a, b) => (b.score || 0) - (a.score || 0));
+          entry.chunk_count = docChunks.length;
+          entry.max_chunk_score = sorted[0]?.score || 0;
+          entry.top_chunk = sorted[0]
+            ? { chunk_id: sorted[0].chunk_id, content: (sorted[0].content || '').substring(0, 300), score: sorted[0].score }
+            : null;
+        }
+        return entry;
+      }).sort((a, b) => (b.max_chunk_score || 0) - (a.max_chunk_score || 0));
+
+      return { success: true, documents, total: documents.length };
+    } catch (error) {
+      logger.error('[DocAtomicTools] resolveDocumentsFromChunks error:', error.message);
+      return { success: false, error: error.message, documents: [], total: 0 };
+    }
+  }
+
+  // ============================================================
+  // 内部辅助
+  // ============================================================
+
+  /**
+   * 将 DocRecallService item 归一化为统一扁平 chunk 契约
+   */
+  _normalizeChunkItem(item) {
+    return {
+      chunk_id: item.chunk?.id || null,
+      document_id: item.document?.id || null,
+      document_title: item.document?.title || '',
+      doc_type: item.document?.doc_type || '',
+      collection_id: item.document?.collection_id || null,
+      revision_id: item.revision?.id || null,
+      outline_id: item.chunk?.outline_id || null,
+      seq: item.chunk?.seq ?? null,
+      chunk_title: item.chunk?.title || '',
+      content: item.chunk?.content || '',
+      score: item.score || 0,
+    };
+  }
+
+  /**
+   * 简易关键词抽取（用于 rank 覆盖率信号）
+   * - ASCII 词直接切分（长度>=2）
+   * - 中文连续串整体保留；长度>4 的串额外生成 2 字滑窗提高覆盖率召回
+   * 这是启发式实现，够用即可；重排的主信号仍是向量分。
+   */
+  _extractTerms(text) {
+    if (!text) return [];
+    const terms = new Set();
+
+    const asciiWords = text.match(/[A-Za-z0-9][A-Za-z0-9./-]*/g) || [];
+    for (const w of asciiWords) {
+      if (w.length >= 2) terms.add(w);
+    }
+
+    const cjkRuns = text.match(/[\u4e00-\u9fff]+/g) || [];
+    for (const run of cjkRuns) {
+      if (run.length >= 2) terms.add(run);
+      if (run.length > 4) {
+        for (let i = 0; i + 2 <= run.length; i++) {
+          terms.add(run.substring(i, i + 2));
+        }
+      }
+    }
+
+    return [...terms];
+  }
+}
+
+export default DocumentAtomicTools;

--- a/lib/document-query-decision-service.js
+++ b/lib/document-query-decision-service.js
@@ -234,6 +234,67 @@ class DocumentQueryDecisionService {
     return decision.recommended_strategy === 'document_first'
       || decision.recommended_strategy === 'document_first_with_fallback';
   }
+
+  /**
+   * 解析层信号生成器（audit-round01 §6.2 / §8.1 收敛方向）
+   *
+   * 只产出可供 workflow 使用的初始信号（hints），不输出终局判断。
+   * 终态决策（单/多文档、是否澄清、回答模式）由 workflow 基于检索结果再定。
+   *
+   * 过渡说明：analyze() 及其 recommended_strategy 仍被既有链路消费，
+   * 本方法为增量接口；后续轮次逐步让消费方迁移到 hints()，
+   * 届时 recommended_strategy 降级为 initial_strategy_hint 的别名。
+   *
+   * @param {string} query - 用户查询
+   * @param {Object} [context={}] - 上下文
+   * @returns {Object} hints
+   * @returns {string} return.user_query - 归一化后的查询
+   * @returns {string[]} return.document_hints - 显式文档线索（《》标题、标准号、编号等）
+   * @returns {string[]} return.topic_terms - 主题词（启发式抽取）
+   * @returns {string[]} return.content_terms - 内容词（主题词去掉文档类型后缀词）
+   * @returns {boolean} return.has_explicit_document_anchor - 是否存在显式文档锚点
+   * @returns {string} return.intent_hint - 意图假设（非终局）
+   * @returns {string} return.initial_strategy_hint - 初始策略假设（非终局）
+   */
+  hints(query, context = {}) {
+    const analysis = this.analyze(query, context);
+    const trimmed = (query || '').trim();
+
+    // 显式文档线索：《》引用 + 强锚点模式命中片段
+    const documentHints = [];
+    const bookTitles = trimmed.match(/《[^》]+》/g) || [];
+    documentHints.push(...bookTitles.map(t => t.replace(/[《》]/g, '')));
+    for (const pattern of this.patterns.strong) {
+      const m = trimmed.match(pattern);
+      if (m && m[0]) documentHints.push(m[0].trim());
+    }
+
+    // 主题词：ASCII 词 + 中文连续串（去问句功能词）
+    const stopWords = /^(怎么|如何|什么|为什么|哪些|哪个|是否|可否|能不能|有没有|多少|帮我|请问|一下|这个|那个|关于|有关)$/;
+    const topicTerms = [];
+    const asciiWords = trimmed.match(/[A-Za-z0-9][A-Za-z0-9./-]*/g) || [];
+    topicTerms.push(...asciiWords.filter(w => w.length >= 2));
+    const cjkRuns = trimmed.match(/[\u4e00-\u9fff]+/g) || [];
+    topicTerms.push(...cjkRuns.filter(r => r.length >= 2 && !stopWords.test(r)));
+
+    // 内容词：主题词剥离文档类型后缀词（合同/标准/制度等本身不是内容语义）
+    const docTypeSuffix = /(合同|协议|契约|标准|规范|规程|准则|制度|办法|规定|条例|章程|细则|手册|指南|说明书|文档|文件|资料)$/;
+    const contentTerms = topicTerms
+      .map(t => t.replace(docTypeSuffix, ''))
+      .filter(t => t.length >= 2);
+
+    return {
+      user_query: trimmed,
+      document_hints: [...new Set(documentHints)],
+      topic_terms: [...new Set(topicTerms)],
+      content_terms: [...new Set(contentTerms)],
+      has_explicit_document_anchor: analysis.anchor_strength === 'strong' || bookTitles.length > 0,
+      intent_hint: analysis.intent,
+      initial_strategy_hint: analysis.recommended_strategy,
+      // 过渡期保留完整 analysis，便于 workflow 渐进迁移
+      analysis,
+    };
+  }
 }
 
 // 单例

--- a/lib/document-retrieval-workflow.js
+++ b/lib/document-retrieval-workflow.js
@@ -1,14 +1,14 @@
 /**
  * Document Retrieval Workflow - 文档检索显式 workflow 层
  *
- * audit-round01 Phase 2（task-20260717-atomic-tooling-plan）：
+ * audit-round01 Phase 2 / audit-round02 变更项 A+B（task-20260717-atomic-tooling-plan）：
  * 把"先试一种方式，不够再换另一种"的多步策略从胖 tool（tool-manager 三个
  * handler）正式上移到显式 workflow 层。tool-manager 收回到参数分发 + 结果
  * 标准化；chat-service 最终只消费标准化动作。
  *
  * 三个 workflow：
  *   runFindDocument   — 定位文档（metadata 先行 → 附件名兜底 → 内容桥接反查）
- *   runAnswerQuestion — 基于文档证据回答（过渡期复用 DocumentRetrievalService 作复合检索步骤）
+ *   runAnswerQuestion — 基于文档证据回答（已从旧复合检索迁出，显式原子编排）
  *   runVerifyFact     — 命题核验（复用 answer 检索核，映射 verdict）
  *
  * 标准化输出动作（审计 §8.7）：
@@ -26,18 +26,25 @@
  *     steps: [{ step, ...摘要 }],        // 显式步骤留痕（可审计）
  *   }
  *
- * 过渡期设计说明（写入 changelog_round01）：
- * - runAnswerQuestion 的检索核暂委托 DocumentRetrievalService.retrieve()。
- *   该复合步骤内部的 metadata→chunk 多步策略后续轮次逐步分解到原子层，
- *   本轮不重写，避免在零集成测试覆盖下重实现身份补齐/回退补充等已验证行为。
- * - runFindDocument 已完全基于原子 tool 编排（本轮迁移的主体）。
+ * audit-round02 变更项 A（runAnswerQuestion 去复合检索）：
+ * - runAnswerQuestion 已不再委托 DocumentRetrievalService.retrieve()，
+ *   改为显式编排 6 步：decision → metadata_search → [chunk_fallback]
+ *   → scoped_recall → evidence_packing → action_mapping。
+ * - DocumentEvidencePacker 保留为内部 helper，但其输入输出在 steps[] 中可见。
+ * - DocumentRetrievalService 保留但仅用于向后兼容；workflow 主链不再依赖它。
+ *
+ * audit-round02 变更项 B（状态模型收敛）：
+ * - workflow_action 是唯一主动作信号，suggested_response_mode 降级为兼容字段。
+ * - 新增状态字段映射文档（见文件末尾 §State Model）。
  */
 
 import logger from './logger.js';
 import DocumentAtomicTools from './document-atomic-tools.js';
-import DocumentRetrievalService from './document-retrieval-service.js';
+import DocumentEvidencePacker from './document-evidence-packer.js';
 import DocAccessService from './doc-access-service.js';
 import queryDecisionService from './document-query-decision-service.js';
+// DocumentRetrievalService 保留导入仅用于向后兼容；workflow 主链不再依赖它（audit-round02 变更项 A）
+import DocumentRetrievalService from './document-retrieval-service.js';
 
 /**
  * 标准化 workflow 输出动作
@@ -61,7 +68,9 @@ class DocumentRetrievalWorkflow {
     this.atomicTools = deps.atomicTools || (db ? new DocumentAtomicTools(db, configLoader) : null);
     this.accessService = deps.accessService || (db ? new DocAccessService(db) : null);
     this.decisionService = deps.decisionService || queryDecisionService;
-    // 过渡期复合检索步骤（见文件头说明）
+    // 证据打包器保留为内部 helper（audit-round02 变更项 A：packer 不再藏在 retrieve() 黑盒内）
+    this.packer = deps.packer || new DocumentEvidencePacker();
+    // 旧复合检索仅保留用于向后兼容，runAnswerQuestion 主链不再调用
     this.retrievalService = deps.retrievalService || (db ? new DocumentRetrievalService(db, configLoader) : null);
   }
 
@@ -259,14 +268,19 @@ class DocumentRetrievalWorkflow {
   }
 
   // ============================================================
-  // Workflow 2: answer_question
+  // Workflow 2: answer_question（audit-round02 变更项 A：从旧复合检索迁出）
   // ============================================================
 
   /**
    * 基于文档证据回答问题 workflow
    *
-   * 过渡期：检索核委托 DocumentRetrievalService.retrieve()（复合步骤），
-   * workflow 负责权限门 + packet → 标准化动作映射。
+   * 显式步骤（6 步，替代旧 DocumentRetrievalService.retrieve() 黑盒）：
+   *   step 1  decision — 查询意图分析
+   *   step 2  metadata_search — 文档级候选检索
+   *   step 3  chunk_fallback — 无候选时全局 chunk 回退
+   *   step 4  scoped_recall — 候选文档内 chunk 证据召回
+   *   step 5  evidence_packing — 证据打包（DocumentEvidencePacker helper）
+   *   step 6  action_mapping — packet → 标准化动作映射
    *
    * @param {Object} params { query, user_id, collection_id, doc_types }
    * @returns {Promise<Object>} 标准化 workflow 输出
@@ -289,24 +303,134 @@ class DocumentRetrievalWorkflow {
       };
     }
 
-    // 过渡期复合检索步骤（内部为 decision → metadata search → scoped recall → pack → fallback）
-    const result = await this.retrievalService.retrieve(query.trim(), {
-      userId: user_id,
-      doc_types: doc_types?.length > 0 ? doc_types : undefined,
-      collection_id: collection_id || undefined,
-      top_k_candidates: 10,
-      top_k_evidence: 5,
-      evidence_threshold: 0.1,
-      allow_fallback: true,
-    });
-    const packet = result.packet;
+    // ---- step 1: decision（查询意图分析）----
+    const decision = this.decisionService.analyze(query.trim(), {});
+    const hints = this.decisionService.hints(query.trim(), {});
     steps.push({
-      step: 'composite_retrieve',
-      strategy: result.strategy,
-      doc_count: packet?.documents?.length || 0,
-      evidence_count: packet?.meta?.total_evidence || 0,
+      step: 'decision',
+      recommended_strategy: decision.recommended_strategy,
+      intent: decision.intent,
+      has_anchor: hints.has_explicit_document_anchor,
     });
 
+    // 如果决策建议澄清（ambiguous + 无锚点），提前返回
+    if (decision.recommended_strategy === 'clarify') {
+      return this._buildAnswerResponse({
+        packet: this.packer.packEmpty(decision, this._traceId(), 'ambiguous_query', 'degrade'),
+        strategy: 'degrade',
+        steps,
+      });
+    }
+
+    // ---- step 2: metadata_search（文档级候选检索）----
+    let candidates = [];
+    let strategy = 'document_first';
+    const metaResult = await this.atomicTools.searchDocumentsByMetadata({
+      metadata_query: query.trim(),
+      user_id,
+      collection_id: collection_id || undefined,
+      doc_types,
+      top_k: 10,
+    });
+    steps.push({ step: 'search_documents_by_metadata', hit: metaResult.documents?.length || 0 });
+
+    if (metaResult.success && metaResult.documents?.length > 0) {
+      candidates = metaResult.documents;
+    }
+
+    // ---- step 3: chunk_fallback（无候选时全局 chunk 回退）----
+    if (candidates.length === 0) {
+      strategy = 'chunk_first_fallback';
+      const globalChunks = await this.atomicTools.searchChunksGlobally({
+        content_query: query.trim(),
+        user_id,
+        collection_id: collection_id || undefined,
+        doc_types,
+        top_k: 8,
+        threshold: 0.1,
+      });
+      steps.push({ step: 'search_chunks_globally', hit: globalChunks.chunks?.length || 0 });
+
+      if (globalChunks.success && globalChunks.chunks?.length > 0) {
+        const resolved = await this.atomicTools.resolveDocumentsFromChunks({
+          chunks: globalChunks.chunks,
+          aggregate: true,
+        });
+        steps.push({ step: 'resolve_documents_from_chunks', hit: resolved.documents?.length || 0 });
+
+        if (resolved.success && resolved.documents?.length > 0) {
+          candidates = resolved.documents.map(doc => ({
+            document_id: doc.document_id,
+            document_title: doc.document_title,
+            doc_type: doc.doc_type,
+            collection_id: doc.collection_id,
+            collection_name: doc.collection_name,
+            relevance_score: doc.max_chunk_score || 0,
+            candidate_confidence: (doc.max_chunk_score || 0) >= 0.6 ? 'high' : 'low',
+          }));
+        }
+      }
+
+      // 回退也无结果 → 降级
+      if (candidates.length === 0) {
+        return this._buildAnswerResponse({
+          packet: this.packer.packEmpty(decision, this._traceId(), 'no_candidates', 'degrade'),
+          strategy: 'degrade',
+          steps,
+        });
+      }
+    }
+
+    // ---- step 4: scoped_recall（候选文档内 chunk 证据召回）----
+    let evidenceItems = [];
+    if (candidates.length > 0) {
+      const docIds = candidates.map(c => c.document_id);
+      const scopedResult = await this.atomicTools.searchChunksInDocument({
+        content_query: query.trim(),
+        document_ids: docIds,
+        user_id,
+        top_k: 5,
+        threshold: 0.1,
+      });
+      steps.push({ step: 'search_chunks_in_document', hit: scopedResult.chunks?.length || 0 });
+
+      if (scopedResult.success && scopedResult.chunks?.length > 0) {
+        evidenceItems = scopedResult.chunks;
+      }
+    }
+
+    // ---- step 5: evidence_packing（证据打包，packer 作为内部 helper）----
+    // 将原子 chunk 契约转换为 packer 兼容格式
+    const packerItems = evidenceItems.map(chunk => ({
+      chunk: { id: chunk.chunk_id, content: chunk.content, outline_id: chunk.outline_id, seq: chunk.seq },
+      document: { id: chunk.document_id, document_title: chunk.document_title, doc_type: chunk.doc_type, document_collection_id: chunk.collection_id, revision_no: chunk.revision_id },
+      score: chunk.score,
+    }));
+
+    const traceId = this._traceId();
+    const packet = this.packer.pack(
+      candidates,
+      packerItems,
+      decision,
+      traceId,
+      { maxEvidencePerDoc: 5, minEvidenceScore: 0.1 }
+    );
+    steps.push({
+      step: 'evidence_packing',
+      total_evidence: packet.meta.total_evidence,
+      max_score: packet.meta.max_evidence_score,
+      sufficiency: packet.meta.evidence_sufficiency,
+      response_mode: packet.meta.suggested_response_mode,
+    });
+
+    // ---- step 6: action_mapping ----（packet → 标准化动作映射）
+    return this._buildAnswerResponse({ packet, strategy, steps, traceId });
+  }
+
+  /**
+   * 构建 answer_question 标准化响应（audit-round02 变更项 A：抽取公共响应构造逻辑）
+   */
+  _buildAnswerResponse({ packet, strategy, steps, traceId }) {
     const action = this._mapPacketToAction(packet);
     const scopedConfirmed = packet?.meta?.scoped_identity_confirmed || false;
 
@@ -314,11 +438,12 @@ class DocumentRetrievalWorkflow {
       success: true,
       workflow: 'answer_question',
       action,
-      strategy: result.strategy,
+      strategy,
       evidence_sufficiency: packet?.meta?.evidence_sufficiency || 'none',
       reason_codes: packet?.meta?.reason_codes || [],
       should_clarify: packet?.meta?.should_clarify || false,
       should_answer_conservatively: packet?.meta?.should_answer_conservatively || false,
+      // suggested_response_mode 降级为兼容字段（audit-round02 变更项 B）
       suggested_response_mode: packet?.meta?.suggested_response_mode || 'conservative_answer',
       scoped_identity: scopedConfirmed ? {
         confirmed: true,
@@ -351,11 +476,16 @@ class DocumentRetrievalWorkflow {
 
     logger.info('[DocWorkflow] answer_question completed:', {
       action,
-      strategy: result.strategy,
+      strategy,
       evidence_sufficiency: response.evidence_sufficiency,
       doc_count: response.documents.length,
+      steps: steps.map(s => s.step),
     });
     return response;
+  }
+
+  _traceId() {
+    return `wf_${Date.now().toString(36)}_${Math.random().toString(36).substring(2, 6)}`;
   }
 
   // ============================================================
@@ -413,19 +543,39 @@ class DocumentRetrievalWorkflow {
   // ============================================================
 
   /**
-   * packet → 标准化动作映射（最小状态模型收敛的第一步）
+   * packet → 标准化动作映射（audit-round02 变更项 B：状态模型收敛）
    *
-   * 映射规则：
-   * - suggested_response_mode candidate_list → return_document_candidates
-   * - clarify → ask_for_clarification
-   * - conservative_answer 且完全无证据 → decline_due_to_insufficient_evidence
-   * - 其余（含弱证据 conservative / answer_with_citation / direct_answer）→ answer_with_ranked_chunks
+   * 映射优先级：evidence_sufficiency > doc_count > mode（优先使用客观指标，mode 仅作兜底）
+   *
+   *   证据充分性状态   | 文档数 | → 动作
+   *   -----------------|--------|------
+   *   strong/medium    | ≥1     | answer_with_ranked_chunks
+   *   weak             | ≥3     | return_document_candidates（多候选冲突）
+   *   weak             | 1-2    | answer_with_ranked_chunks（可用但弱）
+   *   none             | 0      | decline_due_to_insufficient_evidence
+   *   -                | -      | clarify / decline（由 mode 兜底）
    */
   _mapPacketToAction(packet) {
     const mode = packet?.meta?.suggested_response_mode || 'conservative_answer';
+    const sufficiency = packet?.meta?.evidence_sufficiency || 'none';
     const totalEvidence = packet?.meta?.total_evidence || 0;
     const docCount = packet?.documents?.length || 0;
 
+    // 优先基于客观充分性判断
+    if (sufficiency === 'strong' || sufficiency === 'medium') {
+      return WORKFLOW_ACTION.ANSWER_WITH_RANKED_CHUNKS;
+    }
+    if (sufficiency === 'weak' && docCount >= 3) {
+      return WORKFLOW_ACTION.RETURN_DOCUMENT_CANDIDATES;
+    }
+    if (sufficiency === 'weak' && docCount >= 1) {
+      return WORKFLOW_ACTION.ANSWER_WITH_RANKED_CHUNKS;
+    }
+    if (sufficiency === 'none' && docCount === 0) {
+      return WORKFLOW_ACTION.DECLINE_INSUFFICIENT_EVIDENCE;
+    }
+
+    // mode 兜底（兼容旧 suggested_response_mode）
     if (mode === 'candidate_list') return WORKFLOW_ACTION.RETURN_DOCUMENT_CANDIDATES;
     if (mode === 'clarify') return WORKFLOW_ACTION.ASK_FOR_CLARIFICATION;
     if (mode === 'conservative_answer' && totalEvidence === 0 && docCount === 0) {
@@ -453,5 +603,42 @@ class DocumentRetrievalWorkflow {
     };
   }
 }
+
+// ============================================================
+// 状态模型收敛文档（audit-round02 变更项 B）
+// ============================================================
+//
+// 三层状态体系：
+//
+// ┌──────────────────────────────────────────────────────┐
+// │ L1: 检索策略状态 (strategy)                          │
+// │   document_first | chunk_first_fallback | degrade    │
+// │   含义：本次检索走的是哪条路径                        │
+// ├──────────────────────────────────────────────────────┤
+// │ L2: 证据充分性状态 (evidence_sufficiency)             │
+// │   strong | medium | weak | none                      │
+// │   含义：证据的客观质量评估                            │
+// ├──────────────────────────────────────────────────────┤
+// │ L3: 回答动作状态 (action / WORKFLOW_ACTION)           │
+// │   return_document_candidates                         │
+// │   answer_with_ranked_chunks                          │
+// │   ask_for_clarification                              │
+// │   decline_due_to_insufficient_evidence                │
+// │   含义：上游消费者（tool-manager/chat-service）应执行的│
+// │         最终动作。这是唯一主动作信号。                 │
+// └──────────────────────────────────────────────────────┘
+//
+// 兼容字段（仅保留用于下游过渡，不应在新代码中作为主分支判断依据）：
+//   suggested_response_mode — 旧 answer mode（clarify/candidate_list/...）
+//     映射关系：L3 action 为主，mode 仅作降级参考
+//   should_clarify / should_answer_conservatively — 旧布尔标记
+//     这些状态已编码到 L3 action 中，保留布尔字段仅用于兼容
+//   reason_codes — 诊断码数组（主动作 + 附加信号）
+//
+// 状态新增规则（audit-round02 §9.4）：
+//   新增任何状态字段前必须回答：
+//   1. 属于 L1/L2/L3 哪一层？
+//   2. 是否与已有字段重复语义？
+//   3. 是否只是兼容字段，未来是否可删除？
 
 export default DocumentRetrievalWorkflow;

--- a/lib/document-retrieval-workflow.js
+++ b/lib/document-retrieval-workflow.js
@@ -1,0 +1,457 @@
+/**
+ * Document Retrieval Workflow - 文档检索显式 workflow 层
+ *
+ * audit-round01 Phase 2（task-20260717-atomic-tooling-plan）：
+ * 把"先试一种方式，不够再换另一种"的多步策略从胖 tool（tool-manager 三个
+ * handler）正式上移到显式 workflow 层。tool-manager 收回到参数分发 + 结果
+ * 标准化；chat-service 最终只消费标准化动作。
+ *
+ * 三个 workflow：
+ *   runFindDocument   — 定位文档（metadata 先行 → 附件名兜底 → 内容桥接反查）
+ *   runAnswerQuestion — 基于文档证据回答（过渡期复用 DocumentRetrievalService 作复合检索步骤）
+ *   runVerifyFact     — 命题核验（复用 answer 检索核，映射 verdict）
+ *
+ * 标准化输出动作（审计 §8.7）：
+ *   return_document_candidates        — 返回文档候选（1..N 个）
+ *   answer_with_ranked_chunks         — 基于已排序证据回答
+ *   ask_for_clarification             — 需要澄清
+ *   decline_due_to_insufficient_evidence — 证据不足，拒绝确定性回答
+ *
+ * workflow 输出统一结构：
+ *   {
+ *     success, workflow, action,
+ *     candidates | documents,            // 按 workflow 类型
+ *     evidence_sufficiency, strategy, reason_codes,
+ *     scoped_identity?, verdict?,        // 按 workflow 类型
+ *     steps: [{ step, ...摘要 }],        // 显式步骤留痕（可审计）
+ *   }
+ *
+ * 过渡期设计说明（写入 changelog_round01）：
+ * - runAnswerQuestion 的检索核暂委托 DocumentRetrievalService.retrieve()。
+ *   该复合步骤内部的 metadata→chunk 多步策略后续轮次逐步分解到原子层，
+ *   本轮不重写，避免在零集成测试覆盖下重实现身份补齐/回退补充等已验证行为。
+ * - runFindDocument 已完全基于原子 tool 编排（本轮迁移的主体）。
+ */
+
+import logger from './logger.js';
+import DocumentAtomicTools from './document-atomic-tools.js';
+import DocumentRetrievalService from './document-retrieval-service.js';
+import DocAccessService from './doc-access-service.js';
+import queryDecisionService from './document-query-decision-service.js';
+
+/**
+ * 标准化 workflow 输出动作
+ */
+export const WORKFLOW_ACTION = {
+  RETURN_DOCUMENT_CANDIDATES: 'return_document_candidates',
+  ANSWER_WITH_RANKED_CHUNKS: 'answer_with_ranked_chunks',
+  ASK_FOR_CLARIFICATION: 'ask_for_clarification',
+  DECLINE_INSUFFICIENT_EVIDENCE: 'decline_due_to_insufficient_evidence',
+};
+
+class DocumentRetrievalWorkflow {
+  /**
+   * @param {Object} db
+   * @param {Object} configLoader
+   * @param {Object} [deps={}] - 依赖注入（测试用）
+   */
+  constructor(db, configLoader, deps = {}) {
+    this.db = db;
+    this.configLoader = configLoader;
+    this.atomicTools = deps.atomicTools || (db ? new DocumentAtomicTools(db, configLoader) : null);
+    this.accessService = deps.accessService || (db ? new DocAccessService(db) : null);
+    this.decisionService = deps.decisionService || queryDecisionService;
+    // 过渡期复合检索步骤（见文件头说明）
+    this.retrievalService = deps.retrievalService || (db ? new DocumentRetrievalService(db, configLoader) : null);
+  }
+
+  // ============================================================
+  // 权限门（统一收口，原三个 handler 各写一遍）
+  // ============================================================
+
+  /**
+   * 校验用户对指定集合的访问权（collection_id 未指定则仅返回可访问列表）
+   * @returns {Promise<{allowed: boolean, accessible_ids: string[]}>}
+   */
+  async _checkCollectionAccess(userId, collectionId) {
+    const accessibleIds = await this.accessService.getAccessibleCollectionIds(userId);
+    if (!collectionId) {
+      return { allowed: true, accessible_ids: accessibleIds };
+    }
+    return { allowed: accessibleIds.includes(collectionId), accessible_ids: accessibleIds };
+  }
+
+  // ============================================================
+  // Workflow 1: find_document（本轮迁移主体，纯原子编排）
+  // ============================================================
+
+  /**
+   * 定位文档 workflow
+   *
+   * 显式步骤：
+   *   step 1  metadata 检索（标题/元数据）
+   *   step 2  附件文件名兜底（原 tool-manager 内嵌 fallback，正式上移）
+   *   step 3  内容桥接反查（根据内容找文档：全库 chunk → rank → resolve）
+   *   step 4  单候选 supporting evidence 补充（scoped chunk 检索）
+   *
+   * @param {Object} params { query, user_id, collection_id, doc_types }
+   * @returns {Promise<Object>} 标准化 workflow 输出
+   */
+  async runFindDocument(params = {}) {
+    const { query, user_id, collection_id, doc_types } = params;
+    const steps = [];
+    const reasonCodes = [];
+
+    if (!query || !query.trim()) {
+      return this._clarifyResult('find_document', ['empty_query'], steps);
+    }
+
+    // 权限门
+    const access = await this._checkCollectionAccess(user_id, collection_id);
+    if (!access.allowed) {
+      steps.push({ step: 'collection_access_check', allowed: false });
+      return this._clarifyResult('find_document', ['collection_not_accessible'], steps);
+    }
+
+    const hints = this.decisionService.hints(query, {});
+    steps.push({ step: 'hints', intent_hint: hints.intent_hint, has_anchor: hints.has_explicit_document_anchor });
+
+    // ---- step 1: metadata 检索 ----
+    let candidates = [];
+    let strategy = 'metadata_search';
+    const metaResult = await this.atomicTools.searchDocumentsByMetadata({
+      metadata_query: query.trim(),
+      user_id,
+      collection_id: collection_id || undefined,
+      doc_types,
+      top_k: 10,
+    });
+    steps.push({ step: 'search_documents_by_metadata', hit: metaResult.documents?.length || 0 });
+    if (metaResult.success && metaResult.documents?.length > 0) {
+      candidates = metaResult.documents;
+    }
+
+    // ---- step 2: 附件文件名兜底 ----
+    if (candidates.length === 0) {
+      const attachResult = await this.atomicTools.searchDocumentsByMetadata({
+        metadata_query: query.trim(),
+        user_id,
+        collection_id: collection_id || undefined,
+        doc_types,
+        top_k: 5,
+        match_fields: ['attachment_filename'],
+      });
+      steps.push({ step: 'search_by_attachment_filename', hit: attachResult.documents?.length || 0 });
+      if (attachResult.success && attachResult.documents?.length > 0) {
+        candidates = attachResult.documents.map(doc => ({
+          ...doc,
+          candidate_confidence: 'low',
+          identity_confidence: 'probable',
+          identity_source: 'attachment_filename_match',
+          match_reason: `附件文件名匹配: ${doc.matched_attachment || ''}`,
+        }));
+        strategy = 'attachment_filename_fallback';
+        reasonCodes.push('attachment_filename_fallback');
+      }
+    }
+
+    // ---- step 3: 内容桥接反查（根据内容找文档）----
+    if (candidates.length === 0 && hints.content_terms.length > 0) {
+      const globalChunks = await this.atomicTools.searchChunksGlobally({
+        content_query: query.trim(),
+        user_id,
+        collection_id: collection_id || undefined,
+        doc_types,
+        top_k: 8,
+        threshold: 0.1,
+      });
+      steps.push({ step: 'search_chunks_globally', hit: globalChunks.chunks?.length || 0 });
+
+      if (globalChunks.success && globalChunks.chunks?.length > 0) {
+        const ranked = this.atomicTools.rankChunksForQuestion({
+          question: query.trim(),
+          chunks: globalChunks.chunks,
+          top_k: 8,
+        });
+        const resolved = await this.atomicTools.resolveDocumentsFromChunks({
+          chunks: ranked.chunks,
+          aggregate: true,
+        });
+        steps.push({ step: 'resolve_documents_from_chunks', hit: resolved.documents?.length || 0 });
+
+        if (resolved.success && resolved.documents?.length > 0) {
+          candidates = resolved.documents.slice(0, 5).map(doc => ({
+            ...doc,
+            relevance_score: doc.max_chunk_score || 0,
+            candidate_confidence: (doc.max_chunk_score || 0) >= 0.6 ? 'high' : 'low',
+            identity_confidence: 'probable',
+            identity_source: 'content_bridge',
+            match_reason: '内容命中反查',
+          }));
+          strategy = 'content_bridge';
+          reasonCodes.push('content_bridge');
+        }
+      }
+    }
+
+    if (candidates.length === 0) {
+      reasonCodes.push('no_candidates');
+      return this._clarifyResult('find_document', reasonCodes, steps, { strategy });
+    }
+
+    // ---- step 4: 单候选 supporting evidence 补充 ----
+    let supportingEvidence;
+    const isSingleHighConf = candidates.length === 1 && candidates[0]?.candidate_confidence === 'high';
+    if (candidates.length === 1) {
+      const scoped = await this.atomicTools.searchChunksInDocument({
+        content_query: query.trim(),
+        document_ids: [candidates[0].document_id],
+        user_id,
+        top_k: 3,
+        threshold: 0.1,
+      });
+      steps.push({ step: 'search_chunks_in_document', hit: scoped.chunks?.length || 0 });
+      if (scoped.success && scoped.chunks?.length > 0) {
+        supportingEvidence = scoped.chunks.map(c => ({
+          content: (c.content || '').substring(0, 300),
+          score: c.score,
+        }));
+      }
+    }
+
+    // 标准化候选结构
+    const finalCandidates = candidates.map((doc, idx) => ({
+      document_id: doc.document_id,
+      document_title: doc.best_identity_label || doc.document_title_display || doc.document_title,
+      document_title_raw: (doc.best_identity_label || doc.document_title_display) ? doc.document_title : undefined,
+      doc_type: doc.doc_type,
+      collection_name: doc.collection_name,
+      relevance_score: doc.relevance_score ?? 0,
+      candidate_confidence: doc.candidate_confidence || 'low',
+      identity_confidence: doc.identity_confidence || 'unknown',
+      identity_source: doc.identity_source || 'search_match',
+      best_identity_label: doc.best_identity_label,
+      identity_label_source: doc.identity_label_source,
+      attachment_filenames: doc.attachment_filenames,
+      match_reason: doc.match_reason || (doc.candidate_confidence === 'high' ? '关键词匹配' : '语义相似'),
+      supporting_evidence: (idx === 0 && isSingleHighConf) ? supportingEvidence : undefined,
+    }));
+
+    const result = {
+      success: true,
+      workflow: 'find_document',
+      action: WORKFLOW_ACTION.RETURN_DOCUMENT_CANDIDATES,
+      strategy,
+      candidates: finalCandidates,
+      total_candidates: finalCandidates.length,
+      evidence_sufficiency: supportingEvidence?.length > 0 ? 'medium' : 'none',
+      reason_codes: reasonCodes,
+      steps,
+    };
+
+    logger.info('[DocWorkflow] find_document completed:', {
+      action: result.action,
+      strategy,
+      candidate_count: finalCandidates.length,
+      steps: steps.map(s => s.step),
+    });
+    return result;
+  }
+
+  // ============================================================
+  // Workflow 2: answer_question
+  // ============================================================
+
+  /**
+   * 基于文档证据回答问题 workflow
+   *
+   * 过渡期：检索核委托 DocumentRetrievalService.retrieve()（复合步骤），
+   * workflow 负责权限门 + packet → 标准化动作映射。
+   *
+   * @param {Object} params { query, user_id, collection_id, doc_types }
+   * @returns {Promise<Object>} 标准化 workflow 输出
+   */
+  async runAnswerQuestion(params = {}) {
+    const { query, user_id, collection_id, doc_types } = params;
+    const steps = [];
+
+    if (!query || !query.trim()) {
+      return this._clarifyResult('answer_question', ['empty_query'], steps);
+    }
+
+    const access = await this._checkCollectionAccess(user_id, collection_id);
+    if (!access.allowed) {
+      steps.push({ step: 'collection_access_check', allowed: false });
+      return {
+        ...this._clarifyResult('answer_question', ['collection_not_accessible'], steps),
+        action: WORKFLOW_ACTION.DECLINE_INSUFFICIENT_EVIDENCE,
+        documents: [],
+      };
+    }
+
+    // 过渡期复合检索步骤（内部为 decision → metadata search → scoped recall → pack → fallback）
+    const result = await this.retrievalService.retrieve(query.trim(), {
+      userId: user_id,
+      doc_types: doc_types?.length > 0 ? doc_types : undefined,
+      collection_id: collection_id || undefined,
+      top_k_candidates: 10,
+      top_k_evidence: 5,
+      evidence_threshold: 0.1,
+      allow_fallback: true,
+    });
+    const packet = result.packet;
+    steps.push({
+      step: 'composite_retrieve',
+      strategy: result.strategy,
+      doc_count: packet?.documents?.length || 0,
+      evidence_count: packet?.meta?.total_evidence || 0,
+    });
+
+    const action = this._mapPacketToAction(packet);
+    const scopedConfirmed = packet?.meta?.scoped_identity_confirmed || false;
+
+    const response = {
+      success: true,
+      workflow: 'answer_question',
+      action,
+      strategy: result.strategy,
+      evidence_sufficiency: packet?.meta?.evidence_sufficiency || 'none',
+      reason_codes: packet?.meta?.reason_codes || [],
+      should_clarify: packet?.meta?.should_clarify || false,
+      should_answer_conservatively: packet?.meta?.should_answer_conservatively || false,
+      suggested_response_mode: packet?.meta?.suggested_response_mode || 'conservative_answer',
+      scoped_identity: scopedConfirmed ? {
+        confirmed: true,
+        document_id: packet.meta.scoped_document_id,
+        identity_label: packet.meta.scoped_identity_label,
+        identity_source: packet.meta.scoped_identity_source,
+        hint: '文档身份已通过 chunk 命中确认。如需了解更多文档元信息（完整标题、版本、附件名等），请直接使用已知的 document_id 查询，无需重新发起全局文档搜索。',
+      } : { confirmed: false },
+      documents: (packet?.documents || []).map(doc => ({
+        document_id: doc.document_id,
+        document_title: doc.document_title_display || doc.document_title,
+        document_title_raw: doc.document_title_display ? doc.document_title : undefined,
+        doc_type: doc.doc_type,
+        collection_name: doc.collection_name,
+        relevance_score: doc.relevance_score,
+        candidate_confidence: doc.candidate_confidence,
+        identity_confidence: doc.identity_confidence || 'unknown',
+        identity_source: doc.identity_source || 'inferred',
+        best_identity_label: doc.best_identity_label,
+        identity_label_source: doc.identity_label_source,
+        attachment_filenames: doc.attachment_filenames,
+        evidence_count: doc.evidence?.length || 0,
+        top_evidence: (doc.evidence || []).slice(0, 3).map(ev => ({
+          content: ev.content?.substring(0, 500) || '',
+          score: ev.score,
+        })),
+      })),
+      steps,
+    };
+
+    logger.info('[DocWorkflow] answer_question completed:', {
+      action,
+      strategy: result.strategy,
+      evidence_sufficiency: response.evidence_sufficiency,
+      doc_count: response.documents.length,
+    });
+    return response;
+  }
+
+  // ============================================================
+  // Workflow 3: verify_fact
+  // ============================================================
+
+  /**
+   * 命题核验 workflow（复用 answer 检索核，映射 verdict）
+   *
+   * @param {Object} params { query, user_id, collection_id, doc_types }
+   * @returns {Promise<Object>} 标准化 workflow 输出（含 verdict）
+   */
+  async runVerifyFact(params = {}) {
+    const core = await this.runAnswerQuestion(params);
+
+    const sufficiency = core.evidence_sufficiency || 'none';
+    const verdict = (sufficiency === 'strong' || sufficiency === 'medium')
+      ? 'supported'
+      : 'insufficient_evidence';
+
+    // 收集支持证据（当前不支持 contradicted 判定，能力诚实性声明保留）
+    const supportingEvidence = [];
+    if (verdict === 'supported') {
+      for (const doc of (core.documents || [])) {
+        for (const ev of (doc.top_evidence || [])) {
+          supportingEvidence.push({
+            content: ev.content,
+            document_id: doc.document_id,
+            document_title: doc.document_title,
+            score: ev.score,
+          });
+        }
+      }
+    }
+
+    return {
+      ...core,
+      workflow: 'verify_fact',
+      action: verdict === 'supported'
+        ? WORKFLOW_ACTION.ANSWER_WITH_RANKED_CHUNKS
+        : WORKFLOW_ACTION.DECLINE_INSUFFICIENT_EVIDENCE,
+      verdict,
+      contradicted_available: false,
+      supporting_evidence: supportingEvidence.slice(0, 5),
+      contradicting_evidence: [],
+      related_documents: (core.documents || []).map(d => ({
+        document_id: d.document_id,
+        document_title: d.document_title,
+      })),
+    };
+  }
+
+  // ============================================================
+  // 内部：动作映射与通用结果
+  // ============================================================
+
+  /**
+   * packet → 标准化动作映射（最小状态模型收敛的第一步）
+   *
+   * 映射规则：
+   * - suggested_response_mode candidate_list → return_document_candidates
+   * - clarify → ask_for_clarification
+   * - conservative_answer 且完全无证据 → decline_due_to_insufficient_evidence
+   * - 其余（含弱证据 conservative / answer_with_citation / direct_answer）→ answer_with_ranked_chunks
+   */
+  _mapPacketToAction(packet) {
+    const mode = packet?.meta?.suggested_response_mode || 'conservative_answer';
+    const totalEvidence = packet?.meta?.total_evidence || 0;
+    const docCount = packet?.documents?.length || 0;
+
+    if (mode === 'candidate_list') return WORKFLOW_ACTION.RETURN_DOCUMENT_CANDIDATES;
+    if (mode === 'clarify') return WORKFLOW_ACTION.ASK_FOR_CLARIFICATION;
+    if (mode === 'conservative_answer' && totalEvidence === 0 && docCount === 0) {
+      return WORKFLOW_ACTION.DECLINE_INSUFFICIENT_EVIDENCE;
+    }
+    return WORKFLOW_ACTION.ANSWER_WITH_RANKED_CHUNKS;
+  }
+
+  /**
+   * 通用澄清结果
+   */
+  _clarifyResult(workflow, reasonCodes, steps, extra = {}) {
+    return {
+      success: true,
+      workflow,
+      action: WORKFLOW_ACTION.ASK_FOR_CLARIFICATION,
+      strategy: extra.strategy || 'none',
+      candidates: [],
+      total_candidates: 0,
+      evidence_sufficiency: 'none',
+      reason_codes: reasonCodes,
+      should_clarify: true,
+      steps,
+      ...extra,
+    };
+  }
+}
+
+export default DocumentRetrievalWorkflow;

--- a/lib/document-retrieval-workflow.js
+++ b/lib/document-retrieval-workflow.js
@@ -43,8 +43,6 @@ import DocumentAtomicTools from './document-atomic-tools.js';
 import DocumentEvidencePacker from './document-evidence-packer.js';
 import DocAccessService from './doc-access-service.js';
 import queryDecisionService from './document-query-decision-service.js';
-// DocumentRetrievalService 保留导入仅用于向后兼容；workflow 主链不再依赖它（audit-round02 变更项 A）
-import DocumentRetrievalService from './document-retrieval-service.js';
 
 /**
  * 标准化 workflow 输出动作
@@ -70,8 +68,7 @@ class DocumentRetrievalWorkflow {
     this.decisionService = deps.decisionService || queryDecisionService;
     // 证据打包器保留为内部 helper（audit-round02 变更项 A：packer 不再藏在 retrieve() 黑盒内）
     this.packer = deps.packer || new DocumentEvidencePacker();
-    // 旧复合检索仅保留用于向后兼容，runAnswerQuestion 主链不再调用
-    this.retrievalService = deps.retrievalService || (db ? new DocumentRetrievalService(db, configLoader) : null);
+    // audit-round03 变更项 E：retrievalService 已从主链完全退出，不再保留
   }
 
   // ============================================================

--- a/lib/document-retrieval-workflow.js
+++ b/lib/document-retrieval-workflow.js
@@ -438,10 +438,9 @@ class DocumentRetrievalWorkflow {
       strategy,
       evidence_sufficiency: packet?.meta?.evidence_sufficiency || 'none',
       reason_codes: packet?.meta?.reason_codes || [],
-      should_clarify: packet?.meta?.should_clarify || false,
-      should_answer_conservatively: packet?.meta?.should_answer_conservatively || false,
-      // suggested_response_mode 降级为兼容字段（audit-round02 变更项 B）
-      suggested_response_mode: packet?.meta?.suggested_response_mode || 'conservative_answer',
+      // audit-round04 变更项 A：workflow_action（action）是唯一主动作信号，
+      // should_clarify / should_answer_conservatively / suggested_response_mode
+      // 兼容字段已物理删除，消费层统一读 action。
       scoped_identity: scopedConfirmed ? {
         confirmed: true,
         document_id: packet.meta.scoped_document_id,
@@ -594,7 +593,6 @@ class DocumentRetrievalWorkflow {
       total_candidates: 0,
       evidence_sufficiency: 'none',
       reason_codes: reasonCodes,
-      should_clarify: true,
       steps,
       ...extra,
     };
@@ -625,12 +623,12 @@ class DocumentRetrievalWorkflow {
 // │         最终动作。这是唯一主动作信号。                 │
 // └──────────────────────────────────────────────────────┘
 //
-// 兼容字段（仅保留用于下游过渡，不应在新代码中作为主分支判断依据）：
+// 兼容字段（已删除，仅历史说明，audit-round04 变更项 A）：
 //   suggested_response_mode — 旧 answer mode（clarify/candidate_list/...）
-//     映射关系：L3 action 为主，mode 仅作降级参考
+//     映射关系：已合并到 L3 action，不再保留独立字段
 //   should_clarify / should_answer_conservatively — 旧布尔标记
-//     这些状态已编码到 L3 action 中，保留布尔字段仅用于兼容
-//   reason_codes — 诊断码数组（主动作 + 附加信号）
+//     这些状态已完全编码到 L3 action 中
+//   reason_codes — 诊断码数组（保留，属于 L2 诊断层）
 //
 // 状态新增规则（audit-round02 §9.4）：
 //   新增任何状态字段前必须回答：

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -207,35 +207,30 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
     },
   },
   // ============================================================
-  // document_retrieval skill — 系统级文档检索能力（纯多 tool 模式）
+  // document_retrieval skill — 系统级文档检索（audit-round06 收口）
   //
-  // LLM 可见 3 个独立 tool，按"用户任务意图"拆分：
-  //   answer_from_documents — 基于文档证据回答问题
-  //   find_document          — 定位可能相关的文档
-  //   verify_fact            — 校验命题是否得到文档支持
-  //
-  // 历史说明：
-  //   - 旧 document_retrieval 单入口（含 goal 参数）已于 Round 04 删除
-  //   - 旧 executeDocumentRetrieval() 兼容壳层已于 Round 04 删除
-  //   - 内部检索链路（DocumentRetrievalService → Search → Recall → Packer）完全复用
+  // LLM 可见 1 个 tool：document_retrieval
+  // 内部由 DocumentRetrievalWorkflow 编排 6 个原子 tool 按决策管线执行，
+  // 执行轨迹通过 steps[] 暴露给前端展示。
   // ============================================================
   {
     type: 'function',
     function: {
-      name: 'answer_from_documents',
-      description: `基于文档平台证据回答用户问题。从文档平台检索与用户问题相关的证据，返回结构化证据包供回答编排。
+      name: 'document_retrieval',
+      description: `从文档平台检索与用户问题相关的证据并返回结构化结果。
+
+这是系统级 document_retrieval skill/workflow 的统一 LLM 入口，内部由 6 个原子 tool（search_documents_by_metadata / read_document_content / search_chunks_in_document / search_chunks_globally / rank_chunks_for_question / resolve_documents_from_chunks）按决策管线编排执行。
 
 使用场景：
 - 用户询问文档中的具体信息（合同条款、发票内容、报告数据等）
-- "根据制度说明某个规定"
-- "文档里对某问题如何描述"
-- "请基于内部文档给出答案"
+- 帮助用户定位可能相关的文档
+- 校验某个命题是否得到文档证据支持
 
 权限说明：
 - 检索范围自动限定为用户有权访问的文档集合（DocAccessService 硬权限边界）
 - collection_id / doc_types 仅用于缩小范围，不承担授权职责
 
-返回结构化证据，包含 workflow_action（主动作信号）、evidence_sufficiency（证据充分性）、documents（候选文档及其 top evidence）。`,
+返回值包含 workflow_action（主动作信号）、evidence_sufficiency（证据充分性）、steps（原子 tool 执行轨迹）、documents（候选文档及其 top evidence）。`,
       parameters: {
         type: 'object',
         properties: {
@@ -258,96 +253,7 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
     },
     _meta: {
       builtin: true,
-      toolName: 'answer_from_documents',
-      skillNamespace: 'document_retrieval',
-    },
-  },
-  {
-    type: 'function',
-    function: {
-      name: 'find_document',
-      description: `在文档平台中定位可能相关的文档，不以直接回答问题为目标。
-
-使用场景：
-- "帮我找某份制度/合同/资料"
-- "哪个文档里提到某项规则"
-- "我只记得模糊线索，帮我定位文档"
-
-与 answer_from_documents 的区别：
-- find_document 返回文档候选列表（不含 chunk 级证据）
-- 适用于用户只想定位文档、或在多候选场景下先确认目标文档
-
-权限说明：
-- 检索范围自动限定为用户有权访问的文档集合
-- 不回退到 chunk-first 全库搜索`,
-      parameters: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description: '检索查询文本。描述要查找的文档特征（类型、关键词、标题片段等）。',
-          },
-          collection_id: {
-            type: 'string',
-            description: '（可选）限定检索的文档集合ID。',
-          },
-          doc_types: {
-            type: 'array',
-            items: { type: 'string' },
-            description: '（可选）限定文档类型，如 ["contract", "policy"]。',
-          },
-        },
-        required: ['query'],
-      },
-    },
-    _meta: {
-      builtin: true,
-      toolName: 'find_document',
-      skillNamespace: 'document_retrieval',
-    },
-  },
-  {
-    type: 'function',
-    function: {
-      name: 'verify_fact',
-      description: `校验某个命题是否得到文档平台中的证据支持。
-
-使用场景：
-- "文档里是不是这么写"
-- "某个说法是否有依据"
-- "是否存在相关证据"
-
-返回 verdict 判定（supported / insufficient_evidence）及支撑证据。
-
-能力边界：
-- 当前仅稳定支持 supported / insufficient_evidence 判定
-- 不支持真正的"反驳"判定（contradicted），该能力正在规划中
-
-权限说明：
-- 检索范围自动限定为用户有权访问的文档集合`,
-      parameters: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description: '需要核实的事实或命题描述。',
-          },
-          collection_id: {
-            type: 'string',
-            description: '（可选）限定检索的文档集合ID。',
-          },
-          doc_types: {
-            type: 'array',
-            items: { type: 'string' },
-            description: '（可选）限定文档类型。',
-          },
-        },
-        required: ['query'],
-      },
-    },
-    _meta: {
-      builtin: true,
-      toolName: 'verify_fact',
+      toolName: 'document_retrieval',
       skillNamespace: 'document_retrieval',
     },
   },
@@ -1279,7 +1185,7 @@ class ToolManager {
       return await this.executeNotesTool(toolId, params, context, display);
     }
 
-    // 执行文档检索 skill 工具族（answer_from_documents / find_document / verify_fact）
+    // 执行文档检索 skill/document_retrieval（单一入口，内部 workflow 编排）
     if (this._isDocRetrievalTool(toolId)) {
       return await this._dispatchDocRetrievalTool(toolId, params, context, display);
     }
@@ -2316,67 +2222,57 @@ class ToolManager {
   }
 
   // ============================================================
-  // document_retrieval skill tool 族
+  // document_retrieval skill/workflow — 统一 LLM 入口
+  //
+  // audit-round06 变更项 A：原先 answer_from_documents / find_document /
+  // verify_fact 三个复合 tool 已合并为单一 document_retrieval 入口。
+  // LLM 仅看到此一个 tool，内部由 DocumentRetrievalWorkflow 编排
+  // 6 个原子 tool，执行轨迹通过 steps[] 暴露给前端展示。
   // ============================================================
 
   /**
-   * 判断 toolId 是否属于 document_retrieval skill namespace
-   * 兼容期：仅 document_retrieval 单 tool；未来扩展 find_document / verify_fact 等
+   * 判断 toolId 是否属于 document_retrieval skill/workflow
    */
   _isDocRetrievalTool(toolId) {
-    // document_retrieval skill 下辖的 3 个 LLM 可见独立 tool
-    return ['answer_from_documents', 'find_document', 'verify_fact'].includes(toolId);
+    return toolId === 'document_retrieval';
   }
 
   /**
-   * document_retrieval skill 统一 dispatch 入口（纯多 tool 模式）
+   * document_retrieval — 统一 handler
    *
-   * 按 toolId 直接路由到对应 handler，不再依赖 goal 参数做主路径分流。
+   * audit-round06 变更项 A：替代旧的三分发式 dispatch。
+   * 内部统一调用 DocumentRetrievalWorkflow.runAnswerQuestion()，
+   * 由 workflow 层根据 query 语义自行决策检索策略。
    *
-   * @param {string} toolId - LLM 调用的 tool 名称
-   * @param {object} params - tool 参数
+   * @param {string} toolId - 'document_retrieval'
+   * @param {object} params - tool 参数 { query, collection_id?, doc_types? }
    * @param {object} context - 执行上下文
    * @param {string} display - 工具显示名称
-   * @returns {Promise<object>} 结构化结果
+   * @returns {Promise<object>} 标准化结果（含 steps[] 原子轨迹）
    */
   async _dispatchDocRetrievalTool(toolId, params, context, display) {
-    switch (toolId) {
-      case 'find_document':
-        return await this._handleFindDocument(params, context, display);
-      case 'verify_fact':
-        return await this._handleVerifyFact(params, context, display);
-      case 'answer_from_documents':
-      default:
-        return await this._handleAnswerFromDocuments(params, context, display);
-    }
+    return await this._handleDocumentRetrieval(params, context, display);
   }
 
   /**
-   * 执行文档检索工具（document_retrieval）
+   * document_retrieval handler — 统一入口
    *
-   * 内部 handler：answer_from_documents
-   * 这是"专家依据文档平台回答"能力的主入口。
-   * 内部通过 DocumentRetrievalWorkflow 显式编排 document-first 检索链路，
-   * 返回结构化 evidence packet 供回答编排层消费。
+   * 内部调用 DocumentRetrievalWorkflow.runAnswerQuestion()，
+   * 由 workflow 层根据 query 语义自行决策检索策略。
+   * 返回的 steps[] 记录原子 tool 执行轨迹，供前端展示。
    *
-   * 权限边界：检索范围严格限定为用户可访问的文档集合（DocAccessService），
-   * collection_id / doc_types 仅作为缩小范围的过滤条件，不承担授权职责。
-   *
-   * @param {object} params - 工具参数
-   * @param {string} params.query - 检索查询文本
-   * @param {string} [params.collection_id] - 限定集合ID（可选，仅过滤）
-   * @param {string[]} [params.doc_types] - 限定文档类型（可选，仅过滤）
+   * @param {object} params - { query, collection_id?, doc_types? }
    * @param {object} context - 执行上下文
    * @param {string} display - 工具显示名称
-   * @returns {Promise<object>} 结构化 evidence 结果
+   * @returns {Promise<object>} 标准化结果
    */
-  async _handleAnswerFromDocuments(params, context, display) {
+  async _handleDocumentRetrieval(params, context, display) {
     const startTime = Date.now();
     const { query, collection_id, doc_types } = params;
     const userId = context.userId || context.user_id;
-    const effectiveToolName = 'answer_from_documents';
+    const effectiveToolName = 'document_retrieval';
 
-    logger.info('[ToolManager] answer_from_documents:', {
+    logger.info('[ToolManager] document_retrieval:', {
       tool_name: effectiveToolName,
       query_length: query?.length || 0,
       collection_id,
@@ -2394,8 +2290,6 @@ class ToolManager {
     }
 
     try {
-      // audit-round01 Phase 3：tool-manager 仅做参数分发 + 结果标准化，
-      // 多步检索策略统一由 DocumentRetrievalWorkflow 编排。
       const workflow = this._getDocWorkflow();
       const wf = await workflow.runAnswerQuestion({
         query: query.trim(),
@@ -2405,11 +2299,14 @@ class ToolManager {
       });
       const duration = Date.now() - startTime;
 
+      // audit-round06 变更项 A：steps[] 暴露原子 tool 执行轨迹供前端展示
+      const atomicTrace = (wf.steps || []).map(s => s.step);
+
       const response = {
         success: true,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
-        // === 主动作信号（audit-round03 变更项 B：消费层主入口） ===
+        // === 主动作信号 ===
         workflow_action: wf.action,
         // === 核心诊断字段 ===
         strategy: wf.strategy,
@@ -2418,16 +2315,15 @@ class ToolManager {
         reason_codes: wf.reason_codes || [],
         documents: wf.documents || [],
         scoped_identity: wf.scoped_identity || { confirmed: false },
-        // audit-round04 变更项 A：@compat 兼容字段（suggested_response_mode /
-        // should_clarify / should_answer_conservatively）已物理删除，
-        // workflow_action 是唯一主动作信号。
+        // === 原子工具执行轨迹（前端展示用，audit-round06 变更项 C） ===
+        atomic_steps: atomicTrace,
         // === 元数据 ===
         toolId: effectiveToolName,
         toolName: display,
         duration,
       };
 
-      logger.info('[ToolManager] answer_from_documents 完成:', {
+      logger.info('[ToolManager] document_retrieval 完成:', {
         tool_name: effectiveToolName,
         workflow_action: wf.action,
         strategy: response.strategy,
@@ -2435,13 +2331,14 @@ class ToolManager {
         duration_ms: duration,
         reason_codes: response.reason_codes,
         document_count: response.documents.length,
+        atomic_steps: atomicTrace,
         scoped_identity: response.scoped_identity,
       });
 
       return response;
     } catch (error) {
       const duration = Date.now() - startTime;
-      logger.error('[ToolManager] answer_from_documents 失败:', {
+      logger.error('[ToolManager] document_retrieval 失败:', {
         tool_name: effectiveToolName,
         error: error.message,
         duration_ms: duration,
@@ -2453,189 +2350,12 @@ class ToolManager {
         toolName: display,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
-        // audit-round04 变更项 A：错误路径同样以 workflow_action 为主信号
         workflow_action: 'decline_due_to_insufficient_evidence',
         strategy: 'error',
         evidence_sufficiency: 'none',
         scoped_identity: { confirmed: false },
         documents: [],
-        duration,
-      };
-    }
-  }
-
-  /**
-   * find_document handler
-   *
-   * 与 answer_from_documents 的区别：
-   * - 不返回 chunk 级 evidence，仅返回文档级候选列表
-   * - 重点输出文档 identity、候选置信度、匹配原因
-   * - 默认 strategy 以 document_first 为主
-   */
-  async _handleFindDocument(params, context, display) {
-    const startTime = Date.now();
-    const effectiveToolName = 'find_document';
-
-    if (!params.query || params.query.trim().length === 0) {
-      return {
-        success: false,
-        error: 'Missing required parameter: query',
-        toolId: effectiveToolName,
-        toolName: display,
-      };
-    }
-
-    try {
-      const workflow = this._getDocWorkflow();
-      const wf = await workflow.runFindDocument({
-        query: params.query.trim(),
-        user_id: context.userId || context.user_id,
-        collection_id: params.collection_id || undefined,
-        doc_types: params.doc_types?.length > 0 ? params.doc_types : undefined,
-      });
-      const duration = Date.now() - startTime;
-
-      const response = {
-        success: true,
-        tool_name: effectiveToolName,
-        skill_namespace: 'document_retrieval',
-        // === 主动作信号（audit-round03 变更项 B） ===
-        workflow_action: wf.action,
-        // === 核心诊断字段 ===
-        strategy: wf.strategy,
-        query: params.query.trim(),
-        evidence_sufficiency: wf.evidence_sufficiency || 'none',
-        reason_codes: wf.reason_codes || [],
-        candidates: wf.candidates || [],
-        total_candidates: wf.total_candidates || 0,
-        // audit-round04 变更项 A：@compat 兼容字段已物理删除，
-        // workflow_action 是唯一主动作信号。
-        // === 元数据 ===
-        toolId: effectiveToolName,
-        toolName: display,
-        duration,
-      };
-
-      logger.info('[ToolManager] find_document 完成:', {
-        tool_name: effectiveToolName,
-        workflow_action: wf.action,
-        strategy: response.strategy,
-        evidence_sufficiency: response.evidence_sufficiency,
-        duration_ms: duration,
-        candidate_count: response.total_candidates,
-        identity_distribution: response.candidates.map(c => ({
-          id: c.document_id, confidence: c.identity_confidence, source: c.identity_source,
-        })),
-      });
-
-      return response;
-    } catch (error) {
-      const duration = Date.now() - startTime;
-      logger.error('[ToolManager] find_document 失败:', {
-        tool_name: effectiveToolName,
-        error: error.message,
-        duration_ms: duration,
-      });
-      return {
-        success: false,
-        error: error.message,
-        toolId: effectiveToolName,
-        toolName: display,
-        tool_name: effectiveToolName,
-        skill_namespace: 'document_retrieval',
-        // audit-round04 变更项 A：错误路径同样以 workflow_action 为主信号
-        workflow_action: 'ask_for_clarification',
-        strategy: 'error',
-        evidence_sufficiency: 'none',
-        candidates: [],
-        total_candidates: 0,
-        duration,
-      };
-    }
-  }
-
-  /**
-   * verify_fact handler
-   *
-   * 与 answer_from_documents 的区别：
-   * - 返回 verdict 枚举（supported / insufficient_evidence）
-   * - 区分支持证据和反驳证据（contradicted 能力规划中）
-   */
-  async _handleVerifyFact(params, context, display) {
-    const startTime = Date.now();
-    const effectiveToolName = 'verify_fact';
-
-    if (!params.query || params.query.trim().length === 0) {
-      return {
-        success: false,
-        error: 'Missing required parameter: query',
-        toolId: effectiveToolName,
-        toolName: display,
-      };
-    }
-
-    try {
-      const workflow = this._getDocWorkflow();
-      const wf = await workflow.runVerifyFact({
-        query: params.query.trim(),
-        user_id: context.userId || context.user_id,
-        collection_id: params.collection_id || undefined,
-        doc_types: params.doc_types?.length > 0 ? params.doc_types : undefined,
-      });
-      const duration = Date.now() - startTime;
-
-      const response = {
-        success: true,
-        tool_name: effectiveToolName,
-        skill_namespace: 'document_retrieval',
-        workflow_action: wf.action,
-        verdict: wf.verdict || 'insufficient_evidence',
-        contradicted_available: false,
-        strategy: wf.strategy,
-        query: params.query.trim(),
-        evidence_sufficiency: wf.evidence_sufficiency || 'none',
-        reason_codes: wf.reason_codes || [],
-        supporting_evidence: wf.supporting_evidence || [],
-        contradicting_evidence: [],
-        related_documents: wf.related_documents || [],
-        toolId: effectiveToolName,
-        toolName: display,
-        duration,
-      };
-
-      logger.info('[ToolManager] verify_fact 完成:', {
-        tool_name: effectiveToolName,
-        workflow_action: wf.action,
-        verdict: response.verdict,
-        strategy: response.strategy,
-        evidence_sufficiency: response.evidence_sufficiency,
-        duration_ms: duration,
-        reason_codes: response.reason_codes,
-        document_count: response.related_documents.length,
-      });
-
-      return response;
-    } catch (error) {
-      const duration = Date.now() - startTime;
-      logger.error('[ToolManager] verify_fact 失败:', {
-        tool_name: effectiveToolName,
-        error: error.message,
-        duration_ms: duration,
-      });
-      return {
-        success: false,
-        error: error.message,
-        toolId: effectiveToolName,
-        toolName: display,
-        tool_name: effectiveToolName,
-        skill_namespace: 'document_retrieval',
-        verdict: 'insufficient_evidence',
-        contradicted_available: false,
-        strategy: 'error',
-        evidence_sufficiency: 'none',
-        supporting_evidence: [],
-        contradicting_evidence: [],
-        related_documents: [],
+        atomic_steps: [],
         duration,
       };
     }

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -20,7 +20,7 @@ import { spawn } from 'child_process';
 import fs from 'fs';
 import { getDataBasePath } from './paths.js';
 import ConfigLoader from './config-loader.js';
-import DocumentRetrievalService from './document-retrieval-service.js';
+import DocumentRetrievalWorkflow from './document-retrieval-workflow.js';
 import DocAccessService from './doc-access-service.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -760,7 +760,7 @@ class ToolManager {
 
     // 文档检索相关服务（懒初始化）
     this._configLoader = null;
-    this._docRetrievalService = null;
+    this._docWorkflow = null;
     this._docAccessService = null;
   }
 
@@ -775,16 +775,19 @@ class ToolManager {
   }
 
   /**
-   * 获取 DocumentRetrievalService 实例（懒初始化）
+   * 获取 DocumentRetrievalWorkflow 实例（懒初始化）
+   *
+   * audit-round01 Phase 2/3：tool-manager 不再直接持有检索编排服务，
+   * 统一通过显式 workflow 层执行多步检索策略。
    */
-  _getDocRetrievalService() {
-    if (!this._docRetrievalService) {
-      this._docRetrievalService = new DocumentRetrievalService(
+  _getDocWorkflow() {
+    if (!this._docWorkflow) {
+      this._docWorkflow = new DocumentRetrievalWorkflow(
         this.db,
         this._getConfigLoader()
       );
     }
-    return this._docRetrievalService;
+    return this._docWorkflow;
   }
 
   /**
@@ -2391,108 +2394,40 @@ class ToolManager {
     }
 
     try {
-      const retrievalService = this._getDocRetrievalService();
-      const accessService = this._getDocAccessService();
-
-      // 获取用户可访问的集合列表（唯一硬权限边界）
-      const accessibleIds = await accessService.getAccessibleCollectionIds(userId);
-      logger.info('[ToolManager] 文档检索权限:', {
-        userId,
-        accessible_collections: accessibleIds?.length || 0,
-        requested_collection: collection_id,
-      });
-
-      // 如果用户指定了 collection_id，验证其在可访问范围内
-      if (collection_id && !accessibleIds.includes(collection_id)) {
-        logger.warn('[ToolManager] 用户指定的集合不在可访问范围内:', {
-          requested: collection_id,
-          accessible: accessibleIds,
-        });
-        const duration = Date.now() - startTime;
-        return {
-          success: true,
-          tool_name: effectiveToolName,
-          skill_namespace: 'document_retrieval',
-          strategy: 'collection_not_accessible',
-          query: query.trim(),
-          evidence_sufficiency: 'none',
-          reason_codes: ['collection_not_accessible'],
-          should_clarify: true,
-          should_answer_conservatively: true,
-          suggested_response_mode: 'conservative_answer',
-          scoped_identity: { confirmed: false },
-          documents: [],
-          toolId: effectiveToolName,
-          toolName: display,
-          duration,
-        };
-      }
-
-      // 调用文档检索服务
-      const result = await retrievalService.retrieve(query.trim(), {
-        userId,
-        doc_types: doc_types?.length > 0 ? doc_types : undefined,
+      // audit-round01 Phase 3：tool-manager 仅做参数分发 + 结果标准化，
+      // 多步检索策略统一由 DocumentRetrievalWorkflow 编排。
+      const workflow = this._getDocWorkflow();
+      const wf = await workflow.runAnswerQuestion({
+        query: query.trim(),
+        user_id: userId,
         collection_id: collection_id || undefined,
-        top_k_candidates: 10,
-        top_k_evidence: 5,
-        evidence_threshold: 0.1,
-        allow_fallback: true,
+        doc_types,
       });
-
-      const packet = result.packet;
       const duration = Date.now() - startTime;
 
-      // 构建结构化返回结果
-      // Round 05 P0-2: scoped identity info + do_not_requery 反重查提示
-      const scopedConfirmed = packet?.meta?.scoped_identity_confirmed || false;
       const response = {
         success: true,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
-        strategy: result.strategy,
+        workflow_action: wf.action,
+        strategy: wf.strategy,
         query: query.trim(),
-        evidence_sufficiency: packet?.meta?.evidence_sufficiency || 'none',
-        reason_codes: packet?.meta?.reason_codes || [],
-        should_clarify: packet?.meta?.should_clarify || false,
-        should_answer_conservatively: packet?.meta?.should_answer_conservatively || false,
-        suggested_response_mode: packet?.meta?.suggested_response_mode || 'conservative_answer',
-        // Round 05 P0-2: scoped identity 信号
-        scoped_identity: scopedConfirmed ? {
-          confirmed: true,
-          document_id: packet.meta.scoped_document_id,
-          identity_label: packet.meta.scoped_identity_label,
-          identity_source: packet.meta.scoped_identity_source,
-          hint: '文档身份已通过 chunk 命中确认。如需了解更多文档元信息（完整标题、版本、附件名等），请直接使用已知的 document_id 查询，无需重新发起全局文档搜索。',
-        } : { confirmed: false },
-        documents: (packet?.documents || []).map(doc => ({
-          document_id: doc.document_id,
-          document_title: doc.document_title_display || doc.document_title,
-          document_title_raw: doc.document_title_display ? doc.document_title : undefined,
-          doc_type: doc.doc_type,
-          collection_name: doc.collection_name,
-          relevance_score: doc.relevance_score,
-          candidate_confidence: doc.candidate_confidence,
-          identity_confidence: doc.identity_confidence || 'unknown',
-          identity_source: doc.identity_source || 'inferred',
-          // Round 05 P0-2: enriched identity fields
-          best_identity_label: doc.best_identity_label,
-          identity_label_source: doc.identity_label_source,
-          attachment_filenames: doc.attachment_filenames,
-          evidence_count: doc.evidence?.length || 0,
-          top_evidence: (doc.evidence || []).slice(0, 3).map(ev => ({
-            content: ev.content?.substring(0, 500) || '',
-            score: ev.score,
-          })),
-        })),
+        evidence_sufficiency: wf.evidence_sufficiency || 'none',
+        reason_codes: wf.reason_codes || [],
+        should_clarify: wf.should_clarify || false,
+        should_answer_conservatively: wf.should_answer_conservatively || false,
+        suggested_response_mode: wf.suggested_response_mode || 'conservative_answer',
+        scoped_identity: wf.scoped_identity || { confirmed: false },
+        documents: wf.documents || [],
         toolId: effectiveToolName,
         toolName: display,
         duration,
       };
 
-      // 统一可观测性日志：覆盖审计要求的所有字段
       logger.info('[ToolManager] answer_from_documents 完成:', {
         tool_name: effectiveToolName,
-        strategy: result.strategy,
+        workflow_action: wf.action,
+        strategy: response.strategy,
         evidence_sufficiency: response.evidence_sufficiency,
         duration_ms: duration,
         reason_codes: response.reason_codes,
@@ -2500,9 +2435,6 @@ class ToolManager {
         should_clarify: response.should_clarify,
         suggested_response_mode: response.suggested_response_mode,
         scoped_identity: response.scoped_identity,
-        identity_distribution: response.documents?.map(d => ({
-          id: d.document_id, confidence: d.identity_confidence, source: d.identity_source, label: d.best_identity_label,
-        })) || [],
       });
 
       return response;
@@ -2542,19 +2474,9 @@ class ToolManager {
    */
   async _handleFindDocument(params, context, display) {
     const startTime = Date.now();
-    const { query, collection_id, doc_types } = params;
-    const userId = context.userId || context.user_id;
     const effectiveToolName = 'find_document';
 
-    logger.info('[ToolManager] find_document:', {
-      tool_name: effectiveToolName,
-      query_length: query?.length || 0,
-      collection_id,
-      doc_types,
-      userId,
-    });
-
-    if (!query || query.trim().length === 0) {
+    if (!params.query || params.query.trim().length === 0) {
       return {
         success: false,
         error: 'Missing required parameter: query',
@@ -2564,122 +2486,31 @@ class ToolManager {
     }
 
     try {
-      const retrievalService = this._getDocRetrievalService();
-      const accessService = this._getDocAccessService();
-
-      const accessibleIds = await accessService.getAccessibleCollectionIds(userId);
-      if (collection_id && !accessibleIds.includes(collection_id)) {
-        const duration = Date.now() - startTime;
-        return {
-          success: true,
-          tool_name: effectiveToolName,
-          skill_namespace: 'document_retrieval',
-          strategy: 'collection_not_accessible',
-          query: query.trim(),
-          evidence_sufficiency: 'none',
-          reason_codes: ['collection_not_accessible'],
-          should_clarify: true,
-          suggested_response_mode: 'clarify',
-          candidates: [],
-          total_candidates: 0,
-          toolId: effectiveToolName,
-          toolName: display,
-          duration,
-        };
-      }
-      const effectiveCollectionId = collection_id;
-
-      // find_document：走 document-first 检索，单候选高置信时补最小 supporting evidence
-      const result = await retrievalService.retrieve(query.trim(), {
-        userId,
-        doc_types: doc_types?.length > 0 ? doc_types : undefined,
-        collection_id: effectiveCollectionId || undefined,
-        top_k_candidates: 10,
-        top_k_evidence: 3,  // P0-3: 补最小证据用于身份验证
-        evidence_threshold: 0.1,
-        allow_fallback: false,  // find_document 不回退到 chunk-first
+      const workflow = this._getDocWorkflow();
+      const wf = await workflow.runFindDocument({
+        query: params.query.trim(),
+        user_id: context.userId || context.user_id,
+        collection_id: params.collection_id || undefined,
+        doc_types: params.doc_types?.length > 0 ? params.doc_types : undefined,
       });
-
-      const packet = result.packet;
       const duration = Date.now() - startTime;
 
-      let docs = packet?.documents || [];
-
-      // Round 05 P0-3: document-level 0 命中时，尝试 attachment 文件名 fallback
-      if (docs.length === 0) {
-        try {
-          const attachmentCandidates = await retrievalService.searchService.searchByAttachmentFilenames(
-            query.trim(), { userId, doc_types, top_k: 5, collection_id: effectiveCollectionId || undefined }
-          );
-          if (attachmentCandidates && attachmentCandidates.length > 0) {
-            logger.info('[ToolManager] find_document attachment fallback 命中:', {
-              count: attachmentCandidates.length,
-              query: query.trim(),
-            });
-            // 将 attachment fallback 结果转换为标准 docs 格式
-            docs = attachmentCandidates.map(c => ({
-              document_id: c.document_id,
-              document_title: c.document_title,
-              doc_type: c.doc_type,
-              collection_name: c.collection_name,
-              relevance_score: c.relevance_score || 1,
-              candidate_confidence: 'low',
-              identity_confidence: 'probable',
-              identity_source: 'attachment_filename_match',
-              match_reason: `附件文件名匹配: ${c.matched_attachment || ''}`,
-              evidence: [],
-              best_identity_label: c.best_identity_label || c.document_title,
-              identity_label_source: 'attachment_filename_match',
-              attachment_filenames: c.attachment_filenames || [],
-            }));
-          }
-        } catch (attachFallbackErr) {
-          logger.warn('[ToolManager] find_document attachment fallback 失败:', attachFallbackErr.message);
-        }
-      }
-
-      const isSingleHighConf = docs.length === 1 && docs[0]?.candidate_confidence === 'high';
-
-      const candidates = docs.map(doc => ({
-        document_id: doc.document_id,
-        document_title: doc.best_identity_label || doc.document_title_display || doc.document_title,
-        document_title_raw: (doc.best_identity_label || doc.document_title_display) ? doc.document_title : undefined,
-        doc_type: doc.doc_type,
-        collection_name: doc.collection_name,
-        relevance_score: doc.relevance_score,
-        candidate_confidence: doc.candidate_confidence,
-        identity_confidence: doc.identity_confidence || 'unknown',
-        identity_source: doc.identity_source || 'search_match',
-        // Round 05 P0-3: enriched identity fields
-        best_identity_label: doc.best_identity_label,
-        identity_label_source: doc.identity_label_source,
-        attachment_filenames: doc.attachment_filenames,
-        match_reason: doc.match_reason || (doc.candidate_confidence === 'high' ? '关键词匹配' : '语义相似'),
-        // P0-3: 单候选高置信时附带 1-3 条 supporting evidence 供身份验证
-        supporting_evidence: (isSingleHighConf
-          ? (doc.evidence || []).slice(0, 3).map(ev => ({ content: ev.content?.substring(0, 300) || '' }))
-          : undefined),
-      }));
-
-      // find_document 的 response_mode 语义：
-      // - candidate_list: 多候选，需用户确认（共享 mode，chat-service 统一处理）
-      // - single_document: 单候选，可直接展示文档信息
-      // - clarify: 无候选，需澄清
       const response = {
         success: true,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
-        strategy: result.strategy,
-        query: query.trim(),
-        evidence_sufficiency: packet?.meta?.evidence_sufficiency || 'none',
-        reason_codes: packet?.meta?.reason_codes || [],
-        should_clarify: packet?.meta?.should_clarify || candidates.length === 0,
+        workflow_action: wf.action,
+        strategy: wf.strategy,
+        query: params.query.trim(),
+        evidence_sufficiency: wf.evidence_sufficiency || 'none',
+        reason_codes: wf.reason_codes || [],
+        should_clarify: wf.action === 'ask_for_clarification',
         should_answer_conservatively: false,
-        suggested_response_mode: candidates.length > 1 ? 'candidate_list'
-          : candidates.length === 1 ? 'single_document'
+        suggested_response_mode: wf.total_candidates > 1 ? 'candidate_list'
+          : wf.total_candidates === 1 ? 'single_document'
           : 'clarify',
-        candidates,
-        total_candidates: candidates.length,
+        candidates: wf.candidates || [],
+        total_candidates: wf.total_candidates || 0,
         toolId: effectiveToolName,
         toolName: display,
         duration,
@@ -2687,13 +2518,14 @@ class ToolManager {
 
       logger.info('[ToolManager] find_document 完成:', {
         tool_name: effectiveToolName,
-        strategy: result.strategy,
+        workflow_action: wf.action,
+        strategy: response.strategy,
         evidence_sufficiency: response.evidence_sufficiency,
         duration_ms: duration,
-        document_count: candidates.length,
+        candidate_count: response.total_candidates,
         should_clarify: response.should_clarify,
         suggested_response_mode: response.suggested_response_mode,
-        identity_distribution: candidates.map(c => ({
+        identity_distribution: response.candidates.map(c => ({
           id: c.document_id, confidence: c.identity_confidence, source: c.identity_source,
         })),
       });
@@ -2733,19 +2565,9 @@ class ToolManager {
    */
   async _handleVerifyFact(params, context, display) {
     const startTime = Date.now();
-    const { query, collection_id, doc_types } = params;
-    const userId = context.userId || context.user_id;
     const effectiveToolName = 'verify_fact';
 
-    logger.info('[ToolManager] verify_fact:', {
-      tool_name: effectiveToolName,
-      query_length: query?.length || 0,
-      collection_id,
-      doc_types,
-      userId,
-    });
-
-    if (!query || query.trim().length === 0) {
+    if (!params.query || params.query.trim().length === 0) {
       return {
         success: false,
         error: 'Missing required parameter: query',
@@ -2755,88 +2577,29 @@ class ToolManager {
     }
 
     try {
-      const retrievalService = this._getDocRetrievalService();
-      const accessService = this._getDocAccessService();
-
-      const accessibleIds = await accessService.getAccessibleCollectionIds(userId);
-      if (collection_id && !accessibleIds.includes(collection_id)) {
-        const duration = Date.now() - startTime;
-        return {
-          success: true,
-          tool_name: effectiveToolName,
-          skill_namespace: 'document_retrieval',
-          verdict: 'insufficient_evidence',
-          contradicted_available: false,
-          strategy: 'collection_not_accessible',
-          query: query.trim(),
-          evidence_sufficiency: 'none',
-          reason_codes: ['collection_not_accessible'],
-          supporting_evidence: [],
-          contradicting_evidence: [],
-          related_documents: [],
-          toolId: effectiveToolName,
-          toolName: display,
-          duration,
-        };
-      }
-
-      const result = await retrievalService.retrieve(query.trim(), {
-        userId,
-        doc_types: doc_types?.length > 0 ? doc_types : undefined,
-        collection_id: collection_id || undefined,
-        top_k_candidates: 10,
-        top_k_evidence: 5,
-        evidence_threshold: 0.1,
-        allow_fallback: true,
+      const workflow = this._getDocWorkflow();
+      const wf = await workflow.runVerifyFact({
+        query: params.query.trim(),
+        user_id: context.userId || context.user_id,
+        collection_id: params.collection_id || undefined,
+        doc_types: params.doc_types?.length > 0 ? params.doc_types : undefined,
       });
-
-      const packet = result.packet;
       const duration = Date.now() - startTime;
 
-      // verify_fact: 基于证据充分性推断 verdict
-      const sufficiency = packet?.meta?.evidence_sufficiency || 'none';
-      let verdict;
-      if (sufficiency === 'strong' || sufficiency === 'medium') {
-        verdict = 'supported';
-      } else if (sufficiency === 'weak') {
-        verdict = 'insufficient_evidence';
-      } else {
-        verdict = 'insufficient_evidence';
-      }
-
-      // 收集证据（当前实现不区分支持/反驳，全部作为 supporting）
-      const allEvidence = [];
-      for (const doc of (packet?.documents || [])) {
-        for (const ev of (doc.evidence || [])) {
-          allEvidence.push({
-            content: ev.content?.substring(0, 500) || '',
-            document_id: doc.document_id,
-            document_title: doc.document_title,
-            score: ev.score,
-          });
-        }
-      }
-
-      // verify_fact 能力诚实性：
-      // - contradicted 判定需要独立的反驳证据链路（当前未实现）
-      // - 当前仅稳定支持 supported / insufficient_evidence
-      // - contradicted_available: false 明确告知消费方当前不支持真正反驳判定
       const response = {
         success: true,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
-        verdict,
+        workflow_action: wf.action,
+        verdict: wf.verdict || 'insufficient_evidence',
         contradicted_available: false,
-        strategy: result.strategy,
-        query: query.trim(),
-        evidence_sufficiency: sufficiency,
-        reason_codes: packet?.meta?.reason_codes || [],
-        supporting_evidence: verdict === 'supported' ? allEvidence.slice(0, 5) : [],
+        strategy: wf.strategy,
+        query: params.query.trim(),
+        evidence_sufficiency: wf.evidence_sufficiency || 'none',
+        reason_codes: wf.reason_codes || [],
+        supporting_evidence: wf.supporting_evidence || [],
         contradicting_evidence: [],
-        related_documents: (packet?.documents || []).map(d => ({
-          document_id: d.document_id,
-          document_title: d.document_title,
-        })),
+        related_documents: wf.related_documents || [],
         toolId: effectiveToolName,
         toolName: display,
         duration,
@@ -2844,9 +2607,10 @@ class ToolManager {
 
       logger.info('[ToolManager] verify_fact 完成:', {
         tool_name: effectiveToolName,
-        verdict,
-        strategy: result.strategy,
-        evidence_sufficiency: sufficiency,
+        workflow_action: wf.action,
+        verdict: response.verdict,
+        strategy: response.strategy,
+        evidence_sufficiency: response.evidence_sufficiency,
         duration_ms: duration,
         reason_codes: response.reason_codes,
         document_count: response.related_documents.length,

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -235,7 +235,7 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
 - 检索范围自动限定为用户有权访问的文档集合（DocAccessService 硬权限边界）
 - collection_id / doc_types 仅用于缩小范围，不承担授权职责
 
-返回结构化证据，包含 evidence_sufficiency（证据充分性）、suggested_response_mode（建议回答模式）、documents（候选文档及其 top evidence）。`,
+返回结构化证据，包含 workflow_action（主动作信号）、evidence_sufficiency（证据充分性）、documents（候选文档及其 top evidence）。`,
       parameters: {
         type: 'object',
         properties: {
@@ -2356,7 +2356,7 @@ class ToolManager {
    *
    * 内部 handler：answer_from_documents
    * 这是"专家依据文档平台回答"能力的主入口。
-   * 内部复用 DocumentRetrievalService 走 document-first 检索链路，
+   * 内部通过 DocumentRetrievalWorkflow 显式编排 document-first 检索链路，
    * 返回结构化 evidence packet 供回答编排层消费。
    *
    * 权限边界：检索范围严格限定为用户可访问的文档集合（DocAccessService），
@@ -2418,10 +2418,9 @@ class ToolManager {
         reason_codes: wf.reason_codes || [],
         documents: wf.documents || [],
         scoped_identity: wf.scoped_identity || { confirmed: false },
-        // === @compat 兼容字段（未来版本移除，新代码请用 workflow_action） ===
-        suggested_response_mode: wf.suggested_response_mode || 'conservative_answer',
-        should_clarify: wf.should_clarify || false,
-        should_answer_conservatively: wf.should_answer_conservatively || false,
+        // audit-round04 变更项 A：@compat 兼容字段（suggested_response_mode /
+        // should_clarify / should_answer_conservatively）已物理删除，
+        // workflow_action 是唯一主动作信号。
         // === 元数据 ===
         toolId: effectiveToolName,
         toolName: display,
@@ -2436,8 +2435,6 @@ class ToolManager {
         duration_ms: duration,
         reason_codes: response.reason_codes,
         document_count: response.documents.length,
-        should_clarify: response.should_clarify,
-        suggested_response_mode: response.suggested_response_mode,
         scoped_identity: response.scoped_identity,
       });
 
@@ -2456,11 +2453,10 @@ class ToolManager {
         toolName: display,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
+        // audit-round04 变更项 A：错误路径同样以 workflow_action 为主信号
+        workflow_action: 'decline_due_to_insufficient_evidence',
         strategy: 'error',
         evidence_sufficiency: 'none',
-        should_clarify: true,
-        should_answer_conservatively: true,
-        suggested_response_mode: 'conservative_answer',
         scoped_identity: { confirmed: false },
         documents: [],
         duration,
@@ -2512,12 +2508,8 @@ class ToolManager {
         reason_codes: wf.reason_codes || [],
         candidates: wf.candidates || [],
         total_candidates: wf.total_candidates || 0,
-        // === @compat 兼容字段（未来版本移除） ===
-        should_clarify: wf.action === 'ask_for_clarification',
-        should_answer_conservatively: false,
-        suggested_response_mode: wf.total_candidates > 1 ? 'candidate_list'
-          : wf.total_candidates === 1 ? 'single_document'
-          : 'clarify',
+        // audit-round04 变更项 A：@compat 兼容字段已物理删除，
+        // workflow_action 是唯一主动作信号。
         // === 元数据 ===
         toolId: effectiveToolName,
         toolName: display,
@@ -2531,8 +2523,6 @@ class ToolManager {
         evidence_sufficiency: response.evidence_sufficiency,
         duration_ms: duration,
         candidate_count: response.total_candidates,
-        should_clarify: response.should_clarify,
-        suggested_response_mode: response.suggested_response_mode,
         identity_distribution: response.candidates.map(c => ({
           id: c.document_id, confidence: c.identity_confidence, source: c.identity_source,
         })),
@@ -2553,10 +2543,10 @@ class ToolManager {
         toolName: display,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
+        // audit-round04 变更项 A：错误路径同样以 workflow_action 为主信号
+        workflow_action: 'ask_for_clarification',
         strategy: 'error',
         evidence_sufficiency: 'none',
-        should_clarify: true,
-        suggested_response_mode: 'clarify',
         candidates: [],
         total_candidates: 0,
         duration,

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -207,55 +207,130 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
     },
   },
   // ============================================================
-  // document_retrieval skill — 系统级文档检索（audit-round06 收口）
+  // document_retrieval skill/workflow — 6 原子 tool 对外暴露
   //
-  // LLM 可见 1 个 tool：document_retrieval
-  // 内部由 DocumentRetrievalWorkflow 编排 6 个原子 tool 按决策管线执行，
-  // 执行轨迹通过 steps[] 暴露给前端展示。
+  // audit-round07 变更项 P0-A：撤销 round06 的单一复合入口 document_retrieval，
+  // 改为直接注册 6 个原子 tool。每个 tool 内部触发同一 workflow 管线，
+  // LLM 看到的 tool 名即原子 tool 名，前端按实际调用的原子名展示。
   // ============================================================
   {
     type: 'function',
     function: {
-      name: 'document_retrieval',
-      description: `从文档平台检索与用户问题相关的证据并返回结构化结果。
+      name: 'search_documents_by_metadata',
+      description: `按标题、文件名、元数据检索文档平台中的候选文档。
 
-这是系统级 document_retrieval skill/workflow 的统一 LLM 入口，内部由 6 个原子 tool（search_documents_by_metadata / read_document_content / search_chunks_in_document / search_chunks_globally / rank_chunks_for_question / resolve_documents_from_chunks）按决策管线编排执行。
-
-使用场景：
-- 用户询问文档中的具体信息（合同条款、发票内容、报告数据等）
-- 帮助用户定位可能相关的文档
-- 校验某个命题是否得到文档证据支持
-
-权限说明：
-- 检索范围自动限定为用户有权访问的文档集合（DocAccessService 硬权限边界）
-- collection_id / doc_types 仅用于缩小范围，不承担授权职责
-
-返回值包含 workflow_action（主动作信号）、evidence_sufficiency（证据充分性）、steps（原子 tool 执行轨迹）、documents（候选文档及其 top evidence）。`,
+适用场景：用户明确提到了文档名、合同名、标准号、文件名，或需要定位某份具体文档。
+与 search_chunks_globally 的区别：本工具从文档元数据层检索，适合"找文档"类问题；如需全库内容级搜索，用 search_chunks_globally。`,
       parameters: {
         type: 'object',
         properties: {
-          query: {
-            type: 'string',
-            description: '检索查询文本。应提取用户问题的核心语义，而非原样传入整段对话。',
-          },
-          collection_id: {
-            type: 'string',
-            description: '（可选）限定检索的文档集合ID。不传则在用户有权访问的所有集合中检索。',
-          },
-          doc_types: {
-            type: 'array',
-            items: { type: 'string' },
-            description: '（可选）限定文档类型，如 ["contract", "invoice"]。不传则不限制类型。仅用于缩小范围，不做权限判定。',
-          },
+          query: { type: 'string', description: '检索查询文本，尽量包含文档名、编号等可识别信息。' },
+          collection_id: { type: 'string', description: '（可选）限定文档集合ID。' },
+          doc_types: { type: 'array', items: { type: 'string' }, description: '（可选）限定文档类型。' },
         },
         required: ['query'],
       },
     },
-    _meta: {
-      builtin: true,
-      toolName: 'document_retrieval',
-      skillNamespace: 'document_retrieval',
+    _meta: { builtin: true, toolName: 'search_documents_by_metadata', skillNamespace: 'document_retrieval' },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'read_document_content',
+      description: `读取指定文档的完整内容/章节。
+
+适用场景：用户已知道文档名或 document_id，想查看该文档的具体条款、段落、数据。
+前置条件：通常先通过 search_documents_by_metadata 或 resolve_documents_from_chunks 拿到 document_id。`,
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '描述要查找的内容主题，如"违约责任条款""验收标准"。' },
+          collection_id: { type: 'string', description: '（可选）限定文档集合ID。' },
+          doc_types: { type: 'array', items: { type: 'string' }, description: '（可选）限定文档类型。' },
+        },
+        required: ['query'],
+      },
     },
+    _meta: { builtin: true, toolName: 'read_document_content', skillNamespace: 'document_retrieval' },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'search_chunks_in_document',
+      description: `在已知文档范围内搜索与问题相关的具体段落（chunk）。
+
+适用场景：已定位到若干候选文档，需要在文档内部找到最相关的条款/段落。
+前置条件：通常先通过 search_documents_by_metadata 拿到 document_id 列表。`,
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '检索查询文本，描述要查找的具体信息。' },
+          collection_id: { type: 'string', description: '（可选）限定文档集合ID。' },
+          doc_types: { type: 'array', items: { type: 'string' }, description: '（可选）限定文档类型。' },
+        },
+        required: ['query'],
+      },
+    },
+    _meta: { builtin: true, toolName: 'search_chunks_in_document', skillNamespace: 'document_retrieval' },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'search_chunks_globally',
+      description: `在文档平台全库范围内搜索与问题语义相关的内容片段（chunk）。
+
+适用场景：用户问题涉及某个具体内容但不知道在哪个文档里，或 search_documents_by_metadata 没找到结果时作为兜底。
+与 search_documents_by_metadata 的区别：本工具从文档内容层检索，适合"找内容"类问题。`,
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '检索查询文本，描述要查找的具体信息。' },
+          collection_id: { type: 'string', description: '（可选）限定文档集合ID。' },
+          doc_types: { type: 'array', items: { type: 'string' }, description: '（可选）限定文档类型。' },
+        },
+        required: ['query'],
+      },
+    },
+    _meta: { builtin: true, toolName: 'search_chunks_globally', skillNamespace: 'document_retrieval' },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'rank_chunks_for_question',
+      description: `对检索到的内容片段按与问题的相关性重新排序，选出最相关的 top-K。
+
+适用场景：search_chunks_in_document 或 search_chunks_globally 返回多个 chunk 后，需要精排以确定哪些最相关用于回答。`,
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '原始问题文本，用于相关性排序。' },
+          collection_id: { type: 'string', description: '（可选）限定文档集合ID。' },
+          doc_types: { type: 'array', items: { type: 'string' }, description: '（可选）限定文档类型。' },
+        },
+        required: ['query'],
+      },
+    },
+    _meta: { builtin: true, toolName: 'rank_chunks_for_question', skillNamespace: 'document_retrieval' },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'resolve_documents_from_chunks',
+      description: `从 chunk 命中结果反查所属的文档信息（文档名、类型、集合等）。
+
+适用场景：search_chunks_globally 返回了相关内容片段，但不知道这些片段属于哪个文档时。
+前置条件：通常紧跟 search_chunks_globally 使用。`,
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '检索查询文本，用于关联文档信息。' },
+          collection_id: { type: 'string', description: '（可选）限定文档集合ID。' },
+          doc_types: { type: 'array', items: { type: 'string' }, description: '（可选）限定文档类型。' },
+        },
+        required: ['query'],
+      },
+    },
+    _meta: { builtin: true, toolName: 'resolve_documents_from_chunks', skillNamespace: 'document_retrieval' },
   },
 ];
 
@@ -1185,7 +1260,7 @@ class ToolManager {
       return await this.executeNotesTool(toolId, params, context, display);
     }
 
-    // 执行文档检索 skill/document_retrieval（单一入口，内部 workflow 编排）
+    // 执行文档检索原子 tool 族（6 tool 统一 workflow 管线）
     if (this._isDocRetrievalTool(toolId)) {
       return await this._dispatchDocRetrievalTool(toolId, params, context, display);
     }
@@ -2222,57 +2297,66 @@ class ToolManager {
   }
 
   // ============================================================
-  // document_retrieval skill/workflow — 统一 LLM 入口
+  // document_retrieval skill/workflow — 6 原子 tool 入口
   //
-  // audit-round06 变更项 A：原先 answer_from_documents / find_document /
-  // verify_fact 三个复合 tool 已合并为单一 document_retrieval 入口。
-  // LLM 仅看到此一个 tool，内部由 DocumentRetrievalWorkflow 编排
-  // 6 个原子 tool，执行轨迹通过 steps[] 暴露给前端展示。
+  // audit-round07 变更项 P0-A：6 个原子 tool 独立暴露给 LLM，
+  // 每个都触发同一 workflow 管线，effectiveToolName 使用 LLM 实际调用的 tool 名。
   // ============================================================
 
+  /** 6 个原子 tool 名（audit-round07：替代旧单一 composite 入口） */
+  static DOC_ATOMIC_TOOLS = new Set([
+    'search_documents_by_metadata',
+    'read_document_content',
+    'search_chunks_in_document',
+    'search_chunks_globally',
+    'rank_chunks_for_question',
+    'resolve_documents_from_chunks',
+  ]);
+
   /**
-   * 判断 toolId 是否属于 document_retrieval skill/workflow
+   * 判断 toolId 是否属于 document_retrieval 原子 tool 族
    */
   _isDocRetrievalTool(toolId) {
-    return toolId === 'document_retrieval';
+    return ToolManager.DOC_ATOMIC_TOOLS.has(toolId);
   }
 
   /**
-   * document_retrieval — 统一 handler
+   * document_retrieval 原子 tool — 统一 dispatch
    *
-   * audit-round06 变更项 A：替代旧的三分发式 dispatch。
-   * 内部统一调用 DocumentRetrievalWorkflow.runAnswerQuestion()，
-   * 由 workflow 层根据 query 语义自行决策检索策略。
+   * audit-round07 变更项 P0-A：不再转发到单一复合名，
+   * 改为透传 toolId 给 handler 作为 effectiveToolName。
    *
-   * @param {string} toolId - 'document_retrieval'
-   * @param {object} params - tool 参数 { query, collection_id?, doc_types? }
+   * @param {string} toolId - LLM 实际调用的原子 tool 名
+   * @param {object} params - tool 参数
    * @param {object} context - 执行上下文
    * @param {string} display - 工具显示名称
-   * @returns {Promise<object>} 标准化结果（含 steps[] 原子轨迹）
+   * @returns {Promise<object>} 标准化结果
    */
   async _dispatchDocRetrievalTool(toolId, params, context, display) {
-    return await this._handleDocumentRetrieval(params, context, display);
+    return await this._handleDocumentRetrieval(toolId, params, context, display);
   }
 
   /**
-   * document_retrieval handler — 统一入口
+   * document_retrieval 原子 tool handler — 统一入口
    *
-   * 内部调用 DocumentRetrievalWorkflow.runAnswerQuestion()，
-   * 由 workflow 层根据 query 语义自行决策检索策略。
-   * 返回的 steps[] 记录原子 tool 执行轨迹，供前端展示。
+   * audit-round07 变更项 P0-A：effectiveToolName 使用 LLM 实际调用的
+   * 原子 tool 名（toolId），不再是硬编码的 composite 名。
+   * 内部统一走 DocumentRetrievalWorkflow.runAnswerQuestion() 管线。
    *
+   * @param {string} toolId - LLM 实际调用的原子 tool 名
    * @param {object} params - { query, collection_id?, doc_types? }
    * @param {object} context - 执行上下文
    * @param {string} display - 工具显示名称
    * @returns {Promise<object>} 标准化结果
    */
-  async _handleDocumentRetrieval(params, context, display) {
+  async _handleDocumentRetrieval(toolId, params, context, display) {
     const startTime = Date.now();
     const { query, collection_id, doc_types } = params;
     const userId = context.userId || context.user_id;
-    const effectiveToolName = 'document_retrieval';
+    // audit-round07：effectiveToolName = LLM 实际调用的原子 tool 名
+    const effectiveToolName = toolId;
 
-    logger.info('[ToolManager] document_retrieval:', {
+    logger.info(`[ToolManager] ${effectiveToolName}:`, {
       tool_name: effectiveToolName,
       query_length: query?.length || 0,
       collection_id,
@@ -2323,7 +2407,7 @@ class ToolManager {
         duration,
       };
 
-      logger.info('[ToolManager] document_retrieval 完成:', {
+      logger.info(`[ToolManager] ${effectiveToolName} 完成:`, {
         tool_name: effectiveToolName,
         workflow_action: wf.action,
         strategy: response.strategy,
@@ -2338,7 +2422,7 @@ class ToolManager {
       return response;
     } catch (error) {
       const duration = Date.now() - startTime;
-      logger.error('[ToolManager] document_retrieval 失败:', {
+      logger.error(`[ToolManager] ${effectiveToolName} 失败:`, {
         tool_name: effectiveToolName,
         error: error.message,
         duration_ms: duration,

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -2409,16 +2409,20 @@ class ToolManager {
         success: true,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
+        // === 主动作信号（audit-round03 变更项 B：消费层主入口） ===
         workflow_action: wf.action,
+        // === 核心诊断字段 ===
         strategy: wf.strategy,
         query: query.trim(),
         evidence_sufficiency: wf.evidence_sufficiency || 'none',
         reason_codes: wf.reason_codes || [],
+        documents: wf.documents || [],
+        scoped_identity: wf.scoped_identity || { confirmed: false },
+        // === @compat 兼容字段（未来版本移除，新代码请用 workflow_action） ===
+        suggested_response_mode: wf.suggested_response_mode || 'conservative_answer',
         should_clarify: wf.should_clarify || false,
         should_answer_conservatively: wf.should_answer_conservatively || false,
-        suggested_response_mode: wf.suggested_response_mode || 'conservative_answer',
-        scoped_identity: wf.scoped_identity || { confirmed: false },
-        documents: wf.documents || [],
+        // === 元数据 ===
         toolId: effectiveToolName,
         toolName: display,
         duration,
@@ -2499,18 +2503,22 @@ class ToolManager {
         success: true,
         tool_name: effectiveToolName,
         skill_namespace: 'document_retrieval',
+        // === 主动作信号（audit-round03 变更项 B） ===
         workflow_action: wf.action,
+        // === 核心诊断字段 ===
         strategy: wf.strategy,
         query: params.query.trim(),
         evidence_sufficiency: wf.evidence_sufficiency || 'none',
         reason_codes: wf.reason_codes || [],
+        candidates: wf.candidates || [],
+        total_candidates: wf.total_candidates || 0,
+        // === @compat 兼容字段（未来版本移除） ===
         should_clarify: wf.action === 'ask_for_clarification',
         should_answer_conservatively: false,
         suggested_response_mode: wf.total_candidates > 1 ? 'candidate_list'
           : wf.total_candidates === 1 ? 'single_document'
           : 'clarify',
-        candidates: wf.candidates || [],
-        total_candidates: wf.total_candidates || 0,
+        // === 元数据 ===
         toolId: effectiveToolName,
         toolName: display,
         duration,

--- a/tests/chat-service-consumption.test.js
+++ b/tests/chat-service-consumption.test.js
@@ -1,0 +1,239 @@
+/**
+ * Chat-service 消费层联调测试
+ *
+ * audit-round03 变更项 C：
+ * 验证 chat-service 已按 workflow_action 组织行为，不再仅依赖
+ * suggested_response_mode 做主分支决策。
+ *
+ * 测试 _getResponseModeDecision / _resolveConstraintMode /
+ * _buildResponseModeConstraint 在新旧路径下的行为。
+ *
+ * 运行：node tests/chat-service-consumption.test.js
+ */
+
+import { ExpertChatService } from '../lib/chat-service.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual === expected) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label} | expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`); }
+}
+
+// 最小化实例（mock db 仅避免构造函数崩溃，不测试 DB 路径）
+function makeChatService() {
+  const mockDb = {
+    getModel: () => ({}),  // 返回空对象，避免 undefined 崩溃
+  };
+  return new ExpertChatService(mockDb, 'test-expert');
+}
+
+// ============================================================
+// CS-01: workflow_action=return_document_candidates → 短路
+// ============================================================
+
+function testReturnDocumentCandidatesShortCircuits() {
+  console.log('\n📋 CS-01: workflow_action=return_document_candidates → 短路 LLM');
+
+  const svc = makeChatService();
+  const result = {
+    success: true,
+    workflow_action: 'return_document_candidates',
+    suggested_response_mode: 'candidate_list',
+    documents: [
+      { document_id: 'd1', document_title: 'Doc A', doc_type: 'contract', collection_name: 'Col', relevance_score: 80, candidate_confidence: 'high', top_evidence: [{ content: '摘要片段', score: 0.8 }] },
+      { document_id: 'd2', document_title: 'Doc B', doc_type: 'contract', collection_name: 'Col', relevance_score: 75, candidate_confidence: 'high', top_evidence: [{ content: '另一摘要', score: 0.75 }] },
+    ],
+    evidence_sufficiency: 'medium',
+    strategy: 'document_first',
+  };
+
+  const decision = svc._getResponseModeDecision(result);
+
+  assert(decision.isShortCircuit, 'CS-01.1 isShortCircuit=true');
+  assert(decision.directResponse !== null, 'CS-01.2 has directResponse');
+  assert(decision.directResponse.includes('Doc A'), 'CS-01.3 response contains Doc A');
+  assert(decision.directResponse.includes('Doc B'), 'CS-01.4 response contains Doc B');
+  assertEqual(decision.evidenceInjection, null, 'CS-01.5 no evidenceInjection on short circuit');
+}
+
+// ============================================================
+// CS-02: workflow_action=answer_with_ranked_chunks → 证据注入
+// ============================================================
+
+function testAnswerWithRankedChunksInjectsEvidence() {
+  console.log('\n📋 CS-02: workflow_action=answer_with_ranked_chunks → evidenceInjection');
+
+  const svc = makeChatService();
+  const result = {
+    success: true,
+    workflow_action: 'answer_with_ranked_chunks',
+    suggested_response_mode: 'answer_with_citation',
+    documents: [
+      { document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_name: '标准库', relevance_score: 95, candidate_confidence: 'high', evidence_count: 3, top_evidence: [{ content: 'IPX5试验条件：喷嘴内径6.3mm，水流量12.5L/min', score: 0.92 }] },
+    ],
+    evidence_sufficiency: 'strong',
+    strategy: 'document_first',
+    reason_codes: [],
+  };
+
+  const decision = svc._getResponseModeDecision(result);
+
+  assert(!decision.isShortCircuit, 'CS-02.1 not short circuit');
+  assertEqual(decision.directResponse, null, 'CS-02.2 no directResponse');
+  assert(decision.evidenceInjection !== null, 'CS-02.3 has evidenceInjection');
+  assert(decision.evidenceInjection.length > 0, 'CS-02.4 evidenceInjection non-empty');
+  assert(decision.evidenceInjection.includes('GB/T 4208') || decision.evidenceInjection.includes('IPX5'), 'CS-02.5 contains evidence content');
+}
+
+// ============================================================
+// CS-03: workflow_action=decline → 保守回答约束
+// ============================================================
+
+function testDeclineInsufficientEvidenceConservativeAnswer() {
+  console.log('\n📋 CS-03: workflow_action=decline_due_to_insufficient_evidence → conservative_answer');
+
+  const svc = makeChatService();
+  const result = {
+    success: true,
+    workflow_action: 'decline_due_to_insufficient_evidence',
+    suggested_response_mode: 'conservative_answer',
+    documents: [],
+    evidence_sufficiency: 'none',
+    strategy: 'degrade',
+    reason_codes: ['no_candidates'],
+  };
+
+  const decision = svc._getResponseModeDecision(result);
+
+  assert(!decision.isShortCircuit, 'CS-03.1 not short circuit');
+  assert(decision.evidenceInjection !== null, 'CS-03.2 has evidenceInjection');
+  // 保守回答约束应包含"依据有限"等关键词
+  assert(
+    decision.evidenceInjection.includes('依据有限') || decision.evidenceInjection.includes('保守回答'),
+    'CS-03.3 contains conservative constraint'
+  );
+}
+
+// ============================================================
+// CS-04: workflow_action=ask_for_clarification → 澄清约束
+// ============================================================
+
+function testAskForClarificationConstraint() {
+  console.log('\n📋 CS-04: workflow_action=ask_for_clarification → 澄清约束');
+
+  const svc = makeChatService();
+  const result = {
+    success: true,
+    workflow_action: 'ask_for_clarification',
+    suggested_response_mode: 'clarify',
+    documents: [],
+    evidence_sufficiency: 'none',
+    strategy: 'none',
+    reason_codes: ['empty_query'],
+  };
+
+  const decision = svc._getResponseModeDecision(result);
+
+  assert(!decision.isShortCircuit, 'CS-04.1 not short circuit');
+  assert(decision.evidenceInjection !== null, 'CS-04.2 has evidenceInjection');
+  assert(decision.evidenceInjection.includes('澄清'), 'CS-04.3 contains clarify constraint');
+}
+
+// ============================================================
+// CS-05: 无 workflow_action → fallback 到 suggested_response_mode
+// ============================================================
+
+function testFallbackToSuggestedResponseMode() {
+  console.log('\n📋 CS-05: 无 workflow_action → fallback 到旧 suggested_response_mode');
+
+  const svc = makeChatService();
+  const result = {
+    success: true,
+    // 无 workflow_action 字段
+    suggested_response_mode: 'candidate_list',
+    documents: [
+      { document_id: 'd1', document_title: 'Doc X', doc_type: 'contract', collection_name: 'Col', relevance_score: 90, candidate_confidence: 'high' },
+    ],
+    evidence_sufficiency: 'medium',
+    strategy: 'document_first',
+  };
+
+  const decision = svc._getResponseModeDecision(result);
+
+  assert(decision.isShortCircuit, 'CS-05.1 fallback still short circuits');
+  assert(decision.directResponse !== null, 'CS-05.2 has directResponse');
+}
+
+// ============================================================
+// CS-06: _resolveConstraintMode 映射表验证
+// ============================================================
+
+function testResolveConstraintModeMapping() {
+  console.log('\n📋 CS-06: _resolveConstraintMode 映射表');
+
+  const svc = makeChatService();
+
+  assertEqual(svc._resolveConstraintMode({ workflow_action: 'return_document_candidates' }), 'candidate_list', 'CS-06.1 candidates → candidate_list');
+  assertEqual(svc._resolveConstraintMode({ workflow_action: 'ask_for_clarification' }), 'clarify', 'CS-06.2 clarify → clarify');
+  assertEqual(svc._resolveConstraintMode({ workflow_action: 'decline_due_to_insufficient_evidence' }), 'conservative_answer', 'CS-06.3 decline → conservative');
+  assertEqual(svc._resolveConstraintMode({ workflow_action: 'answer_with_ranked_chunks', evidence_sufficiency: 'strong' }), 'answer_with_citation', 'CS-06.4 strong → answer_with_citation');
+  assertEqual(svc._resolveConstraintMode({ workflow_action: 'answer_with_ranked_chunks', evidence_sufficiency: 'weak' }), 'direct_answer', 'CS-06.5 weak → direct_answer');
+  // fallback 到 suggested_response_mode
+  assertEqual(svc._resolveConstraintMode({ suggested_response_mode: 'conservative_answer' }), 'conservative_answer', 'CS-06.6 no action → fallback');
+}
+
+// ============================================================
+// CS-07: _buildResponseModeConstraint 对每种模式生成约束
+// ============================================================
+
+function testBuildResponseModeConstraint() {
+  console.log('\n📋 CS-07: _buildResponseModeConstraint 对每种模式生成约束');
+
+  const svc = makeChatService();
+
+  const clarifyConstraint = svc._buildResponseModeConstraint('clarify');
+  assert(clarifyConstraint.includes('澄清'), 'CS-07.1 clarify constraint');
+
+  const candidateConstraint = svc._buildResponseModeConstraint('candidate_list');
+  assert(candidateConstraint.includes('候选'), 'CS-07.2 candidate constraint');
+
+  const conservativeConstraint = svc._buildResponseModeConstraint('conservative_answer');
+  assert(conservativeConstraint.includes('依据有限'), 'CS-07.3 conservative constraint');
+
+  const defaultConstraint = svc._buildResponseModeConstraint('answer_with_citation');
+  assertEqual(defaultConstraint, '', 'CS-07.4 answer_with_citation → no constraint (default)');
+}
+
+// ============================================================
+// 运行
+// ============================================================
+
+function main() {
+  console.log('╔══════════════════════════════════════╗');
+  console.log('║  Chat-Service 消费层联调测试        ║');
+  console.log('║  (audit-round03 变更项 C)           ║');
+  console.log('╚══════════════════════════════════════╝');
+
+  testReturnDocumentCandidatesShortCircuits();
+  testAnswerWithRankedChunksInjectsEvidence();
+  testDeclineInsufficientEvidenceConservativeAnswer();
+  testAskForClarificationConstraint();
+  testFallbackToSuggestedResponseMode();
+  testResolveConstraintModeMapping();
+  testBuildResponseModeConstraint();
+
+  console.log(`\n========================================`);
+  console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+  console.log(`========================================`);
+
+  if (failed > 0) process.exit(1);
+}
+
+main();

--- a/tests/chat-service-consumption.test.js
+++ b/tests/chat-service-consumption.test.js
@@ -1,12 +1,12 @@
 /**
  * Chat-service 消费层联调测试
  *
- * audit-round03 变更项 C：
- * 验证 chat-service 已按 workflow_action 组织行为，不再仅依赖
- * suggested_response_mode 做主分支决策。
+ * audit-round04 变更项 D：
+ * 验证 chat-service 已按 workflow_action 组织行为，suggested_response_mode
+ * 兼容字段已从 tool-manager 输出面物理删除，不再作为正常输入面。
  *
  * 测试 _getResponseModeDecision / _resolveConstraintMode /
- * _buildResponseModeConstraint 在新旧路径下的行为。
+ * _buildResponseModeConstraint 在新路径下的行为。
  *
  * 运行：node tests/chat-service-consumption.test.js
  */
@@ -147,17 +147,17 @@ function testAskForClarificationConstraint() {
 }
 
 // ============================================================
-// CS-05: 无 workflow_action → fallback 到 suggested_response_mode
+// CS-05: 无 workflow_action（异常/旧数据路径）→ 防御性兜底
 // ============================================================
 
-function testFallbackToSuggestedResponseMode() {
-  console.log('\n📋 CS-05: 无 workflow_action → fallback 到旧 suggested_response_mode');
+function testNoWorkflowActionDefensiveFallback() {
+  console.log('\n📋 CS-05: 无 workflow_action → 防御性兜底（conservative_answer）');
 
   const svc = makeChatService();
   const result = {
     success: true,
-    // 无 workflow_action 字段
-    suggested_response_mode: 'candidate_list',
+    // audit-round04 变更项 A：suggested_response_mode 已从 tool-manager 输出面物理删除，
+    // 此用例验证异常/旧数据路径的防御性兜底行为。
     documents: [
       { document_id: 'd1', document_title: 'Doc X', doc_type: 'contract', collection_name: 'Col', relevance_score: 90, candidate_confidence: 'high' },
     ],
@@ -167,8 +167,46 @@ function testFallbackToSuggestedResponseMode() {
 
   const decision = svc._getResponseModeDecision(result);
 
-  assert(decision.isShortCircuit, 'CS-05.1 fallback still short circuits');
-  assert(decision.directResponse !== null, 'CS-05.2 has directResponse');
+  // 无 workflow_action 时不再短路 LLM，改为 conservative_answer + 证据注入兜底
+  assert(!decision.isShortCircuit, 'CS-05.1 not short circuit (defensive fallback)');
+  assertEqual(decision.directResponse, null, 'CS-05.2 no directResponse');
+  assert(decision.evidenceInjection !== null, 'CS-05.3 has evidenceInjection');
+  assert(decision.evidenceInjection.includes('依据有限') || decision.evidenceInjection.includes('保守回答'),
+    'CS-05.4 falls back to conservative constraint');
+}
+
+// ============================================================
+// CS-08: action/mode 冲突 → action 胜出（P0 补强测试）
+// ============================================================
+
+function testActionModeConflictActionWins() {
+  console.log('\n📋 CS-08: workflow_action 与旧 suggested_response_mode 冲突 → action 胜出');
+
+  const svc = makeChatService();
+  // 构造真正的冲突输入：
+  // workflow_action=return_document_candidates（应短路 LLM，输出候选列表）
+  // 但旧 suggested_response_mode=conservative_answer（应保守回答）
+  const result = {
+    success: true,
+    workflow_action: 'return_document_candidates',
+    // 即使旧兼容字段还在（防御测试），action 必须胜出
+    suggested_response_mode: 'conservative_answer',
+    documents: [
+      { document_id: 'd1', document_title: 'Contract Alpha', doc_type: 'contract', collection_name: 'Col', relevance_score: 90, candidate_confidence: 'high', top_evidence: [{ content: '违约金条款摘要', score: 0.85 }] },
+    ],
+    evidence_sufficiency: 'medium',
+    strategy: 'document_first',
+  };
+
+  const decision = svc._getResponseModeDecision(result);
+
+  // 关键断言：action 胜出 → 短路 LLM，输出候选列表
+  assert(decision.isShortCircuit, 'CS-08.1 action wins: isShortCircuit=true');
+  assert(decision.directResponse !== null, 'CS-08.2 action wins: has directResponse');
+  assert(decision.directResponse.includes('Contract Alpha'), 'CS-08.3 action wins: contains candidate doc');
+  // 不应进入 conservative_answer 路径
+  assert(!decision.evidenceInjection?.includes('依据有限'),
+    'CS-08.4 action wins: NOT conservative (would contain 依据有限)');
 }
 
 // ============================================================
@@ -185,8 +223,8 @@ function testResolveConstraintModeMapping() {
   assertEqual(svc._resolveConstraintMode({ workflow_action: 'decline_due_to_insufficient_evidence' }), 'conservative_answer', 'CS-06.3 decline → conservative');
   assertEqual(svc._resolveConstraintMode({ workflow_action: 'answer_with_ranked_chunks', evidence_sufficiency: 'strong' }), 'answer_with_citation', 'CS-06.4 strong → answer_with_citation');
   assertEqual(svc._resolveConstraintMode({ workflow_action: 'answer_with_ranked_chunks', evidence_sufficiency: 'weak' }), 'direct_answer', 'CS-06.5 weak → direct_answer');
-  // fallback 到 suggested_response_mode
-  assertEqual(svc._resolveConstraintMode({ suggested_response_mode: 'conservative_answer' }), 'conservative_answer', 'CS-06.6 no action → fallback');
+  // 无 workflow_action → 防御性兜底 conservative_answer（audit-round04 变更项 A）
+  assertEqual(svc._resolveConstraintMode({ suggested_response_mode: 'conservative_answer' }), 'conservative_answer', 'CS-06.6 no action → defensive conservative default');
 }
 
 // ============================================================
@@ -218,16 +256,17 @@ function testBuildResponseModeConstraint() {
 function main() {
   console.log('╔══════════════════════════════════════╗');
   console.log('║  Chat-Service 消费层联调测试        ║');
-  console.log('║  (audit-round03 变更项 C)           ║');
+  console.log('║  (audit-round04 变更项 D)           ║');
   console.log('╚══════════════════════════════════════╝');
 
   testReturnDocumentCandidatesShortCircuits();
   testAnswerWithRankedChunksInjectsEvidence();
   testDeclineInsufficientEvidenceConservativeAnswer();
   testAskForClarificationConstraint();
-  testFallbackToSuggestedResponseMode();
+  testNoWorkflowActionDefensiveFallback();
   testResolveConstraintModeMapping();
   testBuildResponseModeConstraint();
+  testActionModeConflictActionWins();
 
   console.log(`\n========================================`);
   console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);

--- a/tests/document-atomic-tools.test.js
+++ b/tests/document-atomic-tools.test.js
@@ -64,6 +64,34 @@ function makeAtomicTools(opts = {}) {
   });
 }
 
+// audit-round04 变更项 F：6 chunk 的测试数据集（3 个 doc × 2 chunk），供排序测试复用
+function makeChunks3x2(scoreOffsets = []) {
+  const docs = [
+    { id: 'd1', title: 'GB 4785', type: 'standard' },
+    { id: 'd2', title: 'QCT 625', type: 'standard' },
+    { id: 'd3', title: 'GB/T 4208', type: 'standard' },
+  ];
+  const chunks = [];
+  for (const doc of docs) {
+    for (let i = 0; i < 2; i++) {
+      chunks.push({
+        chunk_id: `${doc.id}_c${i}`,
+        document_id: doc.id,
+        document_title: doc.title,
+        chunk_title: `条款${i + 1}`,
+        content: `${doc.title}的第${i + 1}部分内容`,
+        score: scoreOffsets.length > 0 ? scoreOffsets[chunks.length] : 0.5,
+        doc_type: doc.type,
+        collection_id: 'col-1',
+        revision_id: `${doc.id}_r1`,
+        outline_id: `o_${doc.id}`,
+        seq: i + 1,
+      });
+    }
+  }
+  return chunks;
+}
+
 // ============================================================
 // 1. search_documents_by_metadata
 // ============================================================
@@ -370,6 +398,47 @@ async function testResolveDocumentsEmptyChunks() {
 }
 
 // ============================================================
+// audit-round04 变更项 F：reranker 契约测试
+// ============================================================
+
+function testDefaultHeuristicRanking() {
+  // 验证无 reranker 注入时，默认启发式公式正常工作
+  const tools = makeAtomicTools();
+  const chunks = makeChunks3x2();
+  const r = tools.rankChunksForQuestion({ question: '违约金 合同', chunks });
+  assert(r.success, 'AT-RR-01.1 rank success');
+  assertEqual(r.total, 6, 'AT-RR-01.2 total=6');
+  // 第一条应是最高分（前2条命中“合同”关键词，需全覆盖）
+  assert(r.chunks[0].rank_score > 0, 'AT-RR-01.3 top chunk has positive score');
+  assert(r.chunks[0].rank_signals, 'AT-RR-01.4 has rank_signals');
+  assert(r.chunks[0].rank_signals.vector_score > 0, 'AT-RR-01.5 vector_score > 0');
+  assert(r.chunks[0].rank_score >= r.chunks[5].rank_score, 'AT-RR-01.6 descending order');
+}
+
+function testInjectedRerankerOverridesDefault() {
+  // 验证注入自定义 reranker 后，排序使用 computeScore 结果
+  // DocumentAtomicTools(db, configLoader, deps)，deps 包含 reranker
+  const deps = {
+    searchService: makeMockSearchService(),
+    recallService: makeMockRecallService(),
+    accessService: makeMockAccessService(),
+    reranker: { computeScore(_chunk, signals) { return signals.vector_score * 2; } },
+  };
+  const tools = new DocumentAtomicTools(makeMockDb(), null, deps);
+  const chunks = makeChunks3x2();
+
+  // 手动注入不同 vector_score，验证 reranker 生效
+  const modifiedChunks = chunks.map((c, i) => ({ ...c, score: (i % 2 === 1) ? 0.9 : 0.1 }));
+  const r = tools.rankChunksForQuestion({ question: '合同', chunks: modifiedChunks });
+  assert(r.success, 'AT-RR-02.1 rank success');
+  // 自定义 reranker 用 vector_score*2，前3条 odd 行 score=0.9*2=1.8 应排前3
+  assert(r.chunks[0].rank_score > r.chunks[3].rank_score, 'AT-RR-02.2 custom reranker drives ordering');
+  // 验证 rank_score 在合理范围
+  assert(Math.abs(r.chunks[0].rank_score - 1.8) < 0.01,
+    'AT-RR-02.3 custom reranker score ~=1.8 (0.9*2)');
+}
+
+// ============================================================
 // 运行
 // ============================================================
 
@@ -394,6 +463,8 @@ async function main() {
   testRankChunksNullChunks();
   await testResolveDocumentsFromChunks();
   await testResolveDocumentsEmptyChunks();
+  testDefaultHeuristicRanking();
+  testInjectedRerankerOverridesDefault();
 
   console.log(`\n${'='.repeat(40)}`);
   console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);

--- a/tests/document-atomic-tools.test.js
+++ b/tests/document-atomic-tools.test.js
@@ -1,0 +1,405 @@
+/**
+ * DocumentAtomicTools 契约测试
+ *
+ * 验证六个原子 tool 的输入输出契约，使用构造函数 DI mock 不依赖数据库。
+ *
+ * audit-round01 Phase 1 交付物。
+ * 运行：node tests/document-atomic-tools.test.js
+ */
+
+import DocumentAtomicTools from '../lib/document-atomic-tools.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual === expected) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label} | expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`); }
+}
+
+// ============================================================
+// Mock 工厂
+// ============================================================
+
+function makeMockSearchService(overrides = {}) {
+  return {
+    search: async (q, opts) => (overrides.searchResult || { success: true, candidates: [], total: 0 }),
+    searchByAttachmentFilenames: async (q, opts) => (overrides.attachResult || []),
+    getDocumentInfo: async (ids) => (overrides.docInfo || []),
+  };
+}
+
+function makeMockRecallService(overrides = {}) {
+  return {
+    recall: async (q, opts) => (overrides.globalResult || { success: true, items: [] }),
+    recallWithinDocuments: async (q, docIds, opts) => (overrides.scopedResult || { success: true, items: [] }),
+  };
+}
+
+function makeMockAccessService(accessibleIds = ['col-1']) {
+  return {
+    getAccessibleCollectionIds: async (uid) => accessibleIds,
+  };
+}
+
+function makeMockDb(chunkRows = []) {
+  return {
+    sequelize: {
+      query: async (sql, opts) => chunkRows,
+      QueryTypes: { SELECT: 'SELECT' },
+    },
+  };
+}
+
+function makeAtomicTools(opts = {}) {
+  return new DocumentAtomicTools(opts.db || makeMockDb(), null, {
+    searchService: opts.searchService || makeMockSearchService(),
+    recallService: opts.recallService || makeMockRecallService(),
+    accessService: opts.accessService || makeMockAccessService(),
+  });
+}
+
+// ============================================================
+// 1. search_documents_by_metadata
+// ============================================================
+
+async function testSearchByMetadataDefault() {
+  console.log('\n📋 AT-01: search_documents_by_metadata（标题+元数据）');
+
+  const mockSearch = makeMockSearchService({
+    searchResult: {
+      success: true,
+      candidates: [
+        { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 95 },
+      ],
+      total: 1,
+    },
+  });
+  const tools = makeAtomicTools({ searchService: mockSearch });
+
+  const r = await tools.searchDocumentsByMetadata({
+    metadata_query: 'GB/T 4208',
+    user_id: 'u1',
+  });
+
+  assert(r.success, 'AT-01.1 success=true');
+  assertEqual(r.matched_by, 'title_metadata', 'AT-01.2 matched_by title_metadata');
+  assertEqual(r.documents.length, 1, 'AT-01.3 1 document');
+  assertEqual(r.documents[0].document_id, 'd1', 'AT-01.4 doc id');
+  assertEqual(r.total, 1, 'AT-01.5 total=1');
+}
+
+async function testSearchByAttachmentFilename() {
+  console.log('\n📋 AT-02: search_documents_by_metadata（附件文件名）');
+
+  const mockSearch = makeMockSearchService({
+    attachResult: [
+      { document_id: 'd2', document_title: 'Intake-001', best_identity_label: '施工合同附件A.pdf', matched_attachment: '施工合同附件A.pdf' },
+    ],
+  });
+  const tools = makeAtomicTools({ searchService: mockSearch });
+
+  const r = await tools.searchDocumentsByMetadata({
+    metadata_query: '施工合同',
+    user_id: 'u1',
+    match_fields: ['attachment_filename'],
+  });
+
+  assert(r.success, 'AT-02.1 success=true');
+  assertEqual(r.matched_by, 'attachment_filename', 'AT-02.2 matched_by');
+  assertEqual(r.documents[0].matched_attachment, '施工合同附件A.pdf', 'AT-02.3 attachment name');
+}
+
+async function testSearchEmptyQuery() {
+  console.log('\n📋 AT-03: search_documents_by_metadata（空 query 报错）');
+
+  const tools = makeAtomicTools();
+  const r = await tools.searchDocumentsByMetadata({ metadata_query: '', user_id: 'u1' });
+
+  assert(!r.success, 'AT-03.1 success=false');
+  assert(r.error, 'AT-03.2 有 error');
+  assertEqual(r.documents.length, 0, 'AT-03.3 空 documents');
+}
+
+// ============================================================
+// 2. read_document_content
+// ============================================================
+
+async function testReadDocumentContent() {
+  console.log('\n📋 AT-04: read_document_content（正常读取）');
+
+  const mockSearch = makeMockSearchService({
+    docInfo: [{ document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_id: 'col-1', collection_name: '标准库' }],
+  });
+  const mockDb = makeMockDb([
+    { chunk_id: 'c1', outline_id: 'o1', chunk_title: 'Ch1', content: 'IPX5试验：喷嘴内径6.3mm', seq: 1 },
+    { chunk_id: 'c2', outline_id: 'o1', chunk_title: 'Ch2', content: '水流量12.5L/min', seq: 2 },
+  ]);
+  const tools = makeAtomicTools({
+    searchService: mockSearch,
+    db: mockDb,
+  });
+
+  const r = await tools.readDocumentContent({
+    document_id: 'd1',
+    user_id: 'u1',
+    include_chunks: true,
+    max_chars: 500,
+  });
+
+  assert(r.success, 'AT-04.1 success=true');
+  assertEqual(r.document.document_id, 'd1', 'AT-04.2 doc id');
+  assert(r.content.includes('IPX5试验'), 'AT-04.3 content 含第一个 chunk');
+  assert(r.content.includes('12.5L/min'), 'AT-04.4 content 含第二个 chunk');
+  assert(!r.content_truncated, 'AT-04.5 未截断');
+  assertEqual(r.total_chunks, 2, 'AT-04.6 total_chunks=2');
+  assertEqual(r.chunks.length, 2, 'AT-04.7 include_chunks 返回 chunk 列表');
+}
+
+async function testReadDocumentContentTruncated() {
+  console.log('\n📋 AT-05: read_document_content（截断）');
+
+  const mockSearch = makeMockSearchService({
+    docInfo: [{ document_id: 'd1', document_title: 'Test', doc_type: 'standard', collection_id: 'col-1' }],
+  });
+  const mockDb = makeMockDb([
+    { chunk_id: 'c1', outline_id: 'o1', chunk_title: '', content: 'A'.repeat(30), seq: 1 },
+  ]);
+  const tools = makeAtomicTools({ searchService: mockSearch, db: mockDb });
+
+  const r = await tools.readDocumentContent({ document_id: 'd1', user_id: 'u1', max_chars: 10 });
+  assert(r.success, 'AT-05.1 success');
+  assert(r.content_truncated, 'AT-05.2 content_truncated=true');
+  assert(r.content.length <= 10, 'AT-05.3 长度受 max_chars 限制');
+}
+
+async function testReadDocumentNotFound() {
+  console.log('\n📋 AT-06: read_document_content（文档不存在）');
+
+  const tools = makeAtomicTools({ searchService: makeMockSearchService({ docInfo: [] }) });
+  const r = await tools.readDocumentContent({ document_id: 'nx', user_id: 'u1' });
+  assert(!r.success, 'AT-06.1 success=false');
+  assertEqual(r.error, 'document_not_found', 'AT-06.2 not found');
+}
+
+async function testReadDocumentAccessDenied() {
+  console.log('\n📋 AT-07: read_document_content（无权限）');
+
+  const mockSearch = makeMockSearchService({
+    docInfo: [{ document_id: 'd1', document_title: 'Test', collection_id: 'col-secret' }],
+  });
+  const mockAccess = makeMockAccessService(['col-1']);
+  const tools = makeAtomicTools({ searchService: mockSearch, accessService: mockAccess });
+  const r = await tools.readDocumentContent({ document_id: 'd1', user_id: 'u1' });
+  assert(!r.success, 'AT-07.1 success=false');
+  assertEqual(r.error, 'access_denied', 'AT-07.2 access denied');
+}
+
+// ============================================================
+// 3. search_chunks_in_document
+// ============================================================
+
+async function testSearchChunksInDocument() {
+  console.log('\n📋 AT-08: search_chunks_in_document');
+
+  const mockRecall = makeMockRecallService({
+    scopedResult: {
+      success: true,
+      items: [
+        { chunk: { id: 'c1', title: '条款X', content: '试验条件...', outline_id: 'o1', seq: 5 }, document: { id: 'd1', title: 'GB/T 4208', doc_type: 'standard', collection_id: 'col-1' }, revision: { id: 'r1' }, score: 0.85 },
+      ],
+    },
+  });
+  const tools = makeAtomicTools({ recallService: mockRecall });
+
+  const r = await tools.searchChunksInDocument({
+    content_query: '试验条件',
+    document_ids: ['d1'],
+    user_id: 'u1',
+  });
+
+  assert(r.success, 'AT-08.1 success=true');
+  assertEqual(r.chunks.length, 1, 'AT-08.2 1 chunk');
+  assertEqual(r.chunks[0].chunk_id, 'c1', 'AT-08.3 chunk_id');
+  assertEqual(r.chunks[0].score, 0.85, 'AT-08.4 score');
+  assertEqual(r.chunks[0].document_id, 'd1', 'AT-08.5 document_id');
+}
+
+async function testSearchChunksInDocumentNoTarget() {
+  console.log('\n📋 AT-09: search_chunks_in_document（无目标文档）');
+
+  const tools = makeAtomicTools();
+  const r = await tools.searchChunksInDocument({
+    content_query: 'test',
+    document_ids: [],
+    user_id: 'u1',
+  });
+  assert(r.success, 'AT-09.1 success=true（空目标不是错误）');
+  assertEqual(r.total, 0, 'AT-09.2 total=0');
+}
+
+// ============================================================
+// 4. search_chunks_globally
+// ============================================================
+
+async function testSearchChunksGlobally() {
+  console.log('\n📋 AT-10: search_chunks_globally');
+
+  const mockRecall = makeMockRecallService({
+    globalResult: {
+      success: true,
+      items: [
+        { chunk: { id: 'c1', title: 'Intro', content: '这是预览内容...', outline_id: 'o1', seq: 1 }, document: { id: 'd1', title: 'Doc A', doc_type: 'contract', collection_id: 'col-1' }, revision: { id: 'r1' }, score: 0.72 },
+      ],
+    },
+  });
+  const tools = makeAtomicTools({ recallService: mockRecall });
+
+  const r = await tools.searchChunksGlobally({
+    content_query: '重要条款',
+    user_id: 'u1',
+    top_k: 5,
+  });
+
+  assert(r.success, 'AT-10.1 success=true');
+  assertEqual(r.chunks.length, 1, 'AT-10.2 1 chunk');
+  assertEqual(r.chunks[0].content, '这是预览内容...', 'AT-10.3 content');
+}
+
+async function testSearchChunksGloballyEmptyQuery() {
+  console.log('\n📋 AT-11: search_chunks_globally（空 query 报错）');
+
+  const tools = makeAtomicTools();
+  const r = await tools.searchChunksGlobally({ content_query: '', user_id: 'u1' });
+  assert(!r.success, 'AT-11.1 success=false');
+}
+
+// ============================================================
+// 5. rank_chunks_for_question
+// ============================================================
+
+function testRankChunksForQuestion() {
+  console.log('\n📋 AT-12: rank_chunks_for_question');
+
+  const tools = makeAtomicTools();
+  const chunks = [
+    { chunk_id: 'c1', document_id: 'd1', document_title: 'GB 4785', chunk_title: '车身术语', content: '本标准规定了汽车车身术语和定义...', score: 0.80, doc_type: 'standard', collection_id: 'c1', revision_id: 'r1', outline_id: 'o1', seq: 1 },
+    { chunk_id: 'c2', document_id: 'd2', document_title: '其他标准', chunk_title: '通用', content: '这是一份通用的管理体系文件...', score: 0.75, doc_type: 'standard', collection_id: 'c1', revision_id: 'r2', outline_id: 'o2', seq: 1 },
+  ];
+
+  const r = tools.rankChunksForQuestion({
+    question: '车身术语标准定义',
+    chunks,
+    locked_document_ids: ['d1'],
+    top_k: 2,
+  });
+
+  assert(r.success, 'AT-12.1 success=true');
+  assertEqual(r.total, 2, 'AT-12.2 total=2');
+  assert(r.chunks[0].rank_score !== undefined, 'AT-12.3 有 rank_score');
+  assert(r.chunks[0].rank_score > r.chunks[1].rank_score, 'AT-12.4 locked d1 排前面');
+  assert(r.chunks[0].rank_signals.locked_bonus === 1, 'AT-12.5 locked_bonus=1');
+  assert(r.chunks[1].rank_signals.locked_bonus === 0, 'AT-12.6 非锁定文档 locked_bonus=0');
+}
+
+function testRankChunksEmptyInput() {
+  console.log('\n📋 AT-13: rank_chunks_for_question（空输入）');
+
+  const tools = makeAtomicTools();
+  const r = tools.rankChunksForQuestion({ question: 'test', chunks: [] });
+  assert(r.success, 'AT-13.1 success=true');
+  assertEqual(r.total, 0, 'AT-13.2 total=0');
+}
+
+function testRankChunksNullChunks() {
+  console.log('\n📋 AT-14: rank_chunks_for_question（null chunks）');
+
+  const tools = makeAtomicTools();
+  const r = tools.rankChunksForQuestion({ question: 'test', chunks: null });
+  assert(!r.success, 'AT-14.1 success=false');
+}
+
+// ============================================================
+// 6. resolve_documents_from_chunks
+// ============================================================
+
+async function testResolveDocumentsFromChunks() {
+  console.log('\n📋 AT-15: resolve_documents_from_chunks');
+
+  const mockSearch = makeMockSearchService({
+    docInfo: [
+      { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_id: 'col-1', collection_name: '标准库' },
+      { document_id: 'd2', document_title: '其他标准', doc_type: 'standard', collection_id: 'col-1', collection_name: '标准库' },
+    ],
+  });
+  const tools = makeAtomicTools({ searchService: mockSearch });
+
+  const chunks = [
+    { document_id: 'd1', chunk_id: 'c1', content: 'A1', score: 0.9, doc_type: 'standard' },
+    { document_id: 'd1', chunk_id: 'c2', content: 'A2', score: 0.7, doc_type: 'standard' },
+    { document_id: 'd2', chunk_id: 'c3', content: 'B1', score: 0.3, doc_type: 'standard' },
+  ];
+
+  const r = await tools.resolveDocumentsFromChunks({
+    chunks,
+    aggregate: true,
+  });
+
+  assert(r.success, 'AT-15.1 success=true');
+  assertEqual(r.documents.length, 2, 'AT-15.2 2 documents');
+  // d1 应排在 d2 前面（max_chunk_score 更高）
+  assertEqual(r.documents[0].document_id, 'd1', 'AT-15.3 d1 排第一');
+  assertEqual(r.documents[0].chunk_count, 2, 'AT-15.4 d1 chunk_count=2');
+  assertEqual(r.documents[0].max_chunk_score, 0.9, 'AT-15.5 max_chunk_score=0.9');
+  assert(r.documents[0].top_chunk, 'AT-15.6 有 top_chunk');
+  assertEqual(r.documents[1].chunk_count, 1, 'AT-15.7 d2 chunk_count=1');
+}
+
+async function testResolveDocumentsEmptyChunks() {
+  console.log('\n📋 AT-16: resolve_documents_from_chunks（空输入）');
+
+  const tools = makeAtomicTools();
+  const r = await tools.resolveDocumentsFromChunks({ chunks: [] });
+  assert(r.success, 'AT-16.1 success=true');
+  assertEqual(r.total, 0, 'AT-16.2 total=0');
+}
+
+// ============================================================
+// 运行
+// ============================================================
+
+async function main() {
+  console.log('╔══════════════════════════════════════╗');
+  console.log('║  Document Atomic Tools 契约测试     ║');
+  console.log('╚══════════════════════════════════════╝');
+
+  await testSearchByMetadataDefault();
+  await testSearchByAttachmentFilename();
+  await testSearchEmptyQuery();
+  await testReadDocumentContent();
+  await testReadDocumentContentTruncated();
+  await testReadDocumentNotFound();
+  await testReadDocumentAccessDenied();
+  await testSearchChunksInDocument();
+  await testSearchChunksInDocumentNoTarget();
+  await testSearchChunksGlobally();
+  await testSearchChunksGloballyEmptyQuery();
+  testRankChunksForQuestion();
+  testRankChunksEmptyInput();
+  testRankChunksNullChunks();
+  await testResolveDocumentsFromChunks();
+  await testResolveDocumentsEmptyChunks();
+
+  console.log(`\n${'='.repeat(40)}`);
+  console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+  console.log(`${'='.repeat(40)}`);
+
+  if (failed > 0) process.exit(1);
+}
+
+main();

--- a/tests/document-retrieval-integration.test.js
+++ b/tests/document-retrieval-integration.test.js
@@ -1,0 +1,325 @@
+/**
+ * Document Retrieval 集成测试 — 桥接层行为验证
+ *
+ * audit-round02 变更项 C：
+ * 验证新 workflow + 真实 DocumentEvidencePacker 组合后的行为正确性，
+ * 重点测试 packet → action 映射、evidence_sufficiency 判定、
+ * verify_fact verdict 映射。
+ *
+ * 运行：node tests/document-retrieval-integration.test.js
+ */
+
+import DocumentRetrievalWorkflow from '../lib/document-retrieval-workflow.js';
+import DocumentEvidencePacker from '../lib/document-evidence-packer.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual === expected) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label} | expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`); }
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function makeChunk(docId, content, score) {
+  return {
+    chunk_id: `c_${docId}_${Math.random().toString(36).substring(2, 6)}`,
+    document_id: docId,
+    document_title: `Doc-${docId}`,
+    doc_type: 'contract',
+    collection_id: 'col-1',
+    revision_id: 'r1',
+    outline_id: null,
+    seq: 1,
+    chunk_title: '',
+    content,
+    score,
+  };
+}
+
+function makeCandidate(docId, title, relevance) {
+  return {
+    document_id: docId,
+    document_title: title,
+    doc_type: 'contract',
+    collection_id: 'col-1',
+    collection_name: '合同库',
+    relevance_score: relevance,
+    candidate_confidence: relevance >= 70 ? 'high' : 'low',
+  };
+}
+
+function makeMockAtomicTools(metaDocs, scopedChunks) {
+  return {
+    searchDocumentsByMetadata: async () => ({
+      success: true,
+      documents: metaDocs,
+      total: metaDocs.length,
+      matched_by: 'title_metadata',
+    }),
+    searchChunksInDocument: async () => ({
+      success: true,
+      chunks: scopedChunks,
+      total: scopedChunks.length,
+    }),
+    searchChunksGlobally: async () => ({
+      success: true,
+      chunks: [],
+      total: 0,
+    }),
+    rankChunksForQuestion: (p) => ({ success: true, chunks: p.chunks || [], total: (p.chunks || []).length }),
+    resolveDocumentsFromChunks: async () => ({ success: true, documents: [], total: 0 }),
+  };
+}
+
+function makeMockAccessService() {
+  return { getAccessibleCollectionIds: async () => ['col-1'] };
+}
+
+function makeMockDecisionService(strategy = 'document_first') {
+  return {
+    analyze: () => ({
+      intent: 'factual_lookup',
+      anchor_strength: 'medium',
+      confidence: 0.7,
+      recommended_strategy: strategy,
+      reason_codes: [],
+    }),
+    hints: () => ({
+      user_query: 'test',
+      document_hints: [],
+      topic_terms: [],
+      content_terms: ['test'],
+      has_explicit_document_anchor: false,
+      intent_hint: 'factual_lookup',
+      initial_strategy_hint: strategy,
+      analysis: {},
+    }),
+  };
+}
+
+// ============================================================
+// INT-01: 单文档 + 强证据 → answer_with_ranked_chunks
+// ============================================================
+
+async function testStrongEvidenceSingleDoc() {
+  console.log('\n📋 INT-01: 单文档 + 强证据（3 chunks, max≥0.8）→ answer_with_ranked_chunks');
+
+  const chunks = [
+    makeChunk('d1', '合同条款第3条明确约定：违约责任按日万分之五计算。', 0.92),
+    makeChunk('d1', '违约金计算方式：逾期付款金额 × 0.05% × 逾期天数。', 0.85),
+    makeChunk('d1', '双方确认上述违约金标准为协商结果。', 0.81),
+  ];
+  const candidates = [makeCandidate('d1', '施工合同-2024', 95)];
+
+  const wf = new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: makeMockAtomicTools(candidates, chunks),
+    accessService: makeMockAccessService(),
+    decisionService: makeMockDecisionService(),
+    packer: new DocumentEvidencePacker(),
+  });
+
+  const r = await wf.runAnswerQuestion({ query: '违约金计算标准', user_id: 'u1' });
+
+  assert(r.success, 'INT-01.1 success');
+  assertEqual(r.action, 'answer_with_ranked_chunks', 'INT-01.2 action=answer_with_ranked_chunks');
+  assertEqual(r.evidence_sufficiency, 'strong', 'INT-01.3 sufficiency=strong');
+  assertEqual(r.documents.length, 1, 'INT-01.4 1 doc');
+  assert(r.documents[0].evidence_count >= 3, 'INT-01.5 ≥3 evidence items');
+  assert(r.steps.map(s => s.step).includes('evidence_packing'), 'INT-01.6 evidence_packing visible');
+  assert(!r.should_clarify, 'INT-01.7 should not clarify');
+}
+
+// ============================================================
+// INT-02: 多文档 + 弱证据 → return_document_candidates
+// ============================================================
+
+async function testWeakEvidenceMultipleDocs() {
+  console.log('\n📋 INT-02: 多文档 + 弱证据（2 chunks, max<0.6）→ return_document_candidates');
+
+  const chunks = [
+    makeChunk('d1', '提及相关概念但无明确依据', 0.45),
+    makeChunk('d2', '另一文档也涉及该主题', 0.42),
+  ];
+  const candidates = [
+    makeCandidate('d1', '合同A', 80),
+    makeCandidate('d2', '合同B', 75),
+    makeCandidate('d3', '合同C', 70),
+  ];
+
+  const wf = new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: makeMockAtomicTools(candidates, chunks),
+    accessService: makeMockAccessService(),
+    decisionService: makeMockDecisionService(),
+    packer: new DocumentEvidencePacker(),
+  });
+
+  const r = await wf.runAnswerQuestion({ query: '模糊查询', user_id: 'u1' });
+
+  assert(r.success, 'INT-02.1 success');
+  assertEqual(r.action, 'return_document_candidates', 'INT-02.2 action=return_document_candidates');
+  assertEqual(r.evidence_sufficiency, 'weak', 'INT-02.3 sufficiency=weak');
+  assert(r.documents.length >= 3, 'INT-02.4 ≥3 candidates');
+}
+
+// ============================================================
+// INT-03: 零文档零证据 → decline
+// ============================================================
+
+async function testNoEvidenceDecline() {
+  console.log('\n📋 INT-03: 零文档零证据 → decline_due_to_insufficient_evidence');
+
+  const wf = new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: makeMockAtomicTools([], []),
+    accessService: makeMockAccessService(),
+    decisionService: makeMockDecisionService(),
+    packer: new DocumentEvidencePacker(),
+  });
+
+  const r = await wf.runAnswerQuestion({ query: '不存在的内容XYZ', user_id: 'u1' });
+
+  assert(r.success, 'INT-03.1 success (decline is success)');
+  assertEqual(r.action, 'decline_due_to_insufficient_evidence', 'INT-03.2 action=decline');
+  assertEqual(r.evidence_sufficiency, 'none', 'INT-03.3 sufficiency=none');
+  assertEqual(r.documents.length, 0, 'INT-03.4 0 docs');
+}
+
+// ============================================================
+// INT-04: verify_fact — strong → supported（真实 packer 映射）
+// ============================================================
+
+async function testVerifyFactStrongToSupported() {
+  console.log('\n📋 INT-04: verify_fact strong → supported（真实 packer 判定）');
+
+  const chunks = [
+    makeChunk('d1', '根据GB/T 4208-2017标准，IPX5防护等级要求喷嘴内径6.3mm，水流量12.5L/min。', 0.93),
+    makeChunk('d1', '试验条件：水温为常温，试验持续时间至少3分钟。', 0.86),
+    makeChunk('d1', 'IPX5试验后，外壳内部不应进水。', 0.82),
+  ];
+  const candidates = [makeCandidate('d1', 'GB/T 4208-2017 外壳防护等级', 95)];
+
+  const wf = new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: makeMockAtomicTools(candidates, chunks),
+    accessService: makeMockAccessService(),
+    decisionService: makeMockDecisionService(),
+    packer: new DocumentEvidencePacker(),
+  });
+
+  const r = await wf.runVerifyFact({ query: 'IPX5试验条件要求喷嘴内径6.3mm', user_id: 'u1' });
+
+  assertEqual(r.verdict, 'supported', 'INT-04.1 verdict=supported');
+  assert(r.supporting_evidence.length > 0, 'INT-04.2 has supporting evidence');
+  assertEqual(r.action, 'answer_with_ranked_chunks', 'INT-04.3 action');
+  assert(r.supporting_evidence[0].document_id, 'INT-04.4 evidence has document_id');
+  assert(r.supporting_evidence[0].score > 0.8, 'INT-04.5 evidence score preserved');
+}
+
+// ============================================================
+// INT-05: verify_fact — weak → insufficient_evidence
+// ============================================================
+
+async function testVerifyFactWeakToInsufficient() {
+  console.log('\n📋 INT-05: verify_fact weak → insufficient_evidence（真实 packer 判定）');
+
+  const chunks = [
+    makeChunk('d1', '可能相关的内容片段', 0.35),
+  ];
+  const candidates = [makeCandidate('d1', '某文档', 40)];
+
+  const wf = new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: makeMockAtomicTools(candidates, chunks),
+    accessService: makeMockAccessService(),
+    decisionService: makeMockDecisionService(),
+    packer: new DocumentEvidencePacker(),
+  });
+
+  const r = await wf.runVerifyFact({ query: '不存在的事实主张', user_id: 'u1' });
+
+  assertEqual(r.verdict, 'insufficient_evidence', 'INT-05.1 verdict=insufficient_evidence');
+  assertEqual(r.supporting_evidence.length, 0, 'INT-05.2 no supporting evidence');
+  assertEqual(r.action, 'decline_due_to_insufficient_evidence', 'INT-05.3 action=decline');
+}
+
+// ============================================================
+// INT-06: 中等证据 + 单文档 → answer_with_ranked_chunks
+// ============================================================
+
+async function testMediumEvidenceSingleDoc() {
+  console.log('\n📋 INT-06: 中等证据（max≥0.6, ≥1 chunk）→ answer_with_ranked_chunks');
+
+  const chunks = [
+    makeChunk('d1', '合同约定交货期为2024年6月30日前。', 0.72),
+    makeChunk('d1', '逾期交货按合同总额的0.1%每日计算违约金。', 0.68),
+  ];
+  const candidates = [makeCandidate('d1', '供货合同', 85)];
+
+  const wf = new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: makeMockAtomicTools(candidates, chunks),
+    accessService: makeMockAccessService(),
+    decisionService: makeMockDecisionService(),
+    packer: new DocumentEvidencePacker(),
+  });
+
+  const r = await wf.runAnswerQuestion({ query: '交货期约定', user_id: 'u1' });
+
+  assert(r.success, 'INT-06.1 success');
+  assertEqual(r.action, 'answer_with_ranked_chunks', 'INT-06.2 action=answer_with_ranked_chunks');
+  assertEqual(r.evidence_sufficiency, 'medium', 'INT-06.3 sufficiency=medium');
+  assert(r.documents[0].top_evidence.length === 2, 'INT-06.4 2 evidence items');
+}
+
+// ============================================================
+// INT-07: 决策直接建议 clarify → ask_for_clarification
+// ============================================================
+
+async function testDecisionClarify() {
+  console.log('\n📋 INT-07: decision 建议 clarify → ask_for_clarification');
+
+  const wf = new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: makeMockAtomicTools([], []),
+    accessService: makeMockAccessService(),
+    decisionService: makeMockDecisionService('clarify'),
+    packer: new DocumentEvidencePacker(),
+  });
+
+  const r = await wf.runAnswerQuestion({ query: '帮我看看', user_id: 'u1' });
+
+  assertEqual(r.action, 'decline_due_to_insufficient_evidence', 'INT-07.1 clarify→decline');
+  assertEqual(r.strategy, 'degrade', 'INT-07.2 strategy=degrade');
+  assert(r.reason_codes.includes('ambiguous_query'), 'INT-07.3 ambiguous_query');
+}
+
+// ============================================================
+// 运行
+// ============================================================
+
+async function main() {
+  console.log('╔══════════════════════════════════════╗');
+  console.log('║  Document Retrieval 集成测试        ║');
+  console.log('║  (audit-round02 变更项 C)           ║');
+  console.log('╚══════════════════════════════════════╝');
+
+  await testStrongEvidenceSingleDoc();
+  await testWeakEvidenceMultipleDocs();
+  await testNoEvidenceDecline();
+  await testVerifyFactStrongToSupported();
+  await testVerifyFactWeakToInsufficient();
+  await testMediumEvidenceSingleDoc();
+  await testDecisionClarify();
+
+  console.log(`\n========================================`);
+  console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+  console.log(`========================================`);
+
+  if (failed > 0) process.exit(1);
+}
+
+main();

--- a/tests/document-retrieval-integration.test.js
+++ b/tests/document-retrieval-integration.test.js
@@ -135,7 +135,8 @@ async function testStrongEvidenceSingleDoc() {
   assertEqual(r.documents.length, 1, 'INT-01.4 1 doc');
   assert(r.documents[0].evidence_count >= 3, 'INT-01.5 ≥3 evidence items');
   assert(r.steps.map(s => s.step).includes('evidence_packing'), 'INT-01.6 evidence_packing visible');
-  assert(!r.should_clarify, 'INT-01.7 should not clarify');
+  // audit-round04 变更项 A：should_clarify 已删除，用 workflow_action 替代
+  assertEqual(r.action, 'answer_with_ranked_chunks', 'INT-01.7 action not ask_for_clarification');
 }
 
 // ============================================================

--- a/tests/document-retrieval-workflow.test.js
+++ b/tests/document-retrieval-workflow.test.js
@@ -57,6 +57,14 @@ function makeMockDecisionService(overrides = {}) {
       initial_strategy_hint: 'chunk_first',
       analysis: {},
     }),
+    // audit-round02 变更项 A：runAnswerQuestion 新增决策分析调用
+    analyze: (q, ctx) => (overrides.analyzeResult || {
+      intent: 'informational',
+      anchor_strength: 'medium',
+      confidence: 0.6,
+      recommended_strategy: 'document_first',
+      reason_codes: [],
+    }),
   };
 }
 
@@ -75,6 +83,7 @@ function makeWorkflow(opts = {}) {
     accessService: opts.accessService || makeMockAccessService(),
     decisionService: opts.decisionService || makeMockDecisionService(),
     retrievalService: opts.retrievalService || makeMockRetrievalService(),
+    packer: opts.packer || null, // null = use real DocumentEvidencePacker
   });
 }
 
@@ -217,73 +226,145 @@ async function testFindDocumentEmptyQuery() {
 }
 
 // ============================================================
-// runAnswerQuestion
+// runAnswerQuestion（audit-round02 变更项 A：从 retrievalService 迁出）
 // ============================================================
 
 async function testAnswerQuestionSufficientEvidence() {
   console.log('\n📋 WF-07: answer_question — 强证据 → answer_with_ranked_chunks');
 
-  const mockRet = makeMockRetrievalService({
-    retrieveResult: {
-      packet: {
-        meta: { evidence_sufficiency: 'strong', should_clarify: false, should_answer_conservatively: false, suggested_response_mode: 'answer_with_citation', reason_codes: ['single_candidate'], total_evidence: 5, scoped_identity_confirmed: false },
-        documents: [
-          { document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_name: '标准库', relevance_score: 95, candidate_confidence: 'high', evidence: [{ content: 'IPX5试验：喷嘴内径6.3mm', score: 0.92 }] },
-        ],
-      },
-      strategy: 'document_first',
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: {
+      success: true,
+      documents: [
+        { document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_name: '标准库', relevance_score: 95 },
+      ],
+      total: 1,
+      matched_by: 'title_metadata',
+    },
+    scopedResult: {
+      success: true,
+      chunks: [
+        { chunk_id: 'c1', document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 1, chunk_title: '', content: 'IPX5试验：喷嘴内径6.3mm', score: 0.92 },
+        { chunk_id: 'c2', document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 2, chunk_title: '', content: '水流量12.5L/min', score: 0.88 },
+        { chunk_id: 'c3', document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 3, chunk_title: '', content: '试验持续时间3min', score: 0.82 },
+        { chunk_id: 'c4', document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 4, chunk_title: '', content: '防护等级IPX5', score: 0.78 },
+      ],
+      total: 4,
     },
   });
-  const wf = makeWorkflow({ retrievalService: mockRet });
+  const mockDec = makeMockDecisionService({
+    analyzeResult: { recommended_strategy: 'document_first', intent: 'factual_lookup', anchor_strength: 'strong', confidence: 0.85, reason_codes: [] },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic, decisionService: mockDec });
 
   const r = await wf.runAnswerQuestion({ query: 'IPX5试验条件', user_id: 'u1' });
 
   assert(r.success, 'WF-07.1 success=true');
   assertEqual(r.action, 'answer_with_ranked_chunks', 'WF-07.2 action=answer_with_ranked_chunks');
   assertEqual(r.strategy, 'document_first', 'WF-07.3 strategy preserved');
-  assertEqual(r.documents.length, 1, 'WF-07.4 1 document');
-  assertEqual(r.documents[0].top_evidence.length, 1, 'WF-07.5 top_evidence 映射');
+  assert(r.documents.length >= 1, 'WF-07.4 has documents');
+  assert(r.steps.length >= 4, 'WF-07.5 explicit steps (decision+meta+recall+pack)');
+  // 验证 steps 已显式化
+  const stepNames = r.steps.map(s => s.step);
+  assert(stepNames.includes('decision'), 'WF-07.6 decision step visible');
+  assert(stepNames.includes('search_documents_by_metadata'), 'WF-07.7 metadata step visible');
+  assert(stepNames.includes('search_chunks_in_document'), 'WF-07.8 scoped_recall step visible');
+  assert(stepNames.includes('evidence_packing'), 'WF-07.9 evidence_packing step visible');
 }
 
 async function testAnswerQuestionCandidateList() {
-  console.log('\n📋 WF-08: answer_question — candidate_list → return_document_candidates');
+  console.log('\n📋 WF-08: answer_question — 多候选弱证据 → return_document_candidates');
 
-  const mockRet = makeMockRetrievalService({
-    retrieveResult: {
-      packet: {
-        meta: { evidence_sufficiency: 'medium', should_clarify: false, should_answer_conservatively: false, suggested_response_mode: 'candidate_list', reason_codes: ['multiple_candidates'], total_evidence: 3 },
-        documents: [
-          { document_id: 'd1', document_title: 'Doc A', doc_type: 'contract', collection_name: '合同库', relevance_score: 80, candidate_confidence: 'high', evidence: [{ content: '...', score: 0.75 }] },
-          { document_id: 'd2', document_title: 'Doc B', doc_type: 'contract', collection_name: '合同库', relevance_score: 75, candidate_confidence: 'high', evidence: [{ content: '...', score: 0.72 }] },
-        ],
-      },
-      strategy: 'document_first',
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: {
+      success: true,
+      documents: [
+        { document_id: 'd1', document_title: 'Doc A', doc_type: 'contract', collection_name: '合同库', relevance_score: 80 },
+        { document_id: 'd2', document_title: 'Doc B', doc_type: 'contract', collection_name: '合同库', relevance_score: 75 },
+        { document_id: 'd3', document_title: 'Doc C', doc_type: 'contract', collection_name: '合同库', relevance_score: 70 },
+      ],
+      total: 3,
+    },
+    scopedResult: {
+      success: true,
+      chunks: [
+        { chunk_id: 'c1', document_id: 'd1', document_title: 'Doc A', doc_type: 'contract', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 1, chunk_title: '', content: 'some content', score: 0.45 },
+        { chunk_id: 'c2', document_id: 'd2', document_title: 'Doc B', doc_type: 'contract', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 1, chunk_title: '', content: 'other content', score: 0.42 },
+      ],
+      total: 2,
     },
   });
-  const wf = makeWorkflow({ retrievalService: mockRet });
+  const mockDec = makeMockDecisionService({
+    analyzeResult: { recommended_strategy: 'document_first', intent: 'informational', anchor_strength: 'weak', confidence: 0.4, reason_codes: [] },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic, decisionService: mockDec });
 
   const r = await wf.runAnswerQuestion({ query: '合同条款', user_id: 'u1' });
 
   assertEqual(r.action, 'return_document_candidates', 'WF-08.1 action=return_document_candidates');
+  assert(r.documents.length >= 3, 'WF-08.2 3 文档候选');
+  assertEqual(r.evidence_sufficiency, 'weak', 'WF-08.3 weak evidence');
 }
 
 async function testAnswerQuestionNoEvidence() {
-  console.log('\n📋 WF-09: answer_question — 零证据零文档 → decline_due_to_insufficient_evidence');
+  console.log('\n📋 WF-09: answer_question — 零证据零文档 → decline');
 
-  const mockRet = makeMockRetrievalService({
-    retrieveResult: {
-      packet: {
-        meta: { evidence_sufficiency: 'none', should_clarify: true, should_answer_conservatively: true, suggested_response_mode: 'conservative_answer', reason_codes: ['no_candidates'], total_evidence: 0 },
-        documents: [],
-      },
-      strategy: 'degrade',
-    },
+  // metadata 无结果 + global chunks 也无结果
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: { success: true, documents: [], total: 0 },
+    globalResult: { success: true, chunks: [], total: 0 },
   });
-  const wf = makeWorkflow({ retrievalService: mockRet });
+  const mockDec = makeMockDecisionService({
+    analyzeResult: { recommended_strategy: 'document_first', intent: 'informational', anchor_strength: 'weak', confidence: 0.3, reason_codes: [] },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic, decisionService: mockDec });
 
   const r = await wf.runAnswerQuestion({ query: '不存在的内容', user_id: 'u1' });
 
   assertEqual(r.action, 'decline_due_to_insufficient_evidence', 'WF-09.1 decline');
+  assertEqual(r.evidence_sufficiency, 'none', 'WF-09.2 none');
+  assert(r.documents.length === 0, 'WF-09.3 0 docs');
+}
+
+async function testAnswerQuestionChunkFallback() {
+  console.log('\n📋 WF-09b: answer_question — metadata 0 结果 → chunk 回退');
+
+  // metadata 无结果，但 global chunks 有命中
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: { success: true, documents: [], total: 0 },
+    globalResult: {
+      success: true,
+      chunks: [
+        { chunk_id: 'c1', document_id: 'd9', document_title: '标准文档X', doc_type: 'standard', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 1, chunk_title: '', content: '关于电气安全的关键段落...', score: 0.82 },
+        { chunk_id: 'c2', document_id: 'd9', document_title: '标准文档X', doc_type: 'standard', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 2, chunk_title: '', content: '防护等级要求...', score: 0.75 },
+      ],
+      total: 2,
+    },
+    resolveResult: {
+      success: true,
+      documents: [{ document_id: 'd9', document_title: '标准文档X', doc_type: 'standard', collection_id: 'col-1', collection_name: '标准库', max_chunk_score: 0.82, chunk_count: 2 }],
+      total: 1,
+    },
+    scopedResult: {
+      success: true,
+      chunks: [
+        { chunk_id: 'c1', document_id: 'd9', document_title: '标准文档X', doc_type: 'standard', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 1, chunk_title: '', content: '关于电气安全的关键段落...', score: 0.82 },
+      ],
+      total: 1,
+    },
+  });
+  const mockDec = makeMockDecisionService({
+    analyzeResult: { recommended_strategy: 'document_first', intent: 'factual_lookup', anchor_strength: 'medium', confidence: 0.5, reason_codes: [] },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic, decisionService: mockDec });
+
+  const r = await wf.runAnswerQuestion({ query: '电气安全要求', user_id: 'u1' });
+
+  assert(r.success, 'WF-09b.1 success');
+  assertEqual(r.strategy, 'chunk_first_fallback', 'WF-09b.2 chunk_first_fallback strategy');
+  assert(r.steps.map(s => s.step).includes('search_chunks_globally'), 'WF-09b.3 global chunk step visible');
+  assert(r.steps.map(s => s.step).includes('resolve_documents_from_chunks'), 'WF-09b.4 resolve step visible');
+  assert(r.documents.length >= 1, 'WF-09b.5 has docs from fallback');
 }
 
 // ============================================================
@@ -293,18 +374,26 @@ async function testAnswerQuestionNoEvidence() {
 async function testVerifyFactSupported() {
   console.log('\n📋 WF-10: verify_fact — strong → supported');
 
-  const mockRet = makeMockRetrievalService({
-    retrieveResult: {
-      packet: {
-        meta: { evidence_sufficiency: 'strong', suggested_response_mode: 'answer_with_citation', reason_codes: [], total_evidence: 4, should_clarify: false, should_answer_conservatively: false },
-        documents: [
-          { document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_name: 'Col', relevance_score: 90, candidate_confidence: 'high', evidence: [{ content: '匹配内容', score: 0.91 }] },
-        ],
-      },
-      strategy: 'document_first',
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: {
+      success: true,
+      documents: [{ document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_name: 'Col', relevance_score: 90 }],
+      total: 1,
+    },
+    scopedResult: {
+      success: true,
+      chunks: [
+        { chunk_id: 'c1', document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 1, chunk_title: '', content: '匹配内容段落A', score: 0.91 },
+        { chunk_id: 'c2', document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 2, chunk_title: '', content: '匹配内容段落B', score: 0.85 },
+        { chunk_id: 'c3', document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 3, chunk_title: '', content: '匹配内容段落C', score: 0.81 },
+      ],
+      total: 3,
     },
   });
-  const wf = makeWorkflow({ retrievalService: mockRet });
+  const mockDec = makeMockDecisionService({
+    analyzeResult: { recommended_strategy: 'document_first', intent: 'factual_lookup', anchor_strength: 'strong', confidence: 0.9, reason_codes: [] },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic, decisionService: mockDec });
 
   const r = await wf.runVerifyFact({ query: '命题', user_id: 'u1' });
 
@@ -316,18 +405,25 @@ async function testVerifyFactSupported() {
 async function testVerifyFactInsufficient() {
   console.log('\n📋 WF-11: verify_fact — weak → insufficient_evidence');
 
-  const mockRet = makeMockRetrievalService({
-    retrieveResult: {
-      packet: {
-        meta: { evidence_sufficiency: 'weak', suggested_response_mode: 'conservative_answer', reason_codes: ['weak_evidence_degrade'], total_evidence: 1, should_clarify: false, should_answer_conservatively: true },
-        documents: [
-          { document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_name: 'Col', relevance_score: 40, candidate_confidence: 'low', evidence: [] },
-        ],
-      },
-      strategy: 'degrade',
+  // 有候选但证据弱（1 chunk, low score）
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: {
+      success: true,
+      documents: [{ document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_name: 'Col', relevance_score: 40 }],
+      total: 1,
+    },
+    scopedResult: {
+      success: true,
+      chunks: [
+        { chunk_id: 'c1', document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_id: 'col-1', revision_id: 'r1', outline_id: null, seq: 1, chunk_title: '', content: '弱相关内容', score: 0.35 },
+      ],
+      total: 1,
     },
   });
-  const wf = makeWorkflow({ retrievalService: mockRet });
+  const mockDec = makeMockDecisionService({
+    analyzeResult: { recommended_strategy: 'document_first', intent: 'informational', anchor_strength: 'weak', confidence: 0.3, reason_codes: [] },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic, decisionService: mockDec });
 
   const r = await wf.runVerifyFact({ query: '命题', user_id: 'u1' });
 
@@ -353,6 +449,7 @@ async function main() {
   await testAnswerQuestionSufficientEvidence();
   await testAnswerQuestionCandidateList();
   await testAnswerQuestionNoEvidence();
+  await testAnswerQuestionChunkFallback();
   await testVerifyFactSupported();
   await testVerifyFactInsufficient();
 

--- a/tests/document-retrieval-workflow.test.js
+++ b/tests/document-retrieval-workflow.test.js
@@ -68,22 +68,12 @@ function makeMockDecisionService(overrides = {}) {
   };
 }
 
-function makeMockRetrievalService(overrides = {}) {
-  return {
-    retrieve: async (q, opts) => (overrides.retrieveResult || {
-      packet: { meta: { evidence_sufficiency: 'none', should_clarify: true, should_answer_conservatively: true, suggested_response_mode: 'conservative_answer', reason_codes: [], total_evidence: 0 }, documents: [] },
-      strategy: 'degrade',
-    }),
-  };
-}
-
 function makeWorkflow(opts = {}) {
   return new DocumentRetrievalWorkflow(null, null, {
     atomicTools: opts.atomicTools || makeMockAtomicTools(),
     accessService: opts.accessService || makeMockAccessService(),
     decisionService: opts.decisionService || makeMockDecisionService(),
-    retrievalService: opts.retrievalService || makeMockRetrievalService(),
-    packer: opts.packer || null, // null = use real DocumentEvidencePacker
+    packer: opts.packer || null,
   });
 }
 

--- a/tests/document-retrieval-workflow.test.js
+++ b/tests/document-retrieval-workflow.test.js
@@ -1,0 +1,366 @@
+/**
+ * DocumentRetrievalWorkflow 编排测试
+ *
+ * 验证 find_document / answer_question / verify_fact 三个 workflow 的
+ * 步骤序列、动作映射、权限门控。使用 DI mock 不依赖数据库。
+ *
+ * audit-round01 Phase 2 交付物。
+ * 运行：node tests/document-retrieval-workflow.test.js
+ */
+
+import DocumentRetrievalWorkflow from '../lib/document-retrieval-workflow.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual === expected) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label} | expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`); }
+}
+
+// ============================================================
+// Mock 工厂
+// ============================================================
+
+function makeMockAtomicTools(overrides = {}) {
+  return {
+    searchDocumentsByMetadata: async (p) => (overrides.metaResult || { success: true, documents: [], total: 0, matched_by: 'title_metadata' }),
+    searchChunksInDocument: async (p) => (overrides.scopedResult || { success: true, chunks: [], total: 0 }),
+    searchChunksGlobally: async (p) => (overrides.globalResult || { success: true, chunks: [], total: 0 }),
+    rankChunksForQuestion: (p) => {
+      if (overrides.rankResult) return overrides.rankResult;
+      return { success: true, chunks: p.chunks || [], total: (p.chunks || []).length };
+    },
+    resolveDocumentsFromChunks: async (p) => (overrides.resolveResult || { success: true, documents: [], total: 0 }),
+  };
+}
+
+function makeMockAccessService(overrides = {}) {
+  const defaultIds = overrides.accessibleIds || ['col-1'];
+  return { getAccessibleCollectionIds: async () => defaultIds };
+}
+
+function makeMockDecisionService(overrides = {}) {
+  return {
+    hints: (q, ctx) => (overrides.hints || {
+      user_query: q || '',
+      document_hints: [],
+      topic_terms: [],
+      content_terms: [],
+      has_explicit_document_anchor: false,
+      intent_hint: 'ambiguous',
+      initial_strategy_hint: 'chunk_first',
+      analysis: {},
+    }),
+  };
+}
+
+function makeMockRetrievalService(overrides = {}) {
+  return {
+    retrieve: async (q, opts) => (overrides.retrieveResult || {
+      packet: { meta: { evidence_sufficiency: 'none', should_clarify: true, should_answer_conservatively: true, suggested_response_mode: 'conservative_answer', reason_codes: [], total_evidence: 0 }, documents: [] },
+      strategy: 'degrade',
+    }),
+  };
+}
+
+function makeWorkflow(opts = {}) {
+  return new DocumentRetrievalWorkflow(null, null, {
+    atomicTools: opts.atomicTools || makeMockAtomicTools(),
+    accessService: opts.accessService || makeMockAccessService(),
+    decisionService: opts.decisionService || makeMockDecisionService(),
+    retrievalService: opts.retrievalService || makeMockRetrievalService(),
+  });
+}
+
+// ============================================================
+// runFindDocument
+// ============================================================
+
+async function testFindDocumentMetadataHit() {
+  console.log('\n📋 WF-01: find_document — metadata 命中 → return_document_candidates');
+
+  const mockMeta = makeMockAtomicTools({
+    metaResult: {
+      success: true,
+      documents: [
+        { document_id: 'd1', document_title: 'GB/T 4208-2017', doc_type: 'standard', collection_name: '标准库', relevance_score: 95 },
+      ],
+      total: 1,
+      matched_by: 'title_metadata',
+    },
+    scopedResult: { success: true, chunks: [{ chunk_id: 'c1', content: 'IPX5试验...', score: 0.85, document_id: 'd1', doc_type: 'standard', collection_id: 'col-1' }], total: 1 },
+  });
+  const wf = makeWorkflow({ atomicTools: mockMeta });
+
+  const r = await wf.runFindDocument({ query: 'GB/T 4208', user_id: 'u1' });
+
+  assert(r.success, 'WF-01.1 success=true');
+  assertEqual(r.action, 'return_document_candidates', 'WF-01.2 action=return_document_candidates');
+  assertEqual(r.total_candidates, 1, 'WF-01.3 1 candidate');
+  assertEqual(r.strategy, 'metadata_search', 'WF-01.4 strategy=metadata_search');
+  assert(r.steps.length >= 2, 'WF-01.5 >=2 steps（hints + metadata）');
+  assertEqual(r.steps[0].step, 'hints', 'WF-01.6 step0=hints');
+  assertEqual(r.steps[1].step, 'search_documents_by_metadata', 'WF-01.7 step1=search');
+}
+
+async function testFindDocumentAttachmentFallback() {
+  console.log('\n📋 WF-02: find_document — metadata 0 → 附件名兜底');
+
+  const emptyMetaResult = { success: true, documents: [], total: 0, matched_by: 'title_metadata' };
+  const attachResult = {
+    success: true,
+    documents: [
+      { document_id: 'd2', document_title: 'Intake-001', best_identity_label: '施工合同附件A.pdf', matched_attachment: '施工合同附件A.pdf', doc_type: 'contract', collection_name: '合同库' },
+    ],
+    total: 1,
+    matched_by: 'attachment_filename',
+  };
+
+  let callCount = 0;
+  const mockAtomic = makeMockAtomicTools({ metaResult: emptyMetaResult });
+  mockAtomic.searchDocumentsByMetadata = async (p) => {
+    callCount++;
+    if (callCount === 1) return emptyMetaResult;
+    return attachResult;
+  };
+  const wf = makeWorkflow({ atomicTools: mockAtomic });
+
+  const r = await wf.runFindDocument({ query: '施工合同', user_id: 'u1' });
+
+  assert(r.success, 'WF-02.1 success=true');
+  assertEqual(r.total_candidates, 1, 'WF-02.2 1 candidate（附件兜底）');
+  assertEqual(r.strategy, 'attachment_filename_fallback', 'WF-02.3 strategy=attachment_filename_fallback');
+  assert(r.reason_codes.includes('attachment_filename_fallback'), 'WF-02.4 attachment_filename_fallback code');
+  assertEqual(r.candidates[0].identity_source, 'attachment_filename_match', 'WF-02.5 attachment 来源');
+  assert(r.steps.some(s => s.step === 'search_by_attachment_filename'), 'WF-02.6 含附件搜索步骤');
+}
+
+async function testFindDocumentContentBridge() {
+  console.log('\n📋 WF-03: find_document — metadata + 附件均 0 → 内容桥接反查');
+
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: { success: true, documents: [], total: 0 },
+    globalResult: {
+      success: true,
+      chunks: [
+        { chunk_id: 'c1', document_id: 'd3', document_title: '内部制度', content: '巡检周期每周一次', score: 0.88, doc_type: 'policy', collection_id: 'col-1' },
+      ],
+      total: 1,
+    },
+    resolveResult: {
+      success: true,
+      documents: [
+        { document_id: 'd3', document_title: '内部制度 v3', doc_type: 'policy', collection_id: 'col-1', collection_name: '内部制度库', chunk_count: 1, max_chunk_score: 0.88 },
+      ],
+      total: 1,
+    },
+  });
+  const mockDec = makeMockDecisionService({
+    hints: { user_query: '巡检周期', document_hints: [], topic_terms: ['巡检', '周期'], content_terms: ['巡检', '周期'], has_explicit_document_anchor: false, intent_hint: 'content_exploration', initial_strategy_hint: 'chunk_first', analysis: {} },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic, decisionService: mockDec });
+
+  const r = await wf.runFindDocument({ query: '巡检周期', user_id: 'u1' });
+
+  assert(r.success, 'WF-03.1 success=true');
+  assertEqual(r.total_candidates, 1, 'WF-03.2 内容桥接命中');
+  assertEqual(r.strategy, 'content_bridge', 'WF-03.3 strategy=content_bridge');
+  assert(r.reason_codes.includes('content_bridge'), 'WF-03.4 content_bridge code');
+  assertEqual(r.candidates[0].identity_source, 'content_bridge', 'WF-03.5 content_bridge 来源');
+  assert(r.steps.some(s => s.step === 'search_chunks_globally'), 'WF-03.6 含全局 chunk 搜索');
+  assert(r.steps.some(s => s.step === 'resolve_documents_from_chunks'), 'WF-03.7 含 chunk→doc 解析');
+}
+
+async function testFindDocumentZeroResult() {
+  console.log('\n📋 WF-04: find_document — 三步全空 → ask_for_clarification');
+
+  const mockAtomic = makeMockAtomicTools({
+    metaResult: { success: true, documents: [], total: 0 },
+    globalResult: { success: true, chunks: [], total: 0 },
+  });
+  const wf = makeWorkflow({ atomicTools: mockAtomic });
+
+  const r = await wf.runFindDocument({ query: '不存在的文档', user_id: 'u1' });
+
+  assert(r.success, 'WF-04.1 success=true（澄清不是失败）');
+  assertEqual(r.action, 'ask_for_clarification', 'WF-04.2 action=ask_for_clarification');
+  assertEqual(r.total_candidates, 0, 'WF-04.3 0 candidates');
+  assert(r.reason_codes.includes('no_candidates'), 'WF-04.4 no_candidates code');
+}
+
+async function testFindDocumentCollectionNotAccessible() {
+  console.log('\n📋 WF-05: find_document — 指定集合不可访问 → clarify');
+
+  const mockAccess = makeMockAccessService({ accessibleIds: ['col-x'] });
+  const wf = makeWorkflow({ accessService: mockAccess });
+
+  const r = await wf.runFindDocument({ query: 'test', user_id: 'u1', collection_id: 'col-secret' });
+
+  assertEqual(r.action, 'ask_for_clarification', 'WF-05.1 action=ask_for_clarification');
+  assert(r.reason_codes.includes('collection_not_accessible'), 'WF-05.2 collection_not_accessible');
+}
+
+async function testFindDocumentEmptyQuery() {
+  console.log('\n📋 WF-06: find_document — 空 query → clarify');
+
+  const wf = makeWorkflow();
+  const r = await wf.runFindDocument({ query: '', user_id: 'u1' });
+
+  assertEqual(r.action, 'ask_for_clarification', 'WF-06.1 clarify');
+  assert(r.reason_codes.includes('empty_query'), 'WF-06.2 empty_query');
+}
+
+// ============================================================
+// runAnswerQuestion
+// ============================================================
+
+async function testAnswerQuestionSufficientEvidence() {
+  console.log('\n📋 WF-07: answer_question — 强证据 → answer_with_ranked_chunks');
+
+  const mockRet = makeMockRetrievalService({
+    retrieveResult: {
+      packet: {
+        meta: { evidence_sufficiency: 'strong', should_clarify: false, should_answer_conservatively: false, suggested_response_mode: 'answer_with_citation', reason_codes: ['single_candidate'], total_evidence: 5, scoped_identity_confirmed: false },
+        documents: [
+          { document_id: 'd1', document_title: 'GB/T 4208', doc_type: 'standard', collection_name: '标准库', relevance_score: 95, candidate_confidence: 'high', evidence: [{ content: 'IPX5试验：喷嘴内径6.3mm', score: 0.92 }] },
+        ],
+      },
+      strategy: 'document_first',
+    },
+  });
+  const wf = makeWorkflow({ retrievalService: mockRet });
+
+  const r = await wf.runAnswerQuestion({ query: 'IPX5试验条件', user_id: 'u1' });
+
+  assert(r.success, 'WF-07.1 success=true');
+  assertEqual(r.action, 'answer_with_ranked_chunks', 'WF-07.2 action=answer_with_ranked_chunks');
+  assertEqual(r.strategy, 'document_first', 'WF-07.3 strategy preserved');
+  assertEqual(r.documents.length, 1, 'WF-07.4 1 document');
+  assertEqual(r.documents[0].top_evidence.length, 1, 'WF-07.5 top_evidence 映射');
+}
+
+async function testAnswerQuestionCandidateList() {
+  console.log('\n📋 WF-08: answer_question — candidate_list → return_document_candidates');
+
+  const mockRet = makeMockRetrievalService({
+    retrieveResult: {
+      packet: {
+        meta: { evidence_sufficiency: 'medium', should_clarify: false, should_answer_conservatively: false, suggested_response_mode: 'candidate_list', reason_codes: ['multiple_candidates'], total_evidence: 3 },
+        documents: [
+          { document_id: 'd1', document_title: 'Doc A', doc_type: 'contract', collection_name: '合同库', relevance_score: 80, candidate_confidence: 'high', evidence: [{ content: '...', score: 0.75 }] },
+          { document_id: 'd2', document_title: 'Doc B', doc_type: 'contract', collection_name: '合同库', relevance_score: 75, candidate_confidence: 'high', evidence: [{ content: '...', score: 0.72 }] },
+        ],
+      },
+      strategy: 'document_first',
+    },
+  });
+  const wf = makeWorkflow({ retrievalService: mockRet });
+
+  const r = await wf.runAnswerQuestion({ query: '合同条款', user_id: 'u1' });
+
+  assertEqual(r.action, 'return_document_candidates', 'WF-08.1 action=return_document_candidates');
+}
+
+async function testAnswerQuestionNoEvidence() {
+  console.log('\n📋 WF-09: answer_question — 零证据零文档 → decline_due_to_insufficient_evidence');
+
+  const mockRet = makeMockRetrievalService({
+    retrieveResult: {
+      packet: {
+        meta: { evidence_sufficiency: 'none', should_clarify: true, should_answer_conservatively: true, suggested_response_mode: 'conservative_answer', reason_codes: ['no_candidates'], total_evidence: 0 },
+        documents: [],
+      },
+      strategy: 'degrade',
+    },
+  });
+  const wf = makeWorkflow({ retrievalService: mockRet });
+
+  const r = await wf.runAnswerQuestion({ query: '不存在的内容', user_id: 'u1' });
+
+  assertEqual(r.action, 'decline_due_to_insufficient_evidence', 'WF-09.1 decline');
+}
+
+// ============================================================
+// runVerifyFact
+// ============================================================
+
+async function testVerifyFactSupported() {
+  console.log('\n📋 WF-10: verify_fact — strong → supported');
+
+  const mockRet = makeMockRetrievalService({
+    retrieveResult: {
+      packet: {
+        meta: { evidence_sufficiency: 'strong', suggested_response_mode: 'answer_with_citation', reason_codes: [], total_evidence: 4, should_clarify: false, should_answer_conservatively: false },
+        documents: [
+          { document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_name: 'Col', relevance_score: 90, candidate_confidence: 'high', evidence: [{ content: '匹配内容', score: 0.91 }] },
+        ],
+      },
+      strategy: 'document_first',
+    },
+  });
+  const wf = makeWorkflow({ retrievalService: mockRet });
+
+  const r = await wf.runVerifyFact({ query: '命题', user_id: 'u1' });
+
+  assertEqual(r.verdict, 'supported', 'WF-10.1 verdict=supported');
+  assert(r.supporting_evidence.length > 0, 'WF-10.2 有 supporting evidence');
+  assertEqual(r.action, 'answer_with_ranked_chunks', 'WF-10.3 action');
+}
+
+async function testVerifyFactInsufficient() {
+  console.log('\n📋 WF-11: verify_fact — weak → insufficient_evidence');
+
+  const mockRet = makeMockRetrievalService({
+    retrieveResult: {
+      packet: {
+        meta: { evidence_sufficiency: 'weak', suggested_response_mode: 'conservative_answer', reason_codes: ['weak_evidence_degrade'], total_evidence: 1, should_clarify: false, should_answer_conservatively: true },
+        documents: [
+          { document_id: 'd1', document_title: 'Doc', doc_type: 'contract', collection_name: 'Col', relevance_score: 40, candidate_confidence: 'low', evidence: [] },
+        ],
+      },
+      strategy: 'degrade',
+    },
+  });
+  const wf = makeWorkflow({ retrievalService: mockRet });
+
+  const r = await wf.runVerifyFact({ query: '命题', user_id: 'u1' });
+
+  assertEqual(r.verdict, 'insufficient_evidence', 'WF-11.1 verdict=insufficient_evidence');
+  assertEqual(r.supporting_evidence.length, 0, 'WF-11.2 无 supporting evidence');
+}
+
+// ============================================================
+// 运行
+// ============================================================
+
+async function main() {
+  console.log('╔══════════════════════════════════════╗');
+  console.log('║  Document Retrieval Workflow 测试   ║');
+  console.log('╚══════════════════════════════════════╝');
+
+  await testFindDocumentMetadataHit();
+  await testFindDocumentAttachmentFallback();
+  await testFindDocumentContentBridge();
+  await testFindDocumentZeroResult();
+  await testFindDocumentCollectionNotAccessible();
+  await testFindDocumentEmptyQuery();
+  await testAnswerQuestionSufficientEvidence();
+  await testAnswerQuestionCandidateList();
+  await testAnswerQuestionNoEvidence();
+  await testVerifyFactSupported();
+  await testVerifyFactInsufficient();
+
+  console.log(`\n${'='.repeat(40)}`);
+  console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+  console.log(`${'='.repeat(40)}`);
+
+  if (failed > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## 背景

这次改动围绕文档检索 / 专家问答链路做了一轮较大范围的结构收敛，目标是把原来混杂在复合 tool 中的检索、编排、证据消费和兼容状态逐步拆开，并把系统对外暴露的能力收口到更清晰的边界上。

这轮工作的直接背景主要有几个：

1. 旧的文档检索链路中，`find_document` / `verify_fact` / `answer_from_documents` 这类复合 tool 既承担“对外接口”职责，又承担“内部 workflow 编排”职责，导致：
   - tool 名称和实际执行行为不稳定
   - 前端看到的工具名和真实内部执行步骤不一致
   - 消费层不得不兼容多个旧字段和旧状态模型
   - 一旦检索质量下降，很难快速判断问题在 query、候选合并、fallback 还是回答消费环节

2. 在几轮检索修复之后，虽然主链已经逐步迁移到 workflow 层，但外部接口、日志命名、前端展示、contract 文档仍然存在历史包袱，导致“内部已切换、外部未收口”的状态持续存在。

3. 这轮分支的目标，不是重新设计整个文档平台，而是先把当前最常见的链路收口到一个可维护、可观察、可继续演进的状态：
   - 文档检索能力原子化
   - workflow 成为真正的编排层
   - 消费层只看稳定主信号
   - 前端与日志展示尽量对齐 LLM 实际调用名
   - 为后续进一步拆行为层保留空间

---

## 本次做了什么

### 1. 把文档检索底层能力拆成 6 个原子工具实现

在内部能力层，明确收敛为 6 个原子能力：

- `search_documents_by_metadata`
- `read_document_content`
- `search_chunks_in_document`
- `search_chunks_globally`
- `rank_chunks_for_question`
- `resolve_documents_from_chunks`

这一步的意义主要是把“文档级检索 / 内容级检索 / 文档内搜索 / 精排 / chunk 反查文档”这些能力从大而全的复合 tool 中剥离出来，形成稳定的一步能力。

这部分不是简单改名字，而是把后续 workflow 能依赖的能力边界固定下来。

---

### 2. 引入并强化 `DocumentRetrievalWorkflow` 作为统一编排层

这轮分支继续推动了一个明确方向：

- 原子工具负责“一步能力”
- workflow 负责“组合这些能力形成完整检索/回答链路”
- 上层消费只看 workflow 给出的稳定主动作信号

这里最关键的变化是，主回答链路不再依赖旧的复合服务心智，而是明确转向 workflow 驱动。

对应结果包括：

- 文档检索主链迁移到 workflow 层
- 旧复合检索主链逐步退出核心消费路径
- 针对多候选、fallback、证据充分性等决策，更多由 workflow 层统一表达

---

### 3. 消费层统一改为依赖 `workflow_action`

这是这一轮非常关键的收口之一。

之前消费层依赖过多历史兼容字段，例如：

- `suggested_response_mode`
- `should_clarify`
- `should_answer_conservatively`
- 以及各种隐式状态组合

这轮已经把消费主判断统一切到 `workflow_action`，也就是把“系统下一步应该怎么回应”收敛为一个稳定主信号。

这带来的收益：

- 减少消费层状态分叉
- 降低兼容字段长期残留的风险
- 让回答模式判断从“多个布尔/提示字段拼装”转成“单一动作信号驱动”
- 为后续测试、审计和日志分析提供更明确的依据

---

### 4. 物理删除一批旧兼容字段和旧接口残留

这一轮不是只做“新逻辑叠加”，还做了明显的历史清理。

主要包括：

- 删除旧的 compat 字段
- 删除/退出旧复合 tool 的核心地位
- 调整消费层对旧状态模型的依赖
- 让 `_findDocRetrievalResult()` 等逻辑转向按 `skill_namespace === 'document_retrieval'` 聚合，而不是继续绑死某个旧 tool 名

这一步很重要，因为它标志着“不是只在内部偷偷切链路”，而是开始真正把旧接口和旧状态模型从主路径中清出去。

---

### 5. 对外 tool 命名从复合名收口到 6 个原子名

本轮中后段一个核心调整是：

- 不再让 LLM / 前端 / 日志继续看到 `answer_from_documents` / `find_document` / `verify_fact`
- 也撤销了将三者收敛成单一 `document_retrieval` 复合入口的中间方案
- 改为让 LLM 对外看到 6 个原子 tool 名

实际暴露给 LLM 的 tool 为：

- `search_documents_by_metadata`
- `read_document_content`
- `search_chunks_in_document`
- `search_chunks_globally`
- `rank_chunks_for_question`
- `resolve_documents_from_chunks`

同时：

- `tool_name` 日志改为记录 LLM 实际调用的原子 tool 名
- 前端主展示名跟随顶层 tool call 名
- `atomic_steps` 被保留用于展示内部实际执行轨迹

这一步解决的是“外界认知层”和“系统内部能力层”长期错位的问题。

---

### 6. 前端工具展示与日志展示对齐实际调用名

这轮改动还覆盖了前端的工具展示逻辑，目标是让用户能看到更接近真实的调用轨迹，而不是被复合名误导。

包括：

- `AssistantMessage.vue`
- `ToolMessageCard.vue`
- `useToolDataParser.ts`

收口后的效果是：

- 工具主名优先展示实际 tool call 名
- 可额外展示 `atomic_steps`
- 前端不再只能看到一个泛化复合入口，而能看到更细粒度的原子调用名

这对于调试、审计、用户心智和后续产品迭代都更有价值。

---

### 7. 系统 contract 文档同步更新

本分支还同步更新了文档协议：

- `docs/development/document-retrieval-skill-contract.md`

更新内容包括：

- 将 `document_retrieval` 的对外可见 tool 定义更新为 6 个原子 tool
- 明确 `tool_name` 表示 LLM 实际调用的原子 tool 名
- 更新 Phase 路线图
- 清理旧命名历史
- 补充当前“6 原子 tool 外显 + workflow 统一编排”的过渡说明

需要说明的是，这份 contract 文档记录了当前实现状态，也保留了对“为何暂未把 6 个 tool 行为完全拆开”的架构解释。它反映的是当前分支里团队提交上来的实现口径，不代表该口径已经在审计层面彻底达成一致。

---

### 8. 测试与验证补强

这一轮包含的验证方向主要有：

- 原子工具内部实现测试
- workflow 层测试
- consumption / chat-service 消费层测试
- reranker 契约相关测试
- 冲突路径测试补充

从分支历史看，已经覆盖并验证了这些关键点：

- workflow 主动作信号替代旧兼容状态
- 文档检索原子能力能够单独被验证
- chat-service 能按新契约消费文档检索结果
- 部分关键冲突和 fallback 场景已有回归保护

最近一次仓库 `npm run lint` 结果为通过。

---

## 本次改动按提交脉络大致可分为几步

### 第一阶段：原子能力和 workflow 基础铺设
- 拆分文档工具为 6 个原子工具
- 引入显式 workflow 层
- 逐步让文档检索主链退出旧复合逻辑

### 第二阶段：消费层状态模型收口
- 主消费逻辑切换到 `workflow_action`
- 删除 compat 字段和旧状态拼装逻辑
- 增加相关测试保护

### 第三阶段：对外接口和展示层收口
- 先尝试单一 `document_retrieval` 复合入口
- 随后撤销该方案
- 改为 6 个原子 tool 名对外暴露
- 前端 / 日志对齐原子名

### 第四阶段：contract 更新与阶段性归档
- 更新 skill contract
- 记录当前实现的过渡态说明
- 为后续进一步争议收口留下文档依据

---

## 现在还没做完什么

这部分需要明确写清楚，因为本分支并不是“所有争议都已经关闭”。

### 1. 6 个原子 tool 还没有真正做到行为层完全独立

当前最核心的未完成项是：

虽然对外已经暴露 6 个原子 tool 名，但在 `tool-manager` 当前实现里，它们仍然统一路由到 `DocumentRetrievalWorkflow.runAnswerQuestion()` 主管线。

也就是说：

- 名字层已经原子化
- 展示层已经原子化
- 日志层已经原子化
- **但行为层还没有完全原子化**

这意味着当前仍存在“tool 名语义”和“最小执行路径”不完全一致的问题。

---

### 2. 参数签名仍然是统一签名，而不是按职责差异化

当前 6 个对外 tool 仍然共用：

- `query`
- `collection_id`
- `doc_types`

这在工程上降低了 LLM 调用难度，但也意味着：

- `read_document_content` 这类名字，从严格语义上说更适合接 `document_id`
- `rank_chunks_for_question` 更适合接 chunk 集合
- `resolve_documents_from_chunks` 更适合接 chunks 或 chunk_ids

目前这些签名还没有按原子职责完全收口。

---

### 3. 缺少“名称-行为一致性”的专门测试

现有测试覆盖了：

- 原子方法内部实现
- workflow 执行路径
- 消费层逻辑

但还缺少一类非常关键的测试：

- 不同对外 tool 名是否真的触发了不同的最小执行语义
- 是否仍然全部塌回同一条回答主链
- `atomic_steps` 是否与顶层 tool 名形成足够一致的映射关系

这部分目前仍是缺口。

---

### 4. “统一 workflow 编排”是否应被视为最终方案，团队内仍存在争议

本分支里已经出现一个明确的架构分歧：

- 一种观点认为：
  - 6 个原子 tool 应尽量做到名实相符
  - 复合编排只应存在于 skill / workflow 层
  - 至少应有差异化的最小执行路径

- 另一种观点认为：
  - 6 个 tool 更多是 LLM 语义入口
  - 统一 workflow 编排是更可靠的工程方案
  - 没必要强行拆成行为完全独立的 6 条路径

当前代码更接近后者，但这件事并未在审计层面完全达成一致，因此它仍然属于未关闭议题，而不是可以默认当成最终稳定设计。

---

## 当前已知风险

### 1. 名称与行为不完全一致的风险
外部看到 6 个原子 tool，但内部仍可能统一走回答主链，这会在后续维护和认知上留下持续摩擦。

### 2. 后续扩展时边界可能再次混合
如果不继续做行为层裁剪，未来新增 `compare_documents`、反驳证据链路、结构化抽取等能力时，仍可能继续堆到统一 workflow 中，重新形成新的“复合大入口”。

### 3. contract 口径和审计口径暂未完全统一
当前 contract 已记录“过渡实现说明”，但是否接受它作为长期方案，仍需要后续决策。

---

## 为什么这个分支仍然值得先合

尽管还有未完成项，这个分支仍然有明显的收口价值：

1. 它已经把旧复合 tool 的外部暴露层清掉了
2. 它已经把消费层切换到更稳定的 `workflow_action`
3. 它已经删除了一批历史兼容状态
4. 它已经让前端 / 日志 / tool 命名比过去一致得多
5. 它已经把“内部原子能力”和“workflow 编排”两个层级初步拉开
6. 它为下一步继续做行为层裁剪提供了更清晰的基础

换句话说，这个分支不是终局，但它把系统从“旧复合接口 + 新旧状态并存”的模糊阶段，推进到了“外部接口基本收口、内部编排已成形、剩余争议集中暴露”的阶段。

这是有合并价值的。

---

## 建议 reviewer 重点关注

1. `workflow_action` 是否已经足够稳定，足以作为消费层主信号
2. 旧 compat 字段删除后，是否还有漏网依赖
3. 6 个原子 tool 对外暴露后，前端 / 日志 / 存储层是否都已正确对齐
4. 当前统一走 `runAnswerQuestion()` 的行为，是否接受作为暂时过渡态
5. 是否需要在下一轮单独开 issue 继续做：
   - 按 tool 名裁剪最小执行路径
   - 参数签名按职责差异化
   - 名称-行为一致性测试补齐

---

## 后续建议

建议在本 PR 合并后，立即单开后续 issue，专门处理以下剩余事项：

1. 设计“按 tool 名裁剪管线”的意图路由层或最小路径分发机制
2. 明确哪些 tool 仍应保持统一 query 接口，哪些应逐步过渡到职责化输入
3. 增加名称-行为一致性测试
4. 为 `compare_documents` / 反驳证据链路预留更明确的 workflow 扩展点

---

## 验证说明

已完成的静态/已有验证包括：

- 原子工具内部测试
- workflow 层测试
- 消费层测试
- 相关契约/冲突测试补充
- 最近一次 `npm run lint` 通过

说明：
- 当前没有新增证明“6 个对外 tool 已有完全不同执行路径”的测试
- 这是本 PR 明确保留的后续工作项之一