### PR TITLE
refactor: remove unifuncs debug logging

### DIFF
--- a/data/skills/unifuncs/index.js
+++ b/data/skills/unifuncs/index.js
@@ -101,14 +101,6 @@ async function readWebPage(params) {
   // 同时保留对无前缀版本的支持，方便本地测试
   const apiKey = process.env.SKILL_UNIFUNCS_API_KEY || process.env.UNIFUNCS_API_KEY;
 
-  // 🔍 调试日志：输出环境变量和参数信息
-  console.log('[unifuncs] ========== DEBUG INFO ==========');
-  console.log('[unifuncs] params:', JSON.stringify(params, null, 2));
-  console.log('[unifuncs] SKILL_UNIFUNCS_API_KEY:', process.env.SKILL_UNIFUNCS_API_KEY ? `${process.env.SKILL_UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
-  console.log('[unifuncs] UNIFUNCS_API_KEY:', process.env.UNIFUNCS_API_KEY ? `${process.env.UNIFUNCS_API_KEY.substring(0, 8)}...` : '(not set)');
-  console.log('[unifuncs] resolved apiKey:', apiKey ? `${apiKey.substring(0, 8)}...` : '(not set)');
-  console.log('[unifuncs] ==============================');
-
   if (!url) {
     throw new Error('URL is required');
   }
@@ -123,18 +115,7 @@ async function readWebPage(params) {
     const encodedUrl = encodeURIComponent(url);
     const urlPath = `${API_PATH}${encodedUrl}?apiKey=${apiKey}`;
 
-    // 🔍 调试日志：输出请求信息（隐藏完整 API Key）
-    console.log('[unifuncs] Request URL:', `https://${API_BASE}${API_PATH}${encodedUrl}?apiKey=${apiKey.substring(0, 8)}...`);
-    console.log('[unifuncs] Timeout:', timeout);
-
     const result = await makeRequest(urlPath, timeout);
-
-    // 🔍 调试日志：输出响应信息
-    console.log('[unifuncs] Response status:', result.statusCode, result.statusMessage);
-    console.log('[unifuncs] Response size:', result.size, 'bytes');
-    if (!result.success) {
-      console.log('[unifuncs] Response body:', JSON.stringify(result.body).substring(0, 500));
-    }
 
     return {
       success: result.success,
@@ -146,7 +127,6 @@ async function readWebPage(params) {
       originalUrl: url,
     };
   } catch (error) {
-    console.log('[unifuncs] Error:', error.message);
     return {
       success: false,
       error: error.message,


### PR DESCRIPTION
## Summary

- remove leftover debug logging from the `unifuncs` skill
- stop logging params, API key prefixes, request URL prefixes, response body snippets, and catch-path errors
- keep the skill API call and return structure unchanged

## Verification

- `node --check data/skills/unifuncs/index.js`
- `Select-String` confirms no `console.`
- `git diff --check`
- `git diff --cached --check`

## Notes

- No database schema changes.
- No API contract changes.
- This only changes skill stderr/debug noise; returned success/error objects are unchanged.
