### PR TITLE
refactor: harden skill schema governance

### DIFF
--- a/data/skills/erix-ssh/SKILL.md
+++ b/data/skills/erix-ssh/SKILL.md
@@ -7,6 +7,12 @@ user-invocable: false
 allowed-tools: []
 ---
 
+# Status
+
+Frozen draft. This skill is intentionally not discoverable by `scanSkillsDirectory()` because it has no `index.js` / `index.py` entrypoint.
+
+Do not register or enable it until the resident-process contract, permission boundary, credential handling, and user-facing audit trail are reviewed. See `STATUS.md`.
+
 # SSH - 远程服务器管理
 
 基于会话的 SSH 客户端，支持同步命令执行和 SFTP 文件传输。

--- a/data/skills/erix-ssh/STATUS.md
+++ b/data/skills/erix-ssh/STATUS.md
@@ -1,0 +1,20 @@
+# erix-ssh status
+
+Status: frozen draft.
+
+Decision: do not implement or register this skill in the current optimization round.
+
+Reason:
+
+- It controls remote hosts and has a materially higher permission boundary than normal file-processing skills.
+- The directory contains resident-process building blocks, but no `index.js` / `index.py` skill entrypoint.
+- The historical seed data references `scripts/ssh_client.js`, which does not exist in this directory.
+- Exposing it before the resident-process lifecycle, credential handling, session auditing, and user confirmation model are finalized would create a misleading and risky tool surface.
+
+Activation requirements:
+
+1. Define the resident protocol and lifecycle ownership in code and tests.
+2. Add a real skill entrypoint or explicit resident registration flow.
+3. Add permission checks and user-visible audit events for connection, command execution, sudo, and file transfer.
+4. Update `scripts/skills-data.json` only after the implementation is verified end-to-end.
+5. Add focused tests for session isolation and secret redaction.

--- a/data/skills/wikijs/SKILL.md
+++ b/data/skills/wikijs/SKILL.md
@@ -6,6 +6,12 @@ user-invocable: false
 allowed-tools: []
 ---
 
+# Status
+
+Frozen draft. This skill is intentionally not discoverable by `scanSkillsDirectory()` because it has no `index.js` / `index.py` entrypoint.
+
+Do not register or enable it until the external Wiki.js write boundary, credentials, and API wrapper contract are reviewed. See `STATUS.md`.
+
 # Wiki.js - Wiki 交互技能
 
 通过 GraphQL API 和 REST 上传端点操作 Wiki.js 实例。

--- a/data/skills/wikijs/STATUS.md
+++ b/data/skills/wikijs/STATUS.md
@@ -1,0 +1,19 @@
+# wikijs status
+
+Status: frozen draft.
+
+Decision: do not implement or register this skill in the current optimization round.
+
+Reason:
+
+- It can mutate an external Wiki.js instance through GraphQL and upload endpoints.
+- The directory contains client/reference scripts, but no `index.js` / `index.py` skill entrypoint.
+- The runtime contract is unclear: it needs explicit credential source, dry-run/write behavior, and user-facing audit/error handling before exposure.
+
+Activation requirements:
+
+1. Define whether this is a read-only, write-capable, or migration-only skill.
+2. Add a real skill entrypoint with explicit tool schemas.
+3. Use project-standard configuration/secrets handling instead of implicit ambient credentials.
+4. Add dry-run support for write operations where practical.
+5. Add focused tests for request construction, credential absence, and non-2xx/error responses.

--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -171,20 +171,24 @@ class SkillLoader {
    */
   convertToolToOpenAIFormat(toolRow, skill) {
     // 解析 parameters 字段
-    let parameters = { type: 'object', properties: {}, required: [] };
+    let parameters = this.createEmptyParametersSchema();
     
     if (toolRow.parameters) {
       try {
         const paramsObj = typeof toolRow.parameters === 'string' ? JSON.parse(toolRow.parameters) : toolRow.parameters;
         if (paramsObj.type === 'object' && paramsObj.properties) {
           // 已经是完整的 JSON Schema 格式
-          parameters = paramsObj;
+          parameters = this.normalizeParametersSchema(paramsObj, toolRow.id);
         } else if (paramsObj.parameters) {
           // 嵌套在 parameters 字段中
-          parameters = paramsObj.parameters;
+          parameters = this.normalizeParametersSchema(paramsObj.parameters, toolRow.id);
         } else if (paramsObj.properties) {
           // 只有 properties 字段
-          parameters = { type: 'object', properties: paramsObj.properties, required: paramsObj.required || [] };
+          parameters = this.normalizeParametersSchema({
+            type: 'object',
+            properties: paramsObj.properties,
+            required: paramsObj.required || [],
+          }, toolRow.id);
         }
       } catch (e) {
         logger.warn(`[SkillLoader] 解析 parameters 字段失败 for tool ${toolRow.id}:`, e.message);
@@ -204,6 +208,7 @@ class SkillLoader {
           ),
           required,
         };
+        parameters = this.normalizeParametersSchema(parameters, toolRow.id);
         logger.debug(`[SkillLoader] 从 description 解析到 ${Object.keys(parsedParams).length} 个参数 for tool ${toolRow.id}`);
       }
     }
@@ -234,6 +239,89 @@ class SkillLoader {
         method: toolRow.method,
       },
     };
