### PR TITLE
feat: 文档检索 Phase 3——暂缓项裁决与轻量落地（桥接hint+候选分组+attribute覆盖）

### DIFF
--- a/docs/development/document-retrieval-skill-contract.md
+++ b/docs/development/document-retrieval-skill-contract.md
@@ -147,6 +147,17 @@ DocumentSearchService / DocRecallService / DocAccessService / DocumentHandleStor
 
 | Phase | 内容 | 状态 |
 |-------|------|------|
-| Phase 1 | 真原子 schema + handle 基础设施 + 消费层数据驱动 + 一致性测试 | ✅ 本契约版本 |
-| Phase 2 | 吸收查询解析锚点识别、四维混合 rerank、证据打包增强 | 规划中 |
-| Phase 3 | 重评跨文档桥接、多候选 mergeable、候选条件化短路、handle MySQL 持久化 | 待 Phase 1/2 运行数据裁决 |
+| Phase 1 | 真原子 schema + handle 基础设施 + 消费层数据驱动 + 一致性测试 | ✅ 已合并（#967） |
+| Phase 2 | parser 锚点识别、四维 rerank、coverage 覆盖统计 | ✅ 已完成（#968） |
+| Phase 3 | 暂缓项裁决 | ✅ 已裁决 |
+
+### Phase 3 裁决记录（feat-260719-03）
+
+| 暂缓项 | 裁决 | 形态 |
+|--------|------|------|
+| 跨文档桥接 | 做（轻量） | scoped 无命中时 tool 响应 hint 引导 + prompt 范式四，无服务端机制 |
+| 多候选 mergeable | 做（数据面） | metadata 检索附 `candidates_analysis` 分组统计（by_doc_type / by_collection / same_*），决策归 LLM |
+| attribute/参数覆盖 | 做（裁剪） | coverage 增加 attribute_total / covered / missed 维度，替代完整闭合检测 |
+| 候选条件化短路 | 不做 | 违背数据驱动契约；prompt 规则 3 已覆盖；运行数据不佳可重开 |
+| handle MySQL 持久化 | 不做 | 内存 + 滑动 TTL + hint 自愈已闭环；多实例需求出现再评 |
+| DocumentOrchestrationService 决策表 | 不做 | 编排器思维与真实原子化冲突；merge 价值已由 candidates_analysis 数据面覆盖 |

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -2084,6 +2084,10 @@ search_chunks_globally → 用返回的 chunkset handle 调 rank_chunks_for_ques
 已知目标文档范围时，用 search_chunks_in_document（传 document_ids 或 doc_ref handle）替代首步的全局检索。
 适用于"文档里对某问题如何描述""某说法是否有文档依据"。
 
+范式四（跨文档桥接）：
+search_chunks_in_document 在指定文档内无命中时，答案可能存在于其他文档——改调 search_chunks_globally 做全库内容检索，再按需接 rank / resolve。
+不要因为指定文档内没找到就放弃；也不要在已确认目标文档后无意义地重复全局检索。
+
 【handle 使用规则（关键）】
 - chunkset / rankedset / docref 是上游工具返回的结果引用，从响应中照原样取用，禁止编造。
 - 工具返回 handle_not_found_or_expired 时，按响应中的 hint 重新调用上游检索工具获取新 handle。

--- a/lib/document-atomic-tools.js
+++ b/lib/document-atomic-tools.js
@@ -150,13 +150,36 @@ class DocumentAtomicTools {
         top_k,
       });
 
