### PR TITLE
refactor: add static skill tool logging safeguards

### DIFF
--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -23,6 +23,7 @@ import { spawn } from 'child_process';
 import logger from './logger.js';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
 import { getDataBasePath, getSkillsPath, getSkillPath, getWorkspaceRoot, getFontsPath } from './paths.js';
+import { buildSkillToolFunctionName } from './skill-tool-naming.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -211,7 +212,7 @@ class SkillLoader {
     // Issue #417: 技能工具名称统一方案
     const toolId = toolRow.id;  // 保留数据库 ID 用于内部引用
     const skillMark = skill.mark || skill.id;  // 使用 mark 字段，fallback 到 id
-    const toolFunctionName = `${skillMark}__${toolRow.name}`;  // 如 "kb-search__search"
+    const toolFunctionName = buildSkillToolFunctionName(skillMark, toolRow.name);  // 如 "kb-search__search"
 
     return {
       type: 'function',
@@ -908,7 +909,7 @@ class SkillLoader {
       // 从 Markdown 解析的工具使用 skill_mark__tool_name 格式（与 convertToolToOpenAIFormat 一致）
       // Issue #417: 技能工具名称统一方案
       const skillMark = skill.mark || skill.id;  // 使用 mark 字段，fallback 到 id
-      const toolFunctionName = `${skillMark}__${toolName}`;
+      const toolFunctionName = buildSkillToolFunctionName(skillMark, toolName);
       
       tools.push({
         type: 'function',

--- a/lib/skill-tool-naming.js
+++ b/lib/skill-tool-naming.js
@@ -1,0 +1,22 @@
+const SKILL_TOOL_FUNCTION_SEPARATOR = '__';
+
+/**
+ * Build the OpenAI function name used for a skill tool.
+ *
+ * Keep this intentionally behavior-preserving: current production names are
+ * `${skill.mark || skill.id}__${tool.name}`. Validation/sanitization should be
+ * added as a separate migration so existing tool names do not silently drift.
+ */
+function buildSkillToolFunctionName(skillMarkOrId, toolName) {
+  return `${skillMarkOrId}${SKILL_TOOL_FUNCTION_SEPARATOR}${toolName}`;
+}
+
+export {
+  SKILL_TOOL_FUNCTION_SEPARATOR,
+  buildSkillToolFunctionName,
+};
+
+export default {
+  SKILL_TOOL_FUNCTION_SEPARATOR,
+  buildSkillToolFunctionName,
+};

--- a/lib/tool-log-sanitizer.js
+++ b/lib/tool-log-sanitizer.js
@@ -1,0 +1,95 @@
+const DEFAULT_MAX_STRING_LENGTH = 300;
+const DEFAULT_MAX_ARRAY_ITEMS = 8;
+const DEFAULT_MAX_OBJECT_KEYS = 20;
+const DEFAULT_MAX_DEPTH = 4;
+
+const SENSITIVE_KEY_PATTERN = /(api[_-]?key|authorization|bearer|cookie|credential|password|secret|token)/i;
+const LARGE_BINARY_KEY_PATTERN = /(base64|file_content|file_data|image_data|audio_data|binary|buffer)/i;
+
+function truncateString(value, maxLength = DEFAULT_MAX_STRING_LENGTH) {
+  if (typeof value !== 'string') return value;
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...[truncated ${value.length - maxLength} chars]`;
+}
+
+function looksLikeDataUrl(value) {
+  return typeof value === 'string' && /^data:[^;]+;base64,/i.test(value);
+}
+
+function looksLikeLargeBase64(value) {
+  return typeof value === 'string' && value.length > 1024 && /^[A-Za-z0-9+/=\r\n]+$/.test(value);
+}
+
+function summarizeToolLogValue(value, options = {}, depth = 0, seen = new WeakSet()) {
+  const maxStringLength = options.maxStringLength || DEFAULT_MAX_STRING_LENGTH;
+  const maxArrayItems = options.maxArrayItems || DEFAULT_MAX_ARRAY_ITEMS;
+  const maxObjectKeys = options.maxObjectKeys || DEFAULT_MAX_OBJECT_KEYS;
+  const maxDepth = options.maxDepth || DEFAULT_MAX_DEPTH;
+
+  if (value == null) return value;
+
+  if (typeof value === 'string') {
+    if (looksLikeDataUrl(value)) return `[data-url omitted length=${value.length}]`;
+    if (looksLikeLargeBase64(value)) return `[base64 omitted length=${value.length}]`;
+    return truncateString(value, maxStringLength);
+  }
+
+  if (typeof value !== 'object') return value;
+
+  if (Buffer.isBuffer(value)) {
+    return `[buffer length=${value.length}]`;
+  }
+
+  if (seen.has(value)) return '[circular]';
+
+  if (depth >= maxDepth) {
+    if (Array.isArray(value)) return `[array(${value.length}) truncated]`;
+    return '[object truncated]';
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, maxArrayItems)
+      .map(item => summarizeToolLogValue(item, options, depth + 1, seen));
+    if (value.length > maxArrayItems) {
+      items.push(`[+${value.length - maxArrayItems} more items]`);
+    }
+    return items;
+  }
+
+  const summary = {};
+  const keys = Object.keys(value);
+  for (const key of keys.slice(0, maxObjectKeys)) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      summary[key] = '[redacted]';
+      continue;
+    }
+    if (LARGE_BINARY_KEY_PATTERN.test(key)) {
+      const rawValue = value[key];
+      const length = typeof rawValue === 'string' || Array.isArray(rawValue) ? rawValue.length : undefined;
+      summary[key] = length == null ? '[omitted]' : `[omitted length=${length}]`;
+      continue;
+    }
+    summary[key] = summarizeToolLogValue(value[key], options, depth + 1, seen);
+  }
+  if (keys.length > maxObjectKeys) {
+    summary.__truncated_keys__ = keys.length - maxObjectKeys;
+  }
+  return summary;
+}
+
+function summarizeToolParamsForLog(params, options = {}) {
+  return summarizeToolLogValue(params || {}, options);
+}
+
+export {
+  summarizeToolLogValue,
+  summarizeToolParamsForLog,
+};
+
+export default {
+  summarizeToolLogValue,
+  summarizeToolParamsForLog,
+};

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -23,6 +23,7 @@ import ConfigLoader from './config-loader.js';
 import DocumentAtomicTools from './document-atomic-tools.js';
 import DocumentHandleStore, { HANDLE_TYPE } from './document-handle-store.js';
 import DocAccessService from './doc-access-service.js';
+import { summarizeToolParamsForLog } from './tool-log-sanitizer.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -1255,7 +1256,7 @@ class ToolManager {
    */
   async executeTool(toolId, params, context = {}) {
     const display = this.formatToolDisplay(toolId);
-    logger.info(`[ToolManager] 执行工具: ${display}`, { toolId, params });
+    logger.info(`[ToolManager] 执行工具: ${display}`, { toolId, params: summarizeToolParamsForLog(params) });
 
     // 检查是否是内置工具
     const builtinTool = BUILTIN_TOOLS.find(t => t.function.name === toolId);
@@ -2338,7 +2339,7 @@ class ToolManager {
     const userId = context.userId || context.user_id;
     const expertId = context.expertId || context.expert_id;
 
-    logger.info(`[ToolManager] 执行 Notes 工具: ${toolId}`, { userId, expertId, params });
+    logger.info(`[ToolManager] 执行 Notes 工具: ${toolId}`, { userId, expertId, params: summarizeToolParamsForLog(params) });
 
     try {
       // 动态导入 NotesManager

--- a/server/index.js
+++ b/server/index.js
@@ -901,7 +901,7 @@ class ApiServer {
             logger.info('[Startup] ClockCore started with internal jobs');
           } else {
             logger.warn('[Startup] ClockCore disabled by ENABLE_CLOCK_CORE');
-            logger.warn('[Startup] Document pipeline auto-processing is disabled; set ENABLE_CLOCK_CORE=1 to advance pending_ocr/ocr_processing documents');
+            logger.warn('[Startup] Document pipeline auto-processing is disabled; set ENABLE_CLOCK_CORE=1 to advance OCR, clean, outline, and chunk stages');
           }
         }
 

--- a/server/services/assistant/tool-integration.js
+++ b/server/services/assistant/tool-integration.js
@@ -8,6 +8,7 @@
  */
 
 import logger from '../../../lib/logger.js';
+import { summarizeToolParamsForLog } from '../../../lib/tool-log-sanitizer.js';
 
 // 动态导入缓存
 let ToolManagerClass = null;
@@ -138,7 +139,7 @@ export async function getInheritedToolDefinitions(db, toolIds, expertId) {
  * @returns {Promise<object>} 工具执行结果
  */
 export async function executeInheritedTool(db, toolId, params, context) {
-  logger.info(`[ToolIntegration] 执行继承工具: ${toolId}`, params);
+  logger.info(`[ToolIntegration] 执行继承工具: ${toolId}`, summarizeToolParamsForLog(params));
 
   try {
     const ToolManager = await getToolManagerClass();


### PR DESCRIPTION
## Summary

- centralize skill tool function-name construction in `lib/skill-tool-naming.js`
- add `lib/tool-log-sanitizer.js` to redact sensitive tool params and summarize large/binary values in logs
- apply sanitized tool param logging in ToolManager and assistant inherited tool integration
- clarify the ClockCore disabled warning for all document pipeline stages

## Verification

- `node --check server/index.js`
- `node --check lib/skill-tool-naming.js`
- `node --check lib/skill-loader.js`
- `node --check lib/tool-log-sanitizer.js`
- `node --check lib/tool-manager.js`
- `node --check server/services/assistant/tool-integration.js`
- `node -e` behavior check for `buildSkillToolFunctionName`
- `node -e` behavior check for tool log sanitizer redaction/omission/truncation
- module import check for skill/tool modules
- `npm.cmd run lint`
- `git diff --check`
- `git diff --cached --check`

## Notes

- No database schema changes.
- No external API contract changes.
- Only logging output is sanitized; actual tool params and `tool_calls` storage are unchanged.
- Local task notes under `docs/tasks/...` were updated and intentionally not committed.
