### PR TITLE
fix: absorb safe document table and outline fixes

### DIFF
--- a/frontend/src/components/docs/DocContentPanel.vue
+++ b/frontend/src/components/docs/DocContentPanel.vue
@@ -141,7 +141,7 @@ const renderedContent = computed(() => {
 .markdown-body :deep(code) { background: var(--el-fill-color-lighter); padding: 2px 6px; border-radius: var(--el-border-radius-base); font-family: monospace; }
 .markdown-body :deep(pre code) { background: none; padding: 0; }
 .markdown-body :deep(img) { display: block; max-width: 100%; height: auto; margin: 12px auto; border-radius: 6px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08); }
-.markdown-body :deep(table) { border-collapse: collapse; width: 100%; margin: 12px 0; background: #fff; }
+.markdown-body :deep(table) { display: block; border-collapse: collapse; min-width: 100%; width: auto; margin: 12px 0; background: #fff; overflow-x: auto; }
 .markdown-body :deep(th), .markdown-body :deep(td) { border: 1px solid var(--el-border-color-lighter); padding: 8px 10px; vertical-align: top; }
 .markdown-body :deep(th) { background: var(--el-fill-color-lighter); font-weight: 600; }
 .markdown-body :deep(a) { color: var(--el-color-primary); text-decoration: none; }

--- a/frontend/src/composables/useMarkdownFormatter.ts
+++ b/frontend/src/composables/useMarkdownFormatter.ts
@@ -143,6 +143,7 @@ const sanitizeMarkdownHtml = (rawHtml: string): string => {
       'href', 'src', 'alt', 'title', 'class',
       'target', 'rel',
       'width', 'height',
+      'rowspan', 'colspan', 'align', 'valign', 'cellpadding', 'cellspacing', 'border',
       'd', 'fill', 'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
       'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'x1', 'y1', 'x2', 'y2',
       'transform', 'viewBox', 'xmlns', 'id', 'points', 'text-anchor',
@@ -151,6 +152,24 @@ const sanitizeMarkdownHtml = (rawHtml: string): string => {
       'markerWidth', 'markerHeight', 'orient', 'overflow', 'data-*'
     ],
     ALLOW_DATA_ATTR: true,
+  })
+}
+
+const RAW_HTML_BLOCK_RE = /<table[\s\S]*?<\/table>/gi
+
+const protectRawHtmlBlocks = (content: string): { content: string; blocks: string[] } => {
+  const blocks: string[] = []
+  const protectedContent = content.replace(RAW_HTML_BLOCK_RE, (match) => {
+    blocks.push(match)
+    return `\n\n<div data-raw-html-block="${blocks.length - 1}"></div>\n\n`
+  })
+  return { content: protectedContent, blocks }
+}
+
+const restoreRawHtmlBlocks = (html: string, blocks: string[]): string => {
+  if (!blocks.length) return html
+  return html.replace(/<div data-raw-html-block="(\d+)"><\/div>/g, (_, index: string) => {
+    return blocks[Number(index)] ?? ''
   })
 }
 
@@ -167,9 +186,11 @@ const formatMessage = (content: string, cacheKey?: string) => {
   }
 
   try {
-    const normalizedContent = normalizeInlineMath(content)
+    const { content: protectedContent, blocks } = protectRawHtmlBlocks(content)
+    const normalizedContent = normalizeInlineMath(protectedContent)
     const rawHtml = marked.parse(normalizedContent) as string
-    const htmlWithBlockMath = renderBlockMath(rawHtml)
+    const htmlWithTables = restoreRawHtmlBlocks(rawHtml, blocks)
+    const htmlWithBlockMath = renderBlockMath(htmlWithTables)
     const htmlWithMath = renderInlineMathPlaceholders(htmlWithBlockMath)
     const htmlWithNormalizedImages = normalizeRelativeImageSources(htmlWithMath)
     const cleanHtml = sanitizeMarkdownHtml(htmlWithNormalizedImages)

--- a/lib/document-clean-service.js
+++ b/lib/document-clean-service.js
@@ -423,7 +423,7 @@ class DocumentCleanService {
     const transaction = await this.db.sequelize.transaction();
 
     try {
-      const skipTableProtection = options.skipTableProtection !== false;
+      const skipTableProtection = options.skipTableProtection === true;
       const precleanResult = this.precleanText(originalText, stageConfig.rules || {}, skipTableProtection);
       const precleanedText = precleanResult.cleaned_text;
       const cleanedText = stageConfig.enabled === false
@@ -535,6 +535,20 @@ class DocumentCleanService {
       const nextChunk = chunks[i];
       const chunkInput = carriedOver ? `${carriedOver}\n\n${nextChunk}` : nextChunk;
       const result = await this.cleanSingleChunk(modelConfig, stageConfig, chunkInput, contextSummary, options);
+
+      const inputTokens = chunkInput.match(/\[\[(?:TABLE|FORMULA)_(?:BLOCK|INLINE)_\d+\]\]/g) || [];
+      if (inputTokens.length > 0) {
+        const outputText = `${result.processed_part || ''}\n${result.carried_over || ''}`;
+        const missingTokens = inputTokens.filter(token => !outputText.includes(token));
+        if (missingTokens.length > 0) {
+          logger.warn(`[DocumentCleanService] chunk ${i + 1}/${chunks.length}: ${missingTokens.length}/${inputTokens.length} protected placeholder(s) missing from LLM output (${missingTokens.slice(0, 3).join(', ')}), falling back to uncleaned chunk input`);
+          allProcessed.push(chunkInput);
+          carriedOver = '';
+          contextSummary = this.trimContextSummary(result.context_summary);
+          continue;
+        }
+      }
+
       allProcessed.push(result.processed_part || '');
       carriedOver = result.carried_over || '';
       contextSummary = this.trimContextSummary(result.context_summary);
@@ -595,7 +609,7 @@ class DocumentCleanService {
   }
 
   buildPrompt(stageConfig, options = {}) {
-    const skipTableProtection = options.skipTableProtection !== false;
+    const skipTableProtection = options.skipTableProtection === true;
     const defaultPrompt = skipTableProtection
       ? DEFAULT_CLEAN_PROMPT_NO_TABLE_PROTECT
       : DEFAULT_CLEAN_PROMPT;

--- a/lib/document-outline-service.js
+++ b/lib/document-outline-service.js
@@ -10,6 +10,7 @@ import {
   computeTextStats,
   buildOutlinePrompt,
   parseOutlineResponse,
+  reanchorOutlines,
 } from './outline-utils.js';
 import { invokeWithRetry } from './message-llm-client.js';
 
@@ -470,7 +471,16 @@ class DocumentOutlineService {
       logger.warn(`[DocumentOutlineService] Revision ${revisionId}: partial extraction with ${extractionMeta.failedChunks} failed chunks`);
     }
 
-    const enrichedOutlines = this._enrichOutlines(outlines, text);
+    const reanchoredOutlines = reanchorOutlines(outlines, text);
+    const anchorMisses = reanchoredOutlines.filter(o => o.anchored === false).length;
+    if (anchorMisses > 0) {
+      logger.warn(`[DocumentOutlineService] Revision ${revisionId}: ${anchorMisses}/${reanchoredOutlines.length} outline(s) could not be re-anchored to text, keeping LLM line numbers`);
+    }
+    const anchorCorrections = reanchoredOutlines.filter(o => o.corrected === true).length;
+    if (anchorCorrections > 0) {
+      logger.warn(`[DocumentOutlineService] Revision ${revisionId}: ${anchorCorrections} outline(s) had overlapping line anchors and were force-shifted, titles: ${reanchoredOutlines.filter(o => o.corrected === true).map(o => o.title).slice(0, 5).join(' | ')}`);
+    }
+    const enrichedOutlines = this._enrichOutlines(reanchoredOutlines, text);
 
     // 独立事务持久化章节数据
     const saveTx = await this.db.sequelize.transaction();

--- a/lib/outline-utils.js
+++ b/lib/outline-utils.js
@@ -124,6 +124,84 @@ export function extractTextByLineRange(text, fromLine, toLine) {
   return lines.slice(startIdx, endIdx).join('\n');
 }
 
+function normalizeHeadingText(value) {
+  return String(value || '')
+    .replace(/^#+\s*/, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Re-anchor LLM-generated outline ranges to real text line numbers.
+ *
+ * LLMs can identify headings reasonably well, but line counting drifts badly on
+ * long OCR lines and HTML tables. This function trusts heading text/order more
+ * than claimed line numbers:
+ * - exact heading match first, then prefix/contains fallback;
+ * - when multiple candidates match, prefer the one closest to the claimed line;
+ * - if matching fails, keep the LLM line and mark `anchored=false`;
+ * - finally enforce monotonic from_line and recompute to_line by next heading.
+ */
+export function reanchorOutlines(outlines, text) {
+  if (!Array.isArray(outlines) || outlines.length === 0) return [];
+
+  const lines = String(text || '').split('\n');
+  const normalizedLines = lines.map(line => normalizeHeadingText(line));
+
+  const anchored = [];
+  for (const outline of outlines) {
+    const title = normalizeHeadingText(outline?.title);
+    const claimed = Number.isFinite(outline?.from_line) ? outline.from_line : 0;
+    let bestLine = -1;
+    let bestScore = -Infinity;
+
+    if (title) {
+      for (let i = 0; i < normalizedLines.length; i++) {
+        const line = normalizedLines[i];
+        if (!line) continue;
+
+        let score = 0;
+        if (line === title) score = 100;
+        else if (line.startsWith(title)) score = 80;
+        else if (title.startsWith(line) && line.length >= 4) score = 60;
+        else if (title.length >= 6 && line.includes(title)) score = 40;
+        if (score === 0) continue;
+
+        const distance = Math.abs((i + 1) - claimed);
+        const finalScore = score * 100000 - distance;
+        if (finalScore > bestScore) {
+          bestScore = finalScore;
+          bestLine = i + 1;
+        }
+      }
+    }
+
+    anchored.push({
+      ...outline,
+      from_line: bestLine > 0 ? bestLine : claimed,
+      anchored: bestLine > 0,
+    });
+  }
+
+  for (let i = 1; i < anchored.length; i++) {
+    if (anchored[i].from_line <= anchored[i - 1].from_line) {
+      anchored[i].from_line = anchored[i - 1].from_line + 1;
+      anchored[i].corrected = true;
+    }
+  }
+
+  for (let i = 0; i < anchored.length; i++) {
+    const next = anchored[i + 1];
+    anchored[i].to_line = next ? next.from_line - 1 : lines.length;
+    if (anchored[i].to_line < anchored[i].from_line) {
+      anchored[i].to_line = anchored[i].from_line;
+    }
+  }
+
+  return anchored;
+}
+
 export function computeTextStats(text) {
   if (!text) {
     return { textHash: '', byteCount: 0, tokenCount: 0 };


### PR DESCRIPTION
## Summary

Absorb the low-risk, independently verifiable subset from PR #976:

- keep raw HTML table blocks intact during markdown formatting and allow table merge attributes through sanitization
- make document preview tables horizontally scrollable for wide/complex OCR tables
- enable table placeholder protection by default during document cleaning
- fall back to the uncleaned chunk when the LLM drops protected table/formula placeholders
- re-anchor extracted outlines by heading text after OCR/LLM extraction to reduce line drift

Intentionally not included in this PR:

- TaskID import UI/API/service flow
- MinerU v2 default submit/finalize contract switch
- OCR finalize metadata lock / idempotency changes
- resident skill global API_BASE injection

## Verification

- `npm.cmd run lint`
- `cd frontend && npm.cmd run type-check`
- `node -e "import('./lib/outline-utils.js').then(m=>console.log(Object.keys(m).sort().join(',')))"`
- `node -e "import('./lib/document-outline-service.js').then(()=>console.log('document-outline-service import ok'))"`
- `node -e "import('./lib/document-clean-service.js').then(()=>console.log('document-clean-service import ok'))"`
- focused `reanchorOutlines` behavior check
- `git diff --check`
- `cd frontend && npm.cmd run build-only`

## Relation to #976

This is a scoped safe-absorb PR for part of #976. The higher-risk TaskID import and MinerU v2 finalize work still need a separate rebase/rework pass before merge.

