### PR TITLE
refactor: extract stream turn context builder

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -57,6 +57,7 @@ import { getToolCallDisplayNames, presentToolCalls, toToolCallArray } from './to
 import { buildToolCallSnapshot } from './tool-call-snapshot-builder.js';
 import { addTokenUsage } from './token-usage-accumulator.js';
 import { createRoundStateSnapshot, restoreRoundStateSnapshot } from './chat/round-state-snapshot.js';
+import { buildStreamTurnContext, buildToolContext } from './chat/turn-context-builder.js';
 import Utils from './utils.js';
 import path from 'path';
 import { getSystemSettingService } from '../server/services/system-setting.service.js';
@@ -704,20 +705,32 @@ class ChatService {
       const startTime = Date.now();
       const modelConfig = model_id ? await this.getModelConfig(model_id) : expertService.getDefaultModelConfig();
       const thinkingConfig = expertService.getThinkingConfig(modelConfig);
-      const toolContext = { user_id, expert_id, session };
+      const toolContext = buildToolContext({ user_id, expert_id, session });
       const tools = await expertService.toolManager.getToolDefinitions(toolContext);
 
-      const llmPayload = {
-        model: modelConfig.model_name,
+      const turnContext = buildStreamTurnContext({
+        user_id,
+        expert_id,
+        topic_id,
+        task_id,
+        taskContext,
+        session,
+        request_id,
+        modelConfig,
+        thinkingConfig,
         messages: context.messages,
-        stream: true,
-        stream_options: { include_usage: true },
-        _debug: { model_config: { provider_name: modelConfig.provider_name, base_url: modelConfig.base_url, max_tokens: modelConfig.max_tokens, max_output_tokens: modelConfig.max_output_tokens }, context_messages_count: context.messages.length, tools_count: tools.length },
-      };
+        tools,
+      });
+      const { llmPayload } = turnContext;
       this.saveLLMPayload(user_id, expert_id, llmPayload);
 
       // 9. 执行多轮 LLM 调用
-      const llmResult = await this._executeLLMRounds(expertService, { modelConfig, thinkingConfig, tools, currentMessages: context.messages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, request_id, onDelta, shouldStop, runtimeState });
+      const llmResult = await this._executeLLMRounds(expertService, {
+        ...turnContext.roundInput,
+        onDelta,
+        shouldStop,
+        runtimeState,
+      });
       const { fullContent, fullReasoningContent, tokenUsage } = llmResult;
       let finalContent = fullContent;
       const latency = Date.now() - startTime;

--- a/lib/chat/turn-context-builder.js
+++ b/lib/chat/turn-context-builder.js
@@ -1,0 +1,78 @@
+/**
+ * Turn context builder.
+ *
+ * This module builds the data envelope for one stream chat turn after the
+ * async prerequisites have already been resolved by ChatService.
+ */
+
+export function buildToolContext({ user_id, expert_id, session }) {
+  return { user_id, expert_id, session };
+}
+
+export function buildStreamLlmPayload({ modelConfig, messages, tools }) {
+  return {
+    model: modelConfig.model_name,
+    messages,
+    stream: true,
+    stream_options: { include_usage: true },
+    _debug: {
+      model_config: {
+        provider_name: modelConfig.provider_name,
+        base_url: modelConfig.base_url,
+        max_tokens: modelConfig.max_tokens,
+        max_output_tokens: modelConfig.max_output_tokens,
+      },
+      context_messages_count: messages.length,
+      tools_count: tools.length,
+    },
+  };
+}
+
+export function buildStreamTurnContext({
+  user_id,
+  expert_id,
+  topic_id,
+  task_id,
+  taskContext,
+  session,
+  request_id,
+  modelConfig,
+  thinkingConfig,
+  messages,
+  tools,
+}) {
+  const toolContext = buildToolContext({ user_id, expert_id, session });
+  const llmPayload = buildStreamLlmPayload({ modelConfig, messages, tools });
+
+  return {
+    caller: {
+      user_id,
+      session,
+    },
+    expert: {
+      expert_id,
+    },
+    scope: {
+      topic_id,
+      task_id,
+      taskContext,
+      request_id,
+    },
+    toolContext,
+    llmPayload,
+    roundInput: {
+      modelConfig,
+      thinkingConfig,
+      tools,
+      currentMessages: messages,
+      llmPayload,
+      user_id,
+      expert_id,
+      taskContext,
+      topic_id,
+      task_id,
+      session,
+      request_id,
+    },
+  };
+}

--- a/tests/test-turn-context-builder.mjs
+++ b/tests/test-turn-context-builder.mjs
@@ -1,0 +1,130 @@
+/**
+ * Tests for stream turn context builder helpers.
+ *
+ * Usage:
+ *   node tests/test-turn-context-builder.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  buildStreamLlmPayload,
+  buildStreamTurnContext,
+  buildToolContext,
+} from '../lib/chat/turn-context-builder.js';
+
+function createFixture() {
+  const session = { userId: 'user_1', roles: ['creator'] };
+  const modelConfig = {
+    model_name: 'test-model',
+    provider_name: 'test-provider',
+    base_url: 'https://example.test/v1',
+    max_tokens: 4096,
+    max_output_tokens: 2048,
+  };
+  const thinkingConfig = {
+    thinking: false,
+    reasoning: null,
+  };
+  const messages = [{ role: 'user', content: 'hello' }];
+  const tools = [{ type: 'function', function: { name: 'demo_tool' } }];
+  const taskContext = {
+    workspace_mode: 'task',
+    absolute_workspace_path: 'D:/workspace/task',
+  };
+
+  return { session, modelConfig, thinkingConfig, messages, tools, taskContext };
+}
+
+function testBuildToolContext() {
+  const { session } = createFixture();
+
+  assert.deepEqual(buildToolContext({
+    user_id: 'user_1',
+    expert_id: 'expert_1',
+    session,
+  }), {
+    user_id: 'user_1',
+    expert_id: 'expert_1',
+    session,
+  });
+}
+
+function testBuildStreamLlmPayload() {
+  const { modelConfig, messages, tools } = createFixture();
+  const payload = buildStreamLlmPayload({ modelConfig, messages, tools });
+
+  assert.deepEqual(payload, {
+    model: 'test-model',
+    messages,
+    stream: true,
+    stream_options: { include_usage: true },
+    _debug: {
+      model_config: {
+        provider_name: 'test-provider',
+        base_url: 'https://example.test/v1',
+        max_tokens: 4096,
+        max_output_tokens: 2048,
+      },
+      context_messages_count: 1,
+      tools_count: 1,
+    },
+  });
+}
+
+function testBuildStreamTurnContext() {
+  const { session, modelConfig, thinkingConfig, messages, tools, taskContext } = createFixture();
+  const turnContext = buildStreamTurnContext({
+    user_id: 'user_1',
+    expert_id: 'expert_1',
+    topic_id: 'topic_1',
+    task_id: 'task_1',
+    taskContext,
+    session,
+    request_id: 'request_1',
+    modelConfig,
+    thinkingConfig,
+    messages,
+    tools,
+  });
+
+  assert.deepEqual(turnContext.caller, {
+    user_id: 'user_1',
+    session,
+  });
+  assert.deepEqual(turnContext.expert, {
+    expert_id: 'expert_1',
+  });
+  assert.deepEqual(turnContext.scope, {
+    topic_id: 'topic_1',
+    task_id: 'task_1',
+    taskContext,
+    request_id: 'request_1',
+  });
+  assert.deepEqual(turnContext.toolContext, {
+    user_id: 'user_1',
+    expert_id: 'expert_1',
+    session,
+  });
+  assert.equal(turnContext.roundInput.modelConfig, modelConfig);
+  assert.equal(turnContext.roundInput.thinkingConfig, thinkingConfig);
+  assert.equal(turnContext.roundInput.tools, tools);
+  assert.equal(turnContext.roundInput.currentMessages, messages);
+  assert.equal(turnContext.roundInput.llmPayload, turnContext.llmPayload);
+  assert.equal(turnContext.roundInput.user_id, 'user_1');
+  assert.equal(turnContext.roundInput.expert_id, 'expert_1');
+  assert.equal(turnContext.roundInput.taskContext, taskContext);
+  assert.equal(turnContext.roundInput.topic_id, 'topic_1');
+  assert.equal(turnContext.roundInput.task_id, 'task_1');
+  assert.equal(turnContext.roundInput.session, session);
+  assert.equal(turnContext.roundInput.request_id, 'request_1');
+}
+
+function main() {
+  testBuildToolContext();
+  testBuildStreamLlmPayload();
+  testBuildStreamTurnContext();
+
+  console.log('Turn context builder tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add a lightweight stream turn context builder for caller/expert/scope/tool context/LLM payload/round input shaping
- Use it in `ChatService.streamChat()` after async prerequisites are resolved
- Keep topic switching, task context loading, compression, recall, and tool loading in ChatService for now
- Add focused tests for tool context, stream LLM payload, and round input envelope shape

## Validation

- `node tests\test-turn-context-builder.mjs`
- `node -e "import('./lib/chat-service.js').then(() => console.log('chat-service import ok'))"`
- `node tests\test-round-state-snapshot.mjs`
- `node tests\test-tool-call-snapshot-builder.mjs`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- No API contract changes
- No database changes
- Stream path only; non-stream chat remains unchanged
- Does not change Assistant access policy or inherited tool policy
- `docs/tasks` notes are local-only and not included in this PR
