### PR TITLE
test: cover skill runtime contracts

### DIFF
--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -1098,7 +1098,10 @@ class ToolManager {
       const assistantManager = getAssistantManager(this.db);
       if (assistantManager) {
         const assistantTools = assistantManager.getAssistantTools();
-        definitions.push(...assistantTools);
+        for (const tool of assistantTools) {
+          const { _meta, ...llmTool } = tool;
+          definitions.push(llmTool);
+        }
       }
     } catch (err) {
       logger.warn('[ToolManager] 获取助理工具失败:', err.message);

--- a/tests/test-skill-environment-contract.mjs
+++ b/tests/test-skill-environment-contract.mjs
@@ -1,0 +1,182 @@
+/**
+ * Contract tests for SkillLoader.buildSkillEnvironment().
+ *
+ * These tests define the Loader -> Runner environment boundary without
+ * invoking external tools, databases, or live skill execution.
+ *
+ * Usage:
+ *   node tests/test-skill-environment-contract.mjs
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import SkillLoader from '../lib/skill-loader.js';
+
+function snapshotEnv(keys) {
+  return Object.fromEntries(keys.map(key => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot) {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function withTempRuntimeEnv(callback) {
+  const envKeys = ['DATA_BASE_PATH', 'SKILLS_BASE_PATH', 'FONTS_BASE_PATH', 'API_BASE'];
+  const snapshot = snapshotEnv(envKeys);
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-env-contract-'));
+
+  process.env.DATA_BASE_PATH = path.join(tempRoot, 'data');
+  process.env.SKILLS_BASE_PATH = path.join(tempRoot, 'skills');
+  process.env.FONTS_BASE_PATH = path.join(tempRoot, 'fonts');
+  process.env.API_BASE = 'http://127.0.0.1:3017';
+
+  try {
+    fs.mkdirSync(process.env.DATA_BASE_PATH, { recursive: true });
+    fs.mkdirSync(process.env.SKILLS_BASE_PATH, { recursive: true });
+    fs.mkdirSync(process.env.FONTS_BASE_PATH, { recursive: true });
+    return callback(tempRoot);
+  } finally {
+    restoreEnv(snapshot);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function testBuildsCompleteSkillRuntimeEnv() {
+  withTempRuntimeEnv((tempRoot) => {
+    const loader = new SkillLoader({});
+    const workingDirectory = path.join(tempRoot, 'work', 'user-1', 'task-1');
+    const env = loader.buildSkillEnvironment(
+      'demo-skill',
+      {
+        url: 'https://example.test',
+        retry_count: 3,
+        user_access_token: 'must-not-shadow-user-token',
+      },
+      'demo-skill',
+      'index.js',
+      {
+        userId: 'user-1',
+        expertId: 'expert-1',
+        accessToken: 'token-1',
+        workingDirectory,
+        isAdmin: true,
+        isSkillCreator: true,
+      },
+      {
+        allowed_node_modules: ['fs', 'path'],
+        allowed_python_packages: ['pypdf'],
+      },
+      {
+        vm_execution: 12,
+        python_execution: 240,
+      }
+    );
+
+    assert.equal(env.SKILL_ID, 'demo-skill');
+    assert.equal(env.SKILL_PATH, path.join(process.env.SKILLS_BASE_PATH, 'demo-skill'));
+    assert.equal(env.SCRIPT_PATH, 'index.js');
+    assert.equal(env.DATA_BASE_PATH, process.env.DATA_BASE_PATH);
+    assert.equal(env.SKILLS_BASE_PATH, process.env.SKILLS_BASE_PATH);
+    assert.equal(env.FONTS_BASE_PATH, process.env.FONTS_BASE_PATH);
+    assert.equal(env.SKILL_CONFIG, JSON.stringify({
+      url: 'https://example.test',
+      retry_count: 3,
+      user_access_token: 'must-not-shadow-user-token',
+    }));
+
+    assert.equal(env.USER_ACCESS_TOKEN, 'token-1');
+    assert.equal(env.USER_ID, 'user-1');
+    assert.equal(env.EXPERT_ID, 'expert-1');
+    assert.equal(env.IS_ADMIN, 'true');
+    assert.equal(env.IS_SKILL_CREATOR, 'true');
+    assert.equal(env.API_BASE, 'http://127.0.0.1:3017');
+    assert.equal(env.WORKING_DIRECTORY, workingDirectory);
+    assert.equal(env.PROJECT_ROOT, process.cwd());
+    assert.equal(env.NODE_OPTIONS, '--max-old-space-size=128');
+
+    assert.deepEqual(JSON.parse(env.ALLOWED_NODE_MODULES), ['fs', 'path']);
+    assert.deepEqual(JSON.parse(env.ALLOWED_PYTHON_PACKAGES), ['pypdf']);
+    assert.equal(env.VM_TIMEOUT, '12000');
+    assert.equal(env.PYTHON_TIMEOUT, '240000');
+
+    assert.equal(env.SKILL_URL, 'https://example.test');
+    assert.equal(env.SKILL_RETRY_COUNT, '3');
+    assert.equal(env.SKILL_USER_ACCESS_TOKEN, 'must-not-shadow-user-token');
+    assert.equal(env.INTERNAL_API_SECRET, undefined, 'internal secrets must not be inherited from system env by default');
+  });
+}
+
+function testRejectsRelativeWorkingDirectory() {
+  withTempRuntimeEnv(() => {
+    const loader = new SkillLoader({});
+
+    assert.throws(
+      () => loader.buildSkillEnvironment(
+        'demo-skill',
+        {},
+        'demo-skill',
+        'index.js',
+        {
+          userId: 'user-1',
+          workingDirectory: 'relative/path',
+        }
+      ),
+      /工作目录必须是绝对路径/
+    );
+  });
+}
+
+function testRequiresSourcePath() {
+  withTempRuntimeEnv(() => {
+    const loader = new SkillLoader({});
+
+    assert.throws(
+      () => loader.buildSkillEnvironment('demo-skill', {}, null),
+      /has no source_path configured/
+    );
+  });
+}
+
+function testOptionalContractFieldsStayAbsentWhenNotConfigured() {
+  withTempRuntimeEnv(() => {
+    const loader = new SkillLoader({});
+    const env = loader.buildSkillEnvironment(
+      'demo-skill',
+      {},
+      'demo-skill',
+      'index.js',
+      {
+        userId: 'user-1',
+      }
+    );
+
+    assert.equal(env.WORKING_DIRECTORY, '');
+    assert.equal(env.USER_ACCESS_TOKEN, '');
+    assert.equal(env.EXPERT_ID, '');
+    assert.equal(env.IS_ADMIN, 'false');
+    assert.equal(env.IS_SKILL_CREATOR, 'false');
+    assert.equal(env.ALLOWED_NODE_MODULES, undefined);
+    assert.equal(env.ALLOWED_PYTHON_PACKAGES, undefined);
+    assert.equal(env.VM_TIMEOUT, undefined);
+    assert.equal(env.PYTHON_TIMEOUT, undefined);
+  });
+}
+
+function main() {
+  testBuildsCompleteSkillRuntimeEnv();
+  testRejectsRelativeWorkingDirectory();
+  testRequiresSourcePath();
+  testOptionalContractFieldsStayAbsentWhenNotConfigured();
+
+  console.log('SkillLoader buildSkillEnvironment contract tests passed.');
+}
+
+main();

--- a/tests/test-tool-definitions-contract.mjs
+++ b/tests/test-tool-definitions-contract.mjs
@@ -1,0 +1,178 @@
+/**
+ * Contract tests for ToolManager.getToolDefinitions().
+ *
+ * These tests protect the final LLM-visible tool definition shape. Execution
+ * metadata such as _meta may exist internally, but must not leak into the
+ * definitions sent to the model.
+ *
+ * Usage:
+ *   node tests/test-tool-definitions-contract.mjs
+ */
+
+import assert from 'node:assert/strict';
+import ToolManager from '../lib/tool-manager.js';
+import { setAssistantManager } from '../server/services/assistant/index.js';
+
+function createManager() {
+  return new ToolManager(null, 'expert-tool-definitions-test');
+}
+
+function assertNoMetaFields(value, path = 'tool') {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  assert.equal(value._meta, undefined, `${path} must not expose _meta`);
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoMetaFields(item, `${path}[${index}]`));
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    assertNoMetaFields(child, `${path}.${key}`);
+  }
+}
+
+function findTool(tools, name) {
+  return tools.find(tool => (tool.function?.name || tool.name) === name);
+}
+
+async function testFinalDefinitionsStripInternalMeta() {
+  const manager = createManager();
+  const mcpCalls = [];
+
+  manager.skills.set('demo-skill', {
+    id: 'demo-skill',
+    name: 'Demo Skill',
+  });
+
+  manager.skillLoader.getToolDefinitions = (skill) => {
+    assert.equal(skill.id, 'demo-skill');
+    return [
+      {
+        type: 'function',
+        function: {
+          name: 'demo__search',
+          description: 'Demo search tool',
+          parameters: {
+            type: 'object',
+            properties: {
+              q: { type: 'string' },
+            },
+            required: ['q'],
+          },
+        },
+        _meta: {
+          skillId: 'demo-skill',
+          toolName: 'search',
+        },
+      },
+    ];
+  };
+
+  setAssistantManager({
+    getAssistantTools: () => [
+      {
+        type: 'function',
+        function: {
+          name: 'assistant_summon',
+          description: 'Summon an assistant',
+          parameters: {
+            type: 'object',
+            properties: {
+              assistant_id: { type: 'string' },
+              input: { type: 'object' },
+            },
+            required: ['assistant_id', 'input'],
+          },
+        },
+        _meta: {
+          assistant: true,
+        },
+      },
+    ],
+  });
+
+  global.residentSkillManager = {
+    invokeByName: async (skillId, toolName, params, context, timeoutMs) => {
+      mcpCalls.push({ skillId, toolName, params, context, timeoutMs });
+      return {
+        tools: [
+          {
+            name: 'mcp_demo_lookup',
+            server_name: 'demo',
+            original_name: 'lookup',
+            description: 'Lookup demo data',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+          },
+        ],
+      };
+    },
+  };
+
+  try {
+    const tools = await manager.getToolDefinitions({ userId: 'user-1' });
+    const toolNames = tools.map(tool => tool.function?.name || tool.name);
+
+    assert.ok(toolNames.includes('execute'), 'builtin tools should be included');
+    assert.ok(toolNames.includes('demo__search'), 'skill tools should be included');
+    assert.ok(toolNames.includes('assistant_summon'), 'assistant tools should be included');
+    assert.ok(toolNames.includes('mcp_demo_lookup'), 'MCP tools should be included');
+
+    for (const tool of tools) {
+      assertNoMetaFields(tool, tool.function?.name || tool.name || 'tool');
+    }
+
+    assert.equal(findTool(tools, 'demo__search').function.parameters.required[0], 'q');
+    assert.equal(findTool(tools, 'mcp_demo_lookup').function.description, '[MCP/demo] Lookup demo data');
+    assert.deepEqual(mcpCalls, [
+      {
+        skillId: 'mcp-client',
+        toolName: 'invoke',
+        params: { action: 'list_tools' },
+        context: { userId: 'user-1' },
+        timeoutMs: 30000,
+      },
+    ]);
+  } finally {
+    setAssistantManager(null);
+    delete global.residentSkillManager;
+  }
+}
+
+async function testUnavailableOptionalSourcesDoNotBreakDefinitions() {
+  const manager = createManager();
+
+  setAssistantManager(null);
+  delete global.residentSkillManager;
+
+  const tools = await manager.getToolDefinitions({});
+  const toolNames = tools.map(tool => tool.function?.name || tool.name);
+
+  assert.ok(toolNames.includes('execute'), 'builtin tools should still be available');
+  assert.equal(findTool(tools, 'assistant_summon'), undefined);
+  assert.equal(findTool(tools, 'mcp_demo_lookup'), undefined);
+  for (const tool of tools) {
+    assertNoMetaFields(tool, tool.function?.name || tool.name || 'tool');
+  }
+}
+
+async function main() {
+  await testFinalDefinitionsStripInternalMeta();
+  await testUnavailableOptionalSourcesDoNotBreakDefinitions();
+
+  console.log('ToolManager getToolDefinitions contract tests passed.');
+}
+
+main().catch(error => {
+  setAssistantManager(null);
+  delete global.residentSkillManager;
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add contract coverage for `ToolManager.getToolDefinitions()` final LLM-visible tool definitions.
- Add contract coverage for `SkillLoader.buildSkillEnvironment()` Loader -> Runner environment variables.
- Strip `_meta` from assistant tool definitions in `ToolManager.getToolDefinitions()` to keep all tool sources consistent.

## Validation

- `node tests\test-tool-definitions-contract.mjs`
- `node tests\test-skill-environment-contract.mjs`
- `node tests\test-tool-manager-dispatch.mjs`
- `node tests\test-skill-parameters-schema-quality.mjs`
- `node tests\test-skill-directory-scan.mjs`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No database schema changes.
- No external API contract changes.
- `docs/tasks` notes remain local and are not included in this PR.