+  }
+
+  /**
+   * 构建空的 OpenAI function parameters schema。
+   * @returns {{type: string, properties: object, required: string[]}}
+   */
+  createEmptyParametersSchema() {
+    return { type: 'object', properties: {}, required: [] };
+  }
+
+  /**
+   * 归一化 skill_tools.parameters，防止坏数据直接透传给 LLM。
+   *
+   * 这里不是完整 JSON Schema validator；它只做运行时需要的最小治理：
+   * - 根节点固定为 object schema
+   * - properties 必须是对象
+   * - required 必须是已存在属性名数组
+   * - 属性 schema 至少要是对象并带合法 type；清理导入器遗留的 property-level required
+   *
+   * @param {object} schema - 原始 parameters schema
+   * @param {string} toolId - 日志上下文中的工具 ID
+   * @returns {object} 归一化后的 schema
+   */
+  normalizeParametersSchema(schema, toolId = '') {
+    if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+      logger.warn(`[SkillLoader] parameters schema 不是对象，已回退为空 schema for tool ${toolId}`);
+      return this.createEmptyParametersSchema();
+    }
+
+    const rawProperties = schema.properties && typeof schema.properties === 'object' && !Array.isArray(schema.properties)
+      ? schema.properties
+      : {};
+
+    const properties = Object.fromEntries(
+      Object.entries(rawProperties)
+        .filter(([name]) => typeof name === 'string' && name.length > 0)
+        .map(([name, propertySchema]) => [name, this.normalizePropertySchema(propertySchema)])
+    );
+
+    const propertyNames = new Set(Object.keys(properties));
+    const required = Array.isArray(schema.required)
+      ? schema.required.filter(name => typeof name === 'string' && propertyNames.has(name))
+      : [];
+
+    return {
+      ...schema,
+      type: 'object',
+      properties,
+      required,
+    };
+  }
+
+  /**
+   * 归一化单个参数的 JSON Schema。
+   * @param {object|string} propertySchema - 原始属性 schema
+   * @returns {object} 归一化后的属性 schema
+   */
+  normalizePropertySchema(propertySchema) {
+    const allowedTypes = new Set(['string', 'number', 'integer', 'boolean', 'array', 'object', 'null']);
+    const schema = propertySchema && typeof propertySchema === 'object' && !Array.isArray(propertySchema)
+      ? { ...propertySchema }
+      : { type: typeof propertySchema === 'string' ? propertySchema : 'string' };
+
+    delete schema.required;
+
+    if (Array.isArray(schema.type)) {
+      schema.type = schema.type.filter(type => allowedTypes.has(type));
+      if (schema.type.length === 0) {
+        schema.type = 'string';
+      }
+    } else if (!allowedTypes.has(schema.type)) {
+      schema.type = 'string';
+    }
+
+    if (schema.type === 'array' && (!schema.items || typeof schema.items !== 'object' || Array.isArray(schema.items))) {
+      schema.items = { type: 'string' };
+    }
+
+    if (schema.type === 'object' && schema.properties && (typeof schema.properties !== 'object' || Array.isArray(schema.properties))) {
+      delete schema.properties;
+    }
+
+    return schema;
   }
 
   /**
@@ -916,6 +1004,11 @@ class SkillLoader {
       
       // 解析参数（从描述中提取）
       const parameters = this.parseParametersFromDescription(toolDesc);
+      const parameterSchema = this.normalizeParametersSchema({
+        type: 'object',
+        properties: parameters,
+        required: Object.keys(parameters).filter(k => parameters[k].required),
+      }, `${skill.id}.${toolName}`);
       
       // 从 Markdown 解析的工具使用 skill_mark__tool_name 格式（与 convertToolToOpenAIFormat 一致）
       // Issue #417: 技能工具名称统一方案
@@ -927,11 +1020,7 @@ class SkillLoader {
         function: {
           name: toolFunctionName,
           description: this.extractFirstSentence(toolDesc),
-          parameters: {
-            type: 'object',
-            properties: parameters,
-            required: Object.keys(parameters).filter(k => parameters[k].required),
-          },
+          parameters: parameterSchema,
         },
         // 保留原始信息用于执行和显示
         _meta: {

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -8,7 +8,8 @@
  * 3. 处理 LLM 的工具调用请求
  * 4. 执行工具并返回结果
  *
- * 注：builtin 工具已迁移为普通技能（data/skills/），所有技能统一通过 skill-runner 执行
+ * 注：普通文件系统技能统一通过 skill-runner 执行；系统级工具、驻留工具、
+ * MCP 工具与 document_retrieval 原子工具保留专用分派路径。
  */
 
 import SkillLoader from './skill-loader.js';
