### PR TITLE
refactor: route app detail through runtime frontend

### DIFF
--- a/apps/current-feature-analyzer/manifest.json
+++ b/apps/current-feature-analyzer/manifest.json
@@ -9,6 +9,9 @@
   "license": "MIT",
   "runtime": {
     "tick": "tick/index.js",
+    "frontend": {
+      "entry": "frontend/views/CurrentFeatureAnalyzerView.vue"
+    },
     "server": {}
   },
   "tags": [

--- a/frontend/src/api/mini-apps.ts
+++ b/frontend/src/api/mini-apps.ts
@@ -17,8 +17,27 @@ export interface MiniApp {
   is_active: boolean
   revision: number
   states?: AppState[]
+  runtime?: AppRuntimeInfo
   created_at: string
   updated_at: string
+}
+
+export interface AppRuntimeFrontend {
+  entry?: string
+  component?: string
+  legacy?: boolean
+  meta?: Record<string, unknown> | null
+}
+
+export interface AppRuntimeInfo {
+  valid: boolean
+  errors?: string[]
+  warnings?: string[]
+  manifest_error?: string
+  has_tick: boolean
+  has_frontend: boolean
+  frontend?: AppRuntimeFrontend | null
+  has_backup: boolean
 }
 
 export interface AppField {
@@ -251,6 +270,10 @@ export async function getApps(): Promise<MiniApp[]> {
 
 export async function getApp(appId: string): Promise<MiniApp> {
   return apiRequest<MiniApp>(apiClient.get(`/app-registry/${appId}`))
+}
+
+export async function getAppWithRuntime(appId: string): Promise<MiniApp> {
+  return apiRequest<MiniApp>(apiClient.get(`/app-registry/${appId}/runtime`))
 }
 
 export async function createApp(data: Partial<MiniApp>): Promise<MiniApp> {

--- a/frontend/src/views/AppDetailView.vue
+++ b/frontend/src/views/AppDetailView.vue
@@ -7,7 +7,7 @@
     </div>
     <div v-else-if="!AppComponent" class="empty-state">
       <p>该应用尚未配置前端组件</p>
-      <p class="empty-hint">请在应用管理中配置 component 字段</p>
+      <p class="empty-hint">请在应用 manifest 中配置 runtime.frontend.entry 或 component 字段</p>
       <button class="btn-back" @click="goBack">← 返回</button>
     </div>
     <component v-else :is="AppComponent" :app="currentApp" />
@@ -17,7 +17,7 @@
 <script setup lang="ts">
 import { shallowRef, ref, onMounted, defineAsyncComponent, type Component } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { getApp, type MiniApp } from '@/api/mini-apps'
+import { getAppWithRuntime, type AppRuntimeFrontend, type MiniApp } from '@/api/mini-apps'
 
 const AppComponentMap: Record<string, Component> = {
   'ContractMgrView': defineAsyncComponent(() => import('@/views/contract-mgr/ContractMgrView.vue')),
@@ -30,6 +30,8 @@ const AppComponentMap: Record<string, Component> = {
   'CurrentFeatureAnalyzerView': defineAsyncComponent(() => import('@apps/current-feature-analyzer/frontend/views/CurrentFeatureAnalyzerView.vue')),
 }
 
+const RuntimeComponentModules = import.meta.glob('@apps/*/frontend/views/*.vue')
+
 const route = useRoute()
 const router = useRouter()
 const currentApp = shallowRef<MiniApp | null>(null)
@@ -39,18 +41,42 @@ const isLoading = ref(true)
 onMounted(async () => {
   try {
     const appId = route.params.appId as string
-    currentApp.value = await getApp(appId)
-    const componentKey = currentApp.value?.component
-    if (componentKey && componentKey in AppComponentMap) {
-      AppComponent.value = AppComponentMap[componentKey]!
-    }
-    // 如果 componentKey 不存在于 AppComponentMap 中，AppComponent 保持 null，显示空状态
+    currentApp.value = await getAppWithRuntime(appId)
+    AppComponent.value = resolveAppComponent(currentApp.value)
   } catch (error) {
     console.error('Failed to load app:', error)
   } finally {
     isLoading.value = false
   }
 })
+
+function resolveAppComponent(app: MiniApp | null): Component | null {
+  if (!app) return null
+
+  const runtimeComponent = resolveRuntimeFrontendComponent(app.id, app.runtime?.frontend)
+  if (runtimeComponent) return runtimeComponent
+
+  const componentKey = app.runtime?.frontend?.component || app.component
+  if (componentKey && componentKey in AppComponentMap) {
+    return AppComponentMap[componentKey]!
+  }
+
+  return null
+}
+
+function resolveRuntimeFrontendComponent(appId: string, frontend?: AppRuntimeFrontend | null): Component | null {
+  if (!frontend?.entry || frontend.legacy) return null
+
+  const entry = frontend.entry.replace(/^\.?\//, '')
+  const loader = [
+    `@apps/${appId}/${entry}`,
+    `../apps/${appId}/${entry}`,
+  ].map((moduleKey) => RuntimeComponentModules[moduleKey]).find(Boolean)
+
+  if (!loader) return null
+
+  return defineAsyncComponent(loader as () => Promise<Component>)
+}
 
 function goBack() {
   router.push('/apps')

--- a/lib/app-runtime-loader.js
+++ b/lib/app-runtime-loader.js
@@ -317,6 +317,27 @@ class AppRuntimeLoader {
     return null;
   }
 
+  buildFrontendDescriptor(manifest) {
+    const runtime = manifest.runtime || {};
+
+    if (runtime.frontend?.entry) {
+      return {
+        entry: runtime.frontend.entry,
+        meta: runtime.frontend.meta || null,
+        legacy: false,
+      };
+    }
+
+    if (manifest.component) {
+      return {
+        component: manifest.component,
+        legacy: true,
+      };
+    }
+
+    return null;
+  }
+
   buildTickContext(app, registry, extraServices = {}) {
     const Sequelize = this.db.sequelize.constructor;
     
@@ -452,12 +473,14 @@ class AppRuntimeLoader {
     const manifest = await this.loadManifest(appId);
     const validation = await this.validateRuntime(manifest);
     const paths = this.resolveRuntimePaths(manifest);
+    const frontend = this.buildFrontendDescriptor(manifest);
     
     return {
       appId,
       manifest,
       validation,
       paths,
+      frontend,
       hasTick: !!paths.tick,
       hasFrontend: !!paths.frontendEntry || !!manifest.component,
       hasBackupExport: !!paths.backupExport,

--- a/server/services/app-registry.service.js
+++ b/server/services/app-registry.service.js
@@ -177,6 +177,10 @@ async getAppWithRuntime(appId) {
             manifest_error: manifestError,
             has_tick: false,
             has_frontend: !!app.component,
+            frontend: app.component ? {
+              component: app.component,
+              legacy: true,
+            } : null,
             has_backup: false,
           },
         },
@@ -193,6 +197,7 @@ async getAppWithRuntime(appId) {
           warnings: runtimeInfo.validation?.warnings ?? [],
           has_tick: runtimeInfo.hasTick,
           has_frontend: runtimeInfo.hasFrontend,
+          frontend: runtimeInfo.frontend || null,
           has_backup: runtimeInfo.hasBackupExport,
         },
       },
@@ -431,12 +436,17 @@ async getAppWithRuntime(appId) {
           valid: runtimeInfo.validation?.valid ?? true,
           has_tick: runtimeInfo.hasTick,
           has_frontend: runtimeInfo.hasFrontend,
+          frontend: runtimeInfo.frontend || null,
           has_backup: runtimeInfo.hasBackupExport,
         } : {
           valid: false,
           error: runtimeError,
           has_tick: false,
           has_frontend: !!app.component,
+          frontend: app.component ? {
+            component: app.component,
+            legacy: true,
+          } : null,
           has_backup: false,
         },
       });


### PR DESCRIPTION
## Summary

- Expose safe app frontend runtime metadata from `AppRuntimeLoader` and app registry runtime payloads.
- Make `AppDetailView` load `runtime.frontend.entry` first, with legacy `component` whitelist fallback.
- Move `current-feature-analyzer` onto manifest-declared frontend entry while preserving the legacy component field.

## Validation

- `node --input-type=module -e "...getAppRuntimeInfo('current-feature-analyzer')..."`
- `npm.cmd run lint`
- `cd frontend && npm.cmd run type-check`
- `cd frontend && npm.cmd run build-only`

No issue linked.
