### PR TITLE
refactor: decouple document MCP caller from AppClock

### DIFF
--- a/lib/app-clock.js
+++ b/lib/app-clock.js
@@ -3,7 +3,6 @@ import Utils from './utils.js';
 import { Sequelize } from 'sequelize';
 import path from 'path';
 import fs from 'fs';
-import jwt from 'jsonwebtoken';
 import ExtensionTableService from '../server/services/extension-table.service.js';
 import InternalLLMService from './internal-llm-service.js';
 import DocumentOcrService from './document-ocr-service.js';
@@ -13,6 +12,7 @@ import DocumentChunkService from './document-chunk-service.js';
 import DocumentEmbeddingService from './document-embedding-service.js';
 import { DOC_PIPELINE_KEYS, mergeWithDefaults } from './doc-pipeline-defaults.js';
 import AppRuntimeLoader from './app-runtime-loader.js';
+import McpToolCaller from './mcp-tool-caller.js';
 
 const MAX_TICK_OUTPUT_STRING_LENGTH = parseInt(process.env.APP_CLOCK_MAX_OUTPUT_LENGTH || '4096', 10);
 const MAX_TICK_OUTPUT_ARRAY_ITEMS = parseInt(process.env.APP_CLOCK_MAX_OUTPUT_ARRAY_ITEMS || '10', 10);