@@ -29,8 +30,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
- * 内置工具定义
- * 这些工具不依赖技能目录，直接在代码中定义
+ * 内置工具定义。
+ *
+ * 分派边界：
+ * - execute / recall / notes.* 是系统级能力，不依赖技能目录。
+ * - document_retrieval 工具族是文档平台原子检索能力，定义在这里但执行到专用 handler。
+ * - 普通技能工具来自 skill_tools 表，经 skill-runner 子进程执行。
+ * - resident:// 技能工具经 ResidentSkillManager 执行。
+ * - mcp_* 工具经 mcp-client 驻留技能代理执行。
  */
 const BUILTIN_TOOLS = [
   {
@@ -1239,9 +1246,14 @@ class ToolManager {
   }
 
   /**
-   * 执行工具调用
-   * 所有技能统一通过 skill-runner 子进程隔离执行
-   * 支持驻留工具（resident:// 协议）直接调用 ResidentSkillManager
+   * 执行工具调用。
+   *
+   * 分派顺序：
+   * 1. BUILTIN_TOOLS：execute / recall / notes.* / document_retrieval 原子工具
+   * 2. mcp_*：经 mcp-client 驻留技能代理执行
+   * 3. assistant_*：核心 Assistant 服务工具
+   * 4. resident://：经 ResidentSkillManager 执行
+   * 5. 普通 skill_tools：经 skill-runner 子进程隔离执行
    *
    * @param {string} toolId - 工具 ID（toolName__skillIdShort 格式）
    * @param {object} params - 工具参数

--- a/scripts/skills-data.json
+++ b/scripts/skills-data.json
@@ -246,7 +246,7 @@
       "disable_model_invocation": true,
       "user_invocable": true,
       "allowed_tools": null,
-      "is_active": true
+      "is_active": false
     },
     {
       "id": "mnbdoe1alv92mmh4f28y",

--- a/tests/test-skill-directory-scan.mjs
+++ b/tests/test-skill-directory-scan.mjs
@@ -1,0 +1,102 @@
+/**
+ * Tests for SkillLoader directory scanning and tool parameter schema normalization.
+ *
+ * Usage:
+ *   node tests/test-skill-directory-scan.mjs
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import SkillLoader from '../lib/skill-loader.js';
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+async function testScanSkillsDirectory() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-directory-scan-'));
+  const skillsBasePath = path.join(tempRoot, 'skills');
+
+  try {
+    writeFile(path.join(skillsBasePath, 'javascript-skill', 'SKILL.md'), '# JS Skill');
+    writeFile(path.join(skillsBasePath, 'javascript-skill', 'index.js'), 'export default async function execute() {}');
+
+    writeFile(path.join(skillsBasePath, 'python-skill', 'skill.md'), '# Python Skill');
+    writeFile(path.join(skillsBasePath, 'python-skill', 'index.py'), 'def execute(*args, **kwargs):\n    return {}');
+
+    writeFile(path.join(skillsBasePath, 'draft-skill', 'SKILL.md'), '# Draft Skill');
+    writeFile(path.join(skillsBasePath, 'entry-only-skill', 'index.js'), 'export default async function execute() {}');
+    writeFile(path.join(skillsBasePath, 'plain-file.txt'), 'ignored');
+
+    const loader = new SkillLoader({}, { skillsBasePath });
+    const discovered = await loader.scanSkillsDirectory();
+    const ids = discovered.map(skill => skill.id).sort();
+
+    assert.deepEqual(ids, ['javascript-skill', 'python-skill']);
+    assert.ok(discovered.every(skill => path.isAbsolute(skill.path)));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function testMissingSkillsDirectory() {
+  const missingBasePath = path.join(os.tmpdir(), `missing-skills-${Date.now()}`);
+  const loader = new SkillLoader({}, { skillsBasePath: missingBasePath });
+
+  return loader.scanSkillsDirectory().then(discovered => {
+    assert.deepEqual(discovered, []);
+  });
+}
+
+function testParameterSchemaNormalization() {
+  const loader = new SkillLoader({});
+  const skill = { id: 'skill-one', mark: 'skill', name: 'Skill One' };
+
+  const tool = loader.convertToolToOpenAIFormat({
+    id: 'tool-one',
+    name: 'run',
+    description: 'Run tool',
+    parameters: JSON.stringify({
+      type: 'array',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search query',
+          required: true,
+        },
+        count: {
+          type: 'definitely-not-json-schema',
+        },
+        tags: {
+          type: 'array',
+        },
+      },
+      required: ['query', 'missing'],
+    }),
+  }, skill);
+
+  const schema = tool.function.parameters;
+
+  assert.equal(schema.type, 'object');
+  assert.deepEqual(schema.required, ['query']);
+  assert.equal(schema.properties.query.type, 'string');
+  assert.equal(schema.properties.query.required, undefined);
+  assert.equal(schema.properties.count.type, 'string');
+  assert.deepEqual(schema.properties.tags.items, { type: 'string' });
+}
+
+async function main() {
+  await testScanSkillsDirectory();
+  await testMissingSkillsDirectory();
+  testParameterSchemaNormalization();
+
+  console.log('Skill directory scan and parameter schema tests passed.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test-skill-parameters-schema-quality.mjs
+++ b/tests/test-skill-parameters-schema-quality.mjs
@@ -1,0 +1,45 @@
+/**
+ * Static audit for skill tool parameter schemas exported in scripts/skills-data.json.
+ *
+ * Usage:
+ *   node tests/test-skill-parameters-schema-quality.mjs
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import SkillLoader from '../lib/skill-loader.js';
+
+const data = JSON.parse(fs.readFileSync('scripts/skills-data.json', 'utf-8'));
+const loader = new SkillLoader({});
+const tools = Array.isArray(data.tools) ? data.tools : [];
+
+const rawDiffs = [];
+
+for (const tool of tools) {
+  const normalized = loader.normalizeParametersSchema(tool.parameters, tool.id);
+  const properties = normalized.properties || {};
+  const propertyNames = new Set(Object.keys(properties));
+
+  assert.equal(normalized.type, 'object', `${tool.name} should normalize to an object schema`);
+  assert.ok(!Array.isArray(properties), `${tool.name} properties must be an object`);
+  assert.ok(Array.isArray(normalized.required), `${tool.name} required must be an array`);
+
+  for (const requiredName of normalized.required) {
+    assert.equal(typeof requiredName, 'string', `${tool.name} required entries must be strings`);
+    assert.ok(propertyNames.has(requiredName), `${tool.name} required entry must exist in properties: ${requiredName}`);
+  }
+
+  for (const [propertyName, propertySchema] of Object.entries(properties)) {
+    assert.equal(typeof propertySchema, 'object', `${tool.name}.${propertyName} schema must be an object`);
+    assert.equal(propertySchema.required, undefined, `${tool.name}.${propertyName} must not use property-level required`);
+  }
+
+  if (JSON.stringify(tool.parameters || null) !== JSON.stringify(normalized)) {
+    rawDiffs.push(`${tool.skill_id}/${tool.name}`);
+  }
+}
+
+console.log(`Audited ${tools.length} skill tool schemas; ${rawDiffs.length} legacy schemas require runtime normalization.`);
+if (rawDiffs.length > 0) {
+  console.log(`Normalized legacy schemas: ${rawDiffs.join(', ')}`);
+}


### PR DESCRIPTION
## Summary

- Harden `skill_tools.parameters` conversion with runtime JSON Schema normalization.
- Add formal tests for `scanSkillsDirectory()` and seed schema quality.
- Clarify `ToolManager` dispatch boundaries for builtin / normal skill / resident / MCP / document_retrieval tools.
- Mark `erix-ssh` and `wikijs` as frozen drafts; disable the historical erix-ssh seed record because it has no valid entrypoint and references a missing script.

## Verification

- `node tests/test-skill-directory-scan.mjs`
- `node tests/test-skill-parameters-schema-quality.mjs`
- `node -e "import('./lib/skill-loader.js').then(m => console.log('SkillLoader exports:', Object.keys(m)))"`
- `node -e "import('./lib/tool-manager.js').then(m => console.log('ToolManager exports:', Object.keys(m)))"`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No database schema changes.
- No external MCP/LLM/DB calls required.
- Local task trace: `docs/tasks/active/refactor-260728-01-skill-system-governance/round08-schema-scan-dispatch-drafts.md` (kept local per project rules).
