### PR TITLE
fix: Phase B round12 最终收口

### DIFF
--- a/docs/design/app-platform-boundaries.md
+++ b/docs/design/app-platform-boundaries.md
@@ -43,13 +43,13 @@
 |------|------|
 | Registry 配置 | `getRegistryConfig()`, `updateRegistryConfig(updates)` |
 | 索引拉取 | `fetchIndex()` |
-| App 安装 | `installApp(appId, options)` — 通过 `installAppMetadata()` 写 App 元数据到 DB |
-| App 卸载 | `uninstallApp(appId, options)` |
-| 更新检查 | `checkUpdate(appId)` |
+| App 安装 | `installApp(appId, options)` — 通过 `AppRegistryService.createApp()` 写 App 元数据 |
+| App 卸载 | `uninstallApp(appId, options)` — 优先通过 `AppRegistryService.deleteApp()` 删除 App 元数据 |
+| 更新检查 | `checkUpdate(appId)` — 优先通过 `AppRegistryService.getAppById()` 读取本地版本 |
 | 依赖检查 | `checkDependencies(manifest)` |
 | Manifest 拉取 | `fetchManifest(appId)` |
 
-**注意**：Market 的 `installAppMetadata()` 目前直接写 `mini_app` 表。后续应收口为通过 `AppRegistryService.createApp()` 写入。
+**注意**：Market 的 App 元数据写入、卸载与更新检查主路径已优先委托 `AppRegistryService`。直接访问 `mini_app` 的代码仅作为无 Registry 注入时的兼容 fallback 保留。
 
 ### 2.3 MiniAppService — 数据面
 
@@ -94,7 +94,8 @@
 
 | 当前路径 | 目标路径 | 状态 |
 |----------|----------|------|
-| `mini-apps.ts` → `/api/mini-apps` | Registry → `/api/app-registry` | 待迁移（Phase B 后续轮次） |
+| `mini-apps.ts` App CRUD / Config | Registry → `/api/app-registry` | 已迁移，文件名待 Phase C/D 清理 |
+| `mini-apps.ts` Record / extension / content / compare | Legacy data → `/api/mini-apps` | 兼容保留，待后续迁移 |
 | `mini-apps.ts` → states/handlers API | 已删除 | 已移除 |
 
 ---

