### PR TITLE
refactor: extract tool call snapshot builder

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -54,6 +54,7 @@ import logger from './logger.js';
 import { isRetryableError } from './llm-retry.js';
 import { resolveThinkingRequestConfig } from './llm-thinking-config.js';
 import { getToolCallDisplayNames, presentToolCalls, toToolCallArray } from './tool-call-presenter.js';
+import { buildToolCallSnapshot } from './tool-call-snapshot-builder.js';
 import { addTokenUsage, snapshotTokenUsage } from './token-usage-accumulator.js';
 import Utils from './utils.js';
 import path from 'path';
@@ -570,48 +571,6 @@ class ChatService {
   }
 
   /**
-   * 构建 assistant 完成态使用的工具调用快照
-   * 返回前端可直接渲染的摘要结构，而不是完整工具结果真相源。
-   * 完整结果仍以独立 tool message 为准。
-   * @param {Array} toolCallsWithResults - 工具调用及结果数组
-   * @returns {Array}
-   */
-  buildToolCallSnapshot(toolCallsWithResults = []) {
-    if (!Array.isArray(toolCallsWithResults) || toolCallsWithResults.length === 0) {
-      return [];
-    }
-
-    return toolCallsWithResults.map(call => {
-      const rawResult = call.result?.data;
-      let resultPreview = null;
-
-      if (typeof rawResult === 'string') {
-        resultPreview = rawResult.slice(0, 200);
-      } else if (rawResult !== undefined) {
-        try {
-          resultPreview = JSON.stringify(rawResult).slice(0, 200);
-        } catch (error) {
-          resultPreview = '[unserializable result]';
-        }
-      } else if (call.result?.error) {
-        resultPreview = String(call.result.error).slice(0, 200);
-      }
-
-      return {
-        tool_call_id: call.id || call.tool_call_id || null,
-        name: call.function?.name || call.name || 'unknown',
-        display_name: call.displayName || call.function?.name || call.name || 'unknown',
-        arguments: call.function?.arguments || call.arguments || null,
-        success: call.result?.success !== false,
-        duration: call.duration || 0,
-        result_preview: resultPreview,
-        tool_message_id: call.tool_message_id || null,
-        timestamp: call.timestamp || new Date().toISOString(),
-      };
-    });
-  }
-
-  /**
    * 执行工具调用（私有方法）
    * @returns {Promise<Array>} 工具执行结果数组
    */
