### PR TITLE
refactor: Phase C 抽出 app host context builder

### DIFF
--- a/lib/app-host-context-builder.js
+++ b/lib/app-host-context-builder.js
@@ -1,0 +1,64 @@
+import logger from './logger.js';
+
+function getQueryTypes(db) {
+  return db.sequelize.constructor.QueryTypes;
+}
+
+function buildAppServices(db, appId) {
+  const QueryTypes = getQueryTypes(db);
+
+  return {
+    query: async (sql, replacements = []) => {
+      return await db.sequelize.query(sql, {
+        replacements,
+        type: QueryTypes.SELECT,
+      });
+    },
+    execute: async (sql, replacements = []) => {
+      return await db.sequelize.query(sql, {
+        replacements,
+        type: QueryTypes.RAW,
+      });
+    },
+    getModel: (modelName) => {
+      return db.getModel(modelName);
+    },
+    log: (level, message, meta = {}) => {
+      if (level === 'error') {
+        logger.error(`[App:${appId}] ${message}`, meta);
+      } else if (level === 'warn') {
+        logger.warn(`[App:${appId}] ${message}`, meta);
+      } else {
+        logger.info(`[App:${appId}] ${message}`, meta);
+      }
+    },
+  };
+}
+
+export function buildAppHostContext({
+  db,
+  appId,
+  appRecord = null,
+  requestContext = null,
+} = {}) {
+  if (!db) {
+    throw new Error('buildAppHostContext requires db');
+  }
+  if (!appId) {
+    throw new Error('buildAppHostContext requires appId');
+  }
+
+  const session = requestContext?.state?.session || null;
+
+  return {
+    db,
+    appId,
+    app_id: appId,
+    app: appRecord,
+    request: requestContext,
+    user: session,
+    services: buildAppServices(db, appId),
+  };
+}
+
+export default buildAppHostContext;

--- a/server/middlewares/app-wildcard-router.js
+++ b/server/middlewares/app-wildcard-router.js
@@ -41,6 +41,7 @@ import fs from 'fs';
 import { pathToFileURL } from 'url';
 import multer from '@koa/multer';
 import AppRuntimeLoader from '../../lib/app-runtime-loader.js';
+import { buildAppHostContext } from '../../lib/app-host-context-builder.js';
 
 const APPS_DIR = path.join(process.cwd(), 'apps');
 const HANDLERS_DIR = 'server/handlers';
@@ -175,46 +176,6 @@ async function loadHandler(appId, handlerPath, appsDir) {
   const module = await import(`${pathToFileURL(normalizedPath).href}${cacheBuster}`);
 
   return module;
-}
-
-/**
- * 构建 handler 依赖注入
- * 传递 db、app 信息和服务方法给 handler
- */
-function buildDeps(db, appId, appRecord = null) {
-  const Sequelize = db.sequelize.constructor;
-
-  return {
-    db,
-    appId,
-    app: appRecord,
-    services: {
-      query: async (sql, replacements = []) => {
-        return await db.sequelize.query(sql, {
-          replacements,
-          type: Sequelize.QueryTypes.SELECT,
-        });
-      },
-      execute: async (sql, replacements = []) => {
-        return await db.sequelize.query(sql, {
-          replacements,
-          type: Sequelize.QueryTypes.RAW,
-        });
-      },
-      getModel: (modelName) => {
-        return db.getModel(modelName);
-      },
-      log: (level, message, meta = {}) => {
-        if (level === 'error') {
-          logger.error(`[App:${appId}] ${message}`, meta);
-        } else if (level === 'warn') {
-          logger.warn(`[App:${appId}] ${message}`, meta);
-        } else {
-          logger.info(`[App:${appId}] ${message}`, meta);
-        }
-      },
-    },
-  };
 }
 
 export function createAppWildcardRouter(db, options = {}) {
@@ -387,7 +348,12 @@ export function createAppWildcardRouter(db, options = {}) {
       }
 
       // 构建依赖注入
-      const deps = buildDeps(db, appId, appRecord);
+      const deps = buildAppHostContext({
+        db,
+        appId,
+        appRecord,
+        requestContext: ctx,
+      });
 
       logger.info(`[WildcardRouter] ${method} ${ctx.path} -> ${appId}:${handlerPath}:${methodLower}`);
 


### PR DESCRIPTION
## Summary

- Add `buildAppHostContext()` as the shared host capability builder for app runtime code.
- Move wildcard handler dependency construction out of `app-wildcard-router`.
- Preserve the existing `(ctx, deps)` handler contract while adding reusable `app_id`, `request`, and `user` context fields.

## Validation

- `npm.cmd run lint`
- `cd frontend && npm.cmd run type-check`
- `git diff --check`
- Module import checks for `lib/app-host-context-builder.js` and `server/middlewares/app-wildcard-router.js`
- Lightweight behavior check for `query`, `execute`, `getModel`, and injected app/user context

