### PR TITLE
feat: 文档检索 Phase 2——parser锚点识别+四维rerank+证据覆盖统计（吸收#963增量）

### DIFF
--- a/lib/document-atomic-tools.js
+++ b/lib/document-atomic-tools.js
@@ -10,7 +10,7 @@
  *   2. readDocumentContent         — 读取文档基本信息 + 正文（短期聚合读取，按 chunk seq 拼装）
  *   3. searchChunksInDocument      — 已知文档范围内的 chunk 向量检索
  *   4. searchChunksGlobally        — 全库 chunk 向量检索（根据内容反找证据）
- *   5. rankChunksForQuestion       — 多信号 chunk 重排（向量分 + 关键词覆盖 + 标题命中 + 锁定文档加权）
+ *   5. rankChunksForQuestion       — 多信号 chunk 重排（Phase 2 四维化：向量分 + 实体/程序词命中 + 结构锚点 + 标题命中 + 锁定加权，附 coverage 覆盖统计）
  *   6. resolveDocumentsFromChunks  — chunk → document 身份反查与聚合
  *
  * 设计原则（对应审计 §3.2 / §8）：
@@ -33,6 +33,7 @@ import logger from './logger.js';
 import DocumentSearchService from './document-search-service.js';
 import DocRecallService from './doc-recall-service.js';
 import DocAccessService from './doc-access-service.js';
