### PR TITLE
refactor: add agent access policy contracts

### DIFF
--- a/lib/agent/capability-scope-builder.js
+++ b/lib/agent/capability-scope-builder.js
@@ -1,0 +1,125 @@
+/**
+ * Capability scope helpers for Agent delegation.
+ *
+ * Effective capabilities are intentionally intersection-based:
+ * caller delegable scope ∩ callee declarations ∩ principal permissions
+ * ∩ workspace constraints ∩ requested scope.
+ */
+
+const ARRAY_CAPABILITY_KEYS = Object.freeze([
+  'tools',
+  'skills',
+  'direct_tools',
+  'mcp_servers',
+  'document_collections',
+]);
+
+const BOOLEAN_CAPABILITY_KEYS = Object.freeze([
+  'document_retrieval',
+  'can_use_skills',
+]);
+
+function uniqueStrings(values) {
+  if (!Array.isArray(values)) return [];
+  return [...new Set(values.filter(value => typeof value === 'string' && value.trim()).map(value => value.trim()))];
+}
+
+function normalizeBoolean(value) {
+  return value === true;
+}
+
+function normalizeScope(scope = {}) {
+  const normalized = {};
+  for (const key of ARRAY_CAPABILITY_KEYS) {
+    normalized[key] = uniqueStrings(scope[key]);
+  }
+  for (const key of BOOLEAN_CAPABILITY_KEYS) {
+    normalized[key] = normalizeBoolean(scope[key]);
+  }
+  return normalized;
+}
+
+function intersectArrays(scopes, key) {
+  if (scopes.length === 0) return [];
+  const [first, ...rest] = scopes.map(scope => new Set(scope[key]));
+  return [...first].filter(value => rest.every(scopeSet => scopeSet.has(value)));
+}
+
+function intersectBooleans(scopes, key) {
+  return scopes.length > 0 && scopes.every(scope => scope[key] === true);
+}
+
+export function buildDeclaredCapabilityScope(agent_definition = {}) {
+  const declarations = agent_definition.capability_declarations || {};
+  const skills = Array.isArray(declarations.skills)
+    ? declarations.skills
+        .map(skill => skill.mark || skill.skill_id)
+        .filter(Boolean)
+    : [];
+  const directTools = declarations.direct_tool?.tool_name
+    ? [declarations.direct_tool.tool_name]
+    : [];
+
+  return normalizeScope({
+    tools: [
+      ...skills,
+      ...directTools,
+    ],
+    skills,
+    direct_tools: directTools,
+    document_retrieval: declarations.document_retrieval?.enabled === true,
+    can_use_skills: declarations.can_use_skills === true || skills.length > 0,
+  });
+}
+
+export function intersectCapabilityScopes({
+  caller_scope,
+  callee_scope,
+  principal_scope,
+  workspace_scope,
+  requested_scope,
+} = {}) {
+  const requiredScopes = [
+    normalizeScope(caller_scope),
+    normalizeScope(callee_scope),
+    normalizeScope(principal_scope),
+    normalizeScope(workspace_scope),
+  ];
+  const scopes = requested_scope
+    ? [...requiredScopes, normalizeScope(requested_scope)]
+    : requiredScopes;
+
+  const effective = {};
+  for (const key of ARRAY_CAPABILITY_KEYS) {
+    effective[key] = intersectArrays(scopes, key);
+  }
+  for (const key of BOOLEAN_CAPABILITY_KEYS) {
+    effective[key] = intersectBooleans(scopes, key);
+  }
+
+  return Object.freeze(effective);
+}
+
+export function assertRequestedCapabilitiesAllowed(effective_scope = {}, requested_scope = {}) {
+  const effective = normalizeScope(effective_scope);
+  const requested = normalizeScope(requested_scope);
+
+  for (const key of ARRAY_CAPABILITY_KEYS) {
+    const denied = requested[key].filter(value => !effective[key].includes(value));
+    if (denied.length > 0) {
+      throw new Error(`Requested capability denied: ${key}=${denied.join(',')}`);
+    }
+  }
+
+  for (const key of BOOLEAN_CAPABILITY_KEYS) {
+    if (requested[key] === true && effective[key] !== true) {
+      throw new Error(`Requested capability denied: ${key}`);
+    }
+  }
+}
+
+export default {
+  buildDeclaredCapabilityScope,
+  intersectCapabilityScopes,
+  assertRequestedCapabilitiesAllowed,
+};

