### PR TITLE
refactor: add agent definition resolver

### DIFF
--- a/lib/agent/agent-definition-resolver.js
+++ b/lib/agent/agent-definition-resolver.js
@@ -1,0 +1,84 @@
+/**
+ * Agent definition resolver.
+ *
+ * The resolver coordinates source-specific adapters and returns a readonly
+ * AgentDefinition shape. It does not own persistence or execution.
+ */
+
+export const AGENT_SOURCE_TYPES = Object.freeze({
+  expert: 'expert',
+  legacy_assistant: 'legacy_assistant',
+});
+
+function assertAdapter(adapter, sourceType) {
+  if (!adapter || typeof adapter.resolve !== 'function') {
+    throw new Error(`Agent definition adapter missing resolve(): ${sourceType}`);
+  }
+}
+
+export class AgentDefinitionResolver {
+  constructor(adapters = {}) {
+    this.adapters = new Map();
+
+    for (const [sourceType, adapter] of Object.entries(adapters)) {
+      this.register(sourceType, adapter);
+    }
+  }
+
+  register(source_type, adapter) {
+    if (!source_type) {
+      throw new Error('source_type is required');
+    }
+    assertAdapter(adapter, source_type);
+    this.adapters.set(source_type, adapter);
+  }
+
+  async resolve({ source_type, agent_id, options = {} } = {}) {
+    if (!source_type) {
+      throw new Error('source_type is required');
+    }
+    if (!agent_id) {
+      throw new Error('agent_id is required');
+    }
+
+    const adapter = this.adapters.get(source_type);
+    if (!adapter) {
+      throw new Error(`Unsupported agent source_type: ${source_type}`);
+    }
+
+    const definition = await adapter.resolve(agent_id, options);
+    if (!definition) {
+      return null;
+    }
+
+    validateAgentDefinition(definition);
+    return deepFreezeDefinition(definition);
+  }
+}
+
+export function validateAgentDefinition(definition) {
+  if (!definition || typeof definition !== 'object') {
+    throw new Error('AgentDefinition must be an object');
+  }
+  for (const field of ['agent_id', 'source_type', 'display_name', 'execution_policy']) {
+    if (!definition[field]) {
+      throw new Error(`AgentDefinition missing required field: ${field}`);
+    }
+  }
+  if (!definition.execution_policy.mode) {
+    throw new Error('AgentDefinition execution_policy.mode is required');
+  }
+}
+
+export function deepFreezeDefinition(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value;
+  }
+
+  for (const child of Object.values(value)) {
+    deepFreezeDefinition(child);
+  }
+  return Object.freeze(value);
+}
+
+export default AgentDefinitionResolver;