+import { parseDocumentQuery } from './document-query-parser.js';
 
 /**
  * 第一批原子 tool 名称清单（供 workflow / 未来 tool 暴露引用）
@@ -108,11 +109,25 @@ class DocumentAtomicTools {
       return { success: false, error: 'metadata_query is required', documents: [], total: 0 };
     }
 
+    // Phase 2（吸收 #963）：parser 预处理——编号识别、doc_type 推断、归一化查询。
+    // 仅做"一步检索的输入增强"，不引入任何多步编排。
+    const parsed = parseDocumentQuery(metadata_query.trim());
+    const effectiveDocTypes = (doc_types?.length > 0)
+      ? doc_types
+      : (parsed.doc_type_hints.length > 0 ? parsed.doc_type_hints : undefined);
+    const queryParseInfo = {
+      lookup_intent: parsed.lookup_intent,
+      identifier_hints: parsed.identifier_hints,
+      doc_type_hints: parsed.doc_type_hints,
+      cleaned_query: parsed.cleaned_query,
+    };
+
     try {
+      // 附件文件名分支：附件名可能含编号/特殊字符，保留原始查询
       if (match_fields.length === 1 && match_fields[0] === 'attachment_filename') {
         const rows = await this.searchService.searchByAttachmentFilenames(metadata_query.trim(), {
           userId: user_id,
-          doc_types,
+          doc_types: effectiveDocTypes,
           top_k,
           collection_id: collection_id || undefined,
         });
@@ -121,12 +136,15 @@ class DocumentAtomicTools {
           matched_by: 'attachment_filename',
           documents: rows || [],
           total: rows?.length || 0,
+          query_parse: queryParseInfo,
         };
       }
 
-      const result = await this.searchService.search(metadata_query.trim(), {
+      // title/metadata 分支：使用 parser 归一化查询（编号优先 + 主题词）
+      const effectiveQuery = parsed.cleaned_query || metadata_query.trim();
+      const result = await this.searchService.search(effectiveQuery, {
         userId: user_id,
-        doc_types,
+        doc_types: effectiveDocTypes,
         collection_id: collection_id || undefined,
         tag_ids,
         top_k,
@@ -138,6 +156,7 @@ class DocumentAtomicTools {
         documents: result.candidates || [],
         total: result.total ?? (result.candidates?.length || 0),
         strategy: result.strategy,
+        query_parse: queryParseInfo,
       };
     } catch (error) {
       logger.error('[DocAtomicTools] searchDocumentsByMetadata error:', error.message);
@@ -329,20 +348,24 @@ class DocumentAtomicTools {
   /**
    * 多信号 chunk 重排（同步纯函数，不做 IO）
    *
-   * 信号构成（审计 §8.5：不应只按原召回顺序透传）：
+   * Phase 2（吸收 #963 四维 rerank）：词源由 parseDocumentQuery 提供（经过去噪、
+   * 类型剥离、编号剥离，优于简易分词），信号构成：
    * - vector_score：召回向量相似度（0-1）
-   * - keyword_coverage：问题关键词在 chunk 内容中的覆盖率（0-1）
-   * - title_hit：chunk 所属文档标题 / chunk 标题是否命中问题关键词（0 或 1）
-   * - locked_bonus：chunk 是否来自已锁定文档（0 或 1）
+   * - entity_score：parser 实体词（编号/IPX5/专有名词）在 title+content 的命中率（0-1）
+   * - procedure_score：parser 程序词（试验/检测/条款等）命中率（0-1）
+   * - structural_score：章节锚点/表格条款/seq 位置启发式（0-1）
+   * - title_hit：标题命中实体词（0/1）
+   * - locked_bonus：来自已锁定文档（0/1）
    *
-   * rank_score = 0.6*vector + 0.25*coverage + 0.1*title_hit + 0.05*locked_bonus
+   * rank_score = min(1.0, 0.45*vector + 0.30*entity + 0.15*procedure
+   *              + 0.10*structural + 0.05*title_hit + 0.05*locked_bonus)
    *
    * @param {Object} params
    * @param {string} params.question - 用户问题
    * @param {Object[]} params.chunks - 统一 chunk 契约数组
-   * @param {string[]} [params.locked_document_ids=[]] - 已锁定文档（workflow 已确认目标文档时传入）
+   * @param {string[]} [params.locked_document_ids=[]] - 已锁定文档加权
    * @param {number} [params.top_k] - 截断数量（不传则全量返回）
-   * @returns {Object} { success, chunks[]（含 rank_score / rank_signals，降序）, total }
+   * @returns {Object} { success, chunks[]（含 rank_score / rank_signals，降序）, total, coverage }
    */
   rankChunksForQuestion(params = {}) {
     const { question, chunks, locked_document_ids = [], top_k } = params;
@@ -354,39 +377,95 @@ class DocumentAtomicTools {
       return { success: true, chunks: [], total: 0 };
     }
 
-    const terms = this._extractTerms(question || '');
+    // Phase 2：parser 提供 entity/procedure 词源；parser 未提取到实体词时用简易分词兜底
+    const parsed = question ? parseDocumentQuery(question) : null;
+    let entityTerms = parsed?.facets?.entity_terms || [];
+    const procedureTerms = parsed?.facets?.procedure_terms || [];
+    if (entityTerms.length === 0) {
+      entityTerms = this._extractTerms(question || '').map(t => t.text);
+    }
     const lockedSet = new Set(locked_document_ids);
 
-    // audit-round03 变更项 D：信号计算与评分解耦，支持可替换 reranker
+    const SECTION_PATTERN = /\b\d+\.\d+(?:\.\d+)?\b/;
+    const TABLE_CLAUSE_PATTERN = /(?:表|表格|条款|附录|附图)/;
+
+    // 信号计算与评分解耦，支持可替换 reranker
     const computeSignals = (chunk) => {
-      const content = chunk.content || '';
+      const content = (chunk.content || '').toLowerCase();
+      const title = `${chunk.document_title || ''} ${chunk.chunk_title || ''}`.toLowerCase();
+      const combined = `${title} ${content}`;
       const vectorScore = Math.max(0, Math.min(1, chunk.score || 0));
 
-      let coverage = 0;
-      if (terms.length > 0) {
-        let totalWeight = 0;
-        let hitWeight = 0;
-        for (const t of terms) {
-          totalWeight += t.weight;
-          if (content.includes(t.text)) hitWeight += t.weight;
+      // entity_score：实体词命中率（含命中清单，供审计）
+      let entityScore = 0;
+      const matchedEntities = [];
+      if (entityTerms.length > 0) {
+        let hits = 0;
+        for (const et of entityTerms) {
+          if (combined.includes(et.toLowerCase())) {
+            hits++;
+            matchedEntities.push(et);
+          }
         }
-        coverage = totalWeight > 0 ? hitWeight / totalWeight : 0;
+        entityScore = Math.min(hits / entityTerms.length, 1.0);
       }
 
-      const titleText = `${chunk.document_title || ''} ${chunk.chunk_title || ''}`;
-      const titleHit = terms.some(t => titleText.includes(t.text)) ? 1 : 0;
+      // procedure_score：程序词命中率
+      let procedureScore = 0;
+      const matchedProcedures = [];
+      if (procedureTerms.length > 0) {
+        let hits = 0;
+        for (const pt of procedureTerms) {
+          if (combined.includes(pt.toLowerCase())) {
+            hits++;
+            matchedProcedures.push(pt);
+          }
+        }
+        procedureScore = Math.min(hits / procedureTerms.length, 1.0);
+      }
+
+      // structural_score：章节锚点 / 表格条款 / seq 位置启发式
+      let structuralScore = 0.5; // neutral default
+      if (SECTION_PATTERN.test(combined)) {
+        structuralScore = entityTerms.some(et => /\d/.test(et) && combined.includes(et.toLowerCase())) ? 1.0 : 0.8;
+      }
+      if (TABLE_CLAUSE_PATTERN.test(combined)) {
+        structuralScore = Math.max(structuralScore, 0.7);
+      }
+      const seq = chunk.seq ?? null;
+      if (seq !== null && seq <= 2 && !SECTION_PATTERN.test(combined)) {
+        structuralScore = Math.min(structuralScore, 0.4);
+      }
+
+      const titleHit = entityTerms.some(t => title.includes(t.toLowerCase())) ? 1 : 0;
       const lockedBonus = lockedSet.has(chunk.document_id) ? 1 : 0;
 
-      return { vector_score: vectorScore, keyword_coverage: Math.round(coverage * 100) / 100, title_hit: titleHit, locked_bonus: lockedBonus };
+      return {
+        vector_score: vectorScore,
+        entity_score: Math.round(entityScore * 100) / 100,
+        procedure_score: Math.round(procedureScore * 100) / 100,
+        structural_score: Math.round(structuralScore * 100) / 100,
+        title_hit: titleHit,
+        locked_bonus: lockedBonus,
+        matched_entities: matchedEntities,
+        matched_procedures: matchedProcedures,
+      };
     };
+
+    const defaultScore = (s) => Math.min(1.0,
+      0.45 * s.vector_score +
+      0.30 * s.entity_score +
+      0.15 * s.procedure_score +
+      0.10 * s.structural_score +
+      0.05 * s.title_hit +
+      0.05 * s.locked_bonus
+    );
 
     const ranked = chunks.map(chunk => {
       const signals = computeSignals(chunk);
-
-      // 默认启发式公式（可被 reranker 替换）
       const rankScore = this.reranker?.computeScore
         ? this.reranker.computeScore(chunk, signals)
-        : (0.6 * signals.vector_score + 0.25 * signals.keyword_coverage + 0.1 * signals.title_hit + 0.05 * signals.locked_bonus);
+        : defaultScore(signals);
 
       return {
         ...chunk,
@@ -396,7 +475,22 @@ class DocumentAtomicTools {
     }).sort((a, b) => b.rank_score - a.rank_score);
 
     const finalChunks = typeof top_k === 'number' && top_k > 0 ? ranked.slice(0, top_k) : ranked;
-    return { success: true, chunks: finalChunks, total: finalChunks.length };
+
+    // Phase 2（吸收 #963 _assessCoverage 裁剪版）：基于最终 chunks 统计词覆盖，
+    // 为 LLM 提供证据充分性"数据"（非动作信号）。
+    const hitText = finalChunks.map(c => `${c.document_title || ''} ${c.chunk_title || ''} ${c.content || ''}`.toLowerCase()).join(' ');
+    const coveredEntities = entityTerms.filter(et => hitText.includes(et.toLowerCase()));
+    const coveredProcedures = procedureTerms.filter(pt => hitText.includes(pt.toLowerCase()));
+    const coverage = {
+      entity_total: entityTerms.length,
+      covered_entities: coveredEntities,
+      missed_entities: entityTerms.filter(et => !coveredEntities.includes(et)),
+      procedure_total: procedureTerms.length,
+      covered_procedures: coveredProcedures,
+      missed_procedures: procedureTerms.filter(pt => !coveredProcedures.includes(pt)),
+    };
+
+    return { success: true, chunks: finalChunks, total: finalChunks.length, coverage };
   }
 
   // ============================================================

--- a/lib/document-query-parser.js
+++ b/lib/document-query-parser.js
@@ -1,0 +1,634 @@
+/**
+ * Document Query Parser - 文档查询轻量结构化解析器
+ *
+ * 在 find_document 检索链路中作为第一层，对用户 query 进行轻量结构化解析：
+ * - 抽取检索真正需要的槽位（主题词、类型偏好、编号线索）
+ * - 生成清洗后的检索 query 与主题扩召 query
+ * - 判断用户是否在"找文档身份"（lookup_intent）
+ *
+ * 设计原则：
+ * - 纯规则驱动，不依赖 LLM 调用，零延迟
+ * - 输出可审计、可观测、可增量维护
+ * - query 生成主权归本模块，recall 层原则上只消费不隐式改写
+ *
+ * 使用方式：
+ *   import { parseDocumentQuery } from './document-query-parser.js';
+ *   const parsed = parseDocumentQuery(rawQuery);
+ *
+ * 输出契约（DocumentQueryParseResult）：
+ *   lookup_intent:       boolean   - 是否在找文档身份
+ *   topic_terms:         string[]  - 主题词列表
+ *   doc_type_hints:      string[]  - 文档类型偏好（国家标准/合同/制度等）
+ *   identifier_hints:    string[]  - 标准号/合同号/文号等
+ *   cleaned_query:       string    - 清洗后的主检索 query（仅含主题词）
+ *   expanded_topic_queries: string[] - 主题放宽扩召 query 列表
+ *   noise_terms:         string[]  - 被剔除的口语化噪音词
+ */
+
+import logger from './logger.js';
+
+// ============================================================
+// 噪音词模式：口语化表达，检索时应当剔除
+// ============================================================
+const NOISE_PATTERNS = [
+  // 口语化指代
+  /有一个/g, /有一份/g, /有一篇/g, /有一个叫/g,
+  /规定了/g, /规定了什么/g, /说的是/g, /讲的是/g,
+  /主要讲的是什么/g, /主要讲什么/g, /主要讲的是/g,
+  /主要内容是什么/g, /主要内容/g,
+  /是啥来着/g, /是什么来着/g, /叫什么来着/g,
+  /文件/g, /那个文件/g, /那份文件/g, /那份文档/g,
+  /帮我找/g, /帮我查/g, /帮我看看/g, /帮我看一下/g,
+  /找一下/g, /查一下/g, /看一下/g, /搜一下/g,
+  /请问/g, /我想问/g, /我想知道/g, /我想了解/g,
+  /能不能/g, /可不可以/g, /可以吗/g,
+  /在哪里/g, /在哪/g, /哪里找/g, /怎么找/g,
+  /来着/g, /对吧/g, /对不/g, /是不是/g,
+  // 口语动词补语碎片（audit-round04 P1-1）
+  /一下/g,
+  // 疑问词（audit-round03 P1-2）
+  /哪些/g, /哪个/g, /哪里/g, /什么/g, /怎么/g,
+  /有没有/g, /有没有关于/g, /有没有一个/g,
+  // 口语后缀（audit-round03 P1-2）
+  /那份/g, /那个/g, /那[份个]/g, /这[份个]/g,
+  // 语气/疑问词
+  /吗[\?？]*$/g, /呢[\?？]*$/g, /吧[\?？]*$/g, /啊[\?？]*$/g, /[\?？]/g,
+];
+
+// ============================================================
+// 文档类型提示词 → 标准类型 → 用于剥离的关键词集合
+// ============================================================
+const DOC_TYPE_HINT_MAP = [
+  // 国家标准
+  { patterns: [/国家标准/, /国标/, /国家规范/, /强制性标准/, /推荐性标准/, /^标准$/, /标准号/, /标准名称/], type: '国家标准' },
+  // 行业标准
+  { patterns: [/行业标准/, /行标/, /团体标准/, /企业标准/, /企标/], type: '行业标准' },
+  // 合同/协议
+  { patterns: [/合同/, /协议/, /契约/, /合约/], type: '合同协议' },
+  // 制度/办法/规定 — 注意：不使用裸 /规定/，避免把"规定了"动词误判为文档类型
+  { patterns: [/(?:管理制度|管理规定|暂行规定|试行规定|实施办法|管理办法|暂行条例)/, /制度/, /办法/, /条例/, /章程/, /细则/, /规程/], type: '制度规章' },
+  // 手册/指南
+  { patterns: [/手册/, /指南/, /说明书/, /操作指引/, /作业指导/], type: '手册指南' },
+  // 报告
+  { patterns: [/报告/, /报表/, /分析报告/, /评估报告/], type: '报告' },
+  // 法律文件
+  { patterns: [/法律/, /法规/, /法令/, /司法解释/], type: '法律法规' },
+  // 技术文档
+  { patterns: [/技术文档/, /技术规范/, /技术方案/, /技术规格书/], type: '技术文档' },
+];
+
+// ============================================================
+// 类型关键词剥离模式（从 cleaned_query 中剔除已识别的类型词）
+// 基于 DOC_TYPE_HINT_MAP 的 patterns，提取可剥离的关键词片段
+// ============================================================
+const TYPE_STRIP_PATTERNS = [
+  /国家标准/g, /国标/g, /国家规范/g, /强制性标准/g, /推荐性标准/g,
+  /行业标准/g, /行标/g, /团体标准/g, /企业标准/g, /企标/g,
+  /合同/g, /协议/g, /契约/g, /合约/g,
+  /管理制度/g, /管理规定/g, /暂行规定/g, /试行规定/g, /实施办法/g, /管理办法/g, /暂行条例/g,
+  /制度/g, /办法/g, /条例/g, /章程/g, /细则/g, /规程/g,
+  /手册/g, /指南/g, /说明书/g, /操作指引/g, /作业指导/g,
+  /报告/g, /报表/g, /分析报告/g, /评估报告/g,
+  /法律/g, /法规/g, /法令/g, /司法解释/g,
+  /技术文档/g, /技术规范/g, /技术方案/g, /技术规格书/g,
+];
+
+// ============================================================
+// 结构助词：用于拆分主题词时清理的虚词/连接词
+// ============================================================
+const STRUCTURAL_PARTICLES = /[的之与和及或关于有关涉及对]+/g;
+
+// ============================================================
+// 标准号/编号模式
+// ============================================================
+const IDENTIFIER_PATTERNS = [
+  // GB/T 12345-2020, GB 12345
+  /\bGB[\/\sT]*\d[\d.]*(-\d{2,4})?\b/gi,
+  // ISO 9001:2015
+  /\bISO[\/\s]*\d[\d.:]+\b/gi,
+  // 行业标准号：YY/T, HJ, DB, QB 等
+  /\b(?:YY\/T|HJ|DB\d|\bQB)\s*\d[\d.]*\b/gi,
+  // 合同编号：HT-2024-001
+  /\b(?:HT|CONT|CONTRACT)[-\s]*\d{2,4}[-\s]*\d+\b/gi,
+  // 文件号/文号：国发〔2024〕1号
+  /[〔\[]?\d{4}[〕\]]?\d+\s*号/gi,
+];
+
+// ============================================================
+// 文档定位信号：用户明确在找"文档身份"
+// ============================================================
+const LOOKUP_INTENT_PATTERNS = [
+  /找.*(?:文档|文件|资料|合同|标准|制度|手册|指南|报告)/,
+  /(?:文档|文件|资料|合同|标准|制度|手册|指南|报告).*(?:在哪|叫啥|叫什么|是啥|是什么)/,
+  /有没有.*(?:文档|文件|资料|合同|标准|制度)/,
+  /哪个.*(?:文档|文件|合同|标准|制度)/,
+  /《[^》]+》/,
+  // 编号查询
+  /\bGB[\/\sT]*\d/,
+  /\bISO[\/\s]*\d/,
+  /[〔\[]?\d{4}[〕\]]?\d+\s*号/,
+];
+
+// ============================================================
+// 同义词归一表（主题词扩展用）
+// ============================================================
+const SYNONYM_MAP = {
+  '汽车': ['车辆', '机动车'],
+  '车身': ['车体'],
+  '术语': ['词汇', '用语', '名词'],
+  '定义': ['释义', '含义'],
+  '标准': ['规范', '准则'],
+  '合同': ['协议'],
+  '制度': ['规章', '规定'],
+  '指南': ['手册', '指引'],
+};
+
+// ============================================================
+// Query Facet 抽取 — audit-round01 P1-1
+// 供 evidence rerank / coverage 校验消费，避免各模块重复拆词
+// ============================================================
+const PROCEDURE_TERM_PATTERNS = [
+  /试验/g, /实验/g, /测试/g, /检测/g, /检验/g,
+  /条件/g, /方法/g, /步骤/g, /流程/g, /要求/g, /规定/g, /规范/g,
+  /怎么做/g, /如何做/g, /怎么测/g, /如何测/g,
+];
+
+const ATTRIBUTE_TERM_PATTERNS = [
+  /是什么/g, /什么是/g, /代表什么/g, /含义/g, /定义/g,
+  /等级/g, /级别/g, /分类/g, /类型/g,
+  /多少/g, /多大/g, /多长/g, /多重/g,
+];
+
+/**
+ * 从原始 query 提取结构化 facets（轻量规则驱动）
+ * @param {string} rawQuery
+ * @param {string[]} identifierHints
+ * @returns {Object} facets
+ */
+function _extractQueryFacets(rawQuery, identifierHints) {
+  const trimmed = rawQuery.trim();
+
+  // entity_terms：标识符 + 数字编码 + 专有名词型实体
+  const entityTerms = [];
+
+  // 标识符直接作为实体
+  for (const id of identifierHints) {
+    entityTerms.push(id);
+  }
+
+  // 数字编码型实体（如 IPX5、IPX7、14.2.5、第二位数字为5）
+  const codePatterns = [
+    /\b[A-Z]{2,}[\s-]*\d[\d.]*\b/gi,      // IPX5, GB/T 12345
+    /\b\d+(?:\.\d+)+\b/g,                    // 14.2.5
+    /第[一二三四五六七八九十\d]+位数字为\d+/g,  // 第二位数字为5
+    /第[一二三四五六七八九十\d]+[章节条款项]/g, // 第二章、第3条
+  ];
+  for (const pattern of codePatterns) {
+    const matches = trimmed.match(pattern);
+    if (matches) {
+      for (const m of matches) {
+        const clean = m.replace(/\s+/g, ' ').trim();
+        if (!entityTerms.some(e => e === clean)) {
+          entityTerms.push(clean);
+        }
+      }
+    }
+  }
+
+  // 专有名词型实体（由大写字母起头的中英混合词，如 "IP 防护"）
+  const properNounPattern = /\b[A-Z]{2,}(?:[\s/-]*[^\s,，。；;、]{1,6}){0,3}/g;
+  const properMatches = trimmed.match(properNounPattern);
+  if (properMatches) {
+    for (const m of properMatches) {
+      const clean = m.replace(/\s+/g, ' ').trim();
+      if (clean.length >= 2 && !entityTerms.some(e => e === clean) && !/^[A-Z]+$/.test(clean)) {
+        entityTerms.push(clean);
+      }
+    }
+  }
+
+  // procedure_terms
+  const procedureTerms = [];
+  for (const pattern of PROCEDURE_TERM_PATTERNS) {
+    const matches = trimmed.match(new RegExp(pattern.source, 'g'));
+    if (matches) {
+      for (const m of matches) {
+        if (!procedureTerms.includes(m)) procedureTerms.push(m);
+      }
+    }
+  }
+
+  // attribute_terms
+  const attributeTerms = [];
+  for (const pattern of ATTRIBUTE_TERM_PATTERNS) {
+    const matches = trimmed.match(new RegExp(pattern.source, 'g'));
+    if (matches) {
+      for (const m of matches) {
+        if (!attributeTerms.includes(m)) attributeTerms.push(m);
+      }
+    }
+  }
+
+  // normalized_lookup_query：实体 + 程序词拼接
+  const normalizedParts = [...new Set([...entityTerms, ...procedureTerms])];
+  const normalizedLookupQuery = normalizedParts.join(' ') || trimmed;
+
+  return {
+    entity_terms: [...new Set(entityTerms)],
+    procedure_terms: [...new Set(procedureTerms)],
+    attribute_terms: [...new Set(attributeTerms)],
+    normalized_lookup_query: normalizedLookupQuery,
+  };
+}
+
+/**
+ * @typedef {Object} DocumentQueryParseResult
+ * @property {boolean} lookup_intent - 是否在找文档身份
+ * @property {string[]} topic_terms - 主题词列表
+ * @property {string[]} doc_type_hints - 文档类型偏好
+ * @property {string[]} identifier_hints - 标准号/合同号/文号
+ * @property {string} cleaned_query - 清洗后的主检索 query（仅主题词）
+ * @property {string[]} expanded_topic_queries - 主题放宽扩召 query
+ * @property {string[]} noise_terms - 被剔除的口语化噪音词
+ * @property {string} raw_query - 原始 query
+ * @property {Object} facets - 查询结构化切面（audit-round01 P1-1）
+ * @property {string[]} facets.entity_terms - 核心实体词
+ * @property {string[]} facets.procedure_terms - 程序/方法词
+ * @property {string[]} facets.attribute_terms - 属性/问法词
+ * @property {string} facets.normalized_lookup_query - 归一化查找 query
+ */
+
+/**
+ * 解析文档查询，提取结构化槽位
+ *
+ * 处理顺序（关键）：
+ *   原 query → 剔除噪音词 → 提取文档类型偏好 → 剔除类型关键词 → 提取主题词
+ * 必须先剔除噪音再检测类型，避免"规定了"等噪音词被误判为制度规章。
+ * 必须在提取类型后再剔除类型关键词，保证 cleaned_query 不受类型词污染。
+ *
+ * @param {string} rawQuery - 原始用户查询
+ * @returns {DocumentQueryParseResult}
+ */
+export function parseDocumentQuery(rawQuery) {
+  if (!rawQuery || typeof rawQuery !== 'string' || !rawQuery.trim()) {
+    return _emptyResult(rawQuery || '');
+  }
+
+  const trimmed = rawQuery
+    .replace(/[？]/g, '?')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // 1. 检测文档定位意图（使用原始 query）
+  const lookupIntent = LOOKUP_INTENT_PATTERNS.some(p => p.test(trimmed));
+
+  // 2. 提取编号线索（使用原始 query，编号是精确信号）
+  const identifierHints = [];
+  for (const pattern of IDENTIFIER_PATTERNS) {
+    const matches = trimmed.match(pattern);
+    if (matches) {
+      identifierHints.push(...matches.map(m => m.trim()));
+    }
+  }
+
+  // 3. 【关键顺序变更】先剔除噪音词，再检测类型偏好
+  //    避免"规定了"等口语噪音词被 DOC_TYPE_HINT_MAP 误判为制度规章
+  let cleaned = trimmed;
+  const noiseTerms = [];
+
+  cleaned = cleaned
+    .replace(/主要讲的是什么/g, ' ')
+    .replace(/主要讲什么/g, ' ')
+    .replace(/主要讲的是/g, ' ')
+    .replace(/主要内容是什么/g, ' ')
+    .replace(/主要内容/g, ' ')
+    .replace(/什么标准/g, ' 标准 ')
+    .replace(/什么文件/g, ' 文件 ')
+    .replace(/什么文档/g, ' 文档 ')
+    .replace(/是什么标准/g, ' 标准 ')
+    .replace(/是什么文件/g, ' 文件 ')
+    .replace(/是什么文档/g, ' 文档 ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  for (const pattern of NOISE_PATTERNS) {
+    const matches = cleaned.match(new RegExp(pattern.source, 'g'));
+    if (matches) {
+      noiseTerms.push(...matches);
+    }
+    cleaned = cleaned.replace(pattern, ' ').replace(/\s+/g, ' ').trim();
+  }
+
+  // 4. 在噪音已剔除的文本上检测文档类型偏好
+  //    注意：DOC_TYPE_HINT_MAP 的 patterns 不使用 /g，避免 lastIndex 状态泄漏
+  const docTypeHints = [];
+  for (const entry of DOC_TYPE_HINT_MAP) {
+    for (const p of entry.patterns) {
+      if (p.test(cleaned)) {
+        const trimmedType = entry.type.trim();
+        if (!docTypeHints.includes(trimmedType)) {
+          docTypeHints.push(trimmedType);
+        }
+        break;
+      }
+    }
+  }
+
+  // 5. 【新增】类型关键词剥离：从 cleaned 文本中剔除已识别的类型词
+  //    确保 cleaned_query 不受"国标""合同""制度"等类型词污染
+  let topicText = cleaned;
+  for (const typePattern of TYPE_STRIP_PATTERNS) {
+    topicText = topicText.replace(typePattern, ' ').replace(/\s+/g, ' ').trim();
+  }
+
+  // 6. 清理结构助词（的、之、与、和、及、或、关于、有关、涉及、对）
+  topicText = topicText.replace(STRUCTURAL_PARTICLES, ' ').replace(/\s+/g, ' ').trim();
+
+  // 6.5: 标识符剥离（audit-round04 P1-1）—— 在分词前将已捕获的完整编号从主题文本中移除
+  //     防止编号片段（如"一下HT""GB/T"残片）污染 topic_terms
+  let topicTextForSegmentation = topicText;
+  if (identifierHints.length > 0) {
+    for (const id of identifierHints) {
+      // 转义标识符中的正则特殊字符
+      const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      topicTextForSegmentation = topicTextForSegmentation
+        .replace(new RegExp(escaped, 'gi'), ' ')
+        .replace(/\s+/g, ' ').trim();
+    }
+    // 同时剥离常见标识符前缀碎片（如 "GB/T"、"HT" 等孤立残片）
+    topicTextForSegmentation = topicTextForSegmentation
+      .replace(/\b(?:GB\/T|GB|ISO|HT|CONT|CONTRACT|YY\/T|HJ|DB\d+|QB)\b\s*/gi, ' ')
+      .replace(/\s+/g, ' ').trim();
+  }
+
+  // 7. 从剥离后的纯主题文本中提取主题词
+  const topicTerms = _extractTopicTerms(topicTextForSegmentation || topicText, docTypeHints, identifierHints)
+    .map(t => t.trim())
+    .filter(Boolean)
+    .filter(t => !['标准', '文件', '文档', '规范', '资料'].includes(t));
+
+  // 8. 构造 cleaned_query（兼容 merge 前稳定语义）：
+  //    - 有编号时：编号优先 + 主题词随后
+  //    - 无编号时：优先保留连续主题文本，不强制用空格重组
+  let cleanedQuery;
+  const dedupedIds = [...new Set(identifierHints)];
+  const idPart = dedupedIds.join(' ');
+  const cleanTopicTerms = topicTerms.filter(t => {
+    // 过滤掉标识符残片（如 "GB/T"、"一下HT"）
+    if (/^(?:GB\/T|GB\d*|ISO\d*|HT[-\s]?\d*|CONT[-\s]?\d*|CONTRACT[-\s]?\d*|[A-Z]{2,}\/?\d*)$/i.test(t)) return false;
+    // 过滤已在 identifier_hints 中的片段
+    if (dedupedIds.some(id => t.includes(id) || id.includes(t))) return false;
+    return true;
+  });
+
+  const contiguousTopicText = (topicTextForSegmentation || topicText || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const topicPart = cleanTopicTerms.join(' ');
+
+  if (idPart && topicPart) {
+    cleanedQuery = idPart + ' ' + topicPart;
+  } else if (idPart) {
+    cleanedQuery = idPart;
+  } else if (contiguousTopicText) {
+    cleanedQuery = contiguousTopicText.replace(/\s+/g, '');
+  } else if (topicPart) {
+    cleanedQuery = topicPart;
+  } else {
+    cleanedQuery = topicText || cleaned;
+  }
+  // 最终去重空格
+  cleanedQuery = cleanedQuery.replace(/\s+/g, ' ').trim();
+
+  // 9. 生成主题扩召 query 列表
+  const expandedTopicQueries = _generateExpandedQueries(topicTerms);
+
+  // 10. 提取 query facets（audit-round01 P1-1）
+  const facets = _extractQueryFacets(trimmed, identifierHints);
+
+  const result = {
+    lookup_intent: lookupIntent || identifierHints.length > 0 || docTypeHints.length > 0,
+    topic_terms: topicTerms,
+    doc_type_hints: docTypeHints.map(t => t.trim()).filter(Boolean),
+    identifier_hints: [...new Set(identifierHints)],
+    cleaned_query: cleanedQuery,
+    expanded_topic_queries: expandedTopicQueries,
+    noise_terms: [...new Set(noiseTerms)],
+    raw_query: trimmed,
+    facets,
+  };
+
+  logger.info('[DocQueryParser] Parsed:', {
+    raw_query: trimmed.substring(0, 100),
+    lookup_intent: result.lookup_intent,
+    topic_terms: result.topic_terms,
+    doc_type_hints: result.doc_type_hints,
+    cleaned_query: result.cleaned_query,
+    expanded_count: result.expanded_topic_queries.length,
+  });
+
+  return result;
+}
+
+/**
+ * 从剥离类型词后的纯主题文本中提取主题词
+ *
+ * 注意：调用方已通过 TYPE_STRIP_PATTERNS 剥离了类型关键词，
+ * 因此本函数不再需要基于 doc_type_hints 做字符级过滤。
+ */
+function _extractTopicTerms(topicText, _docTypeHints, identifierHints) {
+  if (!topicText) return [];
+
+  // 1. 优先按标点/空格分割
+  let segments = topicText
+    .split(/[,，。；;、\s]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  // 2. 中文无空格长文本 → 启发式切分
+  if (segments.length <= 1 && topicText.length > 3) {
+    segments = _segmentChineseText(topicText);
+  }
+
+  // 3. 基础过滤 + 标识符碎片过滤（audit-round04 P1-1）
+  return segments.filter(seg => {
+    if (seg.length <= 1) return false;
+    if (/^[\d.,+\-×÷=<>()（）【】\[\]{}]+$/.test(seg)) return false;
+    // 过滤掉纯编号片段
+    if (identifierHints.some(id => seg.includes(id))) return false;
+    // 过滤标识符残片（如 "一下HT" 中的 "一下HT"、"GB/T" 残片）
+    if (/^(?:GB\/T|GB\d*|ISO\d*|HT[-\s]?\d*|CONT[-\s]?\d*|CONTRACT[-\s]?\d*|[A-Z]{2,}\/?\d*)$/i.test(seg)) return false;
+    return true;
+  });
+}
+
+/**
+ * 对中文无空格文本做启发式切分
+ *
+ * 策略（audit-round02 P1 改进）：
+ * - 优先用已知类型关键词作为切分边界（"标准""合同""制度""手册"等）
+ * - 边界内按 2-4 字滑窗切分
+ */
+function _segmentChineseText(text) {
+  // 先用常见类型关键词作为分割锚点
+  const SPLIT_ANCHORS = [
+    '国家标准', '行业标准', '团体标准', '企业标准', '强制性标准', '推荐性标准',
+    '管理制度', '管理规定', '实施办法', '管理办法', '暂行规定', '暂行条例',
+    '技术文档', '技术规范', '技术方案', '技术规格书',
+    '操作指引', '作业指导', '分析报告', '评估报告', '司法解释',
+  ];
+
+  let working = text;
+  const anchorPieces = [];
+
+  for (const anchor of SPLIT_ANCHORS) {
+    if (working.includes(anchor)) {
+      anchorPieces.push(anchor);
+      working = working.replace(anchor, '\n');
+    }
+  }
+
+  // 对剩余文本做滑窗切分
+  const rawSegments = working
+    .split(/[\n]+/)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  const segments = [];
+  for (const raw of rawSegments) {
+    // 尝试 4→3→2 字滑窗
+    let i = 0;
+    while (i < raw.length) {
+      let matched = false;
+      for (const len of [4, 3, 2]) {
+        if (i + len <= raw.length) {
+          const candidate = raw.substring(i, i + len);
+          if (!/^[\d.,+\-×÷=<>()（）\s]+$/.test(candidate)) {
+            segments.push(candidate);
+            i += len;
+            matched = true;
+            break;
+          }
+        }
+      }
+      if (!matched) {
+        i++;
+      }
+    }
+  }
+
+  // 把锚点关键词插回合适位置
+  segments.push(...anchorPieces);
+
+  return segments;
+}
+
+/**
+ * 主题词常见边界表 —— 用于长主题词的放宽拆分（audit-round03 P2-1）
+ * 键：常见尾词/后缀；值：null 表示仅作拆分锚点
+ */
+const TOPIC_SPLIT_SUFFIXES = [
+  '术语', '定义', '标准', '规范', '指南', '手册', '办法', '规定',
+  '制度', '条例', '流程', '方案', '报告', '说明', '要求', '条件',
+  '指标', '参数', '方法', '技术', '系统', '管理', '安全', '质量',
+  '性能', '设计', '测试', '评估', '分析', '计算', '操作', '维护',
+];
+
+/**
+ * 生成主题扩召 query 列表
+ *
+ * 策略：
+ * - A) 多词主题，生成部分组合（去尾部修饰）
+ * - B) 单词主题，查找同义词表生成替换 query
+ * - C) 长单主题词（4+字），按已知词边界拆分放宽（audit-round03 P2-1）
+ * - 不做类型收窄（不追加"标准""国标"等类型词）
+ *
+ * @param {string[]} topicTerms - 主题词列表
+ * @returns {string[]} 扩召 query 列表
+ */
+function _generateExpandedQueries(topicTerms) {
+  if (!topicTerms || topicTerms.length === 0) return [];
+
+  const queries = [];
+
+  // 策略 A：多词主题 → 去尾部修饰，逐步放宽
+  if (topicTerms.length >= 2) {
+    // 去掉最后一个词
+    const droppedLast = topicTerms.slice(0, -1).join(' ');
+    if (droppedLast.length >= 2) {
+      queries.push(droppedLast);
+    }
+    // 去掉第一个词（常用于剥离泛领域前缀，如“汽车 外壳防护等级” → “外壳防护等级”）
+    const droppedFirst = topicTerms.slice(1).join(' ');
+    if (droppedFirst.length >= 2) {
+      queries.push(droppedFirst);
+    }
+    // 去掉前两个词之后的部分（保留核心前两词）
+    if (topicTerms.length >= 3) {
+      const coreTwo = topicTerms.slice(0, 2).join(' ');
+      if (coreTwo.length >= 2 && coreTwo !== droppedLast) {
+        queries.push(coreTwo);
+      }
+    }
+  }
+
+  // 策略 B：单主题词 → 查找同义词
+  for (const term of topicTerms) {
+    const synonyms = SYNONYM_MAP[term];
+    if (synonyms && synonyms.length > 0) {
+      for (const syn of synonyms) {
+        const expandedQuery = topicTerms.map(t => t === term ? syn : t).join(' ');
+        if (expandedQuery !== topicTerms.join(' ') && !queries.includes(expandedQuery)) {
+          queries.push(expandedQuery);
+        }
+      }
+    }
+  }
+
+  // 策略 C：长单主题词（4+ 字）→ 按已知词边界拆分放宽（audit-round03 P2-1）
+  if (topicTerms.length === 1) {
+    const singleTerm = topicTerms[0];
+    if (singleTerm.length >= 4) {
+      for (const suffix of TOPIC_SPLIT_SUFFIXES) {
+        if (singleTerm.endsWith(suffix) && singleTerm.length > suffix.length) {
+          const prefix = singleTerm.slice(0, -suffix.length);
+          if (prefix.length >= 2) {
+            // 拆分：前缀 + 尾词（如 汽车车身 + 术语）
+            queries.push(prefix + ' ' + suffix);
+            // 进一步放宽：仅前缀（如 汽车车身）
+            queries.push(prefix);
+          }
+          break; // 只取第一个匹配的尾词（最长匹配优先）
+        }
+      }
+    }
+  }
+
+  // 去重，限制数量
+  return [...new Set(queries)].slice(0, 5);
+}
+
+/**
+ * 返回空解析结果
+ */
+function _emptyResult(rawQuery) {
+  return {
+    lookup_intent: false,
+    topic_terms: [],
+    doc_type_hints: [],
+    identifier_hints: [],
+    cleaned_query: rawQuery || '',
+    expanded_topic_queries: [],
+    noise_terms: [],
+    raw_query: rawQuery || '',
+    facets: {
+      entity_terms: [],
+      procedure_terms: [],
+      attribute_terms: [],
+      normalized_lookup_query: rawQuery || '',
+    },
+  };
+}
+
+export default { parseDocumentQuery };

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -2631,6 +2631,8 @@ class ToolManager {
       }));
 
       const extra = { documents, total: result.total ?? documents.length };
+      // Phase 2：透传 parser 解析摘要，帮助 LLM 理解编号/类型识别结果
+      if (result.query_parse) extra.query_parse = result.query_parse;
       if (documents.length > 0) {
         const store = this._getDocHandleStore();
         const { handle } = store.create({
@@ -2873,6 +2875,8 @@ class ToolManager {
 
       const chunks = (result.chunks || []).map(c => this._summarizeChunk(c));
       const extra = { chunks, total: result.total ?? chunks.length };
+      // Phase 2：透传词覆盖统计，为 LLM 提供证据充分性数据（非动作信号）
+      if (result.coverage) extra.coverage = result.coverage;
       if (chunks.length > 0) {
         const { handle } = store.create({
           type: HANDLE_TYPE.RANKED_CHUNKSET,

--- a/tests/document-atomic-phase2.test.js
+++ b/tests/document-atomic-phase2.test.js
@@ -1,0 +1,181 @@
+/**
+ * Phase 2 测试：parser 集成 + 四维 rerank + coverage meta
+ *
+ * 覆盖 round01 结论 §6 Phase 2 完成判据：
+ *   - rankChunksForQuestion 四维信号（entity/procedure/structural/title_hit/locked_bonus）
+ *   - 新公式 min(1, 0.45v+0.30e+0.15p+0.10s+0.05t+0.05l)
+ *   - coverage 覆盖统计（covered/missed entities & procedures）
+ *   - searchDocumentsByMetadata 的 parser 预处理（cleaned_query、doc_type 推断、query_parse 透传）
+ *
+ * 运行：node tests/document-atomic-phase2.test.js
+ */
+
+import DocumentAtomicTools from '../lib/document-atomic-tools.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, name, detail = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } else {
+    failed++;
+    console.error(`  ❌ ${name} ${detail}`);
+  }
+}
+
+const approx = (a, b, eps = 0.001) => Math.abs(a - b) < eps;
+
+// 纯函数测试：db=null（rankChunksForQuestion 不触达服务层）
+const tools = new DocumentAtomicTools(null, null);
+
+// ============================================================
+// 场景 1：四维信号计算（entity / procedure / structural / title / locked）
+// ============================================================
+console.log('\n场景 1：四维信号计算');
+{
+  const chunks = [
+    {
+      chunk_id: 'c1',
+      document_id: 'd1',
+      document_title: 'GB/T 4208 外壳防护等级',
+      chunk_title: 'IPX5 试验条件',
+      content: 'IPX5 防水试验：喷嘴内径 6.3mm，按 14.2.5 条款执行喷水试验。',
+      seq: 5,
+      score: 0.8,
+    },
+  ];
+  const r = tools.rankChunksForQuestion({ question: 'IPX5 防水试验条件是什么', chunks });
+  assert(r.success === true, 'rank 成功');
+  const s = r.chunks[0].rank_signals;
+
+  assert(s.entity_score > 0, 'entity_score > 0（IPX5 命中）', `entity=${s.entity_score}`);
+  assert(s.procedure_score > 0, 'procedure_score > 0（试验命中）', `procedure=${s.procedure_score}`);
+  assert(s.structural_score === 1.0, 'structural_score=1.0（章节号 14.2.5 + 数字实体命中）', `structural=${s.structural_score}`);
+  assert(s.title_hit === 1, 'title_hit=1（标题含 IPX5）');
+  assert(s.matched_entities.length > 0, 'matched_entities 可审计', JSON.stringify(s.matched_entities));
+}
+
+// ============================================================
+// 场景 2：新公式验证
+// ============================================================
+console.log('\n场景 2：rank_score 公式 = min(1, 0.45v+0.30e+0.15p+0.10s+0.05t+0.05l)');
+{
+  const chunks = [{
+    chunk_id: 'c1', document_id: 'd1', document_title: '标准A',
+    content: 'IPX5 试验内容 14.2.5', seq: 5, score: 0.8,
+  }];
+  const r = tools.rankChunksForQuestion({ question: 'IPX5 试验', chunks });
+  const s = r.chunks[0].rank_signals;
+  const expected = Math.min(1.0,
+    0.45 * s.vector_score +
+    0.30 * s.entity_score +
+    0.15 * s.procedure_score +
+    0.10 * s.structural_score +
+    0.05 * s.title_hit +
+    0.05 * s.locked_bonus
+  );
+  assert(approx(r.chunks[0].rank_score, Math.round(expected * 10000) / 10000), 'rank_score 与六维公式一致',
+    `actual=${r.chunks[0].rank_score} expected=${expected}`);
+}
+
+// ============================================================
+// 场景 3：structural 启发式边界
+// ============================================================
+console.log('\n场景 3：structural 启发式边界');
+{
+  // 低 seq 且无章节号 → 0.4
+  const r1 = tools.rankChunksForQuestion({
+    question: '概述',
+    chunks: [{ chunk_id: 'c1', document_id: 'd1', document_title: '文档', content: '本文档为概述性介绍。', seq: 1, score: 0.5 }],
+  });
+  assert(r1.chunks[0].rank_signals.structural_score === 0.4, '低 seq 无章节号 → 0.4', `actual=${r1.chunks[0].rank_signals.structural_score}`);
+
+  // 表格/条款关键词 → ≥0.7
+  const r2 = tools.rankChunksForQuestion({
+    question: '费用表',
+    chunks: [{ chunk_id: 'c2', document_id: 'd1', document_title: '文档', content: '见下表：费用明细表格。', seq: 8, score: 0.5 }],
+  });
+  assert(r2.chunks[0].rank_signals.structural_score >= 0.7, '表格关键词 → ≥0.7', `actual=${r2.chunks[0].rank_signals.structural_score}`);
+}
+
+// ============================================================
+// 场景 4：locked_bonus 生效
+// ============================================================
+console.log('\n场景 4：locked_bonus 生效');
+{
+  const chunks = [
+    { chunk_id: 'c1', document_id: 'd1', document_title: '文档A', content: '内容甲', seq: 5, score: 0.7 },
+    { chunk_id: 'c2', document_id: 'd2', document_title: '文档B', content: '内容乙', seq: 5, score: 0.7 },
+  ];
+  const r = tools.rankChunksForQuestion({ question: '内容', chunks, locked_document_ids: ['d2'] });
+  const locked = r.chunks.find(c => c.document_id === 'd2');
+  const unlocked = r.chunks.find(c => c.document_id === 'd1');
+  assert(locked.rank_signals.locked_bonus === 1 && unlocked.rank_signals.locked_bonus === 0, '锁定文档加权');
+  assert(locked.rank_score > unlocked.rank_score, '锁定文档 rank_score 更高');
+}
+
+// ============================================================
+// 场景 5：coverage 覆盖统计
+// ============================================================
+console.log('\n场景 5：coverage 覆盖统计');
+{
+  const chunks = [
+    { chunk_id: 'c1', document_id: 'd1', document_title: '标准', content: 'IPX5 防水试验条件说明。', seq: 3, score: 0.8 },
+  ];
+  const r = tools.rankChunksForQuestion({ question: 'IPX5 和 IPX7 的试验差异', chunks });
+  assert(r.coverage, 'coverage 字段存在');
+  assert(r.coverage.covered_entities.some(e => /IPX5/i.test(e)), 'IPX5 被覆盖');
+  assert(r.coverage.missed_entities.some(e => /IPX7/i.test(e)), 'IPX7 标记为未覆盖（证据充分性数据）');
+  assert(Array.isArray(r.coverage.covered_procedures), 'procedure 覆盖统计存在');
+}
+
+// ============================================================
+// 场景 6：parser 兜底（简易分词接管）
+// ============================================================
+console.log('\n场景 6：entity 词源兜底');
+{
+  const chunks = [
+    { chunk_id: 'c1', document_id: 'd1', document_title: 'Doc', content: 'waterproof testing conditions', seq: 3, score: 0.6 },
+  ];
+  // 纯英文问题：parser 实体提取可能为空，_extractTerms 兜底接管
+  const r = tools.rankChunksForQuestion({ question: 'waterproof testing', chunks });
+  assert(r.success === true, '兜底路径 rank 成功');
+  assert(r.coverage.entity_total >= 0, 'entity 词源兜底不崩溃');
+}
+
+// ============================================================
+// 场景 7：metadata 检索 parser 预处理
+// ============================================================
+console.log('\n场景 7：searchDocumentsByMetadata parser 预处理');
+{
+  const searchCalls = [];
+  const mockSearch = {
+    search: async (query, opts) => {
+      searchCalls.push({ query, opts });
+      return { success: true, candidates: [{ document_id: 'd1', document_title: '标准A' }], total: 1 };
+    },
+    searchByAttachmentFilenames: async () => [],
+    getDocumentInfo: async () => [],
+  };
+  const t = new DocumentAtomicTools(null, null, { searchService: mockSearch });
+
+  // 7a：doc_type 推断（未显式传 doc_types）
+  const r1 = await t.searchDocumentsByMetadata({ metadata_query: 'GB/T 4208 这份标准讲了什么', user_id: 'u1' });
+  assert(r1.success === true, '预处理检索成功');
+  assert(searchCalls[0].query.includes('GB') || searchCalls[0].query.includes('4208'), '检索词含编号（cleaned_query 编号优先）', searchCalls[0].query);
+  assert(r1.query_parse && Array.isArray(r1.query_parse.identifier_hints), 'query_parse 透传编号识别结果');
+  assert(r1.query_parse.identifier_hints.length > 0, '识别出标准编号', JSON.stringify(r1.query_parse.identifier_hints));
+
+  // 7b：显式 doc_types 不被推断覆盖
+  searchCalls.length = 0;
+  await t.searchDocumentsByMetadata({ metadata_query: '这份标准的内容', user_id: 'u1', doc_types: ['contract'] });
+  assert(JSON.stringify(searchCalls[0].opts.doc_types) === JSON.stringify(['contract']), '显式 doc_types 优先于推断');
+}
+
+// ============================================================
+console.log('\n' + '='.repeat(40));
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log('='.repeat(40));
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/document-query-parser.test.js
+++ b/tests/document-query-parser.test.js
@@ -1,0 +1,333 @@
+/**
+ * Document Query Parser 单元测试
+ *
+ * 覆盖审计标准：
+ * - audit-round02 P0-1: 主题/类型分离
+ * - audit-round03 P1-2 & P2-1: 疑问词清理、编号保护、长主题扩召
+ * - audit-round04 P0-1: 幂等性（消除全局正则 lastIndex 状态污染）
+ * - audit-round04 P1-1: 编号不重复、无残片、无口语残留
+ * - audit-round04 P1-2: 精确输出断言（不再仅用 includes()）
+ *
+ * 运行：node tests/document-query-parser.test.js
+ */
+
+import { parseDocumentQuery } from '../lib/document-query-parser.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label}`); }
+}
+
+function assertEq(actual, expected, label) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) { passed++; }
+  else {
+    failed++;
+    console.error(`  ❌ FAIL: ${label}`);
+    console.error(`     expected: ${JSON.stringify(expected)}`);
+    console.error(`     actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertContains(arr, item, label) {
+  if (arr.includes(item)) { passed++; }
+  else { failed++; console.error(`  ❌ FAIL: ${label} — array: ${JSON.stringify(arr)}`); }
+}
+
+// ============================================================
+// 用例 1："国标文件" — 类型词从主题中剥离
+// ============================================================
+function testCase1_GuoBiao() {
+  console.log('\n📋 用例1: 国标文件查询');
+  const r = parseDocumentQuery('有一个规定了汽车车身术语的国标文件是啥来着？');
+
+  assert(r.lookup_intent === true, '1.1 lookup_intent');
+  assertEq(r.cleaned_query, '汽车车身术语', '1.2 cleaned_query 精确值');
+  assertEq(r.doc_type_hints, ['国家标准'], '1.3 doc_type_hints 精确值');
+  assert(r.topic_terms.length > 0, '1.4 topic_terms 非空');
+  assert(!r.topic_terms.some(t => t.includes('国标')), '1.5 topic_terms 不含国标');
+  assert(!r.cleaned_query.includes('国标'), '1.6 cleaned_query 不含国标');
+  assert(!r.cleaned_query.includes('规定了'), '1.7 cleaned_query 不含"规定了"');
+}
+
+// ============================================================
+// 用例 2："制度办法" — 制度类正确识别，不带噪音
+// ============================================================
+function testCase2_ZhiDu() {
+  console.log('\n📋 用例2: 制度办法查询');
+  const r = parseDocumentQuery('公司管理制度有哪些？');
+
+  assert(r.lookup_intent === true, '2.1 lookup_intent');
+  assertEq(r.doc_type_hints, ['制度规章'], '2.2 doc_type_hints 精确值（无空格污染）');
+  assert(!r.cleaned_query.includes('管理制度'), '2.3 cleaned_query 不含管理制度');
+  assert(!r.cleaned_query.includes('哪些'), '2.4 cleaned_query 不含疑问词');
+  assert(!r.cleaned_query.includes('？'), '2.5 cleaned_query 不含问号');
+}
+
+// ============================================================
+// 用例 3："合同编号" — 编号优先，无口语残片（audit-round04 P1-1）
+// ============================================================
+function testCase3_HeTong() {
+  console.log('\n📋 用例3: 合同查询（编号优先）');
+  const r = parseDocumentQuery('帮我找一下HT-2024-001那份合同');
+
+  assert(r.lookup_intent === true, '3.1 lookup_intent');
+  assertContains(r.doc_type_hints, '合同协议', '3.2 doc_type_hints');
+  assertEq(r.identifier_hints, ['HT-2024-001'], '3.3 identifier_hints 精确值');
+  assertEq(r.cleaned_query, 'HT-2024-001', '3.4 cleaned_query=纯编号，无口语残片');
+  assert(!r.cleaned_query.includes('一下'), '3.5 不含"一下"');
+  assert(!r.cleaned_query.includes('那份'), '3.6 不含"那份"');
+  // 编号只出现一次
+  assert((r.cleaned_query.match(/HT-2024-001/g) || []).length === 1, '3.7 编号不重复');
+}
+
+// ============================================================
+// 用例 4："纯主题查找" — 无类型提示
+// ============================================================
+function testCase4_PureTopic() {
+  console.log('\n📋 用例4: 纯主题查找');
+  const r = parseDocumentQuery('汽车安全性能评测');
+
+  assertEq(r.doc_type_hints, [], '4.1 doc_type_hints 为空');
+  assert(r.topic_terms.length >= 1, '4.2 topic_terms 有内容');
+  assert(r.cleaned_query.length > 0, '4.3 cleaned_query 非空');
+  assert(r.lookup_intent === false, '4.4 lookup_intent=false');
+}
+
+// ============================================================
+// 用例 5："模糊口语问法" — 噪音剔除
+// ============================================================
+function testCase5_FuzzyColloquial() {
+  console.log('\n📋 用例5: 模糊口语问法');
+  const r = parseDocumentQuery('有没有关于环保方面的规定文件来着？');
+
+  assert(r.noise_terms.some(t => t.includes('有没有') || t.includes('来着') || t.includes('文件')),
+    '5.1 noise_terms 含口语词');
+  assert(!r.cleaned_query.includes('有没有'), '5.2 不含"有没有"');
+  assert(!r.cleaned_query.includes('来着'), '5.3 不含"来着"');
+  assert(!r.cleaned_query.includes('文件'), '5.4 不含"文件"');
+}
+
+// ============================================================
+// 用例 6：空 query
+// ============================================================
+function testCase6_EmptyQuery() {
+  console.log('\n📋 用例6: 空 query');
+  const r = parseDocumentQuery('');
+  assert(!r.lookup_intent, '6.1 lookup_intent=false');
+  assertEq(r.topic_terms, [], '6.2 topic_terms 空');
+}
+
+// ============================================================
+// 用例 7：标准号精确查询 — 编号优先，无GB/T残片重复
+// ============================================================
+function testCase7_StandardNumber() {
+  console.log('\n📋 用例7: 标准号查询（编号优先）');
+  const r = parseDocumentQuery('GB/T 12345-2020 在哪里');
+
+  assert(r.lookup_intent === true, '7.1 lookup_intent');
+  assertEq(r.identifier_hints, ['GB/T 12345-2020'], '7.2 identifier_hints 精确值');
+  assertEq(r.cleaned_query, 'GB/T 12345-2020', '7.3 cleaned_query=纯编号，无GB/T残片');
+  // GB/T 只出现一次
+  assert((r.cleaned_query.match(/GB\/T/g) || []).length <= 1, '7.4 GB/T 不重复');
+  // topic_terms 不应含 GB/T 残片
+  assert(!r.topic_terms.some(t => t === 'GB/T' || t === 'GB'), '7.5 topic_terms 无 GB 残片');
+}
+
+// ============================================================
+// 用例 8：疑问词清理
+// ============================================================
+function testCase8_QuestionWordCleanup() {
+  console.log('\n📋 用例8: 疑问词清理');
+  const r = parseDocumentQuery('公司管理制度有哪些？');
+  assert(!r.cleaned_query.includes('哪些'), '8.1 不含"哪些"');
+  assert(!r.cleaned_query.includes('？'), '8.2 不含问号');
+  assertContains(r.doc_type_hints, '制度规章', '8.3 类型仍正确');
+}
+
+// ============================================================
+// 用例 9：长主题词扩召
+// ============================================================
+function testCase9_TopicExpansion() {
+  console.log('\n📋 用例9: 长主题词扩召');
+  const r = parseDocumentQuery('汽车车身术语');
+  assert(r.expanded_topic_queries.length >= 1, '9.1 至少 1 个扩召 query');
+  const hasSplit = r.expanded_topic_queries.some(q => q.includes('汽车车身'));
+  assert(hasSplit, '9.2 扩召含主题拆分');
+}
+
+// ============================================================
+// 用例 10：制度+疑问词复合
+// ============================================================
+function testCase10_Supplementary() {
+  console.log('\n📋 用例10: 制度+疑问词复合');
+  const r = parseDocumentQuery('有没有关于安全生产的管理规定？');
+  assert(r.lookup_intent === true, '10.1 lookup_intent');
+  assertContains(r.doc_type_hints, '制度规章', '10.2 制度规章');
+  assert(!r.cleaned_query.includes('有没有'), '10.3 不含口语');
+  assert(!r.cleaned_query.includes('？'), '10.4 不含问号');
+}
+
+// ============================================================
+// 用例 11：ISO 标准号（audit-round04 新增编号类型覆盖）
+// ============================================================
+function testCase11_ISO() {
+  console.log('\n📋 用例11: ISO 标准号');
+  const r = parseDocumentQuery('找一下ISO 9001:2015标准');
+  assert(r.identifier_hints.length >= 1, '11.1 identifier_hints 非空');
+  assert(r.identifier_hints.some(id => /ISO/i.test(id)), '11.2 含 ISO');
+  assert(!r.cleaned_query.includes('找一下'), '11.3 不含口语');
+  assert(r.cleaned_query.length > 0, '11.4 cleaned_query 非空');
+}
+
+// ============================================================
+// 用例 12：文号查询（audit-round04 新增编号类型覆盖）
+// ============================================================
+function testCase12_DocumentNumber() {
+  console.log('\n📋 用例12: 文号查询');
+  const r = parseDocumentQuery('国发〔2024〕1号文件');
+  assert(r.identifier_hints.length >= 1, '12.1 捕获文号');
+  assert(r.lookup_intent === true, '12.2 lookup_intent');
+  assert(!r.cleaned_query.includes('文件'), '12.3 不含"文件"噪音');
+}
+
+// ============================================================
+// 用例 13：标准号 + 内容问法 —— 不应把“主要/标准”误留为主题词
+// ============================================================
+function testCase13_StandardNumberContentQuestion() {
+  console.log('\n📋 用例13: 标准号 + 内容问法');
+  const r = parseDocumentQuery('GB28046.5-2013主要讲的是什么标准？');
+  assertEq(r.identifier_hints, ['GB28046.5-2013'], '13.1 identifier_hints 精确值');
+  assertEq(r.doc_type_hints, [], '13.2 doc_type_hints 不应从内容问法硬推断类型');
+  assertEq(r.cleaned_query, 'GB28046.5-2013', '13.3 cleaned_query 应仅保留标准号');
+  assertEq(r.topic_terms, [], '13.4 topic_terms 应为空');
+}
+
+// ============================================================
+// P0-1: 幂等性测试（audit-round04 核心验收标准）
+// ============================================================
+function testCase_Idempotence_SameQuery() {
+  console.log('\n📋 幂等性1: 同一 query 100 次解析结果一致');
+  const q = '有一个规定了汽车车身术语的国标文件是啥来着？';
+  const results = [];
+  for (let i = 0; i < 100; i++) {
+    results.push(JSON.stringify(parseDocumentQuery(q)));
+  }
+  const allSame = results.every(r => r === results[0]);
+  assert(allSame, 'Idem1: 100 次相同 query 结果完全一致');
+}
+
+function testCase_Idempotence_Alternating() {
+  console.log('\n📋 幂等性2: 两个不同 query 交替 100 轮结果一致');
+  const q1 = '公司管理制度有哪些？';
+  const q2 = 'GB/T 12345-2020 在哪里';
+  const even = [];
+  const odd = [];
+  for (let i = 0; i < 100; i++) {
+    const r = JSON.stringify(parseDocumentQuery(i % 2 === 0 ? q1 : q2));
+    if (i % 2 === 0) even.push(r);
+    else odd.push(r);
+  }
+  assert(even.every(r => r === even[0]), 'Idem2a: 偶数轮（制度查询）全部一致');
+  assert(odd.every(r => r === odd[0]), 'Idem2b: 奇数轮（标准号查询）全部一致');
+}
+
+// ============================================================
+// 执行
+// ============================================================
+console.log('╔══════════════════════════════════════╗');
+console.log('║  Document Query Parser 单元测试     ║');
+console.log('╚══════════════════════════════════════╝');
+
+testCase1_GuoBiao();
+testCase2_ZhiDu();
+testCase3_HeTong();
+testCase4_PureTopic();
+testCase5_FuzzyColloquial();
+testCase6_EmptyQuery();
+testCase7_StandardNumber();
+testCase8_QuestionWordCleanup();
+testCase9_TopicExpansion();
+testCase10_Supplementary();
+testCase11_ISO();
+testCase12_DocumentNumber();
+testCase13_StandardNumberContentQuestion();
+testCase_Idempotence_SameQuery();
+testCase_Idempotence_Alternating();
+
+// ==========================================
+// audit-round01 P1-1: Query Facets 测试
+// ==========================================
+
+function testCase_Facets_EntityTerms() {
+  console.log('\n📋 用例F1: 实体词提取');
+
+  // 国家标准编号
+  const r1 = parseDocumentQuery('GB/T 12345-2020 的防水等级怎么规定');
+  assert(r1.facets.entity_terms.includes('GB/T 12345-2020'), 'F1.1: 标准编号');
+  // 编号后面的年份可能也被提取
+  assert(r1.facets.entity_terms.some(e => e.includes('12345')), 'F1.2: 含数字编号');
+
+  // 合同编号
+  const r2 = parseDocumentQuery('合同 HT-2024-001 的付款条款');
+  assert(r2.facets.entity_terms.includes('HT-2024-001'), 'F1.3: 合同编号');
+
+  // ISO 编号
+  const r3 = parseDocumentQuery('ISO 9001 质量体系');
+  assert(r3.facets.entity_terms.some(e => e.includes('ISO')), 'F1.4: ISO编号');
+
+  // 无实体的自然语言问题
+  const r4 = parseDocumentQuery('合同违约金怎么算');
+  assert(r4.facets.entity_terms.length === 0, 'F1.6: 无编号查询无实体词');
+
+  console.log(`  entity_terms cases: passed`);
+}
+
+function testCase_Facets_ProcedureTerms() {
+  console.log('\n📋 用例F2: 程序词提取');
+
+  const r1 = parseDocumentQuery('这个试验怎么做');
+  assert(r1.facets.procedure_terms.includes('试验'), 'F2.1: 试验');
+  assert(r1.facets.procedure_terms.includes('怎么做'), 'F2.2: 怎么做');
+
+  const r2 = parseDocumentQuery('验收条件和测试方法');
+  assert(r2.facets.procedure_terms.includes('条件'), 'F2.2: 条件');
+  assert(r2.facets.procedure_terms.includes('方法'), 'F2.3: 方法');
+  assert(r2.facets.procedure_terms.includes('测试'), 'F2.4: 测试');
+
+  const r3 = parseDocumentQuery('GB/T 12345 在哪里');
+  assert(r3.facets.procedure_terms.length === 0, 'F2.5: 纯查找无程序词');
+
+  console.log(`  procedure_terms cases: passed`);
+}
+
+function testCase_Facets_NormalizedLookup() {
+  console.log('\n📋 用例F3: 归一化查找 query');
+
+  const r1 = parseDocumentQuery('GB/T 12345-2020 的防水等级怎么规定');
+  assert(r1.facets.normalized_lookup_query.length > 0, 'F3.1: 有 normalized query');
+  assert(r1.facets.normalized_lookup_query.includes('GB/T 12345-2020'), 'F3.2: 包含标准编号');
+  assert(r1.facets.normalized_lookup_query.includes('规定'), 'F3.3: 包含程序词');
+  assert(!r1.facets.normalized_lookup_query.includes('怎么'), 'F3.4: 无口语词');
+
+  // 纯编号查询（无主题词）
+  const r2 = parseDocumentQuery('GB/T 12345-2020');
+  assert(r2.facets.normalized_lookup_query === 'GB/T 12345-2020', 'F3.5: 纯编号保留');
+
+  console.log(`  normalized_lookup_query cases: passed`);
+}
+
+testCase_Facets_EntityTerms();
+testCase_Facets_ProcedureTerms();
+testCase_Facets_NormalizedLookup();
+
+console.log(`\n${'='.repeat(40)}`);
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log(`${'='.repeat(40)}`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## 背景

Phase 1（#967）已完成真原子化接线。本 PR 执行 Phase 2：按审计结论 §6，把 PR #963 中有价值的能力增量吸收进真原子架构（只吸收能力，不吸收编排架构）。

## 变更内容

### 1. parser 锚点识别集成（搬运 #963 `document-query-parser.js`，73 用例同步搬运）

`searchDocumentsByMetadata` 查询预处理：
- 标准号/文号识别（identifier_hints），检索词归一化（编号优先 + 主题词）
- doc_type 推断：调用方未显式传 `doc_types` 时用 parser 推断值（显式传入优先）
- 返回附 `query_parse` 摘要（lookup_intent / identifier_hints / doc_type_hints），LLM 可理解解析结果
- 附件文件名分支保留原始查询（附件名可能含编号特殊字符）

### 2. 四维 rerank（吸收 #963 `_hybridRerank` 信号体系）

`rankChunksForQuestion` 信号升级（词源由 parser 提供，替代简易分词）：

| 信号 | 权重 | 说明 |
|------|------|------|
| vector_score | 0.45 | 召回向量相似度 |
| entity_score | 0.30 | parser 实体词（编号/IPX5/专有名词）命中率 |
| procedure_score | 0.15 | parser 程序词（试验/检测/条款）命中率 |
| structural_score | 0.10 | 章节锚点/表格条款/seq 位置启发式 |
| title_hit | 0.05 | 标题命中（保留项） |
| locked_bonus | 0.05 | 锁定文档加权（保留项） |

公式 `min(1.0, Σ)`，`rank_signals` 含 matched_entities / matched_procedures 全审计信息；`deps.reranker` 可替换注入点保留。

### 3. 证据覆盖统计（吸收 #963 `_assessCoverage` 裁剪版）

`rank_chunks_for_question` 返回新增 `coverage`：covered/missed entities 与 procedures。为 LLM 提供证据充分性**数据**（非系统动作信号，符合数据驱动契约）。

### 裁剪说明（未吸收项）

- `_detectParameterEvidenceClosure`：参数证据闭合检测，复杂度高，暂缓（后续单评）
- `document-evidence-packer` / `evidence-formatter` 本体：新架构证据注入由 chat-service `buildEvidenceInjection` 直接承担，无宿主，仅吸收其覆盖评估思想

## 验证

- `npm run lint` ✅
- 测试 **209 用例全过**：parser 73（搬运）+ handle-store 28 + dispatch 52 + consumption 34 + phase2 新增 22（四维信号/公式/structural 边界/locked/coverage/兜底/metadata 预处理）
- ES 模块导入验证 ✅；启动冒烟 ✅
- 架构边界遵守：无复合入口、无系统动作信号、rank 仍零检索（最小步骤）

## 后续

- token 经济学标杆与真实链路验证（Eric 执行，覆盖 Phase 1+2）
- Phase 3：跨文档桥接 / 多候选 mergeable / 参数闭合检测 / handle 持久化——按运行数据裁决