--- a/server/controllers/app-market.controller.js
+++ b/server/controllers/app-market.controller.js
@@ -168,20 +168,32 @@ class AppMarketController {
   async updateApp(ctx) {
     const { appId } = ctx.params;
     const userId = ctx.state.session.id;
-    const { MiniApp } = this.db.getModels();
     
     // 1. 备份旧 App 的完整 metadata
-    const oldApp = await MiniApp.findByPk(appId);
+    const oldApp = this.registryService
+      ? await this.registryService.getAppById(appId)
+      : await this.db.getModels().MiniApp.findByPk(appId);
     if (!oldApp) {
       ctx.error('App not found', 404);
       return;
     }
     
+    const oldAppData = oldApp.toJSON ? oldApp.toJSON() : oldApp;
     const backup = {
-      visibility: oldApp.visibility,
-      owner_id: oldApp.owner_id,
-      sort_order: oldApp.sort_order,
-      is_active: oldApp.is_active
+      name: oldAppData.name,
+      description: oldAppData.description,
+      icon: oldAppData.icon,
+      type: oldAppData.type,
+      component: oldAppData.component,
+      fields: oldAppData.fields,
+      views: oldAppData.views,
+      config: oldAppData.config,
+      visibility: oldAppData.visibility,
+      owner_id: oldAppData.owner_id,
+      creator_id: oldAppData.creator_id,
+      sort_order: oldAppData.sort_order,
+      is_active: oldAppData.is_active,
+      revision: oldAppData.revision
     };
     
     try {
@@ -195,10 +207,19 @@ class AppMarketController {
       });
       
       // 4. 恢复备份的 metadata（除了 visibility 已在 install 时恢复）
-      await MiniApp.update(
-        { owner_id: backup.owner_id, sort_order: backup.sort_order, is_active: backup.is_active },
-        { where: { id: appId } }
-      );
+      if (this.registryService) {
+        await this.registryService.updateApp(appId, {
+          owner_id: backup.owner_id,
+          sort_order: backup.sort_order,
+          is_active: backup.is_active,
+        });
+      } else {
+        const { MiniApp } = this.db.getModels();
+        await MiniApp.update(
+          { owner_id: backup.owner_id, sort_order: backup.sort_order, is_active: backup.is_active },
+          { where: { id: appId } }
+        );
+      }
       
       ctx.success(result, 'App updated successfully');
     } catch (error) {

--- a/server/index.js
+++ b/server/index.js
@@ -714,7 +714,7 @@ class ApiServer {
     const appRegistryRouter = appRegistryRoutes(this.controllers.appRegistry);
     this.app.use(appRegistryRouter.routes());
     this.app.use(appRegistryRouter.allowedMethods());
-    logger.info('App Registry routes registered (/api/apps/*)');
+    logger.info('App Registry routes registered (/api/app-registry/*)');
 
     // App Wildcard 路由（新架构）- 直接映射 handler 文件
     const wildcardRouter = createAppWildcardRouter(this.db, {

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -850,7 +850,9 @@ class AppMarketService {
     const { keepData = false } = options;
     
     // 1. 检查 App 是否存在
-    const app = await this.models.MiniApp.findByPk(appId);
+    const app = this.registryService
+      ? await this.registryService.getAppById(appId)
+      : await this.models.MiniApp.findByPk(appId);
     if (!app) {
       throw new Error(`App ${appId} 不存在`);
     }
@@ -863,7 +865,10 @@ class AppMarketService {
       manifest = JSON.parse(content);
     } catch (err) {
       // fallback: 从 app.config 读取 extension_tables
-      const config = app.config ? JSON.parse(app.config) : {};
+      let config = app.config || {};
+      if (typeof config === 'string') {
+        try { config = JSON.parse(config); } catch { config = {}; }
+      }
       manifest = {
         migrations: config.migrations || null
       };
@@ -875,12 +880,16 @@ class AppMarketService {
     }
     
     // 4. 删除数据库记录
-    await this.models.MiniApp.destroy({ where: { id: appId } });
+    if (this.registryService) {
+      await this.registryService.deleteApp(appId);
+    } else {
+      await this.models.MiniApp.destroy({ where: { id: appId } });
+      await this.models.AppClockRegistry.destroy({ where: { app_id: appId } });
+    }
     if (this.models.AppState) await this.models.AppState.destroy({ where: { app_id: appId } });
     if (this.models.AppRowHandler) await this.models.AppRowHandler.destroy({ 
       where: { handler: { [Op.like]: `apps/${appId}/handlers/%` } }
     });
-    await this.models.AppClockRegistry.destroy({ where: { app_id: appId } });
     
     // 5. 根据选项决定是否删除数据行
     if (!keepData) {
@@ -909,13 +918,15 @@ class AppMarketService {
   async checkUpdate(appId) {
     this.ensureModels();
     
-    const app = await this.models.MiniApp.findByPk(appId);
+    const app = this.registryService
+      ? await this.registryService.getAppById(appId)
+      : await this.models.MiniApp.findByPk(appId);
     if (!app) {
       throw new Error(`App ${appId} 不存在`);
     }
     
     const manifest = await this.fetchManifest(appId);
-    const localVersion = app.getDataValue ? app.getDataValue('revision') : 1;
+    const localVersion = app.getDataValue ? app.getDataValue('revision') : (app.revision || 1);
     
     return {
       has_update: this.compareVersion(manifest.version, localVersion.toString()) > 0,

--- a/server/services/app-registry.service.js
+++ b/server/services/app-registry.service.js
@@ -112,6 +112,22 @@ class AppRegistryService {
 
     const appJson = app.toJSON();
 
+    if (appJson.fields && typeof appJson.fields === 'string') {
+      try {
+        appJson.fields = JSON.parse(appJson.fields);
+      } catch {
+        appJson.fields = [];
+      }
+    }
+
+    if (appJson.views && typeof appJson.views === 'string') {
+      try {
+        appJson.views = JSON.parse(appJson.views);
+      } catch {
+        appJson.views = {};
+      }
+    }
+
     if (appJson.config && typeof appJson.config === 'string') {
       try {
         appJson.config = JSON.parse(appJson.config);
@@ -241,6 +257,8 @@ async getAppWithRuntime(appId) {
     if (data.type !== undefined) updateData.type = data.type;
     if (data.component !== undefined) updateData.component = data.component;
     if (data.visibility !== undefined) updateData.visibility = data.visibility;
+    if (data.owner_id !== undefined) updateData.owner_id = data.owner_id;
+    if (data.creator_id !== undefined) updateData.creator_id = data.creator_id;
     if (data.is_active !== undefined) updateData.is_active = data.is_active;
     if (data.sort_order !== undefined) updateData.sort_order = data.sort_order;
     


### PR DESCRIPTION
## Summary

- Continue Phase B final consolidation after PR #977.
- Route AppMarket uninstall/check-update/update metadata recovery through AppRegistryService where available.
- Parse Registry `fields/views/config` consistently and update App platform boundary docs/log output.

## Validation

- `npm.cmd run lint`
- `cd frontend && npm.cmd run type-check`
- `git diff --check`
- Module import checks for AppRegistryService, AppMarketService, and AppMarketController
- Lightweight behavior checks for Registry metadata updates and Market registry read/delete path

