### PR TITLE
fix: propagate assistant execution identity

### DIFF
--- a/server/services/assistant/execution-context.js
+++ b/server/services/assistant/execution-context.js
@@ -1,0 +1,26 @@
+/**
+ * Assistant execution context builder.
+ *
+ * Converts a persisted assistant request into the runtime context passed to the
+ * executor. Identity comes from the stored request record; workspace details
+ * may come from the normalized request input.
+ */
+
+export function buildAssistantExecutionContext(request, options = {}) {
+  const input = request?.input && typeof request.input === 'object'
+    ? request.input
+    : {};
+  const workspace = input.workspace && typeof input.workspace === 'object'
+    ? input.workspace
+    : {};
+
+  return {
+    requestId: options.requestId || request?.request_id,
+    workdir: workspace.workdir,
+    topicId: request?.topic_id || workspace.topic_id,
+    expertId: request?.expert_id || workspace.expert_id,
+    userId: request?.user_id || null,
+    contactId: request?.contact_id || null,
+    messageService: options.messageService || null,
+  };
+}

--- a/server/services/assistant/manager.js
+++ b/server/services/assistant/manager.js
@@ -19,6 +19,7 @@ import { getAssistantTools, getInheritedToolDefinitions, executeInheritedTool } 
 import { extractImageInput, executeVisionWithInput, readImageFile } from './vision-processor.js';
 import { refreshAssistantsCache, getAssistant, createAssistant, updateAssistant, deleteAssistant, getAssistantDetail } from './config-repository.js';
 import { executeAssistant } from './executor.js';
+import { buildAssistantExecutionContext } from './execution-context.js';
 import { pushSSENotification, notifyExpertResult, triggerExpertResponse, resendNotification } from './expert-notifier.js';
 
 class AssistantManager {
@@ -579,13 +580,16 @@ class AssistantManager {
       // 执行请求
       let result;
       try {
-        result = await executeAssistant(this.db, assistant, request.input, {
-          requestId,
-          workdir: request.input?.workspace?.workdir,
-          topicId: request.topic_id,
-          expertId: request.expert_id,
-          messageService: this.messageService,
-        });
+        result = await executeAssistant(
+          this.db,
+          assistant,
+          request.input,
+          buildAssistantExecutionContext(request, {
+            requestId,
+            messageService: this.messageService,
+          }),
+          this.messageService
+        );
       } catch (execError) {
         result = { error: execError.message };
       }

--- a/tests/test-assistant-execution-context.mjs
+++ b/tests/test-assistant-execution-context.mjs
@@ -1,0 +1,85 @@
+/**
+ * Tests for assistant execution context builder.
+ *
+ * Usage:
+ *   node tests/test-assistant-execution-context.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { buildAssistantExecutionContext } from '../server/services/assistant/execution-context.js';
+
+function testBuildsContextFromPersistedRequest() {
+  const messageService = { append: () => {} };
+  const context = buildAssistantExecutionContext({
+    request_id: 'req_1',
+    user_id: 'user_1',
+    contact_id: 'contact_1',
+    expert_id: 'expert_1',
+    topic_id: 'topic_1',
+    input: {
+      workspace: {
+        expert_id: 'body_expert',
+        topic_id: 'body_topic',
+        workdir: 'D:/workspace/task',
+      },
+    },
+  }, { messageService });
+
+  assert.deepEqual(context, {
+    requestId: 'req_1',
+    workdir: 'D:/workspace/task',
+    topicId: 'topic_1',
+    expertId: 'expert_1',
+    userId: 'user_1',
+    contactId: 'contact_1',
+    messageService,
+  });
+}
+
+function testFallsBackToWorkspaceForScopeOnly() {
+  const context = buildAssistantExecutionContext({
+    request_id: 'req_2',
+    user_id: null,
+    contact_id: null,
+    expert_id: null,
+    topic_id: null,
+    input: {
+      workspace: {
+        expert_id: 'workspace_expert',
+        topic_id: 'workspace_topic',
+        workdir: 'D:/workspace/fallback',
+      },
+    },
+  });
+
+  assert.equal(context.expertId, 'workspace_expert');
+  assert.equal(context.topicId, 'workspace_topic');
+  assert.equal(context.workdir, 'D:/workspace/fallback');
+  assert.equal(context.userId, null);
+  assert.equal(context.contactId, null);
+}
+
+function testHandlesMissingInput() {
+  const context = buildAssistantExecutionContext({
+    request_id: 'req_3',
+    user_id: 'user_3',
+    contact_id: 'contact_3',
+  }, { requestId: 'override_req' });
+
+  assert.equal(context.requestId, 'override_req');
+  assert.equal(context.workdir, undefined);
+  assert.equal(context.topicId, undefined);
+  assert.equal(context.expertId, undefined);
+  assert.equal(context.userId, 'user_3');
+  assert.equal(context.contactId, 'contact_3');
+}
+
+function main() {
+  testBuildsContextFromPersistedRequest();
+  testFallsBackToWorkspaceForScopeOnly();
+  testHandlesMissingInput();
+
+  console.log('Assistant execution context tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add an assistant execution context builder to map persisted request fields into runtime context
- Propagate `userId` and `contactId` from assistant requests into executor context
- Pass `messageService` as the fifth `executeAssistant()` argument, matching the executor signature
- Add focused tests for identity, workspace fallback, and missing-input behavior

## Validation

- `node tests\test-assistant-execution-context.mjs`
- `node -e "import('./server/services/assistant/manager.js').then(() => console.log('assistant manager import ok'))"`
- `node -e "import('./server/services/assistant/execution-context.js').then(m => console.log(Object.keys(m).join(',')))"`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No API contract changes
- No database changes
- Does not change `/api/assistants/call` authentication policy
- Does not change request-management authorization policy
- `docs/tasks` notes are local-only and not included in this PR
