### PR TITLE
refactor: add agent delegation service contract

### DIFF
--- a/lib/agent/agent-delegation-service.js
+++ b/lib/agent/agent-delegation-service.js
@@ -1,0 +1,128 @@
+/**
+ * Agent delegation service contract.
+ *
+ * This service prepares a child Agent run envelope. It does not execute the
+ * child run yet; execution will be wired in later migration phases.
+ */
+
+import {
+  buildAgentEvent,
+} from './agent-event.js';
+import {
+  deriveChildAgentInvocationContext,
+} from './agent-invocation-context.js';
+import {
+  buildDeclaredCapabilityScope,
+  intersectCapabilityScopes,
+  assertRequestedCapabilitiesAllowed,
+} from './capability-scope-builder.js';
+
+export class AgentDelegationService {
+  constructor({
+    definition_resolver,
+    event_sink = null,
+    max_delegation_depth = 2,
+  } = {}) {
+    if (!definition_resolver || typeof definition_resolver.resolve !== 'function') {
+      throw new Error('definition_resolver is required');
+    }
+
+    this.definition_resolver = definition_resolver;
+    this.event_sink = event_sink;
+    this.max_delegation_depth = max_delegation_depth;
+  }
+
+  async delegate({
+    parent_invocation,
+    target,
+    task,
+    input = {},
+    expected_output = null,
+    requested_scope = null,
+    caller_scope = {},
+    principal_scope = {},
+    workspace_scope = {},
+    invocation_mode = 'llm',
+    source = 'agent_delegate',
+  } = {}) {
+    if (!parent_invocation) {
+      throw new Error('parent_invocation is required');
+    }
+    if (!target?.source_type || !target?.agent_id) {
+      throw new Error('target.source_type and target.agent_id are required');
+    }
+    if (!task || typeof task !== 'string') {
+      throw new Error('task is required');
+    }
+
+    const callee_definition = await this.definition_resolver.resolve({
+      source_type: target.source_type,
+      agent_id: target.agent_id,
+    });
+    if (!callee_definition) {
+      throw new Error(`Agent target not found: ${target.source_type}/${target.agent_id}`);
+    }
+    if (callee_definition.is_active === false) {
+      throw new Error(`Agent target inactive: ${target.source_type}/${target.agent_id}`);
+    }
+
+    const callee_scope = buildDeclaredCapabilityScope(callee_definition);
+    const effective_scope = intersectCapabilityScopes({
+      caller_scope,
+      callee_scope,
+      principal_scope,
+      workspace_scope,
+      requested_scope,
+    });
+    if (requested_scope) {
+      assertRequestedCapabilitiesAllowed(effective_scope, requested_scope);
+    }
+
+    const child_invocation = deriveChildAgentInvocationContext(parent_invocation, {
+      callee_agent_id: callee_definition.agent_id,
+      workspace_scope,
+      capability_scope: effective_scope,
+      invocation_mode,
+      source,
+      max_delegation_depth: this.max_delegation_depth,
+    });
+
+    const delegation = Object.freeze({
+      status: 'accepted',
+      parent_invocation,
+      child_invocation,
+      callee_definition,
+      task,
+      input,
+      expected_output,
+      requested_scope,
+      effective_scope,
+    });
+
+    await this.emit('delegation_created', child_invocation, {
+      task,
+      source_type: callee_definition.source_type,
+      agent_id: callee_definition.agent_id,
+    });
+
+    return delegation;
+  }
+
+  async emit(type, invocation_context, payload = {}) {
+    const event = buildAgentEvent({
+      type,
+      invocation_context,
+      payload,
+    });
+
+    if (typeof this.event_sink === 'function') {
+      await this.event_sink(event);
+    } else if (this.event_sink && typeof this.event_sink.emit === 'function') {
+      await this.event_sink.emit(event);
+    }
+
+    return event;
+  }
+}
+
+export default AgentDelegationService;

