### PR TITLE
refactor: add agent invocation contract

### DIFF
--- a/lib/agent/agent-event.js
+++ b/lib/agent/agent-event.js
@@ -1,0 +1,73 @@
+/**
+ * Agent event contract.
+ *
+ * Events are intentionally persistence-agnostic for now. Later phases can map
+ * them to SSE, legacy assistant records, or future agent_run tables.
+ */
+
+import Utils from '../utils.js';
+
+const AGENT_EVENT_TYPES = Object.freeze([
+  'agent_run_created',
+  'agent_run_started',
+  'agent_tool_called',
+  'agent_tool_completed',
+  'delegation_created',
+  'delegation_completed',
+  'delegation_failed',
+  'agent_run_completed',
+  'agent_run_failed',
+  'agent_run_cancelled',
+]);
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizePayload(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+export function isAgentEventType(type) {
+  return AGENT_EVENT_TYPES.includes(type);
+}
+
+export function buildAgentEvent({
+  type,
+  invocation_context,
+  payload = {},
+  event_id,
+  created_at,
+} = {}) {
+  if (!isAgentEventType(type)) {
+    throw new Error(`Unknown agent event type: ${type}`);
+  }
+  if (!invocation_context || typeof invocation_context !== 'object') {
+    throw new Error('invocation_context is required');
+  }
+
+  return Object.freeze({
+    event_id: normalizeNullableString(event_id) || `evt_${Utils.newID(16)}`,
+    type,
+    run_id: invocation_context.run_id,
+    parent_run_id: invocation_context.parent_run_id || null,
+    principal_user_id: invocation_context.principal_user_id,
+    caller_agent_id: invocation_context.caller_agent_id || null,
+    callee_agent_id: invocation_context.callee_agent_id,
+    delegation_depth: invocation_context.delegation_depth,
+    payload: Object.freeze({ ...normalizePayload(payload) }),
+    created_at: created_at || new Date().toISOString(),
+  });
+}
+
+export { AGENT_EVENT_TYPES };
+
+export default {
+  AGENT_EVENT_TYPES,
+  buildAgentEvent,
+  isAgentEventType,
+};

--- a/lib/agent/agent-invocation-context.js
+++ b/lib/agent/agent-invocation-context.js
@@ -1,0 +1,168 @@
+/**
+ * Agent invocation context contract.
+ *
+ * This is the runtime envelope shared by root chat turns and delegated child
+ * agent runs. It separates the human authorization principal from the agent
+ * caller/callee chain and from LLM protocol roles.
+ */
+
+import Utils from '../utils.js';
+
+const DEFAULT_INVOCATION_MODE = 'llm';
+const DEFAULT_SOURCE = 'agent_runtime';
+const DEFAULT_MAX_DELEGATION_DEPTH = 2;
+
+function createRunId(prefix = 'run') {
+  return `${prefix}_${Utils.newID(16)}`;
+}
+
+function assertObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+}
+
+function assertRequiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeDepth(value) {
+  const depth = Number(value ?? 0);
+  if (!Number.isInteger(depth) || depth < 0) {
+    throw new Error('delegation_depth must be a non-negative integer');
+  }
+  return depth;
+}
+
+function normalizeObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+function normalizeDelegationChain(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(item => typeof item === 'string' && item.trim())
+    .map(item => item.trim());
+}
+
+function assertDepthAllowed(depth, maxDepth) {
+  const limit = Number(maxDepth ?? DEFAULT_MAX_DELEGATION_DEPTH);
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error('max_delegation_depth must be a non-negative integer');
+  }
+  if (depth > limit) {
+    throw new Error(`delegation_depth exceeds max_delegation_depth (${limit})`);
+  }
+}
+
+function freezeContext(context) {
+  return Object.freeze({
+    ...context,
+    workspace_scope: Object.freeze({ ...context.workspace_scope }),
+    capability_scope: Object.freeze({ ...context.capability_scope }),
+    delegation_chain: Object.freeze([...context.delegation_chain]),
+  });
+}
+
+export function buildAgentInvocationContext(input = {}) {
+  assertObject(input, 'input');
+
+  const principal_user_id = normalizeNullableString(input.principal_user_id);
+  const callee_agent_id = normalizeNullableString(input.callee_agent_id);
+  const caller_agent_id = normalizeNullableString(input.caller_agent_id);
+  const run_id = normalizeNullableString(input.run_id) || createRunId();
+  const parent_run_id = normalizeNullableString(input.parent_run_id);
+  const delegation_depth = normalizeDepth(input.delegation_depth);
+
+  assertRequiredString(principal_user_id, 'principal_user_id');
+  assertRequiredString(callee_agent_id, 'callee_agent_id');
+  assertDepthAllowed(delegation_depth, input.max_delegation_depth);
+
+  return freezeContext({
+    run_id,
+    parent_run_id,
+    principal_user_id,
+    caller_agent_id,
+    callee_agent_id,
+    delegation_depth,
+    delegation_chain: normalizeDelegationChain(input.delegation_chain),
+    topic_id: normalizeNullableString(input.topic_id),
+    task_id: normalizeNullableString(input.task_id),
+    request_id: normalizeNullableString(input.request_id),
+    workspace_scope: normalizeObject(input.workspace_scope),
+    capability_scope: normalizeObject(input.capability_scope),
+    invocation_mode: normalizeNullableString(input.invocation_mode) || DEFAULT_INVOCATION_MODE,
+    source: normalizeNullableString(input.source) || DEFAULT_SOURCE,
+  });
+}
+
+export function buildRootAgentInvocationContext(input = {}) {
+  assertObject(input, 'input');
+
+  const agent_id = normalizeNullableString(input.agent_id || input.callee_agent_id);
+
+  return buildAgentInvocationContext({
+    ...input,
+    run_id: input.run_id || createRunId('root_run'),
+    parent_run_id: null,
+    principal_user_id: input.principal_user_id,
+    caller_agent_id: null,
+    callee_agent_id: agent_id,
+    delegation_depth: 0,
+    delegation_chain: agent_id ? [agent_id] : [],
+    source: input.source || 'root_chat',
+  });
+}
+
+export function deriveChildAgentInvocationContext(parent, input = {}) {
+  assertObject(parent, 'parent');
+  assertObject(input, 'input');
+  assertRequiredString(parent.run_id, 'parent.run_id');
+  assertRequiredString(parent.principal_user_id, 'parent.principal_user_id');
+  assertRequiredString(parent.callee_agent_id, 'parent.callee_agent_id');
+
+  const callee_agent_id = normalizeNullableString(input.callee_agent_id || input.agent_id);
+  assertRequiredString(callee_agent_id, 'callee_agent_id');
+
+  const parentChain = normalizeDelegationChain(parent.delegation_chain);
+  const currentChain = parentChain.length > 0
+    ? parentChain
+    : [parent.callee_agent_id];
+  if (currentChain.includes(callee_agent_id)) {
+    throw new Error(`delegation cycle detected for agent: ${callee_agent_id}`);
+  }
+
+  return buildAgentInvocationContext({
+    ...input,
+    run_id: input.run_id || createRunId('child_run'),
+    parent_run_id: parent.run_id,
+    principal_user_id: parent.principal_user_id,
+    caller_agent_id: parent.callee_agent_id,
+    callee_agent_id,
+    delegation_depth: normalizeDepth(parent.delegation_depth) + 1,
+    delegation_chain: [...currentChain, callee_agent_id],
+    topic_id: input.topic_id ?? parent.topic_id,
+    task_id: input.task_id ?? parent.task_id,
+    request_id: input.request_id,
+    workspace_scope: input.workspace_scope ?? parent.workspace_scope,
+    capability_scope: input.capability_scope ?? parent.capability_scope,
+    invocation_mode: input.invocation_mode || DEFAULT_INVOCATION_MODE,
+    source: input.source || 'agent_delegate',
+  });
+}
+
+export default {
+  buildAgentInvocationContext,
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+};

