### PR TITLE
refactor: 收口冻结处理脚本入口

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -89,7 +89,7 @@ const router = createRouter({
             { path: 'attachments', name: 'sys-attachments', component: () => import('@/views/SettingsView.vue'), meta: { settingsGroup: 'system', settingsTab: 'attachment', adminOnly: true } },
             { path: 'mcp', name: 'sys-mcp', component: () => import('@/views/SettingsView.vue'), meta: { settingsGroup: 'system', settingsTab: 'mcp', adminOnly: true } },
             { path: 'apps', name: 'sys-apps', component: () => import('@/views/SettingsView.vue'), meta: { settingsGroup: 'system', settingsTab: 'apps', adminOnly: true } },
-            { path: 'handlers', name: 'sys-handlers', component: () => import('@/views/SettingsView.vue'), meta: { settingsGroup: 'system', settingsTab: 'handlers', adminOnly: true } },
+            { path: 'handlers', redirect: { name: 'sys-apps' } },
             { path: 'app-clock', name: 'sys-app-clock', component: () => import('@/views/SettingsView.vue'), meta: { settingsGroup: 'system', settingsTab: 'appClock', adminOnly: true } },
             { path: 'config', name: 'sys-config', component: () => import('@/views/SettingsView.vue'), meta: { settingsGroup: 'system', settingsTab: 'system', adminOnly: true } },
           ],

--- a/frontend/src/views/AppDetailView.vue
+++ b/frontend/src/views/AppDetailView.vue
@@ -27,7 +27,6 @@ const AppComponentMap: Record<string, Component> = {
   'InvoiceView': defineAsyncComponent(() => import('@/views/invoice/InvoiceView.vue')),
   'OcrToolView': defineAsyncComponent(() => import('@/views/ocr-tool/OcrToolView.vue')),
   'ResumeScreeningView': defineAsyncComponent(() => import('@/views/resume-fast-screening/ResumeScreeningView.vue')),
-  'CurrentFeatureAnalyzerView': defineAsyncComponent(() => import('@apps/current-feature-analyzer/frontend/views/CurrentFeatureAnalyzerView.vue')),
 }
 
 const RuntimeComponentModules = import.meta.glob('@apps/*/frontend/views/*.vue')

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -287,11 +287,6 @@
       <AppManagementTab />
     </div>
 
-    <!-- 处理脚本管理（仅管理员） -->
-    <div v-if="activeTab === 'handlers' && isAdmin" class="settings-section handlers-section">
-      <HandlerManagementTab />
-    </div>
-
     <!-- AppClock 运行状态（仅管理员） -->
     <div v-if="activeTab === 'appClock' && isAdmin" class="settings-section appclock-section">
       <AppClockStatusTab />
@@ -502,7 +497,6 @@ import ResidentProcessesTab from '@/components/settings/ResidentProcessesTab.vue
 import AttachmentTab from '@/components/settings/AttachmentTab.vue'
 import McpTab from '@/components/settings/McpTab.vue'
 import AppManagementTab from '@/components/settings/AppManagementTab.vue'
-import HandlerManagementTab from '@/components/settings/HandlerManagementTab.vue'
 import AppClockStatusTab from '@/components/settings/AppClockStatusTab.vue'
 import Pagination from '@/components/Pagination.vue'
 import packageInfo from '../../package.json'
@@ -549,7 +543,6 @@ const systemMenuItems = [
   { key: 'attachment', label: t('settings.attachmentManagement'), route: '/system/attachments' },
   { key: 'mcp', label: t('settings.mcp.management'), route: '/system/mcp' },
   { key: 'apps', label: t('settings.appManagement.management'), route: '/system/apps' },
-  { key: 'handlers', label: t('settings.handlerManagement.management'), route: '/system/handlers' },
   { key: 'appClock', label: t('appClock.statusPanel'), route: '/system/app-clock' },
   { key: 'system', label: t('settings.systemConfig'), route: '/system/config' },
 ]


### PR DESCRIPTION
## Summary

- 从系统设置菜单移除已冻结的处理脚本管理入口
- 将旧 `/system/handlers` 路由重定向到 App 管理，避免历史链接直接失效
- 从 `AppDetailView.vue` legacy 白名单移除已具备 `runtime.frontend.entry` 的 `CurrentFeatureAnalyzerView`

## Rationale

- `HandlerManagementTab` 已冻结且不再加载历史处理脚本，继续出现在菜单里会误导用户
- `current-feature-analyzer` 已配置 runtime frontend entry，应走新装配路径
- 其它 legacy app 尚未补齐 runtime frontend entry，本轮不扩大迁移范围

## Validation

- `rg` 引用扫描
- `git diff --check`
- `cd frontend && npm.cmd run type-check`
- `npm.cmd run lint`
- `cd frontend && npm.cmd run build-only`

## Notes

- `build-only` 仍有既有大 chunk 警告，本 PR 未处理
- 任务留痕已更新到本地 `docs/tasks`，按项目规则不提交

