### PR TITLE
refactor: harden tool result serialization

### DIFF
--- a/lib/tool-calling-executor.js
+++ b/lib/tool-calling-executor.js
@@ -16,6 +16,7 @@
 import logger from './logger.js';
 import { callLLMWithRetry } from './simple-llm-client.js';
 import LLMClient from './llm-client.js';
+import { stringifyToolResultForMessage } from './tool-result-serializer.js';
 
 /**
  * 执行多轮工具调用（非流式）
@@ -129,7 +130,7 @@ export async function executeWithToolLoop(modelConfig, messages, tools, options 
       messages.push({
         role: 'tool',
         tool_call_id: callId,
-        content: typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResult),
+        content: stringifyToolResultForMessage(toolResult),
       });
 
       // 注入合成 user 消息（多模态图片识别）
@@ -248,7 +249,7 @@ export async function executeStreamWithToolLoop(llmClient, modelConfig, messages
         role: 'tool',
         tool_call_id: toolCall.id,
         name: toolCall.function?.name || toolCall.name,
-        content: typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResult),
+        content: stringifyToolResultForMessage(toolResult),
       });
 
       // 注入合成 user 消息（多模态图片识别）

--- a/lib/tool-result-serializer.js
+++ b/lib/tool-result-serializer.js
@@ -1,0 +1,35 @@
+function stringifyToolResultForMessage(result) {
+  if (typeof result === 'string') return result;
+
+  const seen = new WeakSet();
+
+  try {
+    return JSON.stringify(result, (_key, value) => {
+      if (typeof value === 'bigint') {
+        return value.toString();
+      }
+
+      if (value && typeof value === 'object') {
+        if (seen.has(value)) {
+          return '[circular]';
+        }
+        seen.add(value);
+      }
+
+      return value;
+    });
+  } catch (error) {
+    return JSON.stringify({
+      success: false,
+      error: `Tool result serialization failed: ${error.message}`,
+    });
+  }
+}
+
+export {
+  stringifyToolResultForMessage,
+};
+
+export default {
+  stringifyToolResultForMessage,
+};


### PR DESCRIPTION
## Summary

- add `stringifyToolResultForMessage()` for safe tool result serialization
- use it in non-streaming and streaming `ToolCallingExecutor` tool messages
- preserve normal JSON output while preventing BigInt/circular results from crashing the tool loop

## Verification

- `node --check lib/tool-result-serializer.js`
- `node --check lib/tool-calling-executor.js`
- `node -e` behavior check for normal object/string/BigInt/circular result serialization
- `node -e` import check for `lib/tool-calling-executor.js`
- `npm.cmd run lint`
- `git diff --check`
- `git diff --cached --check`

## Notes

- No database schema changes.
- No API contract changes.
- No truncation/summarization of tool results was introduced; normal JSON tool results stay byte-for-byte equivalent to `JSON.stringify`.
