### PR TITLE
refactor: extract round state snapshot

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -55,7 +55,8 @@ import { isRetryableError } from './llm-retry.js';
 import { resolveThinkingRequestConfig } from './llm-thinking-config.js';
 import { getToolCallDisplayNames, presentToolCalls, toToolCallArray } from './tool-call-presenter.js';
 import { buildToolCallSnapshot } from './tool-call-snapshot-builder.js';
-import { addTokenUsage, snapshotTokenUsage } from './token-usage-accumulator.js';
+import { addTokenUsage } from './token-usage-accumulator.js';
+import { createRoundStateSnapshot, restoreRoundStateSnapshot } from './chat/round-state-snapshot.js';
 import Utils from './utils.js';
 import path from 'path';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
@@ -301,15 +302,13 @@ class ChatService {
         messages = LLMClient.stripHistoricalImages(messages);
       }
 
-      const roundSnapshot = {
+      const roundSnapshot = createRoundStateSnapshot({
         round,
-        messages: typeof structuredClone === 'function'
-          ? structuredClone(messages)
-          : JSON.parse(JSON.stringify(messages)),
+        messages,
         fullContent,
         fullReasoningContent,
-        tokenUsage: snapshotTokenUsage(tokenUsage),
-      };
+        tokenUsage,
+      });
 
       // 同步 request runtime 观测字段（统一状态真相源由 StreamController 持有）
       if (runtimeState) {
@@ -388,14 +387,13 @@ class ChatService {
           const delayMs = Math.min(STREAM_RECOVERY_BASE_DELAY_MS * Math.pow(2, attempt - 1), STREAM_RECOVERY_MAX_DELAY_MS);
           logger.warn(`[ChatService] 第${round + 1}轮 LLM 流式调用失败，准备恢复重试: attempt=${attempt}/${MAX_STREAM_RECOVERY_ATTEMPTS}, delay=${delayMs}ms, error=${error.message}`);
 
-          fullContent = roundSnapshot.fullContent;
-          fullReasoningContent = roundSnapshot.fullReasoningContent;
-          tokenUsage = snapshotTokenUsage(roundSnapshot.tokenUsage);
+          const restoredRoundState = restoreRoundStateSnapshot(roundSnapshot);
+          fullContent = restoredRoundState.fullContent;
+          fullReasoningContent = restoredRoundState.fullReasoningContent;
+          tokenUsage = restoredRoundState.tokenUsage;
           collectedToolCalls = [];
           roundContent = '';
-          messages = typeof structuredClone === 'function'
-            ? structuredClone(roundSnapshot.messages)
-            : JSON.parse(JSON.stringify(roundSnapshot.messages));
+          messages = restoredRoundState.messages;
 
           onDelta?.({
             type: 'recovering',

--- a/lib/chat/round-state-snapshot.js
+++ b/lib/chat/round-state-snapshot.js
@@ -1,0 +1,45 @@
+/**
+ * Round state snapshot helpers.
+ *
+ * Streaming recovery needs to roll back only a small set of per-round state.
+ * Keep that snapshot/restore shape outside ChatService so the orchestration
+ * loop can stay focused on control flow.
+ */
+
+import { snapshotTokenUsage } from '../token-usage-accumulator.js';
+
+export function cloneRoundStateValue(value, structuredCloneFn = globalThis.structuredClone) {
+  if (typeof structuredCloneFn === 'function') {
+    return structuredCloneFn(value);
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function createRoundStateSnapshot(state, options = {}) {
+  const {
+    round,
+    messages = [],
+    fullContent = '',
+    fullReasoningContent = '',
+    tokenUsage = null,
+  } = state || {};
+
+  return {
+    round,
+    messages: cloneRoundStateValue(messages, options.structuredClone),
+    fullContent,
+    fullReasoningContent,
+    tokenUsage: snapshotTokenUsage(tokenUsage),
+  };
+}
+
+export function restoreRoundStateSnapshot(snapshot, options = {}) {
+  return {
+    round: snapshot?.round,
+    messages: cloneRoundStateValue(snapshot?.messages || [], options.structuredClone),
+    fullContent: snapshot?.fullContent || '',
+    fullReasoningContent: snapshot?.fullReasoningContent || '',
+    tokenUsage: snapshotTokenUsage(snapshot?.tokenUsage),
+  };
+}

--- a/tests/test-round-state-snapshot.mjs
+++ b/tests/test-round-state-snapshot.mjs
@@ -1,0 +1,117 @@
+/**
+ * Tests for round state snapshot helpers.
+ *
+ * Usage:
+ *   node tests/test-round-state-snapshot.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  cloneRoundStateValue,
+  createRoundStateSnapshot,
+  restoreRoundStateSnapshot,
+} from '../lib/chat/round-state-snapshot.js';
+
+function testCloneUsesStructuredCloneWhenProvided() {
+  let called = false;
+  const value = [{ role: 'user', content: 'hello' }];
+
+  const cloned = cloneRoundStateValue(value, (input) => {
+    called = true;
+    return input.map(item => ({ ...item, cloned: true }));
+  });
+
+  assert.equal(called, true);
+  assert.deepEqual(cloned, [{ role: 'user', content: 'hello', cloned: true }]);
+}
+
+function testCloneFallsBackToJsonClone() {
+  const value = [{ role: 'user', content: 'hello', nested: { ok: true } }];
+  const cloned = cloneRoundStateValue(value, null);
+
+  assert.deepEqual(cloned, value);
+  assert.notEqual(cloned, value);
+  assert.notEqual(cloned[0].nested, value[0].nested);
+}
+
+function testCreateSnapshotCopiesRollbackState() {
+  const messages = [{ role: 'user', content: 'hello' }];
+  const tokenUsage = {
+    prompt_tokens: 10,
+    completion_tokens: 5,
+    total_tokens: 15,
+  };
+
+  const snapshot = createRoundStateSnapshot({
+    round: 2,
+    messages,
+    fullContent: 'partial answer',
+    fullReasoningContent: 'partial reasoning',
+    tokenUsage,
+  }, { structuredClone: null });
+
+  assert.deepEqual(snapshot, {
+    round: 2,
+    messages,
+    fullContent: 'partial answer',
+    fullReasoningContent: 'partial reasoning',
+    tokenUsage,
+  });
+  assert.notEqual(snapshot.messages, messages);
+  assert.notEqual(snapshot.tokenUsage, tokenUsage);
+}
+
+function testCreateSnapshotPreservesNullTokenUsage() {
+  const snapshot = createRoundStateSnapshot({
+    round: 0,
+    messages: [],
+    tokenUsage: null,
+  }, { structuredClone: null });
+
+  assert.equal(snapshot.tokenUsage, null);
+}
+
+function testRestoreSnapshotCopiesState() {
+  const snapshot = {
+    round: 1,
+    messages: [{ role: 'assistant', content: 'partial' }],
+    fullContent: 'partial',
+    fullReasoningContent: 'thinking',
+    tokenUsage: {
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      total_tokens: 3,
+    },
+  };
+
+  const restored = restoreRoundStateSnapshot(snapshot, { structuredClone: null });
+
+  assert.deepEqual(restored, snapshot);
+  assert.notEqual(restored.messages, snapshot.messages);
+  assert.notEqual(restored.tokenUsage, snapshot.tokenUsage);
+}
+
+function testRestoreMissingSnapshotUsesSafeDefaults() {
+  const restored = restoreRoundStateSnapshot(null, { structuredClone: null });
+
+  assert.deepEqual(restored, {
+    round: undefined,
+    messages: [],
+    fullContent: '',
+    fullReasoningContent: '',
+    tokenUsage: null,
+  });
+}
+
+function main() {
+  testCloneUsesStructuredCloneWhenProvided();
+  testCloneFallsBackToJsonClone();
+  testCreateSnapshotCopiesRollbackState();
+  testCreateSnapshotPreservesNullTokenUsage();
+  testRestoreSnapshotCopiesState();
+  testRestoreMissingSnapshotUsesSafeDefaults();
+
+  console.log('Round state snapshot tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Extract streaming recovery round snapshot/restore logic into `lib/chat/round-state-snapshot.js`
- Keep ChatService in charge of control flow while moving clone/token-usage snapshot details into a focused helper
- Add tests for structuredClone usage, JSON fallback, null token usage, restore defaults, and copy behavior

## Validation

- `node tests\test-round-state-snapshot.mjs`
- `node -e "import('./lib/chat-service.js').then(() => console.log('chat-service import ok'))"`
- `node tests\test-token-usage-accumulator.mjs`
- `node tests\test-tool-call-snapshot-builder.mjs`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No API contract changes
- No database changes
- No stream recovery event shape changes
- `docs/tasks` notes are local-only and not included in this PR
