### PR TITLE
feat: 文档平台 OCR 切换至新 MinerU 网关并适配 v2 产物契约

### DIFF
--- a/lib/doc-pipeline-defaults.js
+++ b/lib/doc-pipeline-defaults.js
@@ -16,7 +16,7 @@ const DOC_PIPELINE_DEFAULTS = {
     type: 'mcp',
     mcp: {
       server: 'mineru',
-      tool: 'create_task_from_file',
+      tool: 'create_task',
       params_mapping: {
         file_base64: 'file_base64',
         file_name: 'file_name',
@@ -102,7 +102,7 @@ const DOC_PIPELINE_DEFAULTS = {
     default_deliverable_tool: 'get_default_deliverable',
     list_deliverables_tool: 'list_deliverables',
     image_deliverables_tool: 'get_image_deliverables',
-    download_deliverable_tool: null,
+    download_deliverable_tool: 'download_deliverable',
     persist_raw_result: true,
     persist_image_attachments: true,
     mcp_timeout_ms: 120000,

--- a/lib/document-ocr-service.js
+++ b/lib/document-ocr-service.js
@@ -260,6 +260,202 @@ class DocumentOcrService {
     }
   }
 
+  _isToolNotFoundError(error) {
+    const message = String(error?.message || error || '');
+    return /unknown tool|tool.*not.*found|no such tool|invalid tool|method.*not.*found/i.test(message);
+  }
+
+  _isToolNotFoundResult(result) {
+    if (!result || typeof result !== 'object') return false;
+    const isError = result.is_error === true || result.isError === true;
+    if (!isError) return false;
+    const text = typeof result.content === 'string' ? result.content : JSON.stringify(result).slice(0, 4000);
+    return /unknown tool|tool.*not.*found|no such tool|invalid tool/i.test(text);
+  }
+
+  async _callSubmitToolWithFallback(serverName, toolName, mcpParams, timeoutMs) {
+    const ALTERNATE_SUBMIT_TOOLS = {
+      create_task: 'create_task_from_file',
+      create_task_from_file: 'create_task',
+    };
+    const alternate = ALTERNATE_SUBMIT_TOOLS[toolName] || null;
+
+    try {
+      const result = await this.callMcp(serverName, toolName, mcpParams, timeoutMs);
+      if (alternate && this._isToolNotFoundResult(result)) {
+        logger.warn(`[DocumentOcrService] submit tool ${toolName} reported not found, retrying with ${alternate}`);
+        return await this.callMcp(serverName, alternate, mcpParams, timeoutMs);
+      }
+      return result;
+    } catch (error) {
+      if (!alternate || !this._isToolNotFoundError(error)) throw error;
+      logger.warn(`[DocumentOcrService] submit tool ${toolName} not available (${error.message}), retrying with ${alternate}`);
+      return await this.callMcp(serverName, alternate, mcpParams, timeoutMs);
+    }
+  }
+
+  _extractDeliverableArtifacts(deliverables) {
+    if (deliverables && Array.isArray(deliverables.artifacts)) {
+      return deliverables.artifacts;
+    }
+    return null;
+  }
+
+  _extractDownloadedContent(download) {
+    if (!download || typeof download !== 'object') return '';
+    const content = download.content;
+    if (typeof content === 'string') {
+      if (download.encoding === 'base64') {
+        try {
+          return Buffer.from(content, 'base64').toString('utf8');
+        } catch {
+          return '';
+        }
+      }
+      return content;
+    }
+    if (typeof download.result === 'string') return download.result;
+    if (download.result && typeof download.result === 'object') {
+      if (typeof download.result.markdown === 'string') return download.result.markdown;
+      if (typeof download.result.content === 'string') return download.result.content;
+    }
+    return '';
+  }
+
+  _buildDownloadedDataUrl(download, artifact) {
+    if (!download || typeof download !== 'object') return null;
+    const content = download.content;
+    if (typeof content !== 'string' || !content) return null;
+    const mediaType = download.media_type || artifact?.media_type || 'application/octet-stream';
+    if (download.encoding === 'base64') {
+      return `data:${mediaType};base64,${content}`;
+    }
+    if (/^data:/i.test(content)) return content;
+    if (/^[a-z0-9+/]+={0,2}$/i.test(content.slice(0, 128).replace(/\s/g, '')) && content.length > 512) {
+      return `data:${mediaType};base64,${content}`;
+    }
+    return null;
+  }
+
+  async _fetchV2ImageDeliverables(serverName, downloadTool, taskId, artifacts, markdownContent, timeoutMs, documentId = null) {
+    const imageArtifacts = artifacts.filter(a => {
+      if (!a || typeof a !== 'object') return false;
+      if (a.artifact_type === 'image_file') return true;
+      const mediaType = a.media_type || '';
+      return typeof mediaType === 'string' && mediaType.startsWith('image/');
+    });
+
+    const items = [];
+    const images = {};
+    const errors = [];
+
+    for (const artifact of imageArtifacts) {
+      if (documentId) await this.assertDocumentNotDeleted(documentId);
+      const filename = artifact.filename || null;
+      const relativePath = artifact.name || filename || null;
+      const item = {
+        filename,
+        relative_path: relativePath,
+        path: artifact.download_key || null,
+        media_type: artifact.media_type || null,
+        referenced_in_markdown: Boolean(
+          markdownContent && filename && markdownContent.includes(filename)
+        ),
+        data_url: null,
+      };
+
+      if (!artifact.download_key) {
+        errors.push(`image artifact missing download_key: ${filename || 'unknown'}`);
+        items.push(item);
+        continue;
+      }
+
+      try {
+        const download = this.unwrapToolStructuredContent(
+          await this.callMcp(serverName, downloadTool, {
+            task_id: taskId,
+            download_key: artifact.download_key,
+            include_content: true,
+          }, timeoutMs)
+        );
+        const dataUrl = this._buildDownloadedDataUrl(download, artifact);
+        if (dataUrl) {
+          item.data_url = dataUrl;
+          if (relativePath) images[relativePath] = dataUrl;
+          if (filename) {
+            images[filename] = dataUrl;
+            images[`images/${filename}`] = dataUrl;
+            images[`./images/${filename}`] = dataUrl;
+          }
+        } else {
+          errors.push(`image download has no usable content: ${filename || artifact.download_key}`);
+        }
+      } catch (error) {
+        logger.warn(`[DocumentOcrService] v2 image download failed for ${filename || artifact.download_key}: ${error.message}`);
+        errors.push(`${filename || artifact.download_key}: ${error.message}`);
+      }
+
+      items.push(item);
+    }
+
+    return {
+      ok: errors.length === 0,
+      raw: null,
+      parsed: { items, images },
+      error: errors.length > 0 ? errors.join('; ') : null,
+    };
+  }
+
+  async _fetchFinalizeBundle(serverName, config, taskId, timeoutMs, documentId = null) {
+    const listDeliverablesTool = config?.list_deliverables_tool || 'list_deliverables';
+    const deliverables = this.extractStructuredToolResult(
+      await this.callMcp(serverName, listDeliverablesTool, { task_id: taskId }, timeoutMs)
+    );
+    const artifacts = this._extractDeliverableArtifacts(deliverables);
+
+    if (!artifacts) {
+      const defaultDeliverableTool = config?.default_deliverable_tool || 'get_default_deliverable';
+      const imageDeliverablesTool = config?.image_deliverables_tool || 'get_image_deliverables';
+      const defaultDeliverable = this.extractStructuredToolResult(
+        await this.callMcp(serverName, defaultDeliverableTool, { task_id: taskId }, timeoutMs)
+      );
+      const imageOutcome = await this.tryGetImageDeliverables(serverName, imageDeliverablesTool, taskId, timeoutMs);
+      return { contract: 'legacy', defaultDeliverable, deliverables, imageOutcome };
+    }
+
+    const downloadTool = config?.download_deliverable_tool || 'download_deliverable';
+    const defaultArtifact = artifacts.find(a => a?.is_default === true)
+      || artifacts.find(a => a?.role === 'primary')
+      || artifacts.find(a => a?.artifact_type === 'markdown')
+      || null;
+    if (!defaultArtifact?.download_key) {
+      throw new Error(`No default markdown artifact found for task ${taskId}`);
+    }
+
+    const defaultDownload = this.unwrapToolStructuredContent(
+      await this.callMcp(serverName, downloadTool, {
+        task_id: taskId,
+        download_key: defaultArtifact.download_key,
+        include_content: true,
+      }, timeoutMs)
+    );
+    const markdownContent = this._extractDownloadedContent(defaultDownload);
+    const defaultDeliverable = {
+      format: defaultDownload?.artifact_type || defaultArtifact.artifact_type || 'markdown',
+      filename: defaultDownload?.filename || defaultArtifact.filename || null,
+      download_key: defaultArtifact.download_key,
+      result: { markdown: markdownContent, content: markdownContent },
+    };
+
+    if (documentId) await this.assertDocumentNotDeleted(documentId);
+    const imageOutcome = await this._fetchV2ImageDeliverables(
+      serverName, downloadTool, taskId, artifacts, markdownContent, timeoutMs, documentId
+    );
+
+    const normalizedDeliverables = { ...deliverables, items: artifacts };
+    return { contract: 'v2_artifacts', defaultDeliverable, deliverables: normalizedDeliverables, imageOutcome };
+  }
+
   async _runJudge(stageConfig, mcpResult, stageContext = {}) {
     const judge = stageConfig?.judge;
     if (!judge || !judge.prompt_template) return mcpResult;
@@ -468,7 +664,7 @@ class DocumentOcrService {
 
       const mcpParams = this._buildMcpParams(config, runtimeOverrides, attachmentContext);
 
-      const submitToolResult = await this.callMcp(
+      const submitToolResult = await this._callSubmitToolWithFallback(
         serverName,
         toolName,
         mcpParams,
@@ -876,23 +1072,16 @@ class DocumentOcrService {
     const timeoutMs = this._resolveMcpTimeout(config, await this._getSystemMcpTimeoutMs());
     const revisionId = ctx.revision.id;
 
-    const defaultDeliverableTool = config?.default_deliverable_tool || 'get_default_deliverable';
-    const listDeliverablesTool = config?.list_deliverables_tool || 'list_deliverables';
-    const imageDeliverablesTool = config?.image_deliverables_tool || 'get_image_deliverables';
-
     const taskId = ocrResult.task_id;
     logger.info(`[DocumentOcrService] finalize start: document=${ctx.document.id} revision=${revisionId} task=${taskId}`);
-    const defaultDeliverable = this.extractStructuredToolResult(
-      await this.callMcp(serverName, defaultDeliverableTool, { task_id: taskId }, timeoutMs)
-    );
-    logger.info(`[DocumentOcrService] finalize default deliverable loaded: format=${defaultDeliverable?.format || 'unknown'} filename=${defaultDeliverable?.filename || 'unknown'}`);
+    const bundle = await this._fetchFinalizeBundle(serverName, config, taskId, timeoutMs, ctx.document.id);
+    const defaultDeliverable = bundle.defaultDeliverable;
+    logger.info(`[DocumentOcrService] finalize default deliverable loaded: format=${defaultDeliverable?.format || 'unknown'} filename=${defaultDeliverable?.filename || 'unknown'} contract=${bundle.contract}`);
     await this.assertDocumentNotDeleted(ctx.document.id);
-    const deliverables = this.extractStructuredToolResult(
-      await this.callMcp(serverName, listDeliverablesTool, { task_id: taskId }, timeoutMs)
-    );
-    logger.info(`[DocumentOcrService] finalize deliverables loaded: items=${Array.isArray(deliverables?.items) ? deliverables.items.length : 0}`);
+    const deliverables = bundle.deliverables;
+    logger.info(`[DocumentOcrService] finalize deliverables loaded: items=${Array.isArray(deliverables?.items) ? deliverables.items.length : 0} contract=${bundle.contract}`);
     await this.assertDocumentNotDeleted(ctx.document.id);
-    const imageDeliverablesOutcome = await this.tryGetImageDeliverables(serverName, imageDeliverablesTool, taskId, timeoutMs);
+    const imageDeliverablesOutcome = bundle.imageOutcome;
     const imageDeliverables = imageDeliverablesOutcome.parsed;
     await this.assertDocumentNotDeleted(ctx.document.id);
     const imageDeliverableSummary = this.summarizeImageDeliverables(imageDeliverables);

--- a/lib/resident-skill-manager.js
+++ b/lib/resident-skill-manager.js
@@ -116,6 +116,7 @@ class ResidentProcess {
         env: {
           ...process.env,
           NODE_ENV: process.env.NODE_ENV || 'development',
+          API_BASE: process.env.API_BASE || 'http://localhost:3017',
           ALLOWED_NODE_MODULES: JSON.stringify(whitelist.nodeModules),
           ALLOWED_PYTHON_PACKAGES: JSON.stringify(whitelist.pythonPackages),
           RESIDENT_MODE: 'true', // 标记为驻留模式


### PR DESCRIPTION
## 变更背景

当前文档平台 OCR 流水线仍主要按照旧版 MinerU 接口与交付物格式运行。随着新 MinerU Gateway v2 接入，原有实现已经无法完整覆盖新的任务提交方式与产物下载契约，具体体现在：

1. `pending_ocr` 阶段默认仍使用旧工具名 `create_task_from_file`
2. `ocr_finalize` 阶段仍偏向旧版交付物消费方式，无法完整处理新的 `artifacts + download_deliverable` 模式
3. 新旧环境并存期间，缺少必要的兼容兜底逻辑

本 PR 的目标是将 OCR 主链路切换到新 MinerU Gateway v2 契约，同时保留对旧环境的兼容，降低切换风险。

## 本次改动

### 1. 调整 OCR 提交阶段默认工具名

文件：
- `lib/doc-pipeline-defaults.js`

改动：
- 将 `pending_ocr.mcp.tool` 默认值从 `create_task_from_file` 调整为 `create_task`
- 将 `ocr_finalize.download_deliverable_tool` 默认值补齐为 `download_deliverable`

意义：
- 配置层明确对齐新网关的默认工具名
- 为 finalize 阶段显式启用下载型交付物能力

### 2. 为 OCR 提交增加新旧工具名 fallback

文件：
- `lib/document-ocr-service.js`

改动：
- 新增提交阶段 fallback 逻辑
- 在调用提交工具时，不再直接固定调用单一工具
- 改为优先调用当前配置工具，若返回 `unknown tool` / `tool not found` / `invalid tool` 等结果，再自动回退到另一套工具名

兼容关系：
- `create_task` <-> `create_task_from_file`

意义：
- 兼容新旧部署环境的工具名差异
- 降低配置切换和灰度阶段的失败概率
- 避免仅因 MCP 工具名未同步而导致整条 OCR 流水线阻塞

### 3. finalize 阶段适配新 MinerU Gateway v2 产物契约

文件：
- `lib/document-ocr-service.js`

改动重点：
- 新增对 `list_deliverables` 返回 artifacts 结构的识别
- 当识别到新契约时：
  - 先读取 deliverables/artifacts 列表
  - 找出默认 Markdown 主产物
  - 通过 `download_deliverable` + `download_key` 下载实际内容
  - 将下载结果回填为系统可继续处理的标准结构
- 增加图片产物下载逻辑：
  - 基于 `artifact_type === image_file` 或 `media_type` 前缀识别图片
  - 下载图片内容
  - 构建 `data_url` 和图片映射，供后续引用
- 保留 legacy fallback：
  - 若未识别到新 artifacts 结构，则继续走旧逻辑
  - 仍兼容 `get_default_deliverable` / `get_image_deliverables`

意义：
- 完成从“直接取结果”到“先列举交付物、再按 key 下载”的契约升级
- 兼容新 MinerU Gateway v2 的主 Markdown + 图片交付物组织方式
- 保证旧环境不因本次升级而直接失效

### 4. 补充驻留进程运行时 API_BASE

文件：
- `lib/resident-skill-manager.js`

改动：
- 驻留进程启动时注入：
  - `API_BASE=http://localhost:3017`（若外部未显式提供则使用默认值）

意义：
- 为新网关相关驻留能力提供明确的 API 基址
- 减少本地运行/调试时因环境变量缺失带来的不确定性

## 影响范围

本次改动影响的文件如下：

- `lib/doc-pipeline-defaults.js`
- `lib/document-ocr-service.js`
- `lib/resident-skill-manager.js`

主要影响链路：

- 文档 OCR 任务提交
- OCR 任务 finalize 收尾
- MinerU 交付物下载与图片处理
- 驻留技能运行时环境

## 兼容性说明

本 PR 不是简单地“切断旧逻辑换成新逻辑”，而是采取了兼容式升级：

### 提交阶段兼容
- 默认使用新工具名 `create_task`
- 若服务端仍是旧实现，则回退到 `create_task_from_file`

### finalize 阶段兼容
- 若返回的是新 `artifacts` 契约，则走 v2 下载链路
- 若仍是旧结果结构，则继续走 legacy 逻辑

这意味着：
- 新环境可直接受益
- 旧环境不会因本次合并立即中断
- 便于后续逐步收口老契约

## 风险点

本次改动的主要风险在于 finalize 阶段逻辑明显变复杂，重点风险包括：

1. 新网关返回的默认 Markdown 产物如果缺少 `download_key`，会导致 finalize 失败
2. 图片类产物的 `artifact_type` / `media_type` 若与预期不一致，可能影响图片回收
3. 下载型交付物链路新增了更多外部调用，超时、空内容、返回结构异常的概率更高
4. 当前通过 fallback 兼容新旧工具名，后续仍需要在配置层彻底统一，避免长期双轨

## 后续建议

建议后续继续推进以下收口工作：

1. 在配置和文档层统一新旧 MinerU 工具命名，减少 fallback 常驻成本
2. 为 v2 artifacts finalize 链路补充更细的自动化测试，覆盖：
   - 默认 markdown 下载
   - 图片交付物下载
   - 空 artifacts / 缺失 default artifact / 缺失 download_key
   - legacy fallback
3. 梳理并固定新网关返回的交付物字段约定，避免运行时通过弱约定猜测结构

## 验证建议

建议重点验证以下场景：

1. 新 MinerU Gateway 环境下提交 OCR，确认可正常创建任务
2. 旧工具名环境下提交 OCR，确认 fallback 生效
3. 新 v2 artifacts 返回下，确认 Markdown 主结果可成功落库
4. 包含图片交付物的文档，确认图片可被正确下载与映射
5. 旧 deliverable 契约环境下，确认 legacy finalize 仍能正常运行

## 提交信息

本 PR 当前包含 1 个提交：

- `d4058d0` `feat: 文档平台 OCR 切换至新 MinerU 网关并适配 v2 产物契约`


Closes #972 