### PR TITLE
refactor: 拆分设置页模型提供商管理

### DIFF
--- a/frontend/src/components/settings/ModelProviderTab.vue
+++ b/frontend/src/components/settings/ModelProviderTab.vue
@@ -1,0 +1,695 @@
+<template>
+  <div class="model-provider-tab">
+    <div class="split-panel">
+      <div class="panel provider-panel">
+        <div class="panel-header">
+          <h3 class="panel-title">{{ $t('settings.providerManagement') }}</h3>
+          <el-button @click="openProviderDialog()" :title="$t('settings.addProvider')">
+            + {{ $t('settings.addProvider') }}
+          </el-button>
+        </div>
+
+        <div v-if="providerStore.isLoading" class="loading-state">
+          {{ $t('common.loading') }}
+        </div>
+
+        <div v-else-if="providerStore.providers.length === 0" class="empty-state">
+          {{ $t('settings.noProviders') }}
+        </div>
+
+        <div v-else class="provider-list-container">
+          <div class="provider-list">
+            <div
+              v-for="provider in paginatedProviders"
+              :key="provider.id"
+              class="provider-item"
+              :class="{
+                active: selectedProvider?.id === provider.id,
+                inactive: !provider.is_active
+              }"
+            >
+              <button
+                class="provider-name-btn"
+                @click="selectProvider(provider)"
+              >
+                <span class="provider-name">{{ provider.name }}</span>
+                <span v-if="!provider.is_active" class="badge inactive">
+                  {{ $t('settings.inactive') }}
+                </span>
+              </button>
+              <el-button size="small" @click.stop="openProviderDialog(provider)">
+                {{ $t('common.edit') }}
+              </el-button>
+            </div>
+          </div>
+
+          <Pagination
+            v-if="providerTotalPages > 1"
+            :current-page="providerPage"
+            :total-pages="providerTotalPages"
+            :total="providerStore.providers.length"
+            @change="(page) => providerPage = page"
+          />
+        </div>
+      </div>
+
+      <div class="panel model-panel">
+        <div class="panel-header">
+          <h3 class="panel-title">
+            {{ selectedProvider
+              ? $t('settings.modelsOfProvider', { name: selectedProvider.name })
+              : $t('settings.modelManagement')
+            }}
+          </h3>
+          <el-button
+            v-if="selectedProvider"
+            @click="openModelDialog()"
+            :title="$t('settings.addModel')"
+          >
+            + {{ $t('settings.addModel') }}
+          </el-button>
+        </div>
+
+        <div v-if="!selectedProvider" class="empty-state select-provider-hint">
+          {{ $t('settings.selectProviderHint') }}
+        </div>
+
+        <div v-else-if="modelStore.isLoading" class="loading-state">
+          {{ $t('common.loading') }}
+        </div>
+
+        <div v-else-if="filteredModels.length === 0" class="empty-state">
+          {{ $t('settings.noModelsForProvider') }}
+        </div>
+
+        <div v-else class="model-list-container">
+          <div class="model-list">
+            <div
+              v-for="model in paginatedModels"
+              :key="model.id"
+              class="model-item"
+              :class="{
+                inactive: !model.is_active
+              }"
+            >
+              <div class="model-info">
+                <span class="model-name">{{ model.name }}</span>
+                <span v-if="model.model_type === 'embedding'" class="badge embedding">
+                  {{ $t('settings.modelTypeEmbedding') }}
+                </span>
+                <span v-if="!model.is_active" class="badge inactive">
+                  {{ $t('settings.inactive') }}
+                </span>
+              </div>
+              <el-button size="small" @click.stop="openModelDialog(model)">
+                {{ $t('common.edit') }}
+              </el-button>
+            </div>
+          </div>
+
+          <Pagination
+            v-if="modelTotalPages > 1"
+            :current-page="modelPage"
+            :total-pages="modelTotalPages"
+            :total="filteredModels.length"
+            @change="(page) => modelPage = page"
+          />
+        </div>
+      </div>
+    </div>
+
+    <el-dialog
+      v-model="showProviderDialog"
+      :title="editingProvider ? $t('settings.editProvider') : $t('settings.addProvider')"
+      width="500px"
+    >
+      <el-form label-width="100px">
+        <el-form-item :label="$t('settings.providerName')" required>
+          <el-input v-model="providerForm.name" :placeholder="$t('settings.providerNamePlaceholder')" />
+        </el-form-item>
+        <el-form-item :label="$t('settings.baseUrl')" required>
+          <el-input v-model="providerForm.base_url" :placeholder="$t('settings.baseUrlPlaceholder')" />
+        </el-form-item>
+        <el-form-item :label="$t('settings.apiKey')">
+          <el-input v-model="providerForm.api_key" type="password" :placeholder="$t('settings.apiKeyPlaceholder')" show-password />
+          <div v-if="editingProvider" class="el-form-item__tip">{{ $t('settings.apiKeyHint') }}</div>
+        </el-form-item>
+        <el-form-item :label="$t('settings.timeout') + ' (秒)'">
+          <el-input-number v-model="providerForm.timeout" :min="5" :max="300" />
+        </el-form-item>
+        <el-form-item :label="$t('settings.userAgent')">
+          <el-input v-model="providerForm.user_agent" :placeholder="$t('settings.userAgentPlaceholder')" />
+          <div class="el-form-item__tip">{{ $t('settings.userAgentHint') }}</div>
+        </el-form-item>
+        <el-form-item>
+          <el-checkbox v-model="providerForm.is_active">{{ $t('settings.isActive') }}</el-checkbox>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button v-if="editingProvider" type="danger" @click="confirmDeleteProviderFromDialog">{{ $t('common.delete') }}</el-button>
+        <el-button @click="closeProviderDialog">{{ $t('common.cancel') }}</el-button>
+        <el-button type="primary" :disabled="!isProviderFormValid" @click="saveProvider">{{ $t('common.save') }}</el-button>
+      </template>
+    </el-dialog>
+
+    <el-dialog
+      v-model="showModelDialog"
+      :title="editingModel ? $t('settings.editModel') : $t('settings.addModel')"
+      width="600px"
+    >
+      <el-form label-width="120px">
+        <el-form-item :label="$t('settings.modelName')" required>
+          <el-input v-model="modelForm.name" :placeholder="$t('settings.modelNamePlaceholder')" />
+        </el-form-item>
+        <el-form-item :label="$t('settings.modelIdentifier')" required>
+          <el-input v-model="modelForm.model_name" :placeholder="$t('settings.modelIdentifierPlaceholder')" />
+          <div class="el-form-item__tip">{{ $t('settings.modelIdentifierHint') }}</div>
+        </el-form-item>
+        <el-form-item :label="$t('settings.provider')" required>
+          <el-select v-model="modelForm.provider_id" clearable>
+            <el-option label="" value="" />
+            <el-option v-for="provider in providerStore.providers" :key="provider.id" :value="provider.id" :label="provider.name" />
+          </el-select>
+        </el-form-item>
+        <el-form-item :label="$t('settings.modelType')">
+          <el-select v-model="modelForm.model_type">
+            <el-option value="text" :label="$t('settings.modelTypeText')" />
+            <el-option value="multimodal" :label="$t('settings.modelTypeMultimodal')" />
+            <el-option value="embedding" :label="$t('settings.modelTypeEmbedding')" />
+          </el-select>
+        </el-form-item>
+
+        <el-form-item v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'" :label="$t('settings.maxTokens')">
+          <el-input-number v-model="modelForm.max_tokens" :placeholder="$t('settings.maxTokensPlaceholder')" />
+          <div class="el-form-item__tip">{{ $t('settings.maxTokensHint') }}</div>
+        </el-form-item>
+
+        <el-form-item v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'" :label="$t('settings.maxOutputTokens')">
+          <el-input-number v-model="modelForm.max_output_tokens" :placeholder="$t('settings.maxOutputTokensPlaceholder')" />
+          <div class="el-form-item__tip">{{ $t('settings.maxOutputTokensHint') }}</div>
+        </el-form-item>
+
+        <el-form-item v-if="modelForm.model_type === 'embedding'" :label="$t('settings.embeddingDim')">
+          <el-input-number v-model="modelForm.embedding_dim" :placeholder="$t('settings.embeddingDimPlaceholder')" />
+        </el-form-item>
+
+        <el-form-item :label="$t('settings.costPer1kInput') + ' (USD)'">
+          <el-input-number v-model="modelForm.cost_per_1k_input" :precision="4" :step="0.0001" :placeholder="$t('settings.costPlaceholder')" />
+        </el-form-item>
+
+        <el-form-item :label="$t('settings.costPer1kOutput') + ' (USD)'">
+          <el-input-number v-model="modelForm.cost_per_1k_output" :precision="4" :step="0.0001" :placeholder="$t('settings.costPlaceholder')" />
+        </el-form-item>
+
+        <el-form-item :label="$t('settings.modelDescription')">
+          <el-input v-model="modelForm.description" type="textarea" :rows="3" :placeholder="$t('settings.descriptionPlaceholder')" />
+        </el-form-item>
+
+        <el-divider v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'">{{ $t('settings.thinkingConfig') }}</el-divider>
+
+        <el-form-item v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'">
+          <el-checkbox v-model="modelForm.supports_reasoning">{{ $t('settings.supportsReasoning') }}</el-checkbox>
+          <div class="el-form-item__tip">{{ $t('settings.supportsReasoningHint') }}</div>
+        </el-form-item>
+
+        <el-form-item v-if="(modelForm.model_type === 'text' || modelForm.model_type === 'multimodal') && modelForm.supports_reasoning" :label="$t('settings.thinkingFormat')">
+          <el-select v-model="modelForm.thinking_format">
+            <el-option value="none" :label="$t('settings.thinkingFormatNone')" />
+            <el-option value="openai" :label="$t('settings.thinkingFormatOpenai')" />
+            <el-option value="glm" :label="$t('settings.thinkingFormatGlm')" />
+            <el-option value="qwen" :label="$t('settings.thinkingFormatQwen')" />
+            <el-option value="deepseek" :label="$t('settings.thinkingFormatDeepseek')" />
+          </el-select>
+          <div class="el-form-item__tip">{{ $t('settings.thinkingFormatHint') }}</div>
+        </el-form-item>
+
+        <el-form-item>
+          <el-checkbox v-model="modelForm.is_active">{{ $t('settings.isActive') }}</el-checkbox>
+        </el-form-item>
+      </el-form>
+
+      <template #footer>
+        <el-button v-if="editingModel" type="danger" @click="confirmDeleteModelFromDialog">{{ $t('common.delete') }}</el-button>
+        <el-button @click="closeModelDialog">{{ $t('common.cancel') }}</el-button>
+        <el-button type="primary" :disabled="!isModelFormValid" @click="saveModel">{{ $t('common.save') }}</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { ElMessageBox } from 'element-plus'
+import Pagination from '@/components/Pagination.vue'
+import { useModelStore } from '@/stores/model'
+import { useProviderStore } from '@/stores/provider'
+import { useToastStore } from '@/stores/toast'
+import type { AIModel, ModelFormData, ModelProvider, ProviderFormData } from '@/types'
+
+const { t } = useI18n()
+const modelStore = useModelStore()
+const providerStore = useProviderStore()
+const toast = useToastStore()
+
+const selectedProvider = ref<ModelProvider | null>(null)
+const providerPage = ref(1)
+const PROVIDER_PAGE_SIZE = 10
+
+const providerTotalPages = computed(() =>
+  Math.ceil(providerStore.providers.length / PROVIDER_PAGE_SIZE)
+)
+
+const paginatedProviders = computed(() => {
+  const start = (providerPage.value - 1) * PROVIDER_PAGE_SIZE
+  return providerStore.providers.slice(start, start + PROVIDER_PAGE_SIZE)
+})
+
+const selectProvider = (provider: ModelProvider) => {
+  selectedProvider.value = provider
+  modelPage.value = 1
+}
+
+const modelPage = ref(1)
+const MODEL_PAGE_SIZE = 10
+
+const filteredModels = computed(() => {
+  if (!selectedProvider.value) return []
+  return modelStore.models.filter(m => m.provider_id === selectedProvider.value!.id)
+})
+
+const modelTotalPages = computed(() =>
+  Math.ceil(filteredModels.value.length / MODEL_PAGE_SIZE)
+)
+
+const paginatedModels = computed(() => {
+  const start = (modelPage.value - 1) * MODEL_PAGE_SIZE
+  return filteredModels.value.slice(start, start + MODEL_PAGE_SIZE)
+})
+
+const showProviderDialog = ref(false)
+const editingProvider = ref<ModelProvider | null>(null)
+const providerForm = reactive<ProviderFormData>({
+  name: '',
+  base_url: '',
+  api_key: '',
+  timeout: 30,
+  user_agent: '',
+  is_active: true,
+})
+
+const isProviderFormValid = computed(() => {
+  return providerForm.name.trim() && providerForm.base_url.trim()
+})
+
+const showModelDialog = ref(false)
+const editingModel = ref<AIModel | null>(null)
+const modelForm = reactive<ModelFormData>({
+  name: '',
+  model_name: '',
+  provider_id: '',
+  model_type: 'text',
+  max_tokens: undefined,
+  max_output_tokens: undefined,
+  embedding_dim: undefined,
+  cost_per_1k_input: undefined,
+  cost_per_1k_output: undefined,
+  description: '',
+  is_active: true,
+  supports_reasoning: false,
+  thinking_format: 'none',
+})
+
+const isModelFormValid = computed(() => {
+  return modelForm.name?.trim() && modelForm.model_name?.trim() && modelForm.provider_id?.trim()
+})
+
+const openProviderDialog = (provider?: ModelProvider) => {
+  if (provider) {
+    editingProvider.value = provider
+    providerForm.name = provider.name
+    providerForm.base_url = provider.base_url
+    providerForm.api_key = ''
+    providerForm.timeout = provider.timeout
+    providerForm.user_agent = provider.user_agent || ''
+    providerForm.is_active = provider.is_active
+  } else {
+    editingProvider.value = null
+    providerForm.name = ''
+    providerForm.base_url = ''
+    providerForm.api_key = ''
+    providerForm.timeout = 30
+    providerForm.user_agent = ''
+    providerForm.is_active = true
+  }
+  showProviderDialog.value = true
+}
+
+const closeProviderDialog = () => {
+  showProviderDialog.value = false
+  editingProvider.value = null
+}
+
+const saveProvider = async () => {
+  try {
+    if (editingProvider.value) {
+      const updateData: Partial<ProviderFormData> = {
+        name: providerForm.name,
+        base_url: providerForm.base_url,
+        timeout: providerForm.timeout,
+        user_agent: providerForm.user_agent || undefined,
+        is_active: providerForm.is_active,
+      }
+      if (providerForm.api_key) {
+        updateData.api_key = providerForm.api_key
+      }
+      await providerStore.updateProvider(editingProvider.value.id, updateData)
+    } else {
+      const newProvider = await providerStore.createProvider({ ...providerForm })
+      selectedProvider.value = newProvider
+    }
+    closeProviderDialog()
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : t('settings.saveProviderFailed')
+    toast.error(errorMsg)
+  }
+}
+
+const confirmDeleteProviderFromDialog = async () => {
+  if (!editingProvider.value) return
+
+  try {
+    await ElMessageBox.confirm(
+      t('settings.deleteProviderConfirm', { name: editingProvider.value.name }),
+      t('common.confirmDelete'),
+      {
+        confirmButtonText: t('common.delete'),
+        cancelButtonText: t('common.cancel'),
+        type: 'warning'
+      }
+    )
+
+    await providerStore.deleteProvider(editingProvider.value.id)
+    if (selectedProvider.value?.id === editingProvider.value.id) {
+      selectedProvider.value = null
+    }
+    closeProviderDialog()
+  } catch (err) {
+    if (err !== 'cancel') {
+      const errorMsg = err instanceof Error ? err.message : t('settings.deleteProviderFailed')
+      toast.error(errorMsg)
+    }
+  }
+}
+
+const openModelDialog = (model?: AIModel) => {
+  if (model) {
+    editingModel.value = model
+    modelForm.name = model.name
+    modelForm.model_name = model.model_name || ''
+    modelForm.provider_id = model.provider_id || ''
+    modelForm.model_type = model.model_type || 'text'
+    modelForm.max_tokens = model.max_tokens
+    modelForm.max_output_tokens = model.max_output_tokens
+    modelForm.embedding_dim = model.embedding_dim
+    modelForm.cost_per_1k_input = model.cost_per_1k_input
+    modelForm.cost_per_1k_output = model.cost_per_1k_output
+    modelForm.description = model.description || ''
+    modelForm.supports_reasoning = model.supports_reasoning ?? false
+    modelForm.thinking_format = model.thinking_format ?? 'none'
+    modelForm.is_active = model.is_active
+  } else {
+    editingModel.value = null
+    modelForm.name = ''
+    modelForm.model_name = ''
+    modelForm.provider_id = selectedProvider.value?.id || ''
+    modelForm.model_type = 'text'
+    modelForm.max_tokens = undefined
+    modelForm.max_output_tokens = undefined
+    modelForm.embedding_dim = undefined
+    modelForm.cost_per_1k_input = undefined
+    modelForm.cost_per_1k_output = undefined
+    modelForm.description = ''
+    modelForm.supports_reasoning = false
+    modelForm.thinking_format = 'none'
+    modelForm.is_active = true
+  }
+  showModelDialog.value = true
+}
+
+const closeModelDialog = () => {
+  showModelDialog.value = false
+  editingModel.value = null
+}
+
+const saveModel = async () => {
+  try {
+    const payload = {
+      ...modelForm,
+      thinking_format: modelForm.supports_reasoning ? modelForm.thinking_format : 'none',
+    }
+
+    if (editingModel.value) {
+      await modelStore.updateModel(editingModel.value.id, payload)
+    } else {
+      await modelStore.createModel(payload)
+    }
+    closeModelDialog()
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : t('settings.saveModelFailed')
+    toast.error(errorMsg)
+  }
+}
+
+const confirmDeleteModelFromDialog = async () => {
+  if (!editingModel.value) return
+
+  try {
+    await ElMessageBox.confirm(
+      t('settings.deleteModelConfirm', { name: editingModel.value.name }),
+      t('common.confirmDelete'),
+      {
+        confirmButtonText: t('common.delete'),
+        cancelButtonText: t('common.cancel'),
+        type: 'warning'
+      }
+    )
+
+    await modelStore.deleteModel(editingModel.value.id)
+    closeModelDialog()
+  } catch (err) {
+    if (err !== 'cancel') {
+      const errorMsg = err instanceof Error ? err.message : t('settings.deleteModelFailed')
+      toast.error(errorMsg)
+    }
+  }
+}
+
+watch(() => providerStore.providers, (newProviders) => {
+  if (selectedProvider.value && !newProviders.find(p => p.id === selectedProvider.value!.id)) {
+    selectedProvider.value = null
+  }
+}, { deep: true })
+
+onMounted(() => {
+  modelStore.loadModels()
+  providerStore.loadProviders()
+})
+</script>
+
+<style scoped>
+.model-provider-tab {
+  min-height: 500px;
+}
+
+.split-panel {
+  display: flex;
+  min-height: 500px;
+}
+
+.panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.provider-panel {
+  flex: 0 0 320px;
+  border-right: 1px solid var(--border-color, #e0e0e0);
+  background: var(--secondary-bg, #f8f9fa);
+}
+
+.model-panel {
+  flex: 1;
+  background: var(--card-bg, #fff);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color, #e0e0e0);
+  background: var(--card-bg, #fff);
+}
+
+.panel-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text-primary, #333);
+}
+
+.provider-list-container,
+.model-list-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.provider-list,
+.model-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.provider-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-bottom: 4px;
+  border-radius: 8px;
+  background: var(--card-bg, #fff);
+  border: 1px solid transparent;
+  transition: all 0.2s;
+}
+
+.provider-item:hover {
+  background: var(--hover-bg, #e8e8e8);
+}
+
+.provider-item.active {
+  background: var(--primary-light, #e3f2fd);
+  border-color: var(--primary-color, #2196f3);
+}
+
+.provider-item.inactive {
+  opacity: 0.6;
+}
+
+.provider-name-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  padding: 4px;
+  min-width: 0;
+}
+
+.provider-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary, #333);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 4px;
+  border-radius: 8px;
+  background: var(--secondary-bg, #f5f5f5);
+  border: 1px solid transparent;
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.model-item:hover {
+  background: var(--hover-bg, #e8e8e8);
+}
+
+.model-item.inactive {
+  opacity: 0.6;
+}
+
+.model-info {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.model-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary, #333);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.badge {
+  padding: 2px 8px;
+  font-size: 11px;
+  border-radius: 4px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.badge.inactive {
+  background: var(--error-bg, #ffebee);
+  color: var(--error-color, #c62828);
+}
+
+.badge.embedding {
+  background: var(--primary-light-bg, #e8f4fe);
+  color: var(--primary-color, #7c5c3d);
+}
+
+.loading-state,
+.empty-state {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-secondary, #666);
+  font-size: 14px;
+}
+
+.select-provider-hint {
+  color: var(--text-tertiary, #999);
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .split-panel {
+    flex-direction: column;
+  }
+
+  .provider-panel {
+    flex: none;
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color, #e0e0e0);
+    max-height: 300px;
+  }
+
+  .model-panel {
+    flex: none;
+    width: 100%;
+    max-height: 400px;
+  }
+}
+</style>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -81,129 +81,8 @@
       <InvitationTab />
     </div>
 
-    <!-- 模型和提供商管理（合并） -->
     <div v-if="activeTab === 'model'" class="settings-section model-provider-section">
-      <div class="split-panel">
-        <!-- 左侧：提供商列表 -->
-        <div class="panel provider-panel">
-          <div class="panel-header">
-            <h3 class="panel-title">{{ $t('settings.providerManagement') }}</h3>
-            <el-button @click="openProviderDialog()" :title="$t('settings.addProvider')">
-              + {{ $t('settings.addProvider') }}
-            </el-button>
-          </div>
-
-          <div v-if="providerStore.isLoading" class="loading-state">
-            {{ $t('common.loading') }}
-          </div>
-
-          <div v-else-if="providerStore.providers.length === 0" class="empty-state">
-            {{ $t('settings.noProviders') }}
-          </div>
-
-          <div v-else class="provider-list-container">
-            <div class="provider-list">
-              <div
-                v-for="provider in paginatedProviders"
-                :key="provider.id"
-                class="provider-item"
-                :class="{
-                  active: selectedProvider?.id === provider.id,
-                  inactive: !provider.is_active
-                }"
-              >
-                <button
-                  class="provider-name-btn"
-                  @click="selectProvider(provider)"
-                >
-                  <span class="provider-name">{{ provider.name }}</span>
-                  <span v-if="!provider.is_active" class="badge inactive">
-                    {{ $t('settings.inactive') }}
-                  </span>
-                </button>
-                <el-button size="small" @click.stop="openProviderDialog(provider)">
-                  {{ $t('common.edit') }}
-                </el-button>
-              </div>
-            </div>
-
-            <!-- 提供商分页 -->
-            <Pagination
-              v-if="providerTotalPages > 1"
-              :current-page="providerPage"
-              :total-pages="providerTotalPages"
-              :total="providerStore.providers.length"
-              @change="(page) => providerPage = page"
-            />
-          </div>
-        </div>
-
-        <!-- 右侧：模型列表 -->
-        <div class="panel model-panel">
-          <div class="panel-header">
-            <h3 class="panel-title">
-              {{ selectedProvider 
-                ? $t('settings.modelsOfProvider', { name: selectedProvider.name }) 
-                : $t('settings.modelManagement') 
-              }}
-            </h3>
-            <el-button
-              v-if="selectedProvider"
-              @click="openModelDialog()"
-              :title="$t('settings.addModel')"
-            >
-              + {{ $t('settings.addModel') }}
-            </el-button>
-          </div>
-
-          <div v-if="!selectedProvider" class="empty-state select-provider-hint">
-            {{ $t('settings.selectProviderHint') }}
-          </div>
-
-          <div v-else-if="modelStore.isLoading" class="loading-state">
-            {{ $t('common.loading') }}
-          </div>
-
-          <div v-else-if="filteredModels.length === 0" class="empty-state">
-            {{ $t('settings.noModelsForProvider') }}
-          </div>
-
-          <div v-else class="model-list-container">
-            <div class="model-list">
-              <div
-                v-for="model in paginatedModels"
-                :key="model.id"
-                class="model-item"
-                :class="{
-                  inactive: !model.is_active
-                }"
-              >
-                <div class="model-info">
-                  <span class="model-name">{{ model.name }}</span>
-                  <span v-if="(model as any).model_type === 'embedding'" class="badge embedding">
-                    {{ $t('settings.modelTypeEmbedding') }}
-                  </span>
-                  <span v-if="!model.is_active" class="badge inactive">
-                    {{ $t('settings.inactive') }}
-                  </span>
-                </div>
-                <el-button size="small" @click.stop="openModelDialog(model)">
-                  {{ $t('common.edit') }}
-                </el-button>
-              </div>
-            </div>
-
-            <!-- 模型分页 -->
-            <Pagination
-              v-if="modelTotalPages > 1"
-              :current-page="modelPage"
-              :total-pages="modelTotalPages"
-              :total="filteredModels.length"
-              @change="(page) => modelPage = page"
-            />
-          </div>
-        </div>
-      </div>
+      <ModelProviderTab />
     </div>
 
     <!-- 专家设置 -->
@@ -537,126 +416,6 @@
       </div>
     </div>
 
-    <!-- Provider 添加/编辑对话框 -->
-    <el-dialog
-      v-model="showProviderDialog"
-      :title="editingProvider ? $t('settings.editProvider') : $t('settings.addProvider')"
-      width="500px"
-    >
-      <el-form label-width="100px">
-        <el-form-item :label="$t('settings.providerName')" required>
-          <el-input v-model="providerForm.name" :placeholder="$t('settings.providerNamePlaceholder')" />
-        </el-form-item>
-        <el-form-item :label="$t('settings.baseUrl')" required>
-          <el-input v-model="providerForm.base_url" :placeholder="$t('settings.baseUrlPlaceholder')" />
-        </el-form-item>
-        <el-form-item :label="$t('settings.apiKey')">
-          <el-input v-model="providerForm.api_key" type="password" :placeholder="$t('settings.apiKeyPlaceholder')" show-password />
-          <div v-if="editingProvider" class="el-form-item__tip">{{ $t('settings.apiKeyHint') }}</div>
-        </el-form-item>
-        <el-form-item :label="$t('settings.timeout') + ' (秒)'">
-          <el-input-number v-model="providerForm.timeout" :min="5" :max="300" />
-        </el-form-item>
-        <el-form-item :label="$t('settings.userAgent')">
-          <el-input v-model="providerForm.user_agent" :placeholder="$t('settings.userAgentPlaceholder')" />
-          <div class="el-form-item__tip">{{ $t('settings.userAgentHint') }}</div>
-        </el-form-item>
-        <el-form-item>
-          <el-checkbox v-model="providerForm.is_active">{{ $t('settings.isActive') }}</el-checkbox>
-        </el-form-item>
-      </el-form>
-      <template #footer>
-        <el-button v-if="editingProvider" type="danger" @click="confirmDeleteProviderFromDialog">{{ $t('common.delete') }}</el-button>
-        <el-button @click="closeProviderDialog">{{ $t('common.cancel') }}</el-button>
-        <el-button type="primary" :disabled="!isProviderFormValid" @click="saveProvider">{{ $t('common.save') }}</el-button>
-      </template>
-    </el-dialog>
-
-    <!-- Model 添加/编辑对话框 -->
-    <el-dialog
-      v-model="showModelDialog"
-      :title="editingModel ? $t('settings.editModel') : $t('settings.addModel')"
-      width="600px"
-    >
-      <el-form label-width="120px">
-        <el-form-item :label="$t('settings.modelName')" required>
-          <el-input v-model="modelForm.name" :placeholder="$t('settings.modelNamePlaceholder')" />
-        </el-form-item>
-        <el-form-item :label="$t('settings.modelIdentifier')" required>
-          <el-input v-model="modelForm.model_name" :placeholder="$t('settings.modelIdentifierPlaceholder')" />
-          <div class="el-form-item__tip">{{ $t('settings.modelIdentifierHint') }}</div>
-        </el-form-item>
-        <el-form-item :label="$t('settings.provider')" required>
-          <el-select v-model="modelForm.provider_id" clearable>
-            <el-option label="" value="" />
-            <el-option v-for="provider in providerStore.providers" :key="provider.id" :value="provider.id" :label="provider.name" />
-          </el-select>
-        </el-form-item>
-        <el-form-item :label="$t('settings.modelType')">
-          <el-select v-model="modelForm.model_type">
-            <el-option value="text" :label="$t('settings.modelTypeText')" />
-            <el-option value="multimodal" :label="$t('settings.modelTypeMultimodal')" />
-            <el-option value="embedding" :label="$t('settings.modelTypeEmbedding')" />
-          </el-select>
-        </el-form-item>
-
-        <el-form-item v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'" :label="$t('settings.maxTokens')">
-          <el-input-number v-model="modelForm.max_tokens" :placeholder="$t('settings.maxTokensPlaceholder')" />
-          <div class="el-form-item__tip">{{ $t('settings.maxTokensHint') }}</div>
-        </el-form-item>
-
-        <el-form-item v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'" :label="$t('settings.maxOutputTokens')">
-          <el-input-number v-model="modelForm.max_output_tokens" :placeholder="$t('settings.maxOutputTokensPlaceholder')" />
-          <div class="el-form-item__tip">{{ $t('settings.maxOutputTokensHint') }}</div>
-        </el-form-item>
-
-        <el-form-item v-if="modelForm.model_type === 'embedding'" :label="$t('settings.embeddingDim')">
-          <el-input-number v-model="modelForm.embedding_dim" :placeholder="$t('settings.embeddingDimPlaceholder')" />
-        </el-form-item>
-
-        <el-form-item :label="$t('settings.costPer1kInput') + ' (USD)'">
-          <el-input-number v-model="modelForm.cost_per_1k_input" :precision="4" :step="0.0001" :placeholder="$t('settings.costPlaceholder')" />
-        </el-form-item>
-
-        <el-form-item :label="$t('settings.costPer1kOutput') + ' (USD)'">
-          <el-input-number v-model="modelForm.cost_per_1k_output" :precision="4" :step="0.0001" :placeholder="$t('settings.costPlaceholder')" />
-        </el-form-item>
-
-        <el-form-item :label="$t('settings.modelDescription')">
-          <el-input v-model="modelForm.description" type="textarea" :rows="3" :placeholder="$t('settings.descriptionPlaceholder')" />
-        </el-form-item>
-
-        <el-divider v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'">{{ $t('settings.thinkingConfig') }}</el-divider>
-
-        <el-form-item v-if="modelForm.model_type === 'text' || modelForm.model_type === 'multimodal'">
-          <el-checkbox v-model="modelForm.supports_reasoning">{{ $t('settings.supportsReasoning') }}</el-checkbox>
-          <div class="el-form-item__tip">{{ $t('settings.supportsReasoningHint') }}</div>
-        </el-form-item>
-
-        <el-form-item v-if="(modelForm.model_type === 'text' || modelForm.model_type === 'multimodal') && modelForm.supports_reasoning" :label="$t('settings.thinkingFormat')">
-          <el-select v-model="modelForm.thinking_format">
-            <el-option value="none" :label="$t('settings.thinkingFormatNone')" />
-            <el-option value="openai" :label="$t('settings.thinkingFormatOpenai')" />
-            <el-option value="glm" :label="$t('settings.thinkingFormatGlm')" />
-            <el-option value="qwen" :label="$t('settings.thinkingFormatQwen')" />
-            <el-option value="deepseek" :label="$t('settings.thinkingFormatDeepseek')" />
-          </el-select>
-          <div class="el-form-item__tip">{{ $t('settings.thinkingFormatHint') }}</div>
-        </el-form-item>
-
-        <el-form-item>
-          <el-checkbox v-model="modelForm.is_active">{{ $t('settings.isActive') }}</el-checkbox>
-        </el-form-item>
-      </el-form>
-
-      <template #footer>
-        <el-button v-if="editingModel" type="danger" @click="confirmDeleteModelFromDialog">{{ $t('common.delete') }}</el-button>
-        <el-button @click="closeModelDialog">{{ $t('common.cancel') }}</el-button>
-        <el-button type="primary" :disabled="!isModelFormValid" @click="saveModel">{{ $t('common.save') }}</el-button>
-      </template>
-    </el-dialog>
-
-    <!-- Expert 添加/编辑对话框 -->
     <!-- Expert 添加/编辑对话框 -->
     <el-dialog
       v-model="showExpertDialog"
@@ -1080,17 +839,17 @@ import { useRoute, useRouter } from 'vue-router'
 import { ElMessageBox } from 'element-plus'
 import { useUserStore } from '@/stores/user'
 import { useModelStore } from '@/stores/model'
-import { useProviderStore } from '@/stores/provider'
 import { useExpertStore } from '@/stores/expert'
 import { useCollectionStore } from '@/stores/collection'
 import { useToastStore } from '@/stores/toast'
 import { compressSmallAvatar, compressLargeAvatar } from '@/utils/imageCompress'
 import { expertApi, userApi, roleApi } from '@/api/services'
-import type { AIModel, ModelProvider, ProviderFormData, ModelFormData, Expert, ExpertSkill, ExpertSkillConfig, UserListItem, CreateUserRequest, UpdateUserRequest, Role, Permission, ExpertSimple, UpdateRoleRequest } from '@/types'
+import type { Expert, ExpertSkill, ExpertSkillConfig, UserListItem, CreateUserRequest, UpdateUserRequest, Role, Permission, ExpertSimple, UpdateRoleRequest } from '@/types'
 import OrganizationTab from '@/components/settings/OrganizationTab.vue'
 import SystemConfigTab from '@/components/settings/SystemConfigTab.vue'
 import AssistantSettingsTab from '@/components/settings/AssistantSettingsTab.vue'
 import InvitationTab from '@/components/settings/InvitationTab.vue'
+import ModelProviderTab from '@/components/settings/ModelProviderTab.vue'
 import ResidentProcessesTab from '@/components/settings/ResidentProcessesTab.vue'
 import AttachmentTab from '@/components/settings/AttachmentTab.vue'
 import McpTab from '@/components/settings/McpTab.vue'
@@ -1106,7 +865,6 @@ const route = useRoute()
 const router = useRouter()
 const userStore = useUserStore()
 const modelStore = useModelStore()
-const providerStore = useProviderStore()
 const expertStore = useExpertStore()
 const collectionStore = useCollectionStore()
 const toast = useToastStore()
@@ -1251,85 +1009,6 @@ const expertAvailableModels = computed(() => {
 // 是否为管理员
 const isAdmin = computed(() => userStore.isAdmin)
 const canManageRoles = computed(() => userStore.canManageRoles)
-
-// Provider 选择
-const selectedProvider = ref<ModelProvider | null>(null)
-const providerPage = ref(1)
-const PROVIDER_PAGE_SIZE = 10
-
-// Provider 分页
-const providerTotalPages = computed(() =>
-  Math.ceil(providerStore.providers.length / PROVIDER_PAGE_SIZE)
-)
-
-const paginatedProviders = computed(() => {
-  const start = (providerPage.value - 1) * PROVIDER_PAGE_SIZE
-  return providerStore.providers.slice(start, start + PROVIDER_PAGE_SIZE)
-})
-
-// 选择提供商
-const selectProvider = (provider: ModelProvider) => {
-  selectedProvider.value = provider
-  modelPage.value = 1 // 重置模型分页
-}
-
-// 模型分页
-const modelPage = ref(1)
-const MODEL_PAGE_SIZE = 10
-
-// 过滤属于选中提供商的模型
-const filteredModels = computed(() => {
-  if (!selectedProvider.value) return []
-  return modelStore.models.filter(m => m.provider_id === selectedProvider.value!.id)
-})
-
-const modelTotalPages = computed(() =>
-  Math.ceil(filteredModels.value.length / MODEL_PAGE_SIZE)
-)
-
-const paginatedModels = computed(() => {
-  const start = (modelPage.value - 1) * MODEL_PAGE_SIZE
-  return filteredModels.value.slice(start, start + MODEL_PAGE_SIZE)
-})
-
-// Provider 对话框
-const showProviderDialog = ref(false)
-const editingProvider = ref<ModelProvider | null>(null)
-const providerForm = reactive<ProviderFormData>({
-  name: '',
-  base_url: '',
-  api_key: '',
-  timeout: 30,
-  user_agent: '',
-  is_active: true,
-})
-
-const isProviderFormValid = computed(() => {
-  return providerForm.name.trim() && providerForm.base_url.trim()
-})
-
-// Model 对话框
-const showModelDialog = ref(false)
-const editingModel = ref<AIModel | null>(null)
-const modelForm = reactive<ModelFormData>({
-  name: '',
-  model_name: '',
-  provider_id: '',
-  model_type: 'text',
-  max_tokens: undefined,
-  max_output_tokens: undefined,
-  embedding_dim: undefined,
-  cost_per_1k_input: undefined,
-  cost_per_1k_output: undefined,
-  description: '',
-  is_active: true,
-  supports_reasoning: false,
-  thinking_format: 'none',
-})
-
-const isModelFormValid = computed(() => {
-  return modelForm.name?.trim() && modelForm.model_name?.trim() && modelForm.provider_id?.trim()
-})
 
 // Expert 对话框
 const showExpertDialog = ref(false)
@@ -1913,173 +1592,6 @@ const handleChangePassword = async () => {
   }
 }
 
-// Provider 管理方法
-const openProviderDialog = (provider?: ModelProvider) => {
-  if (provider) {
-    editingProvider.value = provider
-    providerForm.name = provider.name
-    providerForm.base_url = provider.base_url
-    providerForm.api_key = '' // 编辑时不显示原有 API Key
-    providerForm.timeout = provider.timeout
-    providerForm.user_agent = provider.user_agent || ''
-    providerForm.is_active = provider.is_active
-  } else {
-    editingProvider.value = null
-    providerForm.name = ''
-    providerForm.base_url = ''
-    providerForm.api_key = ''
-    providerForm.timeout = 30
-    providerForm.user_agent = ''
-    providerForm.is_active = true
-  }
-  showProviderDialog.value = true
-}
-
-const closeProviderDialog = () => {
-  showProviderDialog.value = false
-  editingProvider.value = null
-}
-
-const saveProvider = async () => {
-  try {
-    if (editingProvider.value) {
-      // 更新 - 只发送有值的字段
-      const updateData: Partial<ProviderFormData> = {
-        name: providerForm.name,
-        base_url: providerForm.base_url,
-        timeout: providerForm.timeout,
-        user_agent: providerForm.user_agent || undefined,
-        is_active: providerForm.is_active,
-      }
-      if (providerForm.api_key) {
-        updateData.api_key = providerForm.api_key
-      }
-      await providerStore.updateProvider(editingProvider.value.id, updateData)
-    } else {
-      // 创建
-      const newProvider = await providerStore.createProvider({ ...providerForm })
-      // 自动选中新创建的提供商
-      selectedProvider.value = newProvider
-    }
-    closeProviderDialog()
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : t('settings.saveProviderFailed')
-    toast.error(errorMsg)
-  }
-}
-
-const confirmDeleteProviderFromDialog = async () => {
-  if (!editingProvider.value) return
-  
-  try {
-    await ElMessageBox.confirm(
-      t('settings.deleteProviderConfirm', { name: editingProvider.value.name }),
-      t('common.confirmDelete'),
-      {
-        confirmButtonText: t('common.delete'),
-        cancelButtonText: t('common.cancel'),
-        type: 'warning'
-      }
-    )
-    
-    await providerStore.deleteProvider(editingProvider.value.id)
-    if (selectedProvider.value?.id === editingProvider.value.id) {
-      selectedProvider.value = null
-    }
-    closeProviderDialog()
-  } catch (err) {
-    if (err !== 'cancel') {
-      const errorMsg = err instanceof Error ? err.message : t('settings.deleteProviderFailed')
-      toast.error(errorMsg)
-    }
-  }
-}
-
-// Model 管理方法
-const openModelDialog = (model?: AIModel) => {
-  if (model) {
-    editingModel.value = model
-    modelForm.name = model.name
-    modelForm.model_name = model.model_name || ''
-    modelForm.provider_id = model.provider_id || ''
-    modelForm.model_type = model.model_type || 'text'
-    modelForm.max_tokens = model.max_tokens
-    modelForm.max_output_tokens = model.max_output_tokens
-    modelForm.embedding_dim = model.embedding_dim
-    modelForm.cost_per_1k_input = model.cost_per_1k_input
-    modelForm.cost_per_1k_output = model.cost_per_1k_output
-    modelForm.description = model.description || ''
-    modelForm.supports_reasoning = model.supports_reasoning ?? false
-    modelForm.thinking_format = model.thinking_format ?? 'none'
-    modelForm.is_active = model.is_active
-  } else {
-    editingModel.value = null
-    modelForm.name = ''
-    modelForm.model_name = ''
-    // 如果已选择提供商，默认使用该提供商
-    modelForm.provider_id = selectedProvider.value?.id || ''
-    modelForm.model_type = 'text'
-    modelForm.max_tokens = undefined
-    modelForm.max_output_tokens = undefined
-    modelForm.embedding_dim = undefined
-    modelForm.cost_per_1k_input = undefined
-    modelForm.cost_per_1k_output = undefined
-    modelForm.description = ''
-    modelForm.supports_reasoning = false
-    modelForm.thinking_format = 'none'
-    modelForm.is_active = true
-  }
-  showModelDialog.value = true
-}
-
-const closeModelDialog = () => {
-  showModelDialog.value = false
-  editingModel.value = null
-}
-
-const saveModel = async () => {
-  try {
-    const payload = {
-      ...modelForm,
-      thinking_format: modelForm.supports_reasoning ? modelForm.thinking_format : 'none',
-    }
-
-    if (editingModel.value) {
-      await modelStore.updateModel(editingModel.value.id, payload)
-    } else {
-      await modelStore.createModel(payload)
-    }
-    closeModelDialog()
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : t('settings.saveModelFailed')
-    toast.error(errorMsg)
-  }
-}
-
-const confirmDeleteModelFromDialog = async () => {
-  if (!editingModel.value) return
-  
-  try {
-    await ElMessageBox.confirm(
-      t('settings.deleteModelConfirm', { name: editingModel.value.name }),
-      t('common.confirmDelete'),
-      {
-        confirmButtonText: t('common.delete'),
-        cancelButtonText: t('common.cancel'),
-        type: 'warning'
-      }
-    )
-    
-    await modelStore.deleteModel(editingModel.value.id)
-    closeModelDialog()
-  } catch (err) {
-    if (err !== 'cancel') {
-      const errorMsg = err instanceof Error ? err.message : t('settings.deleteModelFailed')
-      toast.error(errorMsg)
-    }
-  }
-}
-
 // Expert 管理方法
 const openExpertDialog = (expert?: Expert) => {
   // 重置 Tab 到基本信息
@@ -2292,13 +1804,6 @@ const saveSkills = async () => {
   }
 }
 
-// 监听提供商列表变化，如果当前选中的提供商被删除，清空选择
-watch(() => providerStore.providers, (newProviders) => {
-  if (selectedProvider.value && !newProviders.find(p => p.id === selectedProvider.value!.id)) {
-    selectedProvider.value = null
-  }
-}, { deep: true })
-
 // 技能筛选
 const filteredSkills = computed(() => {
   if (!skillsSearchQuery.value.trim()) {
@@ -2324,8 +1829,6 @@ onMounted(() => {
   }
   // 加载模型列表
   modelStore.loadModels()
-  // 加载 Provider 列表
-  providerStore.loadProviders()
   // 加载所有专家列表（包括非活跃的）
   expertStore.loadExperts({})
   // 加载权限列表和专家列表（用于角色管理）
@@ -2385,17 +1888,6 @@ onMounted(() => {
   min-width: 0;
 }
 
-.provider-panel {
-  flex: 0 0 320px;
-  border-right: 1px solid var(--border-color, #e0e0e0);
-  background: var(--secondary-bg, #f8f9fa);
-}
-
-.model-panel {
-  flex: 1;
-  background: var(--card-bg, #fff);
-}
-
 .panel-header {
   display: flex;
   justify-content: space-between;
@@ -2414,107 +1906,6 @@ onMounted(() => {
 
 
 
-.provider-list-container,
-.model-list-container {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.provider-list,
-.model-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 8px;
-}
-
-.provider-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-  margin-bottom: 4px;
-  border-radius: 8px;
-  background: var(--card-bg, #fff);
-  border: 1px solid transparent;
-  transition: all 0.2s;
-}
-
-.provider-item:hover {
-  background: var(--hover-bg, #e8e8e8);
-}
-
-.provider-item.active {
-  background: var(--primary-light, #e3f2fd);
-  border-color: var(--primary-color, #2196f3);
-}
-
-.provider-item.inactive {
-  opacity: 0.6;
-}
-
-.provider-name-btn {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-  padding: 4px;
-  min-width: 0;
-}
-
-.provider-name {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-primary, #333);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.model-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px;
-  margin-bottom: 4px;
-  border-radius: 8px;
-  background: var(--secondary-bg, #f5f5f5);
-  border: 1px solid transparent;
-  transition: all 0.2s;
-  cursor: pointer;
-}
-
-.model-item:hover {
-  background: var(--hover-bg, #e8e8e8);
-}
-
-.model-item.inactive {
-  opacity: 0.6;
-}
-
-.model-info {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
-.model-name {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-primary, #333);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .badge {
   padding: 2px 8px;
   font-size: 11px;
@@ -2528,11 +1919,6 @@ onMounted(() => {
   color: var(--error-color, #c62828);
 }
 
-.badge.embedding {
-  background: var(--primary-light-bg, #e8f4fe);
-  color: var(--primary-color, #7c5c3d);
-}
-
 /* 空状态和加载状态 */
 .loading-state,
 .empty-state {
@@ -2541,12 +1927,6 @@ onMounted(() => {
   color: var(--text-secondary, #666);
   font-size: 14px;
 }
-
-.select-provider-hint {
-  color: var(--text-tertiary, #999);
-  font-style: italic;
-}
-
 
 /* 专家设置区域 */
 .expert-section {
@@ -2674,19 +2054,6 @@ onMounted(() => {
     flex-direction: column;
   }
 
-  .provider-panel {
-    flex: none;
-    width: 100%;
-    border-right: none;
-    border-bottom: 1px solid var(--border-color, #e0e0e0);
-    max-height: 300px;
-  }
-
-  .model-panel {
-    flex: none;
-    width: 100%;
-    max-height: 400px;
-  }
 }
 
 .avatar-upload {


### PR DESCRIPTION
## Summary

- Extract Settings model/provider management into `ModelProviderTab.vue`.
- Keep `SettingsView.vue` as the settings-page container and preserve expert model loading.
- Preserve existing provider/model store calls, dialogs, pagination, validation, and delete-confirm behavior.

## Validation

- `npm.cmd run lint`
- `cd frontend && npm.cmd run type-check`
- `cd frontend && npm.cmd run build-only`
- `git diff --check`

## Notes

- No database schema changes.
- No API contract changes.
- No new dependency.
- No i18n key changes.
- Browser manual smoke was not performed in this checkpoint because no already running authenticated frontend session was available.
