### PR TITLE
refactor: preserve flexible skill parameter schemas

### DIFF
--- a/lib/skill-loader.js
+++ b/lib/skill-loader.js
@@ -256,7 +256,7 @@ class SkillLoader {
    * - 根节点固定为 object schema
    * - properties 必须是对象
    * - required 必须是已存在属性名数组
-   * - 属性 schema 至少要是对象并带合法 type；清理导入器遗留的 property-level required
+   * - 属性 schema 必须是对象；清理 property-level required；仅修正明确非法的 type
    *
    * @param {object} schema - 原始 parameters schema
    * @param {string} toolId - 日志上下文中的工具 ID
@@ -304,6 +304,10 @@ class SkillLoader {
 
     delete schema.required;
 
+    if (schema.type === undefined) {
+      return schema;
+    }
+
     if (Array.isArray(schema.type)) {
       schema.type = schema.type.filter(type => allowedTypes.has(type));
       if (schema.type.length === 0) {
@@ -311,10 +315,6 @@ class SkillLoader {
       }
     } else if (!allowedTypes.has(schema.type)) {
       schema.type = 'string';
-    }
-
-    if (schema.type === 'array' && (!schema.items || typeof schema.items !== 'object' || Array.isArray(schema.items))) {
-      schema.items = { type: 'string' };
     }
 
     if (schema.type === 'object' && schema.properties && (typeof schema.properties !== 'object' || Array.isArray(schema.properties))) {

--- a/tests/test-skill-directory-scan.mjs
+++ b/tests/test-skill-directory-scan.mjs
@@ -73,19 +73,37 @@ function testParameterSchemaNormalization() {
         tags: {
           type: 'array',
         },
+        body: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'object' },
+          ],
+          description: 'Flexible request body',
+        },
+        data: {
+          description: 'Flexible chart data',
+        },
       },
-      required: ['query', 'missing'],
+      required: ['query', 'body', 'data', 'missing'],
     }),
   }, skill);
 
   const schema = tool.function.parameters;
 
   assert.equal(schema.type, 'object');
-  assert.deepEqual(schema.required, ['query']);
+  assert.deepEqual(schema.required, ['query', 'body', 'data']);
   assert.equal(schema.properties.query.type, 'string');
   assert.equal(schema.properties.query.required, undefined);
   assert.equal(schema.properties.count.type, 'string');
-  assert.deepEqual(schema.properties.tags.items, { type: 'string' });
+  assert.equal(schema.properties.tags.type, 'array');
+  assert.equal(schema.properties.tags.items, undefined);
+  assert.deepEqual(schema.properties.body.oneOf, [
+    { type: 'string' },
+    { type: 'object' },
+  ]);
+  assert.equal(schema.properties.body.type, undefined);
+  assert.equal(schema.properties.data.description, 'Flexible chart data');
+  assert.equal(schema.properties.data.type, undefined);
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- Make skill parameter schema normalization conservative so it does not narrow flexible tool inputs.
- Preserve typeless property schemas and `oneOf`/flexible schemas instead of forcing `type: string`.
- Stop inventing `items: { type: "string" }` for arrays without explicit item schemas.
- Extend schema normalization tests for flexible request/chart data.

## Verification

- `node tests/test-skill-directory-scan.mjs`
- `node tests/test-skill-parameters-schema-quality.mjs`
- read-only seed diff audit: `{ "count": 0, "names": [] }`
- `node -e "import('./lib/skill-loader.js').then(m => console.log('SkillLoader exports:', Object.keys(m)))"`
- `node tests/test-tool-manager-dispatch.mjs`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No DB changes.
- No seed data rewrite is needed after this conservative normalization fix.
- Local task trace: `docs/tasks/active/refactor-260728-01-skill-system-governance/round12-preserve-flexible-schemas.md` (kept local per project rules).