@@ -111,6 +111,9 @@ class AppClock {
     this.sequelize = db.sequelize;
     this.intervalMs = config.intervalMs || 5000;
     this.residentSkillManager = config.residentSkillManager || null;
+    this.mcpToolCaller = config.mcpToolCaller || new McpToolCaller(db, {
+      residentSkillManager: this.residentSkillManager,
+    });
     this.skillLoader = config.skillLoader || null;
     this.extensionService = new ExtensionTableService(db);
     this.llmService = new InternalLLMService(db);
@@ -725,92 +728,11 @@ class AppClock {
   }
 
   async callMcp(server, tool, params, timeoutMs = 120000) {
-    logger.info(`[AppClock] callMcp: ${server}.${tool}`);
-    logger.debug(`[AppClock] callMcp params keys: ${Object.keys(params || {}).join(', ')}`);
-
-    if (!this.residentSkillManager) {
-      throw new Error(`MCP service "${server}" not available: residentSkillManager not configured`);
-    }
-
-    const adminToken = await this.generateUserToken();
-
-    const invokeParams = {
-      action: 'call_tool',
-      server_name: server,
-      tool_name: tool,
-      arguments: params
-    };
-
-    logger.info(`[AppClock] callMcp invoking mcp-client with action=call_tool, server=${server}, tool=${tool}`);
-
-    try {
-      const result = await this.residentSkillManager.invokeByName(
-        'mcp-client',
-        'invoke',
-        invokeParams,
-        {
-          accessToken: adminToken,
-          isAdmin: true
-        },
-        timeoutMs
-      );
-
-      logger.info(`[AppClock] callMcp result type: ${typeof result}`);
-      logger.debug('[AppClock] callMcp result preview:', truncateString(serializeTickOutput(result), 500));
-      return result;
-    } catch (e) {
-      logger.error(`[AppClock] callMcp failed: ${server}.${tool} - ${e.message}`);
-      logger.error(`[AppClock] callMcp error stack: ${e.stack}`);
-      throw e;
-    }
+    return await this.mcpToolCaller.callMcp(server, tool, params, timeoutMs);
   }
 
   async generateUserToken() {
-    const User = this.db.getModel('user');
-    const UserRole = this.db.getModel('user_role');
-    const Role = this.db.getModel('role');
-
-    const adminRole = await Role.findOne({
-      where: { mark: 'admin' },
-      raw: true
-    });
-
-    if (!adminRole) {
-      throw new Error('Admin role not found');
-    }
-
-    const adminUserRole = await UserRole.findOne({
-      where: { role_id: adminRole.id },
-      raw: true
-    });
-
-    if (!adminUserRole) {
-      throw new Error('No admin user found');
-    }
-
-    const adminUser = await User.findOne({
-      where: { id: adminUserRole.user_id, status: 'active' },
-      raw: true
-    });
-
-    if (!adminUser) {
-      throw new Error('Admin user not found or inactive');
-    }
-
-    const jwtSecret = process.env.JWT_SECRET || 'your-secret-key';
-    const token = jwt.sign(
-      {
-        id: adminUser.id,
-        userId: adminUser.id,
-        role: 'admin',
-        roles: ['admin'],
-        isAdmin: true,
-      },
-      jwtSecret,
-      { expiresIn: '1h' }
-    );
-
-    return token;
+    return await this.mcpToolCaller.generateAdminToken();
   }
 
   async callSkill(name, method, params) {

--- a/lib/clock/job-context-builder.js
+++ b/lib/clock/job-context-builder.js
@@ -26,7 +26,7 @@
  *
  * | 能力               | Phase 1 来源                          | 后续方向             |
  * |--------------------|---------------------------------------|----------------------|
- * | callMcp            | `this.appClock.callMcp.bind()` 桥接   | 独立 MCP client 注入 |
+ * | callMcp            | 平台级 McpToolCaller 注入             | 保持独立注入         |
  * | callLlm            | null（各 service 自行调用 createCallLlmFn） | 统一 LLM 工厂       |
  * | getDocPipelineConfig | systemSettingService.getDocPipelineConfig | 保持不变           |
  *
@@ -52,7 +52,7 @@ import logger from '../logger.js';
  *
  * @param {Object} db - Database 实例
  * @param {Object} [options]
- * @param {Function} [options.callMcp] - MCP 调用函数，Phase 1 通过 AppClock 桥接
+ * @param {Function} [options.callMcp] - MCP 调用函数，由平台级 McpToolCaller 注入
  * @param {Function} [options.callLlm] - LLM 调用函数，Phase 1 各 service 自行解析
  * @param {Function} [options.getDocPipelineConfig] - 获取 doc pipeline 配置
  * @returns {Object} services — 见上述上下文协议

--- a/lib/mcp-tool-caller.js
+++ b/lib/mcp-tool-caller.js
@@ -1,0 +1,185 @@
+import jwt from 'jsonwebtoken';
+import logger from './logger.js';
+
+const DEFAULT_TIMEOUT_MS = 120000;
+const MAX_RESULT_PREVIEW_LENGTH = 500;
+const MAX_RESULT_PREVIEW_ARRAY_ITEMS = 10;
+const MAX_RESULT_PREVIEW_OBJECT_KEYS = 20;
+const MAX_RESULT_PREVIEW_DEPTH = 4;
+
+function truncateString(value, maxLength = MAX_RESULT_PREVIEW_LENGTH) {
+  if (typeof value !== 'string') return value;
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...[truncated ${value.length - maxLength} chars]`;
+}
+
+function looksLikeDataUrl(value) {
+  return typeof value === 'string' && /^data:[^;]+;base64,/i.test(value);
+}
+
+function looksLikeLargeBase64(value) {
+  return typeof value === 'string' && value.length > 1024 && /^[A-Za-z0-9+/=\r\n]+$/.test(value);
+}
+
+function summarizeForLog(value, depth = 0, seen = new WeakSet()) {
+  if (value == null) return value;
+
+  if (typeof value === 'string') {
+    if (looksLikeDataUrl(value)) return `[data-url omitted length=${value.length}]`;
+    if (looksLikeLargeBase64(value)) return `[base64 omitted length=${value.length}]`;
+    return truncateString(value);
+  }
+
+  if (typeof value !== 'object') return value;
+  if (seen.has(value)) return '[circular]';
+
+  if (depth >= MAX_RESULT_PREVIEW_DEPTH) {
+    if (Array.isArray(value)) return `[array(${value.length}) truncated]`;
+    return '[object truncated]';
+  }
+
+  seen.add(value);
+
+  if (Buffer.isBuffer(value)) {
+    return `[buffer length=${value.length}]`;
+  }
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, MAX_RESULT_PREVIEW_ARRAY_ITEMS)
+      .map(item => summarizeForLog(item, depth + 1, seen));
+    if (value.length > MAX_RESULT_PREVIEW_ARRAY_ITEMS) {
+      items.push(`[+${value.length - MAX_RESULT_PREVIEW_ARRAY_ITEMS} more items]`);
+    }
+    return items;
+  }
+
+  const summary = {};
+  const keys = Object.keys(value);
+  for (const key of keys.slice(0, MAX_RESULT_PREVIEW_OBJECT_KEYS)) {
+    summary[key] = summarizeForLog(value[key], depth + 1, seen);
+  }
+  if (keys.length > MAX_RESULT_PREVIEW_OBJECT_KEYS) {
+    summary.__truncated_keys__ = keys.length - MAX_RESULT_PREVIEW_OBJECT_KEYS;
+  }
+  return summary;
+}
+
+function summarizeResult(result) {
+  if (result == null) return result;
+
+  try {
+    return truncateString(JSON.stringify(summarizeForLog(result)));
+  } catch (error) {
+    return `[unserializable result: ${error.message}]`;
+  }
+}
+
+/**
+ * Platform-level MCP tool caller.
+ *
+ * This keeps MCP invocation independent from AppClock so internal platform jobs
+ * such as the document pipeline can call MCP tools without depending on the app
+ * tick runtime.
+ */
+class McpToolCaller {
+  constructor(db, options = {}) {
+    this.db = db;
+    this.residentSkillManager = options.residentSkillManager || null;
+  }
+
+  setResidentSkillManager(residentSkillManager) {
+    this.residentSkillManager = residentSkillManager || null;
+  }
+
+  async generateAdminToken() {
+    const User = this.db.getModel('user');
+    const UserRole = this.db.getModel('user_role');
+    const Role = this.db.getModel('role');
+
+    const adminRole = await Role.findOne({
+      where: { mark: 'admin' },
+      raw: true,
+    });
+
+    if (!adminRole) {
+      throw new Error('Admin role not found');
+    }
+
+    const adminUserRole = await UserRole.findOne({
+      where: { role_id: adminRole.id },
+      raw: true,
+    });
+
+    if (!adminUserRole) {
+      throw new Error('No admin user found');
+    }
+
+    const adminUser = await User.findOne({
+      where: { id: adminUserRole.user_id, status: 'active' },
+      raw: true,
+    });
+
+    if (!adminUser) {
+      throw new Error('Admin user not found or inactive');
+    }
+
+    const jwtSecret = process.env.JWT_SECRET || 'your-secret-key';
+    return jwt.sign(
+      {
+        id: adminUser.id,
+        userId: adminUser.id,
+        role: 'admin',
+        roles: ['admin'],
+        isAdmin: true,
+      },
+      jwtSecret,
+      { expiresIn: '1h' },
+    );
+  }
+
+  async callMcp(server, tool, params, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    return await this.callTool(server, tool, params, timeoutMs);
+  }
+
+  async callTool(server, tool, params, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    logger.info(`[McpToolCaller] callTool: ${server}.${tool}`);
+    logger.debug(`[McpToolCaller] params keys: ${Object.keys(params || {}).join(', ')}`);
+
+    if (!this.residentSkillManager) {
+      throw new Error(`MCP service "${server}" not available: residentSkillManager not configured`);
+    }
+
+    const adminToken = await this.generateAdminToken();
+    const invokeParams = {
+      action: 'call_tool',
+      server_name: server,
+      tool_name: tool,
+      arguments: params,
+    };
+
+    try {
+      const result = await this.residentSkillManager.invokeByName(
+        'mcp-client',
+        'invoke',
+        invokeParams,
+        {
+          accessToken: adminToken,
+          isAdmin: true,
+        },
+        timeoutMs,
+      );
+
+      logger.info(`[McpToolCaller] result type: ${typeof result}`);
+      logger.debug('[McpToolCaller] result preview:', summarizeResult(result));
+      return result;
+    } catch (error) {
+      logger.error(`[McpToolCaller] failed: ${server}.${tool} - ${error.message}`);
+      logger.error(`[McpToolCaller] error stack: ${error.stack}`);
+      throw error;
+    }
+  }
+}
+
+export { McpToolCaller };
+export default McpToolCaller;

--- a/scripts/diagnose-mineru-mcp.js
+++ b/scripts/diagnose-mineru-mcp.js
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 
 import Database from '../lib/db.js';
 import ResidentSkillManager from '../lib/resident-skill-manager.js';
-import AppClock from '../lib/app-clock.js';
+import McpToolCaller from '../lib/mcp-tool-caller.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -92,9 +92,9 @@ async function main() {
   try {
     await residentSkillManager.initialize();
 
-    const appClock = new AppClock(db, { residentSkillManager });
+    const mcpToolCaller = new McpToolCaller(db, { residentSkillManager });
 
-    const admin_token = await appClock.generateUserToken();
+    const admin_token = await mcpToolCaller.generateAdminToken();
 
     const report = {
       started_at: new Date().toISOString(),
@@ -164,7 +164,7 @@ async function main() {
 
     if (options.task_id) {
       await runStep('get_task_status', async () => {
-        return await appClock.callMcp(
+        return await mcpToolCaller.callMcp(
           options.server_name,
           'get_task_status',
           { task_id: options.task_id },
@@ -174,7 +174,7 @@ async function main() {
 
       if (!options.skip_deliverables) {
         await runStep('list_deliverables', async () => {
-          return await appClock.callMcp(
+          return await mcpToolCaller.callMcp(
             options.server_name,
             'list_deliverables',
             { task_id: options.task_id },
@@ -183,7 +183,7 @@ async function main() {
         });
 
         await runStep('get_default_deliverable', async () => {
-          return await appClock.callMcp(
+          return await mcpToolCaller.callMcp(
             options.server_name,
             'get_default_deliverable',
             { task_id: options.task_id },

--- a/scripts/stop-stuck-ocr.js
+++ b/scripts/stop-stuck-ocr.js
@@ -14,7 +14,8 @@ function getAttachmentBasePath() {
 
 import Database from '../lib/db.js';
 import logger from '../lib/logger.js';
-import AppClock from '../lib/app-clock.js';
+import ResidentSkillManager from '../lib/resident-skill-manager.js';
+import McpToolCaller from '../lib/mcp-tool-caller.js';
 import { collectOcrAttachmentIds } from '../lib/doc-ocr-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -48,6 +49,9 @@ async function main() {
   });
 
   await db.connect();
+  let residentSkillManager = null;
+  let mcpToolCaller = null;
+
   const models = db.models;
   const DocOcrResult = models.doc_ocr_result;
   const Document = models.document;
@@ -78,7 +82,10 @@ async function main() {
     if (!args.skipRemoteCancel && ocrResult.task_id && ['pending', 'processing'].includes(ocrResult.status)) {
       remoteCancel = { attempted: true, skipped: false, ok: false };
       try {
-        const result = await AppClock.callMcp('mineru', 'cancel_task', { task_id: ocrResult.task_id }, 30000);
+        residentSkillManager = new ResidentSkillManager(db);
+        await residentSkillManager.initialize();
+        mcpToolCaller = new McpToolCaller(db, { residentSkillManager });
+        const result = await mcpToolCaller.callMcp('mineru', 'cancel_task', { task_id: ocrResult.task_id }, 30000);
         remoteCancel.ok = true;
         remoteCancel.resultType = typeof result;
       } catch (error) {
@@ -191,6 +198,9 @@ async function main() {
       remoteCancel,
     }, null, 2));
   } finally {
+    if (residentSkillManager) {
+      await residentSkillManager.shutdown().catch(() => {});
+    }
     await db.close();
   }
 }

--- a/server/controllers/doc.controller.js
+++ b/server/controllers/doc.controller.js
@@ -108,11 +108,11 @@ class DocController {
       const systemSettingService = getSystemSettingService(this.db);
       this.documentOcrService = new DocumentOcrService(this.db, {
         callMcp: async (server, tool, params, timeoutMs) => {
-          const appClock = ctx?.app?.context?.appClock;
-          if (!appClock || typeof appClock.callMcp !== 'function') {
-            throw new Error('AppClock MCP caller not available');
+          const mcpToolCaller = ctx?.app?.context?.mcpToolCaller;
+          if (!mcpToolCaller || typeof mcpToolCaller.callMcp !== 'function') {
+            throw new Error('MCP tool caller not available');
           }
-          return await appClock.callMcp(server, tool, params, timeoutMs);
+          return await mcpToolCaller.callMcp(server, tool, params, timeoutMs);
         },
         getDocPipelineConfig: async () => {
           const records = await systemSettingService.SystemSetting.findAll({

--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,7 @@ import ResidentSkillManager from '../lib/resident-skill-manager.js';
 import InternalLLMService from '../lib/internal-llm-service.js';
 import SkillLoader from '../lib/skill-loader.js';
 import AppClock from '../lib/app-clock.js';
+import McpToolCaller from '../lib/mcp-tool-caller.js';
 import ClockCore from '../lib/clock/clock-core.js';
 import { buildDocPipelineContext } from '../lib/clock/job-context-builder.js';
 import { run as docPipelineWorkerRun } from '../lib/doc-pipeline-worker.js';
@@ -261,6 +262,7 @@ class ApiServer {
     this.chatService = null;
     this.scheduler = null;
     this.residentSkillManager = null;
+    this.mcpToolCaller = null;
     this.tokenCleanupJob = null;
     this.appClock = null;
     this.clockCore = null;
@@ -380,6 +382,9 @@ class ApiServer {
     // 初始化驻留式技能管理器
     this.residentSkillManager = new ResidentSkillManager(this.db);
     await this.residentSkillManager.initialize();
+    this.mcpToolCaller = new McpToolCaller(this.db, {
+      residentSkillManager: this.residentSkillManager,
+    });
 
     // 初始化 Token 清理任务（Issue #140）
     this.tokenCleanupJob = new TokenCleanupJob(this.db);
@@ -398,6 +403,7 @@ class ApiServer {
       maxConsecutiveFailures: parseInt(process.env.APP_CLOCK_MAX_FAILURES, 10) || 3,
       failureCooldownMs: parseInt(process.env.APP_CLOCK_FAILURE_COOLDOWN_MS, 10) || 120000,
       residentSkillManager: this.residentSkillManager,
+      mcpToolCaller: this.mcpToolCaller,
       skillLoader: new SkillLoader(this.db),
     });
     // 不在这里启动，等 server listen 后统一启动
@@ -415,7 +421,7 @@ class ApiServer {
       preventOverlap: true,
       handler: async (clockContext) => {
         const services = buildDocPipelineContext(this.db, {
-          callMcp: this.appClock?.callMcp?.bind(this.appClock) ?? null,
+          callMcp: this.mcpToolCaller?.callMcp?.bind(this.mcpToolCaller) ?? null,
           callLlm: null,
           getDocPipelineConfig: async () => {
             try {
@@ -826,6 +832,7 @@ class ApiServer {
       this.setupRoutes();
 
       this.app.context.appClock = this.appClock;
+      this.app.context.mcpToolCaller = this.mcpToolCaller;
 
       // 将 SSE 连接池共享给 AssistantManager（在 setupRoutes 之后，因为 StreamController 已创建）
       assistantManager.setExpertConnections(this.controllers.stream.expertConnections);
@@ -894,6 +901,7 @@ class ApiServer {
             logger.info('[Startup] ClockCore started with internal jobs');
           } else {
             logger.warn('[Startup] ClockCore disabled by ENABLE_CLOCK_CORE');
+            logger.warn('[Startup] Document pipeline auto-processing is disabled; set ENABLE_CLOCK_CORE=1 to advance pending_ocr/ocr_processing documents');
           }
         }
 


### PR DESCRIPTION
## Summary

- add platform-level `McpToolCaller` for MCP tool invocation via resident `mcp-client`
- inject `McpToolCaller` into ClockCore document pipeline and DocController manual OCR path
- keep `AppClock.callMcp()` / `generateUserToken()` as compatibility delegates
- move MinerU OCR maintenance scripts off direct AppClock usage
- add startup warning when ClockCore is disabled and document pipeline auto-processing cannot advance

## Verification

- `npm.cmd run lint`
- `git diff --check`
- `git diff --cached --check`
- `node --check lib/mcp-tool-caller.js`
- `node --check lib/app-clock.js`
- `node --check server/index.js`
- `node --check server/controllers/doc.controller.js`
- `node --check scripts/diagnose-mineru-mcp.js`
- `node --check scripts/stop-stuck-ocr.js`
- `node --check lib/clock/job-context-builder.js`
- module import checks for `lib/mcp-tool-caller.js`, `lib/app-clock.js`, `lib/clock/job-context-builder.js`
- fake db / fake resident manager behavior check for `McpToolCaller.callMcp()`

## Notes

- No database schema changes.
- No external API contract changes.
- `docs/tasks/.../round13-mcp-tool-caller.md` was updated locally for task trace and intentionally not committed.
