### PR TITLE
refactor: make tool display route-aware

### DIFF
--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -1228,6 +1228,40 @@ class ToolManager {
   }
 
   /**
+   * 格式化内置工具显示名称。
+   * 内置工具不应该受 toolRegistry 中同名历史/异常记录影响。
+   * @param {string} toolId - 工具 ID
+   * @param {object} builtinTool - BUILTIN_TOOLS 中的工具定义
+   * @returns {string} 友好的显示名称
+   */
+  formatBuiltinToolDisplay(toolId, builtinTool) {
+    const namespace = builtinTool?._meta?.skillNamespace;
+    if (namespace) {
+      return `${namespace}/${toolId}`;
+    }
+    return builtinTool?._meta?.toolName || toolId;
+  }
+
+  /**
+   * 格式化助理工具显示名称。
+   * @param {string} toolId - 工具 ID
+   * @returns {string} 友好的显示名称
+   */
+  formatAssistantToolDisplay(toolId) {
+    return `Assistant/${toolId}`;
+  }
+
+  /**
+   * 记录工具执行入口日志。
+   * @param {string} display - 已按实际分派路线计算的显示名称
+   * @param {string} toolId - 工具 ID
+   * @param {object} params - 工具参数
+   */
+  logToolExecution(display, toolId, params) {
+    logger.info(`[ToolManager] 执行工具: ${display}`, { toolId, params: summarizeToolParamsForLog(params) });
+  }
+
+  /**
    * 获取工具的详细信息
    * @param {string} toolId - 工具 ID
    * @returns {object|null} 工具信息 { skillId, skillName, toolName } 或 MCP 工具信息 { serverName, toolName }
@@ -1267,17 +1301,18 @@ class ToolManager {
    * @returns {Promise<object>} 工具执行结果
    */
   async executeTool(toolId, params, context = {}) {
-    const display = this.formatToolDisplay(toolId);
-    logger.info(`[ToolManager] 执行工具: ${display}`, { toolId, params: summarizeToolParamsForLog(params) });
-
     // 检查是否是内置工具
     const builtinTool = BUILTIN_TOOLS.find(t => t.function.name === toolId);
     if (builtinTool) {
+      const display = this.formatBuiltinToolDisplay(toolId, builtinTool);
+      this.logToolExecution(display, toolId, params);
       return await this.executeBuiltinTool(toolId, params, context, display);
     }
 
     // 检查是否是 MCP 工具（工具名以 mcp_ 开头）
     if (toolId.startsWith('mcp_')) {
+      const display = this.formatToolDisplay(toolId);
+      this.logToolExecution(display, toolId, params);
       return await this.executeMcpTool(toolId, params, context, display);
     }
 
@@ -1287,6 +1322,8 @@ class ToolManager {
       try {
         const assistantManager = getAssistantManager(this.db);
         if (assistantManager) {
+          const display = this.formatAssistantToolDisplay(toolId);
+          this.logToolExecution(display, toolId, params);
           return await assistantManager.executeTool(toolId, params, {
             expertId: context.expertId || context.expert_id,
             userId: context.userId || context.user_id,
@@ -1296,6 +1333,8 @@ class ToolManager {
           });
         }
       } catch (err) {
+        const display = this.formatAssistantToolDisplay(toolId);
+        this.logToolExecution(display, toolId, params);
         logger.error(`[ToolManager] 执行助理工具失败: ${toolId}`, err.message);
         return { success: false, error: err.message };
       }
@@ -1304,6 +1343,7 @@ class ToolManager {
     // 从 toolRegistry 获取工具信息
     const toolInfo = this.toolRegistry.get(toolId);
     if (!toolInfo) {
+      this.logToolExecution(toolId, toolId, params);
       return {
         success: false,
         error: `Tool not found: ${toolId}`,
@@ -1311,6 +1351,8 @@ class ToolManager {
     }
 
     const { skillId, toolName, scriptPath } = toolInfo;
+    const display = this.formatToolDisplay(toolId);
+    this.logToolExecution(display, toolId, params);
 
     // 检查是否是驻留工具（resident:// 协议）
     if (scriptPath && scriptPath.startsWith('resident://')) {

--- a/tests/test-tool-manager-dispatch.mjs
+++ b/tests/test-tool-manager-dispatch.mjs
@@ -13,8 +13,17 @@ function createManager() {
   return new ToolManager(null, 'expert-dispatch-test');
 }
 
+function captureExecutionLogs(manager) {
+  const logs = [];
+  manager.logToolExecution = (display, toolId, params) => {
+    logs.push({ display, toolId, params });
+  };
+  return logs;
+}
+
 async function testBuiltinWinsOverRegistry() {
   const manager = createManager();
+  const logs = captureExecutionLogs(manager);
   const calls = [];
 
   manager.toolRegistry.set('execute', {
@@ -36,10 +45,17 @@ async function testBuiltinWinsOverRegistry() {
 
   assert.deepEqual(result, { success: true, route: 'builtin' });
   assert.deepEqual(calls.map(call => call.route), ['builtin']);
+  assert.equal(calls[0].display, 'execute');
+  assert.deepEqual(logs, [{
+    display: 'execute',
+    toolId: 'execute',
+    params: { type: 'javascript' },
+  }]);
 }
 
 async function testMcpWinsOverRegistry() {
   const manager = createManager();
+  const logs = captureExecutionLogs(manager);
   const calls = [];
 
   manager.toolRegistry.set('mcp_demo_search', {
@@ -61,10 +77,45 @@ async function testMcpWinsOverRegistry() {
 
   assert.deepEqual(result, { success: true, route: 'mcp' });
   assert.deepEqual(calls.map(call => call.route), ['mcp']);
+  assert.equal(calls[0].display, 'MCP/demo/search');
+  assert.deepEqual(logs, [{
+    display: 'MCP/demo/search',
+    toolId: 'mcp_demo_search',
+    params: { q: 'hello' },
+  }]);
+}
+
+async function testDocumentRetrievalUsesBuiltinNamespaceDisplay() {
+  const manager = createManager();
+  const logs = captureExecutionLogs(manager);
+  const calls = [];
+
+  manager.toolRegistry.set('search_documents_by_metadata', {
+    skillId: 'fake-skill',
+    skillName: 'Fake Skill',
+    toolName: 'search_documents_by_metadata',
+    scriptPath: 'index.js',
+  });
+  manager.executeBuiltinTool = async (toolId, params, context, display) => {
+    calls.push({ route: 'builtin', toolId, params, context, display });
+    return { success: true, route: 'document_retrieval' };
+  };
+
+  const result = await manager.executeTool('search_documents_by_metadata', { metadata_query: 'policy' }, {});
+
+  assert.deepEqual(result, { success: true, route: 'document_retrieval' });
+  assert.deepEqual(calls.map(call => call.route), ['builtin']);
+  assert.equal(calls[0].display, 'document_retrieval/search_documents_by_metadata');
+  assert.deepEqual(logs, [{
+    display: 'document_retrieval/search_documents_by_metadata',
+    toolId: 'search_documents_by_metadata',
+    params: { metadata_query: 'policy' },
+  }]);
 }
 
 async function testAssistantWinsOverRegistry() {
   const manager = createManager();
+  const logs = captureExecutionLogs(manager);
   const calls = [];
 
   manager.toolRegistry.set('assistant_summon', {
@@ -101,6 +152,11 @@ async function testAssistantWinsOverRegistry() {
     assert.equal(result.success, true);
     assert.equal(result.route, 'assistant');
     assert.deepEqual(calls.map(call => call.route), ['assistant']);
+    assert.deepEqual(logs, [{
+      display: 'Assistant/assistant_summon',
+      toolId: 'assistant_summon',
+      params: { assistant_id: 'helper-1' },
+    }]);
     assert.deepEqual(result.context, {
       expertId: 'expert-1',
       userId: 'user-1',
@@ -113,8 +169,43 @@ async function testAssistantWinsOverRegistry() {
   }
 }
 
+async function testAssistantFallsBackToRegistryWhenManagerUnavailable() {
+  const manager = createManager();
+  const logs = captureExecutionLogs(manager);
+  const calls = [];
+
+  setAssistantManager(null);
+  manager.skills.set('fake-skill', { id: 'fake-skill', name: 'Fake Skill' });
+  manager.toolRegistry.set('assistant_summon', {
+    skillId: 'fake-skill',
+    skillName: 'Fake Skill',
+    toolName: 'assistant_summon',
+    scriptPath: 'index.js',
+  });
+  manager.skillLoader.executeSkillTool = async (skillId, toolName, params, context, scriptPath) => {
+    calls.push({ route: 'skill', skillId, toolName, params, context, scriptPath });
+    return { fallback: true };
+  };
+
+  const result = await manager.executeTool(
+    'assistant_summon',
+    { assistant_id: 'helper-1' },
+    { taskContext: { absolute_workspace_path: 'D:/work/task' } }
+  );
+
+  assert.equal(result.success, true);
+  assert.deepEqual(result.data, { fallback: true });
+  assert.deepEqual(calls.map(call => call.route), ['skill']);
+  assert.deepEqual(logs, [{
+    display: 'Fake Skill/assistant_summon',
+    toolId: 'assistant_summon',
+    params: { assistant_id: 'helper-1' },
+  }]);
+}
+
 async function testResidentDispatchesBeforeSkillRunner() {
   const manager = createManager();
+  const logs = captureExecutionLogs(manager);
   const calls = [];
 
   manager.toolRegistry.set('ssh__exec', {
@@ -139,10 +230,17 @@ async function testResidentDispatchesBeforeSkillRunner() {
   assert.equal(calls[0].scriptPath, 'resident://exec');
   assert.equal(calls[0].skillId, 'ssh');
   assert.equal(calls[0].toolId, 'ssh__exec');
+  assert.equal(calls[0].display, 'SSH/exec');
+  assert.deepEqual(logs, [{
+    display: 'SSH/exec',
+    toolId: 'ssh__exec',
+    params: { command: 'uptime' },
+  }]);
 }
 
 async function testNormalSkillDispatchesToSkillRunner() {
   const manager = createManager();
+  const logs = captureExecutionLogs(manager);
   const calls = [];
 
   manager.skills.set('searxng', { id: 'searxng', name: 'SearXNG' });
@@ -184,10 +282,16 @@ async function testNormalSkillDispatchesToSkillRunner() {
   assert.equal(calls[0].context.isAdmin, true);
   assert.equal(calls[0].context.isSkillCreator, true);
   assert.equal(calls[0].scriptPath, 'index.js');
+  assert.deepEqual(logs, [{
+    display: 'SearXNG/search',
+    toolId: 'searxng__search',
+    params: { query: 'tool dispatch' },
+  }]);
 }
 
 async function testMissingToolReturnsHonestError() {
   const manager = createManager();
+  const logs = captureExecutionLogs(manager);
 
   const result = await manager.executeTool('missing_tool', {}, {});
 
@@ -195,12 +299,19 @@ async function testMissingToolReturnsHonestError() {
     success: false,
     error: 'Tool not found: missing_tool',
   });
+  assert.deepEqual(logs, [{
+    display: 'missing_tool',
+    toolId: 'missing_tool',
+    params: {},
+  }]);
 }
 
 async function main() {
   await testBuiltinWinsOverRegistry();
   await testMcpWinsOverRegistry();
+  await testDocumentRetrievalUsesBuiltinNamespaceDisplay();
   await testAssistantWinsOverRegistry();
+  await testAssistantFallsBackToRegistryWhenManagerUnavailable();
   await testResidentDispatchesBeforeSkillRunner();
   await testNormalSkillDispatchesToSkillRunner();
   await testMissingToolReturnsHonestError();


### PR DESCRIPTION
## Summary

- Make `ToolManager.executeTool()` compute display/log metadata after route selection.
- Prevent builtin / document_retrieval / assistant tool logs from being polluted by same-name registry entries.
- Keep assistant fallback-to-registry behavior when AssistantManager is unavailable.
- Extend ToolManager dispatch tests to cover route-aware display behavior.

## Verification

- `node tests/test-tool-manager-dispatch.mjs`
- `node tests/test-skill-directory-scan.mjs`
- `node tests/test-skill-parameters-schema-quality.mjs`
- `node -e "import('./lib/tool-manager.js').then(m => console.log('ToolManager exports:', Object.keys(m)))"`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No DB changes.
- No external MCP/LLM calls.
- Local task trace: `docs/tasks/active/refactor-260728-01-skill-system-governance/round11-tool-display-precision.md` (kept local per project rules).