@@ -815,7 +774,7 @@ class ChatService {
       expertService.processHistoryIfNeeded(user_id, topic_id).catch(err => logger.error('[ChatService] 历史归档失败:', err.message));
       await this.updateTopicTimestamp(topic_id);
 
-      const toolCallSnapshot = this.buildToolCallSnapshot(llmResult.allToolCalls || []);
+      const toolCallSnapshot = buildToolCallSnapshot(llmResult.allToolCalls || []);
 
       // 12. 发送完成事件
       onComplete?.({

--- a/lib/tool-call-snapshot-builder.js
+++ b/lib/tool-call-snapshot-builder.js
@@ -1,0 +1,47 @@
+/**
+ * Tool call snapshot builder.
+ *
+ * Produces the assistant-message-facing summary of tool calls. The full tool
+ * result remains stored in separate tool messages; this module only prepares
+ * a compact renderable snapshot for completion payloads.
+ */
+
+export function buildResultPreview(result) {
+  const rawResult = result?.data;
+
+  if (typeof rawResult === 'string') {
+    return rawResult.slice(0, 200);
+  }
+
+  if (rawResult !== undefined) {
+    try {
+      return JSON.stringify(rawResult).slice(0, 200);
+    } catch (error) {
+      return '[unserializable result]';
+    }
+  }
+
+  if (result?.error) {
+    return String(result.error).slice(0, 200);
+  }
+
+  return null;
+}
+
+export function buildToolCallSnapshot(toolCallsWithResults = []) {
+  if (!Array.isArray(toolCallsWithResults) || toolCallsWithResults.length === 0) {
+    return [];
+  }
+
+  return toolCallsWithResults.map(call => ({
+    tool_call_id: call.id || call.tool_call_id || null,
+    name: call.function?.name || call.name || 'unknown',
+    display_name: call.displayName || call.function?.name || call.name || 'unknown',
+    arguments: call.function?.arguments || call.arguments || null,
+    success: call.result?.success !== false,
+    duration: call.duration || 0,
+    result_preview: buildResultPreview(call.result),
+    tool_message_id: call.tool_message_id || null,
+    timestamp: call.timestamp || new Date().toISOString(),
+  }));
+}

--- a/tests/test-tool-call-snapshot-builder.mjs
+++ b/tests/test-tool-call-snapshot-builder.mjs
@@ -1,0 +1,107 @@
+/**
+ * Tests for tool call snapshot builder helpers.
+ *
+ * Usage:
+ *   node tests/test-tool-call-snapshot-builder.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  buildResultPreview,
+  buildToolCallSnapshot,
+} from '../lib/tool-call-snapshot-builder.js';
+
+function testEmptyInputs() {
+  assert.deepEqual(buildToolCallSnapshot(), []);
+  assert.deepEqual(buildToolCallSnapshot(null), []);
+  assert.deepEqual(buildToolCallSnapshot({}), []);
+  assert.deepEqual(buildToolCallSnapshot([]), []);
+}
+
+function testStringPreview() {
+  const text = 'x'.repeat(250);
+  assert.equal(buildResultPreview({ data: text }), 'x'.repeat(200));
+}
+
+function testObjectPreview() {
+  assert.equal(
+    buildResultPreview({ data: { answer: 42 } }),
+    '{"answer":42}'
+  );
+}
+
+function testUnserializablePreview() {
+  const circular = {};
+  circular.self = circular;
+
+  assert.equal(
+    buildResultPreview({ data: circular }),
+    '[unserializable result]'
+  );
+}
+
+function testErrorPreviewFallback() {
+  assert.equal(buildResultPreview({ error: 'failed' }), 'failed');
+  assert.equal(buildResultPreview(null), null);
+}
+
+function testSnapshotShape() {
+  const snapshot = buildToolCallSnapshot([{
+    id: 'call_1',
+    function: {
+      name: 'skill__search',
+      arguments: '{"q":"hello"}',
+    },
+    displayName: '搜索',
+    result: {
+      success: true,
+      data: { ok: true },
+    },
+    duration: 123,
+    tool_message_id: 'msg_tool_1',
+    timestamp: '2026-07-28T03:00:00.000Z',
+  }]);
+
+  assert.deepEqual(snapshot, [{
+    tool_call_id: 'call_1',
+    name: 'skill__search',
+    display_name: '搜索',
+    arguments: '{"q":"hello"}',
+    success: true,
+    duration: 123,
+    result_preview: '{"ok":true}',
+    tool_message_id: 'msg_tool_1',
+    timestamp: '2026-07-28T03:00:00.000Z',
+  }]);
+}
+
+function testSnapshotDefaults() {
+  const [snapshot] = buildToolCallSnapshot([{
+    name: 'plain_tool',
+    result: { success: false, error: 'boom' },
+  }]);
+
+  assert.equal(snapshot.tool_call_id, null);
+  assert.equal(snapshot.name, 'plain_tool');
+  assert.equal(snapshot.display_name, 'plain_tool');
+  assert.equal(snapshot.arguments, null);
+  assert.equal(snapshot.success, false);
+  assert.equal(snapshot.duration, 0);
+  assert.equal(snapshot.result_preview, 'boom');
+  assert.equal(snapshot.tool_message_id, null);
+  assert.ok(!Number.isNaN(Date.parse(snapshot.timestamp)));
+}
+
+function main() {
+  testEmptyInputs();
+  testStringPreview();
+  testObjectPreview();
+  testUnserializablePreview();
+  testErrorPreviewFallback();
+  testSnapshotShape();
+  testSnapshotDefaults();
+
+  console.log('Tool call snapshot builder tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Extract assistant completion tool-call snapshot shaping into `lib/tool-call-snapshot-builder.js`
- Keep the `tool_calls` completion payload shape unchanged
- Add focused tests for preview behavior, defaults, errors, circular data, and snapshot fields

## Validation

- `node tests\test-tool-call-snapshot-builder.mjs`
- `node -e "import('./lib/chat-service.js').then(() => console.log('chat-service import ok'))"`
- `node tests\test-token-usage-accumulator.mjs`
- `node tests\test-tool-call-presenter.mjs`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No API contract changes
- No database changes
- Full tool results remain stored as separate tool messages
- `docs/tasks` notes are local-only and not included in this PR