--- a/tests/test-agent-delegation-service.mjs
+++ b/tests/test-agent-delegation-service.mjs
@@ -1,0 +1,154 @@
+/**
+ * Tests for AgentDelegationService contract.
+ *
+ * Usage:
+ *   node tests/test-agent-delegation-service.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { AgentDelegationService } from '../lib/agent/agent-delegation-service.js';
+import { buildRootAgentInvocationContext } from '../lib/agent/agent-invocation-context.js';
+
+function createParentInvocation() {
+  return buildRootAgentInvocationContext({
+    run_id: 'root_run_1',
+    principal_user_id: 'user_1',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_1',
+  });
+}
+
+function createDefinition(overrides = {}) {
+  return {
+    agent_id: 'expert_child',
+    source_type: 'expert',
+    display_name: 'Child Expert',
+    execution_policy: {
+      mode: 'llm',
+      supports_delegation: true,
+    },
+    capability_declarations: {
+      skills: [{ skill_id: 'skill_search', mark: 'search' }],
+      document_retrieval: { enabled: true },
+    },
+    is_active: true,
+    ...overrides,
+  };
+}
+
+async function testDelegationBuildsChildRun() {
+  const events = [];
+  const service = new AgentDelegationService({
+    definition_resolver: {
+      async resolve({ source_type, agent_id }) {
+        assert.equal(source_type, 'expert');
+        assert.equal(agent_id, 'expert_child');
+        return createDefinition();
+      },
+    },
+    event_sink: event => events.push(event),
+  });
+
+  const delegation = await service.delegate({
+    parent_invocation: createParentInvocation(),
+    target: { source_type: 'expert', agent_id: 'expert_child' },
+    task: 'Search the project',
+    input: { query: 'agent' },
+    caller_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    principal_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    workspace_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    requested_scope: {
+      tools: ['search'],
+      skills: ['search'],
+    },
+  });
+
+  assert.equal(delegation.status, 'accepted');
+  assert.equal(delegation.child_invocation.parent_run_id, 'root_run_1');
+  assert.equal(delegation.child_invocation.principal_user_id, 'user_1');
+  assert.equal(delegation.child_invocation.caller_agent_id, 'expert_parent');
+  assert.equal(delegation.child_invocation.callee_agent_id, 'expert_child');
+  assert.equal(delegation.child_invocation.delegation_depth, 1);
+  assert.deepEqual(delegation.effective_scope.tools, ['search']);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'delegation_created');
+  assert.equal(events[0].callee_agent_id, 'expert_child');
+}
+
+async function testRejectsDeniedCapability() {
+  const service = new AgentDelegationService({
+    definition_resolver: {
+      async resolve() {
+        return createDefinition();
+      },
+    },
+  });
+
+  await assert.rejects(() => service.delegate({
+    parent_invocation: createParentInvocation(),
+    target: { source_type: 'expert', agent_id: 'expert_child' },
+    task: 'Write a file',
+    caller_scope: { tools: ['search'], skills: ['search'] },
+    principal_scope: { tools: ['search'], skills: ['search'] },
+    workspace_scope: { tools: ['search'], skills: ['search'] },
+    requested_scope: { tools: ['write_file'] },
+  }), /Requested capability denied/);
+}
+
+async function testRejectsInactiveTarget() {
+  const service = new AgentDelegationService({
+    definition_resolver: {
+      async resolve() {
+        return createDefinition({ is_active: false });
+      },
+    },
+  });
+
+  await assert.rejects(() => service.delegate({
+    parent_invocation: createParentInvocation(),
+    target: { source_type: 'expert', agent_id: 'expert_child' },
+    task: 'Run inactive target',
+  }), /Agent target inactive/);
+}
+
+async function testRejectsDelegationCycle() {
+  const service = new AgentDelegationService({
+    definition_resolver: {
+      async resolve() {
+        return createDefinition({ agent_id: 'expert_parent' });
+      },
+    },
+  });
+
+  await assert.rejects(() => service.delegate({
+    parent_invocation: createParentInvocation(),
+    target: { source_type: 'expert', agent_id: 'expert_parent' },
+    task: 'Call self',
+  }), /delegation cycle detected/);
+}
+
+async function main() {
+  await testDelegationBuildsChildRun();
+  await testRejectsDeniedCapability();
+  await testRejectsInactiveTarget();
+  await testRejectsDelegationCycle();
+
+  console.log('Agent delegation service tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `AgentDelegationService` contract.
- Resolve target AgentDefinition before delegation.
- Intersect caller/callee/principal/workspace/requested capability scopes.
- Derive child invocation context and emit `delegation_created`.
- Add focused tests for accepted delegation, denied capabilities, inactive targets, and cycles.

## Scope

This PR does not execute child runs, write DB records, wire AssistantManager, expose `agent_delegate`, or change route/API behavior.

## Validation

- `node tests/test-agent-delegation-service.mjs`
- `node tests/test-agent-access-policy.mjs`
- `node tests/test-agent-definition-resolver.mjs`
- `node tests/test-agent-invocation-context.mjs`
- `node -e "import('./lib/agent/agent-delegation-service.js').then(m => console.log(Object.keys(m).join(',')))"`
- `npm.cmd run lint`
- `git diff --check`

## Notes

- Returned delegation status is `accepted`; execution is deliberately left for a later integration phase.
- The service emits `delegation_created` via an optional event sink.
- Capability denial happens before child invocation is returned.