--- a/server/services/assistant/access-policy.js
+++ b/server/services/assistant/access-policy.js
@@ -1,0 +1,67 @@
+/**
+ * Legacy Assistant access policy helpers.
+ *
+ * These helpers are pure and do not change route behavior by themselves. They
+ * define the policy that later controller/service wiring should enforce.
+ */
+
+function getSessionUserId(session = {}) {
+  return session.id || session.userId || null;
+}
+
+function getSessionRoles(session = {}) {
+  return Array.isArray(session.roles) ? session.roles : [];
+}
+
+export function isAdminSession(session = {}) {
+  return session.isAdmin === true || getSessionRoles(session).includes('admin');
+}
+
+export function canAccessAssistantRequest({
+  session,
+  request,
+  accessible_expert_ids = [],
+} = {}) {
+  if (!session || !request) {
+    return false;
+  }
+  if (isAdminSession(session)) {
+    return true;
+  }
+
+  const userId = getSessionUserId(session);
+  if (userId && request.user_id && request.user_id === userId) {
+    return true;
+  }
+
+  if (request.expert_id && accessible_expert_ids.includes(request.expert_id)) {
+    return true;
+  }
+
+  return false;
+}
+
+export function assertAssistantRequestAccess(input = {}) {
+  if (!canAccessAssistantRequest(input)) {
+    throw new Error('assistant_request_access_denied');
+  }
+}
+
+export function normalizeAssistantCallPrincipal({ session, body = {} } = {}) {
+  const userId = getSessionUserId(session);
+  const expertId = session?.expertId || body.workspace?.expert_id || null;
+
+  return Object.freeze({
+    principal_user_id: userId,
+    caller_agent_id: expertId,
+    authenticated: Boolean(userId),
+    is_admin: isAdminSession(session),
+  });
+}
+
+export default {
+  assertAssistantRequestAccess,
+  canAccessAssistantRequest,
+  isAdminSession,
+  normalizeAssistantCallPrincipal,
+};