+      const candidates = result.candidates || [];
+
+      // Phase 3：多候选分组统计（数据面，不含任何"是否合并回答"的决策建议）
+      let candidatesAnalysis;
+      if (candidates.length > 1) {
+        const byDocType = {};
+        const byCollection = {};
+        for (const d of candidates) {
+          const t = d.doc_type || 'unknown';
+          byDocType[t] = (byDocType[t] || 0) + 1;
+          const c = d.collection_name || 'unknown';
+          byCollection[c] = (byCollection[c] || 0) + 1;
+        }
+        candidatesAnalysis = {
+          total: candidates.length,
+          by_doc_type: byDocType,
+          by_collection: byCollection,
+          same_doc_type: Object.keys(byDocType).length === 1,
+          same_collection: Object.keys(byCollection).length === 1,
+        };
+      }
+
       return {
         success: result.success !== false,
         matched_by: 'title_metadata',
-        documents: result.candidates || [],
-        total: result.total ?? (result.candidates?.length || 0),
+        documents: candidates,
+        total: result.total ?? candidates.length,
         strategy: result.strategy,
         query_parse: queryParseInfo,
+        ...(candidatesAnalysis ? { candidates_analysis: candidatesAnalysis } : {}),
       };
     } catch (error) {
       logger.error('[DocAtomicTools] searchDocumentsByMetadata error:', error.message);
@@ -478,9 +501,13 @@ class DocumentAtomicTools {
 
     // Phase 2（吸收 #963 _assessCoverage 裁剪版）：基于最终 chunks 统计词覆盖，
     // 为 LLM 提供证据充分性"数据"（非动作信号）。
+    // Phase 3：纳入 attribute 维度（parser attribute_terms 覆盖统计，
+    // 替代 #963 完整 _detectParameterEvidenceClosure 的裁剪版）。
+    const attributeTerms = parsed?.facets?.attribute_terms || [];
     const hitText = finalChunks.map(c => `${c.document_title || ''} ${c.chunk_title || ''} ${c.content || ''}`.toLowerCase()).join(' ');
     const coveredEntities = entityTerms.filter(et => hitText.includes(et.toLowerCase()));
     const coveredProcedures = procedureTerms.filter(pt => hitText.includes(pt.toLowerCase()));
+    const coveredAttributes = attributeTerms.filter(at => hitText.includes(at.toLowerCase()));
     const coverage = {
       entity_total: entityTerms.length,
       covered_entities: coveredEntities,
@@ -488,6 +515,9 @@ class DocumentAtomicTools {
       procedure_total: procedureTerms.length,
       covered_procedures: coveredProcedures,
       missed_procedures: procedureTerms.filter(pt => !coveredProcedures.includes(pt)),
+      attribute_total: attributeTerms.length,
+      covered_attributes: coveredAttributes,
+      missed_attributes: attributeTerms.filter(at => !coveredAttributes.includes(at)),
     };
 
     return { success: true, chunks: finalChunks, total: finalChunks.length, coverage };

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -2633,6 +2633,8 @@ class ToolManager {
       const extra = { documents, total: result.total ?? documents.length };
       // Phase 2：透传 parser 解析摘要，帮助 LLM 理解编号/类型识别结果
       if (result.query_parse) extra.query_parse = result.query_parse;
+      // Phase 3：透传多候选分组统计（数据面），LLM 自主决定是否合并回答
+      if (result.candidates_analysis) extra.candidates_analysis = result.candidates_analysis;
       if (documents.length > 0) {
         const store = this._getDocHandleStore();
         const { handle } = store.create({
@@ -2757,6 +2759,10 @@ class ToolManager {
 
       const chunks = (result.chunks || []).map(c => this._summarizeChunk(c));
       const extra = { chunks, total: result.total ?? chunks.length, searched_document_ids: targetDocIds };
+      // Phase 3：跨文档桥接引导——范围内无命中时提示全库检索（链路修复 hint，非编排）
+      if (chunks.length === 0) {
+        extra.hint = '指定文档范围内未命中内容证据。若认为答案可能存在于其他文档，可调用 search_chunks_globally 做全库内容检索（跨文档桥接）';
+      }
       if (chunks.length > 0) {
         const store = this._getDocHandleStore();
         const { handle, truncated } = store.create({

--- a/tests/document-atomic-phase3.test.js
+++ b/tests/document-atomic-phase3.test.js
@@ -1,0 +1,140 @@
+/**
+ * Phase 3 测试：暂缓项裁决的 3 个实施项
+ *
+ * 覆盖：
+ *   1. 跨文档桥接 hint（search_chunks_in_document 无命中时引导全库检索）
+ *   2. candidates_analysis 多候选分组统计（数据面，无决策建议）
+ *   3. coverage attribute 维度（替代完整参数闭合检测的裁剪版）
+ *
+ * 运行：node tests/document-atomic-phase3.test.js
+ */
+
+import DocumentAtomicTools from '../lib/document-atomic-tools.js';
+import ToolManager from '../lib/tool-manager.js';
+import { DocumentHandleStore } from '../lib/document-handle-store.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, name, detail = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } else {
+    failed++;
+    console.error(`  ❌ ${name} ${detail}`);
+  }
+}
+
+const ctx = { userId: 'u1', user_id: 'u1', topicId: 'topic-p3' };
+
+// ============================================================
+// 场景 1：跨文档桥接 hint（无命中时引导 search_chunks_globally）
+// ============================================================
+console.log('\n场景 1：跨文档桥接 hint');
+{
+  const tm = Object.create(ToolManager.prototype);
+  tm.db = null;
+  tm.expertId = 'expert-test';
+  tm._docAtomicTools = {
+    searchChunksInDocument: async () => ({ success: true, chunks: [], total: 0 }),
+  };
+  tm._docHandleStore = new DocumentHandleStore();
+  tm._docAccessService = { getAccessibleCollectionIds: async () => ['c1'] };
+
+  const r = await tm._dispatchDocRetrievalTool('search_chunks_in_document', {
+    content_query: '不存在的内容', document_ids: ['d1'],
+  }, ctx, 't');
+
+  assert(r.success === true, '无命中仍为成功（空结果非错误）');
+  assert(r.chunks.length === 0, 'chunks 为空');
+  assert(typeof r.hint === 'string' && r.hint.includes('search_chunks_globally'), 'hint 引导跨文档桥接', r.hint);
+  assert(!r.chunkset, '无命中不产生 chunkset handle');
+
+  // 有命中时不应有 bridge hint
+  const tm2 = Object.create(ToolManager.prototype);
+  tm2.db = null;
+  tm2.expertId = 'expert-test';
+  tm2._docAtomicTools = {
+    searchChunksInDocument: async () => ({
+      success: true,
+      chunks: [{ chunk_id: 'c1', document_id: 'd1', document_title: 'A', content: 'x', score: 0.9 }],
+      total: 1,
+    }),
+  };
+  tm2._docHandleStore = new DocumentHandleStore();
+  tm2._docAccessService = { getAccessibleCollectionIds: async () => ['c1'] };
+  const r2 = await tm2._dispatchDocRetrievalTool('search_chunks_in_document', {
+    content_query: 'x', document_ids: ['d1'],
+  }, ctx, 't');
+  assert(r2.success && !r2.hint, '有命中时不带 bridge hint');
+}
+
+// ============================================================
+// 场景 2：candidates_analysis 分组统计（数据面）
+// ============================================================
+console.log('\n场景 2：candidates_analysis 分组统计');
+{
+  const mockSearch = {
+    search: async () => ({
+      success: true,
+      candidates: [
+        { document_id: 'd1', document_title: '标准A', doc_type: 'standard', collection_name: '库1' },
+        { document_id: 'd2', document_title: '标准B', doc_type: 'standard', collection_name: '库1' },
+        { document_id: 'd3', document_title: '合同C', doc_type: 'contract', collection_name: '库2' },
+      ],
+      total: 3,
+    }),
+    searchByAttachmentFilenames: async () => [],
+    getDocumentInfo: async () => [],
+  };
+  const tools = new DocumentAtomicTools(null, null, { searchService: mockSearch });
+
+  const r = await tools.searchDocumentsByMetadata({ metadata_query: '规定', user_id: 'u1' });
+  assert(r.success === true, '检索成功');
+  const ca = r.candidates_analysis;
+  assert(ca, '多候选时 candidates_analysis 存在');
+  assert(ca.total === 3, '候选总数正确');
+  assert(ca.by_doc_type.standard === 2 && ca.by_doc_type.contract === 1, 'doc_type 分组正确', JSON.stringify(ca.by_doc_type));
+  assert(ca.by_collection['库1'] === 2 && ca.by_collection['库2'] === 1, 'collection 分组正确');
+  assert(ca.same_doc_type === false && ca.same_collection === false, '混合集合判定正确');
+
+  // 纯统计数据：不含"建议合并/建议重选"类决策字段
+  const keys = Object.keys(ca);
+  assert(!keys.some(k => /suggest|recommend|should|action|mode/i.test(k)), '分组统计不含决策建议字段', keys.join(','));
+
+  // 单候选/无候选时不产生
+  const single = new DocumentAtomicTools(null, null, {
+    searchService: {
+      search: async () => ({ success: true, candidates: [{ document_id: 'd1', document_title: 'A', doc_type: 'standard' }], total: 1 }),
+      searchByAttachmentFilenames: async () => [],
+      getDocumentInfo: async () => [],
+    },
+  });
+  const r2 = await single.searchDocumentsByMetadata({ metadata_query: 'x', user_id: 'u1' });
+  assert(r2.candidates_analysis === undefined, '单候选不产生 candidates_analysis');
+}
+
+// ============================================================
+// 场景 3：coverage attribute 维度
+// ============================================================
+console.log('\n场景 3：coverage attribute 维度');
+{
+  const tools = new DocumentAtomicTools(null, null);
+  const chunks = [
+    { chunk_id: 'c1', document_id: 'd1', document_title: '标准', content: '试验温度为 23℃，湿度为 50%。', seq: 3, score: 0.8 },
+  ];
+  const r = tools.rankChunksForQuestion({ question: '试验的温度是多少', chunks });
+  assert(r.coverage, 'coverage 存在');
+  assert(typeof r.coverage.attribute_total === 'number', 'attribute_total 字段存在');
+  assert(Array.isArray(r.coverage.covered_attributes) && Array.isArray(r.coverage.missed_attributes), 'attribute 覆盖/未覆盖清单存在');
+
+  // 既有维度不受影晌
+  assert(typeof r.coverage.entity_total === 'number' && typeof r.coverage.procedure_total === 'number', 'entity/procedure 维度保留');
+}
+
+// ============================================================
+console.log('\n' + '='.repeat(40));
+console.log(`  ✅ 通过: ${passed}  |  ❌ 失败: ${failed}`);
+console.log('='.repeat(40));
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## 背景

Phase 3：对审计结论 §6 的暂缓项进行逐项裁决并轻量落地。裁决依据为设计分析与架构契约自洽性（token 标杆运行数据按 Eric 安排延后，"不做"项在数据到位后可重开）。

> ⚠️ **Stacked PR**：本分支基于 `feat-260719-02-absorb-963-increments`（PR #968），因其改动依赖 Phase 2 的 query_parse / coverage 代码。**合并顺序：先 #968，后本 PR。**

## 裁决案

| 暂缓项 | 裁决 | 形态 / 依据 |
|--------|------|------------|
| 跨文档桥接 | **做（轻量）** | 原子链天然支持桥接（scoped 无结果→LLM 自主调 global），只需引导不建机制 |
| 多候选 mergeable | **做（数据面）** | 保留 #963 决策表的"可合并"价值，但判断权归 LLM（数据驱动，不恢复决策表） |
| attribute/参数覆盖 | **做（裁剪）** | coverage 加 attribute 维度，替代 #963 完整 `_detectParameterEvidenceClosure` |
| 候选条件化短路 | **不做** | 违背数据驱动契约；prompt 规则 3 已覆盖；短路在意图误判时破坏链路 |
| handle MySQL 持久化 | **不做** | 内存+滑动 TTL+hint 自愈已闭环；多实例需求出现再评 |
| OrchestrationService 决策表 | **不做** | 编排器思维与真实原子化冲突；merge 价值已由数据面覆盖 |

## 实施变更（3 项）

1. **跨文档桥接引导**：`search_chunks_in_document` 无命中时返回 `hint` 引导 `search_chunks_globally`；system prompt 补范式四（桥接）
2. **候选分组统计**：`search_documents_by_metadata` 多候选时附 `candidates_analysis`（by_doc_type / by_collection / same_* 统计事实，测试断言不含任何决策建议字段）
3. **attribute 覆盖**：`rank_chunks_for_question` 的 coverage 增加 `attribute_total / covered_attributes / missed_attributes`

contract 文档 §9 已更新为全部裁决完成状态。

## 验证

- `npm run lint` ✅
- 测试 **226 用例全过**：parser 73 + handle-store 28 + dispatch 52 + consumption 34 + phase2 22 + phase3 新增 17（桥接 hint 有无命中两态、分组统计正确性与"无决策字段"断言、attribute 维度）
- ES 模块导入验证 ✅
- 架构边界：无复合入口、无系统动作信号、桥接仅是 hint 文本（非服务端机制）

## 遗留

- token 经济学标杆 + 真实 LLM 链路验证（Eric 执行，覆盖 Phase 1-3）
