### PR TITLE
refactor: extract token usage accumulator

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -54,6 +54,7 @@ import logger from './logger.js';
 import { isRetryableError } from './llm-retry.js';
 import { resolveThinkingRequestConfig } from './llm-thinking-config.js';
 import { getToolCallDisplayNames, presentToolCalls, toToolCallArray } from './tool-call-presenter.js';
+import { addTokenUsage, snapshotTokenUsage } from './token-usage-accumulator.js';
 import Utils from './utils.js';
 import path from 'path';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
@@ -306,7 +307,7 @@ class ChatService {
           : JSON.parse(JSON.stringify(messages)),
         fullContent,
         fullReasoningContent,
-        tokenUsage: tokenUsage ? { ...tokenUsage } : null,
+        tokenUsage: snapshotTokenUsage(tokenUsage),
       };
 
       // 同步 request runtime 观测字段（统一状态真相源由 StreamController 持有）
@@ -358,12 +359,7 @@ class ChatService {
             },
             onUsage: (usage) => {
               if (usage) {
-                if (!tokenUsage) {
-                  tokenUsage = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
-                }
-                tokenUsage.prompt_tokens += usage.prompt_tokens || 0;
-                tokenUsage.completion_tokens += usage.completion_tokens || 0;
-                tokenUsage.total_tokens += usage.total_tokens || 0;
+                tokenUsage = addTokenUsage(tokenUsage, usage);
                 logger.info(`[ChatService] 第${round + 1}轮 token 使用:`, {
                   prompt: usage.prompt_tokens,
                   completion: usage.completion_tokens,
@@ -393,7 +389,7 @@ class ChatService {
 
           fullContent = roundSnapshot.fullContent;
           fullReasoningContent = roundSnapshot.fullReasoningContent;
-          tokenUsage = roundSnapshot.tokenUsage ? { ...roundSnapshot.tokenUsage } : null;
+          tokenUsage = snapshotTokenUsage(roundSnapshot.tokenUsage);
           collectedToolCalls = [];
           roundContent = '';
           messages = typeof structuredClone === 'function'

--- a/lib/token-usage-accumulator.js
+++ b/lib/token-usage-accumulator.js
@@ -1,0 +1,45 @@
+/**
+ * Token usage accumulator helpers.
+ *
+ * Keeps streaming LLM usage accounting out of orchestration code. The helper
+ * preserves the existing contract: usage stays null until a usage event exists.
+ */
+
+export function createEmptyTokenUsage() {
+  return {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
+}
+
+export function normalizeTokenUsage(usage) {
+  if (!usage) {
+    return null;
+  }
+
+  return {
+    prompt_tokens: Number(usage.prompt_tokens) || 0,
+    completion_tokens: Number(usage.completion_tokens) || 0,
+    total_tokens: Number(usage.total_tokens) || 0,
+  };
+}
+
+export function snapshotTokenUsage(usage) {
+  return normalizeTokenUsage(usage);
+}
+
+export function addTokenUsage(currentUsage, usage) {
+  if (!usage) {
+    return snapshotTokenUsage(currentUsage);
+  }
+
+  const current = snapshotTokenUsage(currentUsage) || createEmptyTokenUsage();
+  const incoming = normalizeTokenUsage(usage) || createEmptyTokenUsage();
+
+  return {
+    prompt_tokens: current.prompt_tokens + incoming.prompt_tokens,
+    completion_tokens: current.completion_tokens + incoming.completion_tokens,
+    total_tokens: current.total_tokens + incoming.total_tokens,
+  };
+}

--- a/tests/test-token-usage-accumulator.mjs
+++ b/tests/test-token-usage-accumulator.mjs
@@ -1,0 +1,133 @@
+/**
+ * Tests for token usage accumulator helpers.
+ *
+ * Usage:
+ *   node tests/test-token-usage-accumulator.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  addTokenUsage,
+  createEmptyTokenUsage,
+  normalizeTokenUsage,
+  snapshotTokenUsage,
+} from '../lib/token-usage-accumulator.js';
+
+function testCreateEmptyTokenUsage() {
+  const first = createEmptyTokenUsage();
+  const second = createEmptyTokenUsage();
+
+  assert.deepEqual(first, {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  });
+  assert.notEqual(first, second, 'empty usage factory must return a fresh object');
+}
+
+function testNormalizeTokenUsage() {
+  assert.equal(normalizeTokenUsage(null), null);
+  assert.equal(normalizeTokenUsage(undefined), null);
+
+  assert.deepEqual(normalizeTokenUsage({ prompt_tokens: 3 }), {
+    prompt_tokens: 3,
+    completion_tokens: 0,
+    total_tokens: 0,
+  });
+
+  assert.deepEqual(normalizeTokenUsage({
+    prompt_tokens: '4',
+    completion_tokens: '5',
+    total_tokens: '9',
+  }), {
+    prompt_tokens: 4,
+    completion_tokens: 5,
+    total_tokens: 9,
+  });
+}
+
+function testSnapshotTokenUsage() {
+  const usage = {
+    prompt_tokens: 1,
+    completion_tokens: 2,
+    total_tokens: 3,
+  };
+  const snapshot = snapshotTokenUsage(usage);
+
+  assert.deepEqual(snapshot, usage);
+  assert.notEqual(snapshot, usage, 'snapshot must not reuse the original object');
+  assert.equal(snapshotTokenUsage(null), null);
+}
+
+function testAddTokenUsage() {
+  assert.equal(addTokenUsage(null, null), null);
+
+  assert.deepEqual(addTokenUsage(null, {}), {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  });
+
+  assert.deepEqual(addTokenUsage(null, {
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+  }), {
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+  });
+
+  assert.deepEqual(addTokenUsage({
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+  }, {
+    prompt_tokens: 3,
+    completion_tokens: 7,
+    total_tokens: 10,
+  }), {
+    prompt_tokens: 13,
+    completion_tokens: 11,
+    total_tokens: 24,
+  });
+}
+
+function testAddTokenUsageDoesNotMutateInputs() {
+  const current = {
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+  };
+  const incoming = {
+    prompt_tokens: 3,
+    completion_tokens: 7,
+    total_tokens: 10,
+  };
+
+  const result = addTokenUsage(current, incoming);
+
+  assert.notEqual(result, current);
+  assert.deepEqual(current, {
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+  });
+  assert.deepEqual(incoming, {
+    prompt_tokens: 3,
+    completion_tokens: 7,
+    total_tokens: 10,
+  });
+}
+
+function main() {
+  testCreateEmptyTokenUsage();
+  testNormalizeTokenUsage();
+  testSnapshotTokenUsage();
+  testAddTokenUsage();
+  testAddTokenUsageDoesNotMutateInputs();
+
+  console.log('Token usage accumulator tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Extract token usage initialization, accumulation, and snapshot copying into `lib/token-usage-accumulator.js`
- Use the helper from `ChatService._executeLLMRounds()`
- Add focused contract tests for null-before-first-usage behavior, accumulation, normalization, snapshots, and immutability

## Validation

- `node tests\test-token-usage-accumulator.mjs`
- `node -e "import('./lib/chat-service.js').then(() => console.log('chat-service import ok'))"`
- `node tests\test-tool-call-presenter.mjs`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No API contract changes
- No database changes
- `docs/tasks` notes are local-only and not included in this PR