--- a/tests/test-agent-access-policy.mjs
+++ b/tests/test-agent-access-policy.mjs
@@ -1,0 +1,153 @@
+/**
+ * Tests for Agent capability scope and legacy assistant access policy.
+ *
+ * Usage:
+ *   node tests/test-agent-access-policy.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  assertRequestedCapabilitiesAllowed,
+  buildDeclaredCapabilityScope,
+  intersectCapabilityScopes,
+} from '../lib/agent/capability-scope-builder.js';
+import {
+  canAccessAssistantRequest,
+  isAdminSession,
+  normalizeAssistantCallPrincipal,
+} from '../server/services/assistant/access-policy.js';
+
+function testBuildDeclaredScopeFromExpertDefinition() {
+  const scope = buildDeclaredCapabilityScope({
+    capability_declarations: {
+      skills: [
+        { skill_id: 'skill_1', mark: 'search' },
+        { skill_id: 'skill_2' },
+      ],
+      document_retrieval: {
+        enabled: true,
+      },
+    },
+  });
+
+  assert.deepEqual(scope.skills, ['search', 'skill_2']);
+  assert.deepEqual(scope.tools, ['search', 'skill_2']);
+  assert.equal(scope.document_retrieval, true);
+  assert.equal(scope.can_use_skills, true);
+}
+
+function testBuildDeclaredScopeFromDirectAssistant() {
+  const scope = buildDeclaredCapabilityScope({
+    capability_declarations: {
+      direct_tool: {
+        tool_name: 'ocr_analyze',
+      },
+      can_use_skills: false,
+    },
+  });
+
+  assert.deepEqual(scope.direct_tools, ['ocr_analyze']);
+  assert.deepEqual(scope.tools, ['ocr_analyze']);
+  assert.equal(scope.can_use_skills, false);
+}
+
+function testCapabilityIntersection() {
+  const effective = intersectCapabilityScopes({
+    caller_scope: {
+      tools: ['search', 'ocr_analyze'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    callee_scope: {
+      tools: ['search', 'write_file'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    principal_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    workspace_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: false,
+      can_use_skills: true,
+    },
+  });
+
+  assert.deepEqual(effective.tools, ['search']);
+  assert.deepEqual(effective.skills, ['search']);
+  assert.equal(effective.document_retrieval, false);
+  assert.equal(effective.can_use_skills, true);
+}
+
+function testRequestedCapabilitiesAreDeniedWhenOutsideIntersection() {
+  const effective = intersectCapabilityScopes({
+    caller_scope: { tools: ['search'], can_use_skills: true },
+    callee_scope: { tools: ['search'], can_use_skills: true },
+    principal_scope: { tools: ['search'], can_use_skills: true },
+    workspace_scope: { tools: ['search'], can_use_skills: true },
+  });
+
+  assertRequestedCapabilitiesAllowed(effective, { tools: ['search'] });
+  assert.throws(() => assertRequestedCapabilitiesAllowed(effective, {
+    tools: ['write_file'],
+  }), /Requested capability denied/);
+}
+
+function testAssistantRequestAccessPolicy() {
+  assert.equal(isAdminSession({ roles: ['admin'] }), true);
+  assert.equal(canAccessAssistantRequest({
+    session: { id: 'user_1', roles: ['user'] },
+    request: { user_id: 'user_1', expert_id: 'expert_1' },
+  }), true);
+  assert.equal(canAccessAssistantRequest({
+    session: { id: 'user_2', roles: ['user'] },
+    request: { user_id: 'user_1', expert_id: 'expert_allowed' },
+    accessible_expert_ids: ['expert_allowed'],
+  }), true);
+  assert.equal(canAccessAssistantRequest({
+    session: { id: 'user_2', roles: ['user'] },
+    request: { user_id: 'user_1', expert_id: 'expert_denied' },
+    accessible_expert_ids: ['expert_allowed'],
+  }), false);
+}
+
+function testNormalizeAssistantCallPrincipal() {
+  const principal = normalizeAssistantCallPrincipal({
+    session: {
+      userId: 'user_1',
+      expertId: 'expert_1',
+      roles: ['user'],
+    },
+    body: {
+      workspace: {
+        expert_id: 'body_expert',
+      },
+    },
+  });
+
+  assert.deepEqual(principal, {
+    principal_user_id: 'user_1',
+    caller_agent_id: 'expert_1',
+    authenticated: true,
+    is_admin: false,
+  });
+}
+
+function main() {
+  testBuildDeclaredScopeFromExpertDefinition();
+  testBuildDeclaredScopeFromDirectAssistant();
+  testCapabilityIntersection();
+  testRequestedCapabilitiesAreDeniedWhenOutsideIntersection();
+  testAssistantRequestAccessPolicy();
+  testNormalizeAssistantCallPrincipal();
+
+  console.log('Agent access policy tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add capability scope builder for Agent delegation.
- Add legacy Assistant request access policy helpers.
- Add focused tests for capability intersection and request access rules.

## Scope

This PR is contract-only. It does not wire policy into routes/controllers and does not change `/api/assistants/call` behavior.

## Validation

- `node tests/test-agent-access-policy.mjs`
- `node tests/test-agent-definition-resolver.mjs`
- `node tests/test-agent-invocation-context.mjs`
- `node -e "import('./lib/agent/capability-scope-builder.js').then(m => console.log(Object.keys(m).join(',')))"`
- `node -e "import('./server/services/assistant/access-policy.js').then(m => console.log(Object.keys(m).join(',')))"`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- Effective scope is intersection-based across caller, callee, principal, workspace, and requested scopes.
- Missing capability declarations deny by default.
- Legacy Assistant request access is admin, owner user, or user with access to the related expert.
- Wiring `/api/assistants/call` authentication should be a separate integration decision because current behavior allows anonymous calls.