--- a/lib/chat/turn-context-builder.js
+++ b/lib/chat/turn-context-builder.js
@@ -5,6 +5,8 @@
  * async prerequisites have already been resolved by ChatService.
  */
 
+import { buildRootAgentInvocationContext } from '../agent/agent-invocation-context.js';
+
 export function buildToolContext({ user_id, expert_id, session }) {
   return { user_id, expert_id, session };
 }
@@ -43,8 +45,23 @@ export function buildStreamTurnContext({
 }) {
   const toolContext = buildToolContext({ user_id, expert_id, session });
   const llmPayload = buildStreamLlmPayload({ modelConfig, messages, tools });
+  const agentInvocation = buildRootAgentInvocationContext({
+    principal_user_id: user_id,
+    agent_id: expert_id,
+    topic_id,
+    task_id,
+    request_id,
+    workspace_scope: taskContext?.absolute_workspace_path
+      ? {
+          workdir: taskContext.absolute_workspace_path,
+          workspace_mode: taskContext.workspace_mode || null,
+        }
+      : {},
+    capability_scope: {},
+  });
 
   return {
+    agent_invocation: agentInvocation,
     caller: {
       user_id,
       session,
@@ -73,6 +90,7 @@ export function buildStreamTurnContext({
       task_id,
       session,
       request_id,
+      agent_invocation: agentInvocation,
     },
   };
 }

--- a/server/services/assistant/execution-context.js
+++ b/server/services/assistant/execution-context.js
@@ -6,6 +6,11 @@
  * may come from the normalized request input.
  */
 
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../../../lib/agent/agent-invocation-context.js';
+
 export function buildAssistantExecutionContext(request, options = {}) {
   const input = request?.input && typeof request.input === 'object'
     ? request.input
@@ -21,6 +26,42 @@ export function buildAssistantExecutionContext(request, options = {}) {
     expertId: request?.expert_id || workspace.expert_id,
     userId: request?.user_id || null,
     contactId: request?.contact_id || null,
+    agent_invocation: buildLegacyAssistantInvocationContext(request, input, workspace, options),
     messageService: options.messageService || null,
   };
+}
+
+export function buildLegacyAssistantInvocationContext(request, input = {}, workspace = {}, options = {}) {
+  const userId = request?.user_id || options.userId || null;
+  const rootExpertId = request?.expert_id || workspace.expert_id || options.expertId || null;
+  const assistantId = request?.assistant_id || options.assistantId || null;
+
+  if (!userId || !rootExpertId || !assistantId) {
+    return null;
+  }
+
+  const rootInvocation = options.parentInvocation || buildRootAgentInvocationContext({
+    run_id: options.parentRunId || `legacy_parent_${request?.request_id || 'unknown'}`,
+    principal_user_id: userId,
+    agent_id: rootExpertId,
+    topic_id: request?.topic_id || workspace.topic_id,
+    request_id: request?.request_id,
+    workspace_scope: workspace.workdir ? { workdir: workspace.workdir } : {},
+    capability_scope: {},
+    source: 'legacy_assistant_parent',
+  });
+
+  return deriveChildAgentInvocationContext(rootInvocation, {
+    run_id: options.runId || `legacy_child_${request?.request_id || 'unknown'}`,
+    callee_agent_id: assistantId,
+    request_id: options.requestId || request?.request_id,
+    workspace_scope: workspace.workdir ? { workdir: workspace.workdir } : rootInvocation.workspace_scope,
+    capability_scope: {
+      legacy_inherited_tools: Array.isArray(input.inherited_tools)
+        ? input.inherited_tools
+        : [],
+    },
+    invocation_mode: 'legacy_assistant',
+    source: 'legacy_assistant',
+  });
 }

--- a/tests/test-agent-invocation-context.mjs
+++ b/tests/test-agent-invocation-context.mjs
@@ -1,0 +1,168 @@
+/**
+ * Tests for agent invocation and event contracts.
+ *
+ * Usage:
+ *   node tests/test-agent-invocation-context.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  buildAgentInvocationContext,
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+import {
+  buildAgentEvent,
+  isAgentEventType,
+} from '../lib/agent/agent-event.js';
+
+function testBuildRootInvocation() {
+  const context = buildRootAgentInvocationContext({
+    run_id: 'root_run_1',
+    principal_user_id: 'user_1',
+    agent_id: 'expert_1',
+    topic_id: 'topic_1',
+    task_id: 'task_1',
+    request_id: 'request_1',
+    workspace_scope: { workdir: 'D:/workspace/task' },
+    capability_scope: { tools: ['document_search'] },
+  });
+
+  assert.deepEqual(context, {
+    run_id: 'root_run_1',
+    parent_run_id: null,
+    principal_user_id: 'user_1',
+    caller_agent_id: null,
+    callee_agent_id: 'expert_1',
+    delegation_depth: 0,
+    delegation_chain: ['expert_1'],
+    topic_id: 'topic_1',
+    task_id: 'task_1',
+    request_id: 'request_1',
+    workspace_scope: { workdir: 'D:/workspace/task' },
+    capability_scope: { tools: ['document_search'] },
+    invocation_mode: 'llm',
+    source: 'root_chat',
+  });
+}
+
+function testDeriveChildInvocation() {
+  const root = buildRootAgentInvocationContext({
+    run_id: 'root_run_2',
+    principal_user_id: 'user_2',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_2',
+    workspace_scope: { workdir: 'D:/workspace/task' },
+    capability_scope: { tools: ['document_search'] },
+  });
+
+  const child = deriveChildAgentInvocationContext(root, {
+    run_id: 'child_run_1',
+    callee_agent_id: 'expert_child',
+    request_id: 'request_child',
+  });
+
+  assert.equal(child.parent_run_id, 'root_run_2');
+  assert.equal(child.principal_user_id, 'user_2');
+  assert.equal(child.caller_agent_id, 'expert_parent');
+  assert.equal(child.callee_agent_id, 'expert_child');
+  assert.equal(child.delegation_depth, 1);
+  assert.deepEqual(child.delegation_chain, ['expert_parent', 'expert_child']);
+  assert.deepEqual(child.workspace_scope, { workdir: 'D:/workspace/task' });
+  assert.deepEqual(child.capability_scope, { tools: ['document_search'] });
+}
+
+function testChildCannotOverridePrincipal() {
+  const root = buildRootAgentInvocationContext({
+    run_id: 'root_run_3',
+    principal_user_id: 'real_user',
+    agent_id: 'expert_parent',
+  });
+
+  const child = deriveChildAgentInvocationContext(root, {
+    callee_agent_id: 'expert_child',
+    principal_user_id: 'spoofed_user',
+  });
+
+  assert.equal(child.principal_user_id, 'real_user');
+}
+
+function testRejectsDepthOverflow() {
+  const root = buildRootAgentInvocationContext({
+    run_id: 'root_run_4',
+    principal_user_id: 'user_4',
+    agent_id: 'expert_parent',
+  });
+  const first = deriveChildAgentInvocationContext(root, {
+    callee_agent_id: 'expert_child_1',
+    max_delegation_depth: 1,
+  });
+
+  assert.throws(() => deriveChildAgentInvocationContext(first, {
+    callee_agent_id: 'expert_child_2',
+    max_delegation_depth: 1,
+  }), /delegation_depth exceeds max_delegation_depth/);
+}
+
+function testRejectsCycles() {
+  const root = buildRootAgentInvocationContext({
+    run_id: 'root_run_5',
+    principal_user_id: 'user_5',
+    agent_id: 'expert_parent',
+  });
+
+  assert.throws(() => deriveChildAgentInvocationContext(root, {
+    callee_agent_id: 'expert_parent',
+  }), /delegation cycle detected/);
+}
+
+function testRejectsMissingPrincipal() {
+  assert.throws(() => buildAgentInvocationContext({
+    callee_agent_id: 'expert_1',
+  }), /principal_user_id is required/);
+}
+
+function testBuildAgentEvent() {
+  const context = buildRootAgentInvocationContext({
+    run_id: 'root_run_6',
+    principal_user_id: 'user_6',
+    agent_id: 'expert_6',
+  });
+
+  const event = buildAgentEvent({
+    event_id: 'evt_1',
+    type: 'agent_run_started',
+    invocation_context: context,
+    payload: { reason: 'test' },
+    created_at: '2026-07-28T00:00:00.000Z',
+  });
+
+  assert.equal(isAgentEventType('agent_run_started'), true);
+  assert.equal(isAgentEventType('unknown'), false);
+  assert.deepEqual(event, {
+    event_id: 'evt_1',
+    type: 'agent_run_started',
+    run_id: 'root_run_6',
+    parent_run_id: null,
+    principal_user_id: 'user_6',
+    caller_agent_id: null,
+    callee_agent_id: 'expert_6',
+    delegation_depth: 0,
+    payload: { reason: 'test' },
+    created_at: '2026-07-28T00:00:00.000Z',
+  });
+}
+
+function main() {
+  testBuildRootInvocation();
+  testDeriveChildInvocation();
+  testChildCannotOverridePrincipal();
+  testRejectsDepthOverflow();
+  testRejectsCycles();
+  testRejectsMissingPrincipal();
+  testBuildAgentEvent();
+
+  console.log('Agent invocation context tests passed.');
+}
+
+main();

--- a/tests/test-assistant-execution-context.mjs
+++ b/tests/test-assistant-execution-context.mjs
@@ -12,6 +12,7 @@ function testBuildsContextFromPersistedRequest() {
   const messageService = { append: () => {} };
   const context = buildAssistantExecutionContext({
     request_id: 'req_1',
+    assistant_id: 'assistant_1',
     user_id: 'user_1',
     contact_id: 'contact_1',
     expert_id: 'expert_1',
@@ -32,6 +33,22 @@ function testBuildsContextFromPersistedRequest() {
     expertId: 'expert_1',
     userId: 'user_1',
     contactId: 'contact_1',
+    agent_invocation: {
+      run_id: 'legacy_child_req_1',
+      parent_run_id: 'legacy_parent_req_1',
+      principal_user_id: 'user_1',
+      caller_agent_id: 'expert_1',
+      callee_agent_id: 'assistant_1',
+      delegation_depth: 1,
+      delegation_chain: ['expert_1', 'assistant_1'],
+      topic_id: 'topic_1',
+      task_id: null,
+      request_id: 'req_1',
+      workspace_scope: { workdir: 'D:/workspace/task' },
+      capability_scope: { legacy_inherited_tools: [] },
+      invocation_mode: 'legacy_assistant',
+      source: 'legacy_assistant',
+    },
     messageService,
   });
 }
@@ -57,6 +74,7 @@ function testFallsBackToWorkspaceForScopeOnly() {
   assert.equal(context.workdir, 'D:/workspace/fallback');
   assert.equal(context.userId, null);
   assert.equal(context.contactId, null);
+  assert.equal(context.agent_invocation, null);
 }
 
 function testHandlesMissingInput() {
@@ -72,6 +90,7 @@ function testHandlesMissingInput() {
   assert.equal(context.expertId, undefined);
   assert.equal(context.userId, 'user_3');
   assert.equal(context.contactId, 'contact_3');
+  assert.equal(context.agent_invocation, null);
 }
 
 function main() {

--- a/tests/test-turn-context-builder.mjs
+++ b/tests/test-turn-context-builder.mjs
@@ -100,6 +100,18 @@ function testBuildStreamTurnContext() {
     taskContext,
     request_id: 'request_1',
   });
+  assert.equal(turnContext.agent_invocation.principal_user_id, 'user_1');
+  assert.equal(turnContext.agent_invocation.caller_agent_id, null);
+  assert.equal(turnContext.agent_invocation.callee_agent_id, 'expert_1');
+  assert.equal(turnContext.agent_invocation.delegation_depth, 0);
+  assert.deepEqual(turnContext.agent_invocation.delegation_chain, ['expert_1']);
+  assert.equal(turnContext.agent_invocation.topic_id, 'topic_1');
+  assert.equal(turnContext.agent_invocation.task_id, 'task_1');
+  assert.equal(turnContext.agent_invocation.request_id, 'request_1');
+  assert.deepEqual(turnContext.agent_invocation.workspace_scope, {
+    workdir: 'D:/workspace/task',
+    workspace_mode: 'task',
+  });
   assert.deepEqual(turnContext.toolContext, {
     user_id: 'user_1',
     expert_id: 'expert_1',
@@ -117,6 +129,7 @@ function testBuildStreamTurnContext() {
   assert.equal(turnContext.roundInput.task_id, 'task_1');
   assert.equal(turnContext.roundInput.session, session);
   assert.equal(turnContext.roundInput.request_id, 'request_1');
+  assert.equal(turnContext.roundInput.agent_invocation, turnContext.agent_invocation);
 }
 
 function main() {


### PR DESCRIPTION
## Summary

- Add shared Agent/Sub-agent invocation context contract.
- Add agent lifecycle event contract.
- Attach root chat `agent_invocation` to stream turn context.
- Attach legacy Assistant child `agent_invocation` to assistant execution context when identity is complete.

## Scope

This PR is Phase 1 only. It does not change database schema, external API contracts, frontend Assistant UI, or AssistantManager execution behavior.

## Validation

- `node tests/test-agent-invocation-context.mjs`
- `node tests/test-turn-context-builder.mjs`
- `node tests/test-assistant-execution-context.mjs`
- `node -e "import('./lib/agent/agent-invocation-context.js').then(m => console.log(Object.keys(m).join(',')))"`
- `node -e "import('./lib/agent/agent-event.js').then(m => console.log(Object.keys(m).join(',')))"`
- `node -e "import('./server/services/assistant/execution-context.js').then(m => console.log(Object.keys(m).join(',')))"`
- `node -e "import('./lib/chat/turn-context-builder.js').then(m => console.log(Object.keys(m).join(',')))"`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- `principal_user_id` remains the human authorization root.
- `caller_agent_id -> callee_agent_id` is now explicit for legacy Assistant delegation.
- Missing legacy identity produces `agent_invocation: null` rather than fabricating an incomplete chain.
