### PR TITLE
fix: discover python skill directories

### DIFF
--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -576,6 +576,17 @@ class SkillLoader {
     return null;
   }
 
+  findSkillEntryFile(skillPath) {
+    const variants = ['index.js', 'index.py'];
+    for (const variant of variants) {
+      const fullPath = path.join(skillPath, variant);
+      if (fs.existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+    return null;
+  }
+
   /**
    * 从数据库获取技能配置参数
    * 支持环境变量占位符替换：${ENV_VAR} 格式
@@ -1009,9 +1020,9 @@ class SkillLoader {
       if (entry.isDirectory()) {
         const skillPath = path.join(this.skillsBasePath, entry.name);
         const skillMdPath = this.findSkillMdFile(skillPath);
-        const indexJsPath = path.join(skillPath, 'index.js');
+        const entryFilePath = this.findSkillEntryFile(skillPath);
 
-        if (skillMdPath && fs.existsSync(indexJsPath)) {
+        if (skillMdPath && entryFilePath) {
           skills.push({
             id: entry.name,
             path: skillPath,


### PR DESCRIPTION
## Summary

- make `SkillLoader.scanSkillsDirectory()` recognize both `index.js` and `index.py`
- add a small `findSkillEntryFile()` helper
- allow Python skill directories such as `pypdf` to be discovered automatically

## Verification

- `node --check lib/skill-loader.js`
- `node -e` scan check:
  - `pypdf` is discovered
  - `erix-ssh` is not discovered without a standard entry file
  - `wikijs` is not discovered without a standard entry file
- `git diff --check`
- `git diff --cached --check`

## Notes

- No database schema changes.
- No API contract changes.
- This aligns directory discovery with the already-supported runner/controller `.py` entry behavior.