--- a/lib/agent/expert-agent-definition-adapter.js
+++ b/lib/agent/expert-agent-definition-adapter.js
@@ -1,0 +1,100 @@
+/**
+ * Expert -> AgentDefinition adapter.
+ */
+
+import { AGENT_SOURCE_TYPES, deepFreezeDefinition, validateAgentDefinition } from './agent-definition-resolver.js';
+import { buildModelConfigView } from './model-config-view.js';
+
+function parseJsonObject(value) {
+  if (!value) return null;
+  if (typeof value === 'object' && !Array.isArray(value)) return value;
+  if (typeof value !== 'string') return null;
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeNumber(value, fallback = null) {
+  if (value === null || value === undefined || value === '') return fallback;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : fallback;
+}
+
+function mapSkillDeclaration(skill) {
+  return {
+    skill_id: skill.id || skill.skill_id,
+    name: skill.name || null,
+    mark: skill.mark || null,
+    source_type: skill.source_type || null,
+    user_invocable: skill.user_invocable ?? null,
+    disable_model_invocation: skill.disable_model_invocation ?? null,
+    allowed_tools: skill.allowed_tools || null,
+  };
+}
+
+export function buildExpertAgentDefinition(config, options = {}) {
+  const expert = config?.expert;
+  if (!expert) {
+    return null;
+  }
+
+  const knowledgeConfig = parseJsonObject(expert.knowledge_config);
+  const psycheConfig = parseJsonObject(expert.psyche_config);
+  const skills = Array.isArray(config.skills) ? config.skills : [];
+
+  const definition = {
+    agent_id: expert.id,
+    source_type: AGENT_SOURCE_TYPES.expert,
+    display_name: expert.name,
+    description: expert.introduction || '',
+    system_prompt: expert.prompt_template || expert.system_prompt || expert.introduction || '',
+    model_config: {
+      primary_model: buildModelConfigView(config.expressiveModel, options),
+      reflective_model: buildModelConfigView(config.reflectiveModel, options),
+    },
+    context_policy: {
+      context_strategy: expert.context_strategy || 'full',
+      context_threshold: normalizeNumber(expert.context_threshold, null),
+      psyche_config: psycheConfig,
+      knowledge_config: knowledgeConfig,
+    },
+    capability_declarations: {
+      skills: skills.map(mapSkillDeclaration),
+      document_retrieval: {
+        enabled: Boolean(knowledgeConfig?.enabled),
+        kb_id: knowledgeConfig?.kb_id || null,
+      },
+    },
+    execution_policy: {
+      mode: 'llm',
+      max_tool_rounds: normalizeNumber(expert.max_tool_rounds, null),
+      temperature: normalizeNumber(expert.temperature, null),
+      reflective_temperature: normalizeNumber(expert.reflective_temperature, null),
+      supports_delegation: true,
+    },
+    is_active: expert.is_active !== false,
+    source_record: expert,
+  };
+
+  validateAgentDefinition(definition);
+  return deepFreezeDefinition(definition);
+}
+
+export class ExpertAgentDefinitionAdapter {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async resolve(agent_id, options = {}) {
+    const config = await this.db.getExpertFullConfig(agent_id);
+    return buildExpertAgentDefinition(config, options);
+  }
+}
+
+export default ExpertAgentDefinitionAdapter;

--- a/lib/agent/model-config-view.js
+++ b/lib/agent/model-config-view.js
@@ -1,0 +1,26 @@
+/**
+ * Model config view helpers for AgentDefinition.
+ */
+
+const SENSITIVE_MODEL_FIELDS = new Set(['api_key']);
+
+export function buildModelConfigView(modelConfig, options = {}) {
+  if (!modelConfig || typeof modelConfig !== 'object') {
+    return null;
+  }
+  if (options.include_sensitive_model_config) {
+    return { ...modelConfig };
+  }
+
+  const view = {};
+  for (const [key, value] of Object.entries(modelConfig)) {
+    if (!SENSITIVE_MODEL_FIELDS.has(key)) {
+      view[key] = value;
+    }
+  }
+  return view;
+}
+
+export default {
+  buildModelConfigView,
+};

--- a/server/services/assistant/legacy-agent-definition-adapter.js
+++ b/server/services/assistant/legacy-agent-definition-adapter.js
@@ -1,0 +1,96 @@
+/**
+ * Legacy Assistant -> AgentDefinition adapter.
+ */
+
+import { AGENT_SOURCE_TYPES, deepFreezeDefinition, validateAgentDefinition } from '../../../lib/agent/agent-definition-resolver.js';
+import { buildModelConfigView } from '../../../lib/agent/model-config-view.js';
+import { getAssistantDetail } from './config-repository.js';
+
+function parseJsonObject(value) {
+  if (!value) return null;
+  if (typeof value === 'object' && !Array.isArray(value)) return value;
+  if (typeof value !== 'string') return null;
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeNumber(value, fallback = null) {
+  if (value === null || value === undefined || value === '') return fallback;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : fallback;
+}
+
+export function buildLegacyAssistantAgentDefinition(assistant, modelConfig = null, options = {}) {
+  if (!assistant) {
+    return null;
+  }
+
+  const executionMode = assistant.execution_mode || 'llm';
+  const toolParameters = parseJsonObject(assistant.tool_parameters);
+
+  const definition = {
+    agent_id: assistant.id,
+    source_type: AGENT_SOURCE_TYPES.legacy_assistant,
+    display_name: assistant.name,
+    description: assistant.description || '',
+    system_prompt: assistant.prompt_template || '',
+    model_config: {
+      primary_model: buildModelConfigView(modelConfig, options),
+      reflective_model: null,
+    },
+    context_policy: {
+      timeout_seconds: normalizeNumber(assistant.timeout, null),
+      estimated_time_seconds: normalizeNumber(assistant.estimated_time, null),
+    },
+    capability_declarations: {
+      can_use_skills: Boolean(assistant.can_use_skills),
+      direct_tool: assistant.tool_name
+        ? {
+            tool_name: assistant.tool_name,
+            description: assistant.tool_description || '',
+            parameters: toolParameters,
+          }
+        : null,
+    },
+    execution_policy: {
+      mode: executionMode,
+      max_output_tokens: normalizeNumber(assistant.max_tokens, null),
+      temperature: normalizeNumber(assistant.temperature, null),
+      timeout_seconds: normalizeNumber(assistant.timeout, null),
+      supports_delegation: executionMode === 'llm',
+      legacy: true,
+    },
+    is_active: assistant.is_active !== false,
+    source_record: assistant,
+  };
+
+  validateAgentDefinition(definition);
+  return deepFreezeDefinition(definition);
+}
+
+export class LegacyAssistantAgentDefinitionAdapter {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async resolve(agent_id, options = {}) {
+    const assistant = await getAssistantDetail(this.db, agent_id);
+    if (!assistant) {
+      return null;
+    }
+
+    const modelConfig = assistant.model_id
+      ? await this.db.getModelConfig(assistant.model_id)
+      : null;
+    return buildLegacyAssistantAgentDefinition(assistant, modelConfig, options);
+  }
+}
+
+export default LegacyAssistantAgentDefinitionAdapter;

--- a/tests/test-agent-definition-resolver.mjs
+++ b/tests/test-agent-definition-resolver.mjs
@@ -1,0 +1,206 @@
+/**
+ * Tests for AgentDefinition resolver and source adapters.
+ *
+ * Usage:
+ *   node tests/test-agent-definition-resolver.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  AgentDefinitionResolver,
+  AGENT_SOURCE_TYPES,
+} from '../lib/agent/agent-definition-resolver.js';
+import {
+  buildExpertAgentDefinition,
+  ExpertAgentDefinitionAdapter,
+} from '../lib/agent/expert-agent-definition-adapter.js';
+import {
+  buildLegacyAssistantAgentDefinition,
+  LegacyAssistantAgentDefinitionAdapter,
+} from '../server/services/assistant/legacy-agent-definition-adapter.js';
+
+function createExpertConfig() {
+  return {
+    expert: {
+      id: 'expert_1',
+      name: 'Research Expert',
+      introduction: 'Helps with research.',
+      prompt_template: 'You are precise.',
+      expressive_model_id: 'model_primary',
+      reflective_model_id: 'model_reflective',
+      context_strategy: 'minimal',
+      context_threshold: '0.75',
+      psyche_config: JSON.stringify({ enable_notes: true }),
+      knowledge_config: JSON.stringify({ enabled: true, kb_id: 'kb_1' }),
+      max_tool_rounds: 8,
+      temperature: '0.65',
+      reflective_temperature: '0.25',
+      is_active: true,
+    },
+    expressiveModel: { id: 'model_primary', model_name: 'primary', api_key: 'secret_primary' },
+    reflectiveModel: { id: 'model_reflective', model_name: 'reflective' },
+    skills: [{
+      id: 'skill_1',
+      name: 'Search',
+      mark: 'search',
+      source_type: 'builtin',
+      user_invocable: true,
+    }],
+  };
+}
+
+function testBuildExpertDefinition() {
+  const definition = buildExpertAgentDefinition(createExpertConfig());
+
+  assert.equal(definition.agent_id, 'expert_1');
+  assert.equal(definition.source_type, AGENT_SOURCE_TYPES.expert);
+  assert.equal(definition.display_name, 'Research Expert');
+  assert.equal(definition.system_prompt, 'You are precise.');
+  assert.deepEqual(definition.model_config.primary_model, { id: 'model_primary', model_name: 'primary' });
+  assert.equal(definition.model_config.primary_model.api_key, undefined);
+  assert.deepEqual(definition.context_policy.psyche_config, { enable_notes: true });
+  assert.deepEqual(definition.context_policy.knowledge_config, { enabled: true, kb_id: 'kb_1' });
+  assert.equal(definition.context_policy.context_threshold, 0.75);
+  assert.equal(definition.execution_policy.mode, 'llm');
+  assert.equal(definition.execution_policy.max_tool_rounds, 8);
+  assert.equal(definition.execution_policy.supports_delegation, true);
+  assert.deepEqual(definition.capability_declarations.skills, [{
+    skill_id: 'skill_1',
+    name: 'Search',
+    mark: 'search',
+    source_type: 'builtin',
+    user_invocable: true,
+    disable_model_invocation: null,
+    allowed_tools: null,
+  }]);
+  assert.equal(Object.isFrozen(definition), true);
+}
+
+function testBuildLegacyAssistantDefinition() {
+  const definition = buildLegacyAssistantAgentDefinition({
+    id: 'asst_1',
+    name: 'OCR Assistant',
+    description: 'Runs OCR workflow.',
+    model_id: 'model_1',
+    prompt_template: 'Extract text.',
+    max_tokens: 2048,
+    temperature: '0.4',
+    estimated_time: 20,
+    timeout: 90,
+    tool_name: 'ocr_analyze',
+    tool_description: 'Analyze OCR',
+    tool_parameters: JSON.stringify({ type: 'object' }),
+    can_use_skills: false,
+    execution_mode: 'direct',
+    is_active: true,
+  }, { id: 'model_1', model_name: 'assistant-model', api_key: 'secret_assistant' });
+
+  assert.equal(definition.agent_id, 'asst_1');
+  assert.equal(definition.source_type, AGENT_SOURCE_TYPES.legacy_assistant);
+  assert.equal(definition.execution_policy.mode, 'direct');
+  assert.equal(definition.execution_policy.supports_delegation, false);
+  assert.equal(definition.execution_policy.legacy, true);
+  assert.deepEqual(definition.model_config.primary_model, { id: 'model_1', model_name: 'assistant-model' });
+  assert.deepEqual(definition.capability_declarations.direct_tool, {
+    tool_name: 'ocr_analyze',
+    description: 'Analyze OCR',
+    parameters: { type: 'object' },
+  });
+  assert.equal(Object.isFrozen(definition), true);
+}
+
+async function testResolverDispatchesAdapters() {
+  const resolver = new AgentDefinitionResolver({
+    [AGENT_SOURCE_TYPES.expert]: {
+      async resolve(agentId) {
+        return buildExpertAgentDefinition({
+          ...createExpertConfig(),
+          expert: {
+            ...createExpertConfig().expert,
+            id: agentId,
+          },
+        });
+      },
+    },
+  });
+
+  const definition = await resolver.resolve({
+    source_type: AGENT_SOURCE_TYPES.expert,
+    agent_id: 'expert_from_resolver',
+  });
+
+  assert.equal(definition.agent_id, 'expert_from_resolver');
+  await assert.rejects(() => resolver.resolve({
+    source_type: 'missing',
+    agent_id: 'agent_1',
+  }), /Unsupported agent source_type/);
+}
+
+async function testExpertAdapterUsesDbConfig() {
+  const adapter = new ExpertAgentDefinitionAdapter({
+    async getExpertFullConfig(agentId) {
+      return {
+        ...createExpertConfig(),
+        expert: {
+          ...createExpertConfig().expert,
+          id: agentId,
+        },
+      };
+    },
+  });
+
+  const definition = await adapter.resolve('expert_db');
+  assert.equal(definition.agent_id, 'expert_db');
+}
+
+async function testLegacyAssistantAdapterUsesDb() {
+  const assistantRow = {
+    id: 'asst_db',
+    name: 'LLM Assistant',
+    execution_mode: 'llm',
+    is_active: true,
+    can_use_skills: true,
+    model_id: 'model_db',
+  };
+  const adapter = new LegacyAssistantAgentDefinitionAdapter({
+    getModel(modelName) {
+      assert.equal(modelName, 'assistant');
+      return {
+        async findOne() {
+          return { ...assistantRow };
+        },
+      };
+    },
+    async getModelConfig(modelId) {
+      assert.equal(modelId, 'model_db');
+      return { id: 'model_db', model_name: 'llm-model' };
+    },
+  });
+
+  const definition = await adapter.resolve('asst_db');
+  assert.equal(definition.agent_id, 'asst_db');
+  assert.equal(definition.execution_policy.mode, 'llm');
+  assert.equal(definition.execution_policy.supports_delegation, true);
+  assert.equal(definition.capability_declarations.can_use_skills, true);
+}
+
+function testCanIncludeSensitiveModelConfigWhenExplicit() {
+  const definition = buildExpertAgentDefinition(createExpertConfig(), {
+    include_sensitive_model_config: true,
+  });
+
+  assert.equal(definition.model_config.primary_model.api_key, 'secret_primary');
+}
+
+async function main() {
+  testBuildExpertDefinition();
+  testBuildLegacyAssistantDefinition();
+  await testResolverDispatchesAdapters();
+  await testExpertAdapterUsesDbConfig();
+  await testLegacyAssistantAdapterUsesDb();
+  testCanIncludeSensitiveModelConfigWhenExplicit();
+
+  console.log('Agent definition resolver tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add readonly `AgentDefinitionResolver`.
- Add Expert -> `AgentDefinition` adapter.
- Add legacy Assistant -> `AgentDefinition` adapter.
- Add sanitized model config view so model API keys are not included by default.
- Add focused resolver/adapter tests.

## Scope

This PR does not change runtime behavior, database schema, API contracts, or frontend UI. It only introduces the shared definition contract needed for later Agent/Sub-agent migration.

## Validation

- `node tests/test-agent-definition-resolver.mjs`
- `node tests/test-agent-invocation-context.mjs`
- `node -e "import('./lib/agent/agent-definition-resolver.js').then(m => console.log(Object.keys(m).join(',')))"`
- `node -e "import('./lib/agent/expert-agent-definition-adapter.js').then(m => console.log(Object.keys(m).join(',')))"`
- `node -e "import('./server/services/assistant/legacy-agent-definition-adapter.js').then(m => console.log(Object.keys(m).join(',')))"`
- `node -e "import('./lib/agent/model-config-view.js').then(m => console.log(Object.keys(m).join(',')))"`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- Expert definitions map to `execution_policy.mode = "llm"`.
- Legacy Assistant definitions preserve `direct`, `llm`, or `hybrid`.
- Direct legacy assistants are not marked as delegable LLM agents.
- Full sensitive model config requires explicit `include_sensitive_model_config`.
