### PR TITLE
refactor: extract tool call presenter

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -53,6 +53,7 @@ import { TopicLifecycleManager } from './topic/topic-lifecycle-manager.js';
 import logger from './logger.js';
 import { isRetryableError } from './llm-retry.js';
 import { resolveThinkingRequestConfig } from './llm-thinking-config.js';
+import { getToolCallDisplayNames, presentToolCalls, toToolCallArray } from './tool-call-presenter.js';
 import Utils from './utils.js';
 import path from 'path';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
@@ -346,23 +347,13 @@ class ChatService {
               onDelta?.({ type: 'reasoning_delta', content: reasoningDelta });
             },
             onToolCall: (toolCalls) => {
-              const toolCallsForLog = Array.isArray(toolCalls) ? toolCalls : [toolCalls];
-              const displayNames = toolCallsForLog.map(call => {
-                const toolId = call.function?.name || call.name;
-                return expertService.toolManager.formatToolDisplay(toolId);
-              });
+              const toolCallsForLog = toToolCallArray(toolCalls);
+              const displayNames = getToolCallDisplayNames(toolCallsForLog, expertService.toolManager);
               logger.info(`[ChatService] 第${round + 1}轮收到工具调用:`, displayNames);
 
-              if (Array.isArray(toolCalls)) {
-                collectedToolCalls.push(...toolCalls);
-              } else {
-                collectedToolCalls.push(toolCalls);
-              }
+              collectedToolCalls.push(...toolCallsForLog);
 
-              const toolCallsWithDisplayNames = toolCallsForLog.map(call => {
-                const toolId = call.function?.name || call.name;
-                return { ...call, displayName: expertService.toolManager.formatToolDisplay(toolId) };
-              });
+              const toolCallsWithDisplayNames = presentToolCalls(toolCallsForLog, expertService.toolManager);
               onDelta?.({ type: 'tool_call', toolCalls: toolCallsWithDisplayNames });
             },
             onUsage: (usage) => {

--- a/lib/tool-call-presenter.js
+++ b/lib/tool-call-presenter.js
@@ -1,0 +1,43 @@
+/**
+ * Tool call presentation helpers.
+ *
+ * These helpers only shape tool call data for logs/UI events. They do not
+ * execute tools, filter permissions, or serialize tool results for LLM input.
+ */
+
+export function toToolCallArray(toolCalls) {
+  if (!toolCalls) {
+    return [];
+  }
+  return Array.isArray(toolCalls) ? toolCalls : [toolCalls];
+}
+
+export function getToolCallId(toolCall) {
+  return toolCall?.function?.name || toolCall?.name || null;
+}
+
+export function formatToolCallDisplayName(toolCall, toolManager) {
+  const toolId = getToolCallId(toolCall);
+  if (!toolId) {
+    return '';
+  }
+
+  if (toolManager && typeof toolManager.formatToolDisplay === 'function') {
+    return toolManager.formatToolDisplay(toolId);
+  }
+
+  return toolId;
+}
+
+export function presentToolCalls(toolCalls, toolManager) {
+  return toToolCallArray(toolCalls).map(toolCall => ({
+    ...toolCall,
+    displayName: formatToolCallDisplayName(toolCall, toolManager),
+  }));
+}
+
+export function getToolCallDisplayNames(toolCalls, toolManager) {
+  return toToolCallArray(toolCalls).map(toolCall =>
+    formatToolCallDisplayName(toolCall, toolManager)
+  );
+}

--- a/server/services/assistant/expert-notifier.js
+++ b/server/services/assistant/expert-notifier.js
@@ -11,6 +11,7 @@ import logger from '../../../lib/logger.js';
 import Utils from '../../../lib/utils.js';
 import { executeStreamWithToolLoop } from '../../../lib/tool-calling-executor.js';
 import { formatWorkspaceDisplayFromTask } from '../../../lib/paths.js';
+import { presentToolCalls } from '../../../lib/tool-call-presenter.js';
 
 // 记录已发送的通知，避免重复
 const notifiedRequests = new Set();
@@ -609,13 +610,7 @@ export async function triggerExpertResponse(db, chatService, expertConnections, 
         // 工具调用回调：发送 SSE tool_call 事件
         onToolCall: (toolCalls) => {
           if (!userConnection.res.writableEnded) {
-            const toolCallsWithDisplayNames = (Array.isArray(toolCalls) ? toolCalls : [toolCalls]).map(call => {
-              const toolId = call.function?.name || call.name;
-              return {
-                ...call,
-                displayName: expertService.toolManager.formatToolDisplay(toolId),
-              };
-            });
+            const toolCallsWithDisplayNames = presentToolCalls(toolCalls, expertService.toolManager);
             userConnection.res.write(`event: tool_call\n`);
             userConnection.res.write(`data: ${JSON.stringify({ type: 'tool_call', toolCalls: toolCallsWithDisplayNames })}\n\n`);
           }

--- a/tests/test-tool-call-presenter.mjs
+++ b/tests/test-tool-call-presenter.mjs
@@ -1,0 +1,87 @@
+/**
+ * Tests for tool call presentation helpers.
+ *
+ * Usage:
+ *   node tests/test-tool-call-presenter.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  formatToolCallDisplayName,
+  getToolCallDisplayNames,
+  getToolCallId,
+  presentToolCalls,
+  toToolCallArray,
+} from '../lib/tool-call-presenter.js';
+
+const toolManager = {
+  formatToolDisplay(toolId) {
+    return `display/${toolId}`;
+  },
+};
+
+function testNormalizeToolCalls() {
+  assert.deepEqual(toToolCallArray(null), []);
+  assert.deepEqual(toToolCallArray(undefined), []);
+
+  const call = { function: { name: 'demo_tool' } };
+  assert.deepEqual(toToolCallArray(call), [call]);
+  assert.deepEqual(toToolCallArray([call]), [call]);
+}
+
+function testToolCallId() {
+  assert.equal(getToolCallId({ function: { name: 'fn_name' } }), 'fn_name');
+  assert.equal(getToolCallId({ name: 'plain_name' }), 'plain_name');
+  assert.equal(getToolCallId({}), null);
+}
+
+function testDisplayNameFormatting() {
+  assert.equal(
+    formatToolCallDisplayName({ function: { name: 'skill__search' } }, toolManager),
+    'display/skill__search'
+  );
+  assert.equal(
+    formatToolCallDisplayName({ name: 'plain_tool' }, null),
+    'plain_tool'
+  );
+  assert.equal(formatToolCallDisplayName({}, toolManager), '');
+}
+
+function testPresentToolCalls() {
+  const original = {
+    id: 'call_1',
+    function: {
+      name: 'demo_tool',
+      arguments: '{"q":"hello"}',
+    },
+  };
+
+  const presented = presentToolCalls(original, toolManager);
+
+  assert.equal(presented.length, 1);
+  assert.equal(presented[0].id, 'call_1');
+  assert.equal(presented[0].function.name, 'demo_tool');
+  assert.equal(presented[0].displayName, 'display/demo_tool');
+  assert.equal(original.displayName, undefined, 'presenter must not mutate original tool call');
+}
+
+function testDisplayNames() {
+  const names = getToolCallDisplayNames([
+    { function: { name: 'first' } },
+    { name: 'second' },
+  ], toolManager);
+
+  assert.deepEqual(names, ['display/first', 'display/second']);
+}
+
+function main() {
+  testNormalizeToolCalls();
+  testToolCallId();
+  testDisplayNameFormatting();
+  testPresentToolCalls();
+  testDisplayNames();
+
+  console.log('Tool call presenter tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `lib/tool-call-presenter.js` for LLM tool call display shaping.
- Reuse the presenter in `ChatService` and `expert-notifier`.
- Add focused presenter unit coverage.

## Validation

- `node tests\test-tool-call-presenter.mjs`
- `node -e "import('./lib/chat-service.js').then(() => console.log('chat-service import ok'))"`
- `node -e "import('./server/services/assistant/expert-notifier.js').then(() => console.log('expert-notifier import ok'))"`
- `node tests\test-tool-definitions-contract.mjs`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No tool execution behavior changes.
- No API/event shape changes.
- No database schema changes.
- `docs/tasks` notes remain local and are not included in this PR.
