### PR TITLE
refactor: add root agent runtime and loop

### DIFF
--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -1,0 +1,351 @@
+/**
+ * Agent loop.
+ *
+ * This module owns the streaming LLM/tool loop for an Agent run. Phase A moves
+ * the existing root chat loop here without changing its behavior.
+ */
+
+import LLMClient from '../llm-client.js';
+import logger from '../logger.js';
+import { isRetryableError } from '../llm-retry.js';
+import { getToolCallDisplayNames, presentToolCalls, toToolCallArray } from '../tool-call-presenter.js';
+import { addTokenUsage } from '../token-usage-accumulator.js';
+import { createRoundStateSnapshot, restoreRoundStateSnapshot } from '../chat/round-state-snapshot.js';
+import { getSystemSettingService } from '../../server/services/system-setting.service.js';
+
+const DEFAULT_STREAM_RECOVERY_MAX_ATTEMPTS = 2;
+const DEFAULT_STREAM_RECOVERY_BASE_DELAY_MS = 1500;
+const DEFAULT_STREAM_RECOVERY_MAX_DELAY_MS = 10000;
+
+function resolvePositiveIntegerEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function assertFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+export class AgentLoop {
+  constructor({
+    db,
+    execute_tools,
+    save_llm_payload,
+    generate_tool_call_summary,
+  } = {}) {
+    if (!db) {
+      throw new Error('db is required');
+    }
+    assertFunction(execute_tools, 'execute_tools');
+    assertFunction(save_llm_payload, 'save_llm_payload');
+    assertFunction(generate_tool_call_summary, 'generate_tool_call_summary');
+
+    this.db = db;
+    this.execute_tools = execute_tools;
+    this.save_llm_payload = save_llm_payload;
+    this.generate_tool_call_summary = generate_tool_call_summary;
+  }
+
+  async run(expertService, { modelConfig, thinkingConfig, tools, currentMessages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, request_id, onDelta, shouldStop, runtimeState = null }) {
+    const systemSettingService = getSystemSettingService(this.db);
+    const MAX_TOOL_ROUNDS = expertService.expertConfig?.expert?.max_tool_rounds
+      || await systemSettingService.getMaxToolRounds();
+    const MAX_STREAM_RECOVERY_ATTEMPTS = resolvePositiveIntegerEnv('CHAT_STREAM_RECOVERY_MAX_ATTEMPTS', DEFAULT_STREAM_RECOVERY_MAX_ATTEMPTS);
+    const STREAM_RECOVERY_BASE_DELAY_MS = resolvePositiveIntegerEnv('CHAT_STREAM_RECOVERY_BASE_DELAY_MS', DEFAULT_STREAM_RECOVERY_BASE_DELAY_MS);
+    const STREAM_RECOVERY_MAX_DELAY_MS = resolvePositiveIntegerEnv('CHAT_STREAM_RECOVERY_MAX_DELAY_MS', DEFAULT_STREAM_RECOVERY_MAX_DELAY_MS);
+
+    let fullContent = '';
+    let fullReasoningContent = '';
+    let tokenUsage = null;
+    let allToolCalls = [];
+    let messages = [...currentMessages];
+    let llmCallsCount = 0;  // P0 观测：记录 LLM 调用次数
+
+    const assertNotStopped = () => {
+      if (shouldStop?.()) {
+        throw new Error('Request aborted by user');
+      }
+    };
+
+    const waitForRecoveryDelay = async (delayMs) => {
+      if (delayMs <= 0) {
+        assertNotStopped();
+        return;
+      }
+
+      const stepMs = 100;
+      let remaining = delayMs;
+      while (remaining > 0) {
+        assertNotStopped();
+        const chunk = Math.min(stepMs, remaining);
+        await new Promise(resolve => setTimeout(resolve, chunk));
+        remaining -= chunk;
+      }
+      assertNotStopped();
+    };
+
+    // 更新 payload 基础信息
+    llmPayload.model = modelConfig.model_name;
+    llmPayload.temperature = expertService.llmClient.getExpertLLMParams().temperature;
+    llmPayload.top_p = expertService.llmClient.getExpertLLMParams().top_p;
+    llmPayload.frequency_penalty = expertService.llmClient.getExpertLLMParams().frequency_penalty;
+    llmPayload.presence_penalty = expertService.llmClient.getExpertLLMParams().presence_penalty;
+    llmPayload.max_tokens = modelConfig.max_output_tokens || 32768;
+    if (tools.length > 0) llmPayload.tools = tools;
+
+    logger.info('[AgentLoop] 开始调用 LLM，当前消息数:', messages.length);
+
+    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+      assertNotStopped();
+      llmCallsCount++;  // P0 观测：记录 LLM 调用次数
+
+      logger.info('[AgentLoop] 第', round + 1, '轮调用 LLM...');
+
+      // 回收旧图片（compaction 后，旧 base64 替换为文本占位符）
+      if (round > 0) {
+        messages = LLMClient.stripHistoricalImages(messages);
+      }
+
+      const roundSnapshot = createRoundStateSnapshot({
+        round,
+        messages,
+        fullContent,
+        fullReasoningContent,
+        tokenUsage,
+      });
+
+      // 同步 request runtime 观测字段（统一状态真相源由 StreamController 持有）
+      if (runtimeState) {
+        runtimeState.round = round + 1;
+        runtimeState.round_snapshot_ref = { round: round + 1, taken_at: new Date().toISOString() };
+      }
+
+      let collectedToolCalls = [];
+      let roundContent = '';
+      let attempt = 0;
+
+      while (attempt <= MAX_STREAM_RECOVERY_ATTEMPTS) {
+        assertNotStopped();
+        try {
+          if (runtimeState) {
+            runtimeState.has_active_transport = true;
+          }
+          // 流式调用
+          await expertService.llmClient.callStream(modelConfig, messages, {
+            tools,
+            thinking: thinkingConfig.thinking,
+            reasoning: thinkingConfig.reasoning,
+            reasoning_effort: thinkingConfig.reasoning_effort,
+            enable_thinking: thinkingConfig.enable_thinking,
+            chat_template_kwargs: thinkingConfig.chat_template_kwargs,
+            user_id,  // 添加 user_id 用于 abort 机制
+            request_id,
+            recovery_test_round: round + 1,
+            recovery_test_attempt: attempt,
+            onDelta: (delta) => {
+              roundContent += delta;
+              fullContent += delta;
+              onDelta?.({ type: 'delta', content: delta });
+            },
+            onReasoningDelta: (reasoningDelta) => {
+              fullReasoningContent += reasoningDelta;
+              onDelta?.({ type: 'reasoning_delta', content: reasoningDelta });
+            },
+            onToolCall: (toolCalls) => {
+              const toolCallsForLog = toToolCallArray(toolCalls);
+              const displayNames = getToolCallDisplayNames(toolCallsForLog, expertService.toolManager);
+              logger.info(`[AgentLoop] 第${round + 1}轮收到工具调用:`, displayNames);
+
+              collectedToolCalls.push(...toolCallsForLog);
+
+              const toolCallsWithDisplayNames = presentToolCalls(toolCallsForLog, expertService.toolManager);
+              onDelta?.({ type: 'tool_call', toolCalls: toolCallsWithDisplayNames });
+            },
+            onUsage: (usage) => {
+              if (usage) {
+                tokenUsage = addTokenUsage(tokenUsage, usage);
+                logger.info(`[AgentLoop] 第${round + 1}轮 token 使用:`, {
+                  prompt: usage.prompt_tokens,
+                  completion: usage.completion_tokens,
+                  total: usage.total_tokens,
+                });
+              }
+            },
+          });
+          break;
+        } catch (error) {
+          if (runtimeState) {
+            runtimeState.has_active_transport = false;
+          }
+          const isStopped = error.message === 'Request aborted by user';
+          const isRetryable = isRetryableError(error);
+
+          if (isStopped || !isRetryable || attempt >= MAX_STREAM_RECOVERY_ATTEMPTS) {
+            throw error;
+          }
+
+          attempt += 1;
+          if (runtimeState) {
+            runtimeState.recovery_attempt = attempt;
+          }
+          const delayMs = Math.min(STREAM_RECOVERY_BASE_DELAY_MS * Math.pow(2, attempt - 1), STREAM_RECOVERY_MAX_DELAY_MS);
+          logger.warn(`[AgentLoop] 第${round + 1}轮 LLM 流式调用失败，准备恢复重试: attempt=${attempt}/${MAX_STREAM_RECOVERY_ATTEMPTS}, delay=${delayMs}ms, error=${error.message}`);
+
+          const restoredRoundState = restoreRoundStateSnapshot(roundSnapshot);
+          fullContent = restoredRoundState.fullContent;
+          fullReasoningContent = restoredRoundState.fullReasoningContent;
+          tokenUsage = restoredRoundState.tokenUsage;
+          collectedToolCalls = [];
+          roundContent = '';
+          messages = restoredRoundState.messages;
+
+          onDelta?.({
+            type: 'recovering',
+            request_id,
+            round: round + 1,
+            attempt,
+            max_attempts: MAX_STREAM_RECOVERY_ATTEMPTS,
+            content: fullContent,
+            reasoning_content: fullReasoningContent,
+          });
+
+          await waitForRecoveryDelay(delayMs);
+
+          // 退避完成且未被停止：当前轮即将重新发起，通知状态机 recovering -> running
+          onDelta?.({
+            type: 'recovered',
+            request_id,
+            round: round + 1,
+            attempt,
+          });
+        }
+      }
+
+      // 如果没有工具调用，退出循环
+      if (collectedToolCalls.length === 0) {
+        logger.info(`[AgentLoop] 第${round + 1}轮无工具调用，完成`);
+        if (roundContent) {
+          messages = [...messages, { role: 'assistant', content: roundContent }];
+          llmPayload.messages = messages;
+          llmPayload._debug.context_messages_count = messages.length;
+          llmPayload.cached_at = new Date().toISOString();
+          this.save_llm_payload(user_id, expert_id, llmPayload);
+        }
+        break;
+      }
+
+      logger.info(`[AgentLoop] 第${round + 1}轮开始执行工具调用:`, collectedToolCalls.length);
+      assertNotStopped();
+
+      // 执行工具
+      const toolResults = await this.execute_tools(expertService, {
+        collectedToolCalls,
+        user_id,
+        taskContext,
+        topic_id,
+        task_id,
+        session,
+        expert_id,
+        request_id,
+        onDelta
+      });
+
+      // round02: 文档检索原子结果 → 聚合证据注入（流式与非流式共用入口）
+      // _consumeDocRetrievalResult 统一聚合 → 证据注入 → 链路形态日志
+      const consumption = expertService._consumeDocRetrievalResult(toolResults, {
+        caller: 'AgentLoop.run',
+        extra: { round: round + 1 },
+      });
+
+      if (consumption.found && consumption.evidenceInjection) {
+        // 将聚合证据与使用规则注入到消息历史头部，下一轮 LLM 将看到
+        messages.unshift({
+          role: 'system',
+          content: consumption.evidenceInjection,
+        });
+        logger.info('[AgentLoop] 已注入文档检索证据（流式路径）:', {
+          atomic_tools: consumption.docRetrievalResults.map(r => r.tool_name || r.toolName || 'unknown'),
+          chain_pattern: consumption.chainHealth?.pattern,
+          result_count: consumption.docRetrievalResults.length,
+          round: round + 1,
+        });
+      }
+
+      // 合并工具调用和执行结果
+      const toolCallsWithResults = collectedToolCalls.map((call, index) => {
+        const result = toolResults[index];
+        return {
+          ...call,
+          result: result ? { success: result.success, data: result.data, error: result.error } : null,
+          duration: result?.duration || 0,
+          tool_message_id: result?.toolMessageId || null,
+          // round03：透传原子执行轨迹供前端展示（仅 document_retrieval 原子 tool 有）
+          ...(result?.atomic_steps ? { atomic_steps: result.atomic_steps } : {}),
+          timestamp: new Date().toISOString(),
+        };
+      });
+      allToolCalls.push(...toolCallsWithResults);
+
+      // 更新消息历史
+      messages = [
+        ...messages,
+        { role: 'assistant', content: roundContent || null, tool_calls: collectedToolCalls },
+        ...expertService.toolManager.formatToolResultsForLLM(toolResults),
+      ];
+
+      // 注入合成 user 消息（多模态图片识别）
+      LLMClient.injectImageUserMessages(messages, modelConfig, toolResults);
+
+      // 同步更新 LLM Payload 缓存
+      llmPayload.messages = messages;
+      llmPayload._debug.context_messages_count = messages.length;
+      llmPayload.cached_at = new Date().toISOString();
+      this.save_llm_payload(user_id, expert_id, llmPayload);
+
+      // 检测工具调用轮数阈值，推送 SSE 事件通知用户
+      const currentRound = round + 1;
+      const isLastRound = currentRound >= MAX_TOOL_ROUNDS;
+      const threshold = currentRound / MAX_TOOL_ROUNDS;
+
+      if (isLastRound) {
+        // 达到 100% 上限：生成总结并通知用户
+        const summary = this.generate_tool_call_summary(allToolCalls);
+        onDelta?.({
+          type: 'tool_limit_reached',
+          totalRounds: MAX_TOOL_ROUNDS,
+          executedRounds: currentRound,
+          summary,
+          message: `已达到最大工具调用次数（${currentRound}轮），AI 正在生成总结`
+        });
+        logger.info(`[AgentLoop] 工具调用达上限，生成总结: ${summary.substring(0, 100)}...`);
+      } else if (threshold >= 0.8) {
+        // 达到 80% 阈值：发送警告提示
+        onDelta?.({
+          type: 'tool_limit_warning',
+          currentRound,
+          maxRounds: MAX_TOOL_ROUNDS,
+          remainingRounds: MAX_TOOL_ROUNDS - currentRound,
+          message: `已调用 ${currentRound}/${MAX_TOOL_ROUNDS} 轮（${Math.round(threshold * 100)}%），即将达到上限`
+        });
+        logger.info(`[AgentLoop] 工具调用警告: ${currentRound}/${MAX_TOOL_ROUNDS} 轮`);
+      }
+    }
+
+    // 如果 LLM 没有返回任何内容，生成默认回复
+    if (!fullContent || fullContent.trim() === '') {
+      logger.warn('[AgentLoop] LLM 未返回内容，生成默认回复');
+      fullContent = '我已处理您的请求，但没有生成具体的回复内容。';
+    }
+
+    // P0 观测：记录本轮 LLM 调用次数
+    logger.info(`[AgentLoop] 本轮 LLM 调用次数: ${llmCallsCount}, 专家: ${expert_id}, 策略: ${expertService.expertConfig?.expert?.context_strategy || 'full'}`);
+
+    return { fullContent, fullReasoningContent, tokenUsage, allToolCalls, finalMessages: messages, llmCallsCount };
+  }
+}
+
+export default AgentLoop;

--- a/lib/agent/agent-runtime.js
+++ b/lib/agent/agent-runtime.js
@@ -1,0 +1,95 @@
+/**
+ * Agent runtime facade.
+ *
+ * Phase A keeps the existing root chat LLM loop intact and wraps it with the
+ * shared Agent invocation/event boundary. Child execution is intentionally not
+ * wired here yet.
+ */
+
+import { buildAgentEvent } from './agent-event.js';
+import { buildRootAgentInvocationContext } from './agent-invocation-context.js';
+
+function defaultIsCancelledError(error) {
+  return error?.message === 'Request aborted by user' || error?.name === 'AbortError';
+}
+
+function buildCompletionPayload(result = {}) {
+  const tokenUsage = result?.tokenUsage || null;
+  const allToolCalls = Array.isArray(result?.allToolCalls) ? result.allToolCalls : [];
+
+  return {
+    llm_calls_count: Number.isInteger(result?.llmCallsCount) ? result.llmCallsCount : null,
+    tool_call_count: allToolCalls.length,
+    has_content: Boolean(result?.fullContent && String(result.fullContent).trim()),
+    has_reasoning_content: Boolean(result?.fullReasoningContent && String(result.fullReasoningContent).trim()),
+    token_usage: tokenUsage ? {
+      prompt_tokens: tokenUsage.prompt_tokens || 0,
+      completion_tokens: tokenUsage.completion_tokens || 0,
+      total_tokens: tokenUsage.total_tokens || 0,
+    } : null,
+  };
+}
+
+export class AgentRuntime {
+  constructor({
+    event_sink = null,
+    is_cancelled_error = defaultIsCancelledError,
+  } = {}) {
+    this.event_sink = event_sink;
+    this.is_cancelled_error = is_cancelled_error;
+  }
+
+  async runRoot(input = {}, executor) {
+    if (typeof executor !== 'function') {
+      throw new Error('executor is required');
+    }
+
+    const invocation_context = input.invocation_context || buildRootAgentInvocationContext(input);
+
+    await this.emit('agent_run_created', invocation_context, {
+      source: invocation_context.source,
+    });
+    await this.emit('agent_run_started', invocation_context);
+
+    try {
+      const result = await executor({ invocation_context });
+      await this.emit('agent_run_completed', invocation_context, buildCompletionPayload(result));
+
+      if (result && typeof result === 'object' && !Array.isArray(result)) {
+        return {
+          ...result,
+          agent_invocation_context: invocation_context,
+        };
+      }
+
+      return {
+        result,
+        agent_invocation_context: invocation_context,
+      };
+    } catch (error) {
+      const eventType = this.is_cancelled_error(error) ? 'agent_run_cancelled' : 'agent_run_failed';
+      await this.emit(eventType, invocation_context, {
+        error: error?.message || String(error),
+      });
+      throw error;
+    }
+  }
+
+  async emit(type, invocation_context, payload = {}) {
+    const event = buildAgentEvent({
+      type,
+      invocation_context,
+      payload,
+    });
+
+    if (typeof this.event_sink === 'function') {
+      await this.event_sink(event);
+    } else if (this.event_sink && typeof this.event_sink.emit === 'function') {
+      await this.event_sink.emit(event);
+    }
+
+    return event;
+  }
+}
+
+export default AgentRuntime;

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -17,7 +17,7 @@
  * 【INFRASTRUCTURE LAYER - 基础设施层】
  *   - LLM Payload 缓存管理
  *   - ExpertService 生命周期管理
- *   - 内部工具调用编排 (_executeLLMRounds, _executeTools)
+ *   - 内部工具调用编排 (_executeTools)
  *
  * 【APPLICATION LAYER - 应用层】
  *   - 对话流程编排 (streamChat, chat)
@@ -51,28 +51,14 @@ import LLMPayloadCache from './chat/llm-payload-cache.js';
 import { ConversationOrchestrator } from './chat/conversation-orchestrator.js';
 import { TopicLifecycleManager } from './topic/topic-lifecycle-manager.js';
 import logger from './logger.js';
-import { isRetryableError } from './llm-retry.js';
 import { resolveThinkingRequestConfig } from './llm-thinking-config.js';
-import { getToolCallDisplayNames, presentToolCalls, toToolCallArray } from './tool-call-presenter.js';
 import { buildToolCallSnapshot } from './tool-call-snapshot-builder.js';
-import { addTokenUsage } from './token-usage-accumulator.js';
-import { createRoundStateSnapshot, restoreRoundStateSnapshot } from './chat/round-state-snapshot.js';
 import { buildStreamTurnContext, buildToolContext } from './chat/turn-context-builder.js';
+import AgentRuntime from './agent/agent-runtime.js';
+import AgentLoop from './agent/agent-loop.js';
 import Utils from './utils.js';
 import path from 'path';
-import { getSystemSettingService } from '../server/services/system-setting.service.js';
 import { getWorkspaceRoot, getSkillsPath, getTaskWorkspaceAbsolutePath, getDefaultWorkspaceAbsolutePath, toLogicalWorkspacePath } from './paths.js';
-
-const DEFAULT_STREAM_RECOVERY_MAX_ATTEMPTS = 2;
-const DEFAULT_STREAM_RECOVERY_BASE_DELAY_MS = 1500;
-const DEFAULT_STREAM_RECOVERY_MAX_DELAY_MS = 10000;
-
-function resolvePositiveIntegerEnv(name, fallback) {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
-}
 
 class ChatService {
   /**
@@ -83,6 +69,13 @@ class ChatService {
   constructor(db, options = {}) {
     this.db = db;
     this.assistantManager = options.assistantManager || null;
+    this.agentRuntime = options.agentRuntime || new AgentRuntime({ event_sink: options.agentEventSink || null });
+    this.agentLoop = options.agentLoop || new AgentLoop({
+      db: this.db,
+      execute_tools: (expertService, input) => this._executeTools(expertService, input),
+      save_llm_payload: (user_id, expert_id, payload) => this.saveLLMPayload(user_id, expert_id, payload),
+      generate_tool_call_summary: toolCalls => this._generateToolCallSummary(toolCalls),
+    });
     this.Message = db.getModel('message');
     this.Topic = db.getModel('topic');
     this.ChatRequest = db.getModel('chat_request');
@@ -236,308 +229,6 @@ class ChatService {
         is_skill_creator: session?.roles?.includes('creator') || false,
       };
     }
-  }
-
-  /**
-   * 执行多轮 LLM 调用（私有方法）
-   * 支持流式响应和多轮工具调用
-   * @returns {Promise<object>} LLM 调用结果
-   */
-  async _executeLLMRounds(expertService, { modelConfig, thinkingConfig, tools, currentMessages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, request_id, onDelta, shouldStop, runtimeState = null }) {
-    const systemSettingService = getSystemSettingService(this.db);
-    const MAX_TOOL_ROUNDS = expertService.expertConfig?.expert?.max_tool_rounds
-      || await systemSettingService.getMaxToolRounds();
-    const MAX_STREAM_RECOVERY_ATTEMPTS = resolvePositiveIntegerEnv('CHAT_STREAM_RECOVERY_MAX_ATTEMPTS', DEFAULT_STREAM_RECOVERY_MAX_ATTEMPTS);
-    const STREAM_RECOVERY_BASE_DELAY_MS = resolvePositiveIntegerEnv('CHAT_STREAM_RECOVERY_BASE_DELAY_MS', DEFAULT_STREAM_RECOVERY_BASE_DELAY_MS);
-    const STREAM_RECOVERY_MAX_DELAY_MS = resolvePositiveIntegerEnv('CHAT_STREAM_RECOVERY_MAX_DELAY_MS', DEFAULT_STREAM_RECOVERY_MAX_DELAY_MS);
-
-    let fullContent = '';
-    let fullReasoningContent = '';
-    let tokenUsage = null;
-    let allToolCalls = [];
-    let messages = [...currentMessages];
-    let llmCallsCount = 0;  // P0 观测：记录 LLM 调用次数
-
-    const assertNotStopped = () => {
-      if (shouldStop?.()) {
-        throw new Error('Request aborted by user');
-      }
-    };
-
-    const waitForRecoveryDelay = async (delayMs) => {
-      if (delayMs <= 0) {
-        assertNotStopped();
-        return;
-      }
-
-      const stepMs = 100;
-      let remaining = delayMs;
-      while (remaining > 0) {
-        assertNotStopped();
-        const chunk = Math.min(stepMs, remaining);
-        await new Promise(resolve => setTimeout(resolve, chunk));
-        remaining -= chunk;
-      }
-      assertNotStopped();
-    };
-
-    // 更新 payload 基础信息
-    llmPayload.model = modelConfig.model_name;
-    llmPayload.temperature = expertService.llmClient.getExpertLLMParams().temperature;
-    llmPayload.top_p = expertService.llmClient.getExpertLLMParams().top_p;
-    llmPayload.frequency_penalty = expertService.llmClient.getExpertLLMParams().frequency_penalty;
-    llmPayload.presence_penalty = expertService.llmClient.getExpertLLMParams().presence_penalty;
-    llmPayload.max_tokens = modelConfig.max_output_tokens || 32768;
-    if (tools.length > 0) llmPayload.tools = tools;
-
-    logger.info('[ChatService] 开始调用 LLM，当前消息数:', messages.length);
-
-    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-      assertNotStopped();
-      llmCallsCount++;  // P0 观测：记录 LLM 调用次数
-
-      logger.info('[ChatService] 第', round + 1, '轮调用 LLM...');
-
-      // 回收旧图片（compaction 后，旧 base64 替换为文本占位符）
-      if (round > 0) {
-        messages = LLMClient.stripHistoricalImages(messages);
-      }
-
-      const roundSnapshot = createRoundStateSnapshot({
-        round,
-        messages,
-        fullContent,
-        fullReasoningContent,
-        tokenUsage,
-      });
-
-      // 同步 request runtime 观测字段（统一状态真相源由 StreamController 持有）
-      if (runtimeState) {
-        runtimeState.round = round + 1;
-        runtimeState.round_snapshot_ref = { round: round + 1, taken_at: new Date().toISOString() };
-      }
-
-      let collectedToolCalls = [];
-      let roundContent = '';
-      let attempt = 0;
-
-      while (attempt <= MAX_STREAM_RECOVERY_ATTEMPTS) {
-        assertNotStopped();
-        try {
-          if (runtimeState) {
-            runtimeState.has_active_transport = true;
-          }
-          // 流式调用
-          await expertService.llmClient.callStream(modelConfig, messages, {
-            tools,
-            thinking: thinkingConfig.thinking,
-            reasoning: thinkingConfig.reasoning,
-            reasoning_effort: thinkingConfig.reasoning_effort,
-            enable_thinking: thinkingConfig.enable_thinking,
-            chat_template_kwargs: thinkingConfig.chat_template_kwargs,
-            user_id,  // 添加 user_id 用于 abort 机制
-            request_id,
-            recovery_test_round: round + 1,
-            recovery_test_attempt: attempt,
-            onDelta: (delta) => {
-              roundContent += delta;
-              fullContent += delta;
-              onDelta?.({ type: 'delta', content: delta });
-            },
-            onReasoningDelta: (reasoningDelta) => {
-              fullReasoningContent += reasoningDelta;
-              onDelta?.({ type: 'reasoning_delta', content: reasoningDelta });
-            },
-            onToolCall: (toolCalls) => {
-              const toolCallsForLog = toToolCallArray(toolCalls);
-              const displayNames = getToolCallDisplayNames(toolCallsForLog, expertService.toolManager);
-              logger.info(`[ChatService] 第${round + 1}轮收到工具调用:`, displayNames);
-
-              collectedToolCalls.push(...toolCallsForLog);
-
-              const toolCallsWithDisplayNames = presentToolCalls(toolCallsForLog, expertService.toolManager);
-              onDelta?.({ type: 'tool_call', toolCalls: toolCallsWithDisplayNames });
-            },
-            onUsage: (usage) => {
-              if (usage) {
-                tokenUsage = addTokenUsage(tokenUsage, usage);
-                logger.info(`[ChatService] 第${round + 1}轮 token 使用:`, {
-                  prompt: usage.prompt_tokens,
-                  completion: usage.completion_tokens,
-                  total: usage.total_tokens,
-                });
-              }
-            },
-          });
-          break;
-        } catch (error) {
-          if (runtimeState) {
-            runtimeState.has_active_transport = false;
-          }
-          const isStopped = error.message === 'Request aborted by user';
-          const isRetryable = isRetryableError(error);
-
-          if (isStopped || !isRetryable || attempt >= MAX_STREAM_RECOVERY_ATTEMPTS) {
-            throw error;
-          }
-
-          attempt += 1;
-          if (runtimeState) {
-            runtimeState.recovery_attempt = attempt;
-          }
-          const delayMs = Math.min(STREAM_RECOVERY_BASE_DELAY_MS * Math.pow(2, attempt - 1), STREAM_RECOVERY_MAX_DELAY_MS);
-          logger.warn(`[ChatService] 第${round + 1}轮 LLM 流式调用失败，准备恢复重试: attempt=${attempt}/${MAX_STREAM_RECOVERY_ATTEMPTS}, delay=${delayMs}ms, error=${error.message}`);
-
-          const restoredRoundState = restoreRoundStateSnapshot(roundSnapshot);
-          fullContent = restoredRoundState.fullContent;
-          fullReasoningContent = restoredRoundState.fullReasoningContent;
-          tokenUsage = restoredRoundState.tokenUsage;
-          collectedToolCalls = [];
-          roundContent = '';
-          messages = restoredRoundState.messages;
-
-          onDelta?.({
-            type: 'recovering',
-            request_id,
-            round: round + 1,
-            attempt,
-            max_attempts: MAX_STREAM_RECOVERY_ATTEMPTS,
-            content: fullContent,
-            reasoning_content: fullReasoningContent,
-          });
-
-          await waitForRecoveryDelay(delayMs);
-
-          // 退避完成且未被停止：当前轮即将重新发起，通知状态机 recovering -> running
-          onDelta?.({
-            type: 'recovered',
-            request_id,
-            round: round + 1,
-            attempt,
-          });
-        }
-      }
-
-      // 如果没有工具调用，退出循环
-      if (collectedToolCalls.length === 0) {
-        logger.info(`[ChatService] 第${round + 1}轮无工具调用，完成`);
-        if (roundContent) {
-          messages = [...messages, { role: 'assistant', content: roundContent }];
-          llmPayload.messages = messages;
-          llmPayload._debug.context_messages_count = messages.length;
-          llmPayload.cached_at = new Date().toISOString();
-          this.saveLLMPayload(user_id, expert_id, llmPayload);
-        }
-        break;
-      }
-
-      logger.info(`[ChatService] 第${round + 1}轮开始执行工具调用:`, collectedToolCalls.length);
-      assertNotStopped();
-
-      // 执行工具
-      const toolResults = await this._executeTools(expertService, {
-        collectedToolCalls,
-        user_id,
-        taskContext,
-        topic_id,
-        task_id,
-        session,
-        expert_id,
-        request_id,
-        onDelta
-      });
-
-      // round02: 文档检索原子结果 → 聚合证据注入（流式与非流式共用入口）
-      // _consumeDocRetrievalResult 统一聚合 → 证据注入 → 链路形态日志
-      const consumption = expertService._consumeDocRetrievalResult(toolResults, {
-        caller: '_executeLLMRounds',
-        extra: { round: round + 1 },
-      });
-
-      if (consumption.found && consumption.evidenceInjection) {
-        // 将聚合证据与使用规则注入到消息历史头部，下一轮 LLM 将看到
-        messages.unshift({
-          role: 'system',
-          content: consumption.evidenceInjection,
-        });
-        logger.info('[ChatService._executeLLMRounds] 已注入文档检索证据（流式路径）:', {
-          atomic_tools: consumption.docRetrievalResults.map(r => r.tool_name || r.toolName || 'unknown'),
-          chain_pattern: consumption.chainHealth?.pattern,
-          result_count: consumption.docRetrievalResults.length,
-          round: round + 1,
-        });
-      }
-
-      // 合并工具调用和执行结果
-      const toolCallsWithResults = collectedToolCalls.map((call, index) => {
-        const result = toolResults[index];
-        return {
-          ...call,
-          result: result ? { success: result.success, data: result.data, error: result.error } : null,
-          duration: result?.duration || 0,
-          tool_message_id: result?.toolMessageId || null,
-          // round03：透传原子执行轨迹供前端展示（仅 document_retrieval 原子 tool 有）
-          ...(result?.atomic_steps ? { atomic_steps: result.atomic_steps } : {}),
-          timestamp: new Date().toISOString(),
-        };
-      });
-      allToolCalls.push(...toolCallsWithResults);
-
-      // 更新消息历史
-      messages = [
-        ...messages,
-        { role: 'assistant', content: roundContent || null, tool_calls: collectedToolCalls },
-        ...expertService.toolManager.formatToolResultsForLLM(toolResults),
-      ];
-
-      // 注入合成 user 消息（多模态图片识别）
-      LLMClient.injectImageUserMessages(messages, modelConfig, toolResults);
-
-      // 同步更新 LLM Payload 缓存
-      llmPayload.messages = messages;
-      llmPayload._debug.context_messages_count = messages.length;
-      llmPayload.cached_at = new Date().toISOString();
-      this.saveLLMPayload(user_id, expert_id, llmPayload);
-
-      // 检测工具调用轮数阈值，推送 SSE 事件通知用户
-      const currentRound = round + 1;
-      const isLastRound = currentRound >= MAX_TOOL_ROUNDS;
-      const threshold = currentRound / MAX_TOOL_ROUNDS;
-
-      if (isLastRound) {
-        // 达到 100% 上限：生成总结并通知用户
-        const summary = this._generateToolCallSummary(allToolCalls);
-        onDelta?.({
-          type: 'tool_limit_reached',
-          totalRounds: MAX_TOOL_ROUNDS,
-          executedRounds: currentRound,
-          summary,
-          message: `已达到最大工具调用次数（${currentRound}轮），AI 正在生成总结`
-        });
-        logger.info(`[ChatService] 工具调用达上限，生成总结: ${summary.substring(0, 100)}...`);
-      } else if (threshold >= 0.8) {
-        // 达到 80% 阈值：发送警告提示
-        onDelta?.({
-          type: 'tool_limit_warning',
-          currentRound,
-          maxRounds: MAX_TOOL_ROUNDS,
-          remainingRounds: MAX_TOOL_ROUNDS - currentRound,
-          message: `已调用 ${currentRound}/${MAX_TOOL_ROUNDS} 轮（${Math.round(threshold * 100)}%），即将达到上限`
-        });
-        logger.info(`[ChatService] 工具调用警告: ${currentRound}/${MAX_TOOL_ROUNDS} 轮`);
-      }
-    }
-
-    // 如果 LLM 没有返回任何内容，生成默认回复
-    if (!fullContent || fullContent.trim() === '') {
-      logger.warn('[ChatService] LLM 未返回内容，生成默认回复');
-      fullContent = '我已处理您的请求，但没有生成具体的回复内容。';
-    }
-
-    // P0 观测：记录本轮 LLM 调用次数
-    logger.info(`[ChatService] 本轮 LLM 调用次数: ${llmCallsCount}, 专家: ${expert_id}, 策略: ${expertService.expertConfig?.expert?.context_strategy || 'full'}`);
-
-    return { fullContent, fullReasoningContent, tokenUsage, allToolCalls, finalMessages: messages, llmCallsCount };
   }
 
   /**
@@ -725,12 +416,15 @@ class ChatService {
       this.saveLLMPayload(user_id, expert_id, llmPayload);
 
       // 9. 执行多轮 LLM 调用
-      const llmResult = await this._executeLLMRounds(expertService, {
+      const llmResult = await this.agentRuntime.runRoot({
+        invocation_context: turnContext.agent_invocation,
+      }, ({ invocation_context }) => this.agentLoop.run(expertService, {
         ...turnContext.roundInput,
+        agent_invocation_context: invocation_context,
         onDelta,
         shouldStop,
         runtimeState,
-      });
+      }));
       const { fullContent, fullReasoningContent, tokenUsage } = llmResult;
       let finalContent = fullContent;
       const latency = Date.now() - startTime;
@@ -2274,7 +1968,7 @@ search_chunks_in_document 在指定文档内无命中时，答案可能存在于
    *
    * @param {Array} toolResults - 工具执行结果数组
    * @param {Object} logContext - 日志上下文
-   * @param {string} logContext.caller - 调用方标识（如 '_executeLLMRounds' | 'chat'）
+   * @param {string} logContext.caller - 调用方标识（如 'AgentLoop.run' | 'chat'）
    * @param {Object} [logContext.extra] - 额外日志字段（如 round）
    * @returns {{ found: boolean, docRetrievalResults: Array, evidenceInjection: string|null, chainHealth: Object|null }}
    */

--- a/lib/chat/turn-context-builder.js
+++ b/lib/chat/turn-context-builder.js
@@ -30,6 +30,12 @@ export function buildStreamLlmPayload({ modelConfig, messages, tools }) {
   };
 }
 
+function getToolNames(tools = []) {
+  return tools
+    .map(tool => tool?.function?.name)
+    .filter(Boolean);
+}
+
 export function buildStreamTurnContext({
   user_id,
   expert_id,
@@ -57,7 +63,9 @@ export function buildStreamTurnContext({
           workspace_mode: taskContext.workspace_mode || null,
         }
       : {},
-    capability_scope: {},
+    capability_scope: {
+      tools: getToolNames(tools),
+    },
   });
 
   return {

--- a/tests/test-agent-loop.mjs
+++ b/tests/test-agent-loop.mjs
@@ -1,0 +1,382 @@
+/**
+ * Tests for AgentLoop.
+ *
+ * Usage:
+ *   node tests/test-agent-loop.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { AgentLoop } from '../lib/agent/agent-loop.js';
+
+function createLoop(overrides = {}) {
+  return new AgentLoop({
+    db: {
+      getModel() {
+        return {};
+      },
+    },
+    execute_tools: async () => {
+      throw new Error('execute_tools should not be called');
+    },
+    save_llm_payload: () => {},
+    generate_tool_call_summary: () => 'summary',
+    ...overrides,
+  });
+}
+
+function createExpertService() {
+  return {
+    expertConfig: {
+      expert: {
+        max_tool_rounds: 3,
+        context_strategy: 'full',
+      },
+    },
+    llmClient: {
+      getExpertLLMParams() {
+        return {
+          temperature: 0.7,
+          top_p: 1,
+          frequency_penalty: 0,
+          presence_penalty: 0,
+        };
+      },
+      async callStream(_modelConfig, _messages, options) {
+        options.onDelta('Hello');
+        options.onReasoningDelta('Thinking');
+        options.onUsage({
+          prompt_tokens: 2,
+          completion_tokens: 3,
+          total_tokens: 5,
+        });
+      },
+    },
+  };
+}
+
+function createToolLoopExpertService() {
+  let streamCalls = 0;
+  const toolCall = {
+    id: 'call_1',
+    type: 'function',
+    function: {
+      name: 'demo_tool',
+      arguments: '{}',
+    },
+  };
+
+  return {
+    expertConfig: {
+      expert: {
+        max_tool_rounds: 3,
+        context_strategy: 'full',
+      },
+    },
+    llmClient: {
+      getExpertLLMParams() {
+        return {
+          temperature: 0.7,
+          top_p: 1,
+          frequency_penalty: 0,
+          presence_penalty: 0,
+        };
+      },
+      async callStream(_modelConfig, _messages, options) {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          options.onDelta('Need tool');
+          options.onToolCall([toolCall]);
+          return;
+        }
+
+        options.onDelta('Final answer');
+      },
+    },
+    toolManager: {
+      formatToolDisplay(toolId) {
+        return `Tool: ${toolId}`;
+      },
+      formatToolResultsForLLM(toolResults) {
+        return toolResults.map(result => ({
+          role: 'tool',
+          tool_call_id: result.toolCallId,
+          content: JSON.stringify(result.data),
+        }));
+      },
+    },
+    _consumeDocRetrievalResult() {
+      return { found: false };
+    },
+    getStreamCalls() {
+      return streamCalls;
+    },
+  };
+}
+
+function createRunInput(overrides = {}) {
+  return {
+    modelConfig: {
+      model_name: 'test-model',
+      max_output_tokens: 2048,
+    },
+    thinkingConfig: {
+      thinking: false,
+      reasoning: null,
+      reasoning_effort: null,
+      enable_thinking: false,
+      chat_template_kwargs: null,
+    },
+    tools: [],
+    currentMessages: [{ role: 'user', content: 'hello' }],
+    llmPayload: {
+      _debug: {},
+    },
+    user_id: 'user_1',
+    expert_id: 'expert_1',
+    taskContext: null,
+    topic_id: 'topic_1',
+    task_id: null,
+    session: {},
+    request_id: 'request_1',
+    ...overrides,
+  };
+}
+
+async function testRunCompletesSingleRoundWithoutTools() {
+  const deltas = [];
+  const savedPayloads = [];
+  const loop = createLoop({
+    save_llm_payload: (...args) => savedPayloads.push(args),
+  });
+
+  const result = await loop.run(createExpertService(), createRunInput({
+    onDelta: event => deltas.push(event),
+  }));
+
+  assert.equal(result.fullContent, 'Hello');
+  assert.equal(result.fullReasoningContent, 'Thinking');
+  assert.deepEqual(result.tokenUsage, {
+    prompt_tokens: 2,
+    completion_tokens: 3,
+    total_tokens: 5,
+  });
+  assert.equal(result.llmCallsCount, 1);
+  assert.deepEqual(result.allToolCalls, []);
+  assert.deepEqual(deltas.map(event => event.type), ['delta', 'reasoning_delta']);
+  assert.equal(savedPayloads.length, 1);
+  assert.equal(savedPayloads[0][0], 'user_1');
+  assert.equal(savedPayloads[0][1], 'expert_1');
+  assert.equal(savedPayloads[0][2].messages.at(-1).content, 'Hello');
+}
+
+async function testRunCanBeStoppedBeforeLlmCall() {
+  const loop = createLoop();
+
+  await assert.rejects(() => loop.run(createExpertService(), createRunInput({
+    shouldStop: () => true,
+  })), /Request aborted by user/);
+}
+
+async function testRunExecutesToolsAndContinuesToNextRound() {
+  const executedToolInputs = [];
+  const deltas = [];
+  const savedPayloads = [];
+  const expertService = createToolLoopExpertService();
+  const loop = createLoop({
+    execute_tools: async (_expertService, input) => {
+      executedToolInputs.push(input);
+      return [{
+        success: true,
+        data: { value: 42 },
+        duration: 12,
+        toolCallId: 'call_1',
+        toolMessageId: 'tool_msg_1',
+      }];
+    },
+    save_llm_payload: (user_id, expert_id, payload) => {
+      savedPayloads.push([user_id, expert_id, JSON.parse(JSON.stringify(payload))]);
+    },
+  });
+
+  const result = await loop.run(expertService, createRunInput({
+    tools: [{ type: 'function', function: { name: 'demo_tool' } }],
+    onDelta: event => deltas.push(event),
+  }));
+
+  assert.equal(expertService.getStreamCalls(), 2);
+  assert.equal(executedToolInputs.length, 1);
+  assert.equal(executedToolInputs[0].collectedToolCalls.length, 1);
+  assert.equal(executedToolInputs[0].collectedToolCalls[0].function.name, 'demo_tool');
+  assert.equal(result.fullContent, 'Need toolFinal answer');
+  assert.equal(result.allToolCalls.length, 1);
+  assert.equal(result.allToolCalls[0].result.data.value, 42);
+  assert.deepEqual(deltas.map(event => event.type), ['delta', 'tool_call', 'delta']);
+  assert.equal(deltas[1].toolCalls[0].displayName, 'Tool: demo_tool');
+  assert.equal(savedPayloads.length, 2);
+  assert.equal(savedPayloads[0][2].messages.at(-1).role, 'tool');
+  assert.equal(savedPayloads[1][2].messages.at(-1).content, 'Final answer');
+}
+
+async function testRunRecoversRetryableStreamFailure() {
+  const previousBaseDelay = process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS;
+  const previousMaxDelay = process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS;
+  process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS = '0';
+  process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS = '0';
+
+  try {
+    let streamCalls = 0;
+    const expertService = createExpertService();
+    expertService.llmClient.callStream = async (_modelConfig, _messages, options) => {
+      streamCalls += 1;
+      if (streamCalls === 1) {
+        options.onDelta('Partial');
+        const error = new Error('socket hang up');
+        error.code = 'ECONNRESET';
+        throw error;
+      }
+
+      options.onDelta('Recovered');
+    };
+
+    const deltas = [];
+    const loop = createLoop();
+    const result = await loop.run(expertService, createRunInput({
+      onDelta: event => deltas.push(event),
+    }));
+
+    assert.equal(streamCalls, 2);
+    assert.equal(result.fullContent, 'Recovered');
+    assert.deepEqual(deltas.map(event => event.type), [
+      'delta',
+      'recovering',
+      'recovered',
+      'delta',
+    ]);
+    assert.equal(deltas[1].content, '');
+    assert.equal(deltas[1].reasoning_content, '');
+  } finally {
+    if (previousBaseDelay === undefined) {
+      delete process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS;
+    } else {
+      process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS = previousBaseDelay;
+    }
+    if (previousMaxDelay === undefined) {
+      delete process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS;
+    } else {
+      process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS = previousMaxDelay;
+    }
+  }
+}
+
+async function testRunInjectsDocumentEvidenceBeforeNextRound() {
+  let streamCalls = 0;
+  const secondRoundMessages = [];
+  const expertService = createToolLoopExpertService();
+  expertService.llmClient.callStream = async (_modelConfig, messages, options) => {
+    streamCalls += 1;
+    if (streamCalls === 1) {
+      options.onToolCall([{
+        id: 'call_doc',
+        type: 'function',
+        function: {
+          name: 'search_documents',
+          arguments: '{}',
+        },
+      }]);
+      return;
+    }
+
+    secondRoundMessages.push(...messages);
+    options.onDelta('Answer with evidence');
+  };
+  expertService._consumeDocRetrievalResult = () => ({
+    found: true,
+    evidenceInjection: 'DOCUMENT EVIDENCE',
+    docRetrievalResults: [{ tool_name: 'search_documents' }],
+    chainHealth: { pattern: 'metadata_only' },
+  });
+
+  const loop = createLoop({
+    execute_tools: async () => [{
+      success: true,
+      skill_namespace: 'document_retrieval',
+      data: { items: [] },
+      duration: 1,
+      toolCallId: 'call_doc',
+    }],
+  });
+
+  const result = await loop.run(expertService, createRunInput({
+    tools: [{ type: 'function', function: { name: 'search_documents' } }],
+  }));
+
+  assert.equal(result.fullContent, 'Answer with evidence');
+  assert.equal(secondRoundMessages[0].role, 'system');
+  assert.equal(secondRoundMessages[0].content, 'DOCUMENT EVIDENCE');
+}
+
+async function testRunInjectsImageUserMessageBeforeNextRound() {
+  let streamCalls = 0;
+  const secondRoundMessages = [];
+  const expertService = createToolLoopExpertService();
+  expertService.llmClient.callStream = async (_modelConfig, messages, options) => {
+    streamCalls += 1;
+    if (streamCalls === 1) {
+      options.onToolCall([{
+        id: 'call_image',
+        type: 'function',
+        function: {
+          name: 'draw_image',
+          arguments: '{}',
+        },
+      }]);
+      return;
+    }
+
+    secondRoundMessages.push(...messages);
+    options.onDelta('Image analyzed');
+  };
+
+  const loop = createLoop({
+    execute_tools: async () => [{
+      success: true,
+      toolName: 'draw_image',
+      data: {
+        dataUrl: 'data:image/png;base64,aGVsbG8=',
+        filename: 'demo.png',
+      },
+      duration: 1,
+      toolCallId: 'call_image',
+    }],
+  });
+
+  const result = await loop.run(expertService, createRunInput({
+    modelConfig: {
+      model_name: 'vision-model',
+      model_type: 'multimodal',
+      max_output_tokens: 2048,
+    },
+    tools: [{ type: 'function', function: { name: 'draw_image' } }],
+  }));
+
+  assert.equal(result.fullContent, 'Image analyzed');
+  const syntheticMessage = secondRoundMessages.at(-1);
+  assert.equal(syntheticMessage.role, 'user');
+  assert.equal(syntheticMessage._synthetic, true);
+  assert.equal(syntheticMessage.content[0].type, 'text');
+  assert.equal(syntheticMessage.content[1].type, 'image_url');
+  assert.equal(syntheticMessage.content[1].image_url.url, 'data:image/png;base64,aGVsbG8=');
+}
+
+async function main() {
+  await testRunCompletesSingleRoundWithoutTools();
+  await testRunCanBeStoppedBeforeLlmCall();
+  await testRunExecutesToolsAndContinuesToNextRound();
+  await testRunRecoversRetryableStreamFailure();
+  await testRunInjectsDocumentEvidenceBeforeNextRound();
+  await testRunInjectsImageUserMessageBeforeNextRound();
+
+  console.log('Agent loop tests passed.');
+}
+
+main();

--- a/tests/test-agent-runtime.mjs
+++ b/tests/test-agent-runtime.mjs
@@ -1,0 +1,107 @@
+/**
+ * Tests for AgentRuntime root facade.
+ *
+ * Usage:
+ *   node tests/test-agent-runtime.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { AgentRuntime } from '../lib/agent/agent-runtime.js';
+
+async function testRunRootWrapsExecutorResult() {
+  const events = [];
+  const runtime = new AgentRuntime({
+    event_sink: event => events.push(event),
+  });
+
+  const result = await runtime.runRoot({
+    run_id: 'root_run_runtime_1',
+    principal_user_id: 'user_1',
+    agent_id: 'expert_1',
+    topic_id: 'topic_1',
+    request_id: 'request_1',
+    capability_scope: { tools: ['search'] },
+  }, async ({ invocation_context }) => {
+    assert.equal(invocation_context.run_id, 'root_run_runtime_1');
+    assert.equal(invocation_context.principal_user_id, 'user_1');
+    assert.equal(invocation_context.caller_agent_id, null);
+    assert.equal(invocation_context.callee_agent_id, 'expert_1');
+
+    return {
+      fullContent: 'Done',
+      fullReasoningContent: 'Thinking',
+      tokenUsage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      },
+      allToolCalls: [{ function: { name: 'search' } }],
+      finalMessages: [{ role: 'assistant', content: 'Done' }],
+      llmCallsCount: 1,
+    };
+  });
+
+  assert.equal(result.fullContent, 'Done');
+  assert.equal(result.agent_invocation_context.run_id, 'root_run_runtime_1');
+  assert.deepEqual(events.map(event => event.type), [
+    'agent_run_created',
+    'agent_run_started',
+    'agent_run_completed',
+  ]);
+  assert.equal(events[2].payload.llm_calls_count, 1);
+  assert.equal(events[2].payload.tool_call_count, 1);
+  assert.deepEqual(events[2].payload.token_usage, {
+    prompt_tokens: 10,
+    completion_tokens: 5,
+    total_tokens: 15,
+  });
+}
+
+async function testRunRootEmitsFailure() {
+  const events = [];
+  const runtime = new AgentRuntime({
+    event_sink: event => events.push(event),
+  });
+
+  await assert.rejects(() => runtime.runRoot({
+    run_id: 'root_run_runtime_2',
+    principal_user_id: 'user_2',
+    agent_id: 'expert_2',
+  }, async () => {
+    throw new Error('LLM failed');
+  }), /LLM failed/);
+
+  assert.deepEqual(events.map(event => event.type), [
+    'agent_run_created',
+    'agent_run_started',
+    'agent_run_failed',
+  ]);
+  assert.equal(events[2].payload.error, 'LLM failed');
+}
+
+async function testRunRootEmitsCancelled() {
+  const events = [];
+  const runtime = new AgentRuntime({
+    event_sink: event => events.push(event),
+  });
+
+  await assert.rejects(() => runtime.runRoot({
+    run_id: 'root_run_runtime_3',
+    principal_user_id: 'user_3',
+    agent_id: 'expert_3',
+  }, async () => {
+    throw new Error('Request aborted by user');
+  }), /Request aborted by user/);
+
+  assert.equal(events[2].type, 'agent_run_cancelled');
+}
+
+async function main() {
+  await testRunRootWrapsExecutorResult();
+  await testRunRootEmitsFailure();
+  await testRunRootEmitsCancelled();
+
+  console.log('Agent runtime tests passed.');
+}
+
+main();

--- a/tests/test-chat-service-agent-runtime-facade.mjs
+++ b/tests/test-chat-service-agent-runtime-facade.mjs
@@ -1,0 +1,159 @@
+/**
+ * Tests that streamChat enters the root AgentRuntime facade.
+ *
+ * Usage:
+ *   node tests/test-chat-service-agent-runtime-facade.mjs
+ */
+
+import assert from 'node:assert/strict';
+import ChatService from '../lib/chat-service.js';
+
+function createDbStub() {
+  return {
+    getModel() {
+      return {};
+    },
+  };
+}
+
+function createExpertServiceStub() {
+  const modelConfig = {
+    model_name: 'test-model',
+    provider_name: 'test-provider',
+    base_url: 'https://example.test/v1',
+    max_tokens: 4096,
+    max_output_tokens: 2048,
+  };
+
+  return {
+    recallStrategy: null,
+    memorySystem: {
+      async shouldCompressContext() {
+        return { needCompress: false };
+      },
+    },
+    getDefaultModelConfig() {
+      return modelConfig;
+    },
+    getThinkingConfig() {
+      return {
+        thinking: false,
+        reasoning: null,
+        reasoning_effort: null,
+        enable_thinking: false,
+        chat_template_kwargs: null,
+      };
+    },
+    async buildContext() {
+      return {
+        messages: [{ role: 'user', content: 'hello' }],
+      };
+    },
+    toolManager: {
+      async getToolDefinitions() {
+        return [{ type: 'function', function: { name: 'demo_tool' } }];
+      },
+    },
+    performReflection() {
+      return Promise.resolve();
+    },
+    processHistoryIfNeeded() {
+      return Promise.resolve();
+    },
+  };
+}
+
+function createRuntimeStub(calls) {
+  return {
+    async runRoot(input, executor) {
+      calls.push(input);
+      return executor({ invocation_context: input.invocation_context });
+    },
+  };
+}
+
+async function testStreamChatUsesRootAgentRuntime() {
+  const runtimeCalls = [];
+  const loopCalls = [];
+  const service = new ChatService(createDbStub(), {
+    agentRuntime: createRuntimeStub(runtimeCalls),
+    agentLoop: {
+      async run(expertService, roundInput) {
+        loopCalls.push({ expertService, roundInput });
+        return {
+          fullContent: 'runtime result',
+          fullReasoningContent: '',
+          tokenUsage: {
+            prompt_tokens: 3,
+            completion_tokens: 4,
+            total_tokens: 7,
+          },
+          allToolCalls: [],
+          finalMessages: [],
+          llmCallsCount: 1,
+        };
+      },
+    },
+  });
+  const expertService = createExpertServiceStub();
+
+  service.getExpertService = async () => expertService;
+  service._prepareTaskContext = async () => ({
+    workspace_mode: 'task',
+    absolute_workspace_path: 'D:/workspace/task',
+  });
+  service.checkAndHandleTopicShift = async () => ({
+    topic_id: 'topic_1',
+    isNewTopic: false,
+  });
+  service.saveUserMessageAndBindRequest = async () => 'user_msg_1';
+  service.saveAssistantMessageAndCompleteRequest = async () => 'assistant_msg_1';
+  service.updateTopicTimestamp = async () => {};
+
+  let completePayload = null;
+  await service.streamChat({
+    user_id: 'user_1',
+    expert_id: 'expert_1',
+    content: 'hello',
+    task_id: 'task_1',
+    request_id: 'request_1',
+    session: { userId: 'user_1', roles: [] },
+  }, null, result => {
+    completePayload = result;
+  }, error => {
+    throw error;
+  });
+
+  assert.equal(runtimeCalls.length, 1);
+  const invocation = runtimeCalls[0].invocation_context;
+  assert.equal(invocation.principal_user_id, 'user_1');
+  assert.equal(invocation.caller_agent_id, null);
+  assert.equal(invocation.callee_agent_id, 'expert_1');
+  assert.equal(invocation.topic_id, 'topic_1');
+  assert.equal(invocation.task_id, 'task_1');
+  assert.equal(invocation.request_id, 'request_1');
+  assert.deepEqual(invocation.workspace_scope, {
+    workdir: 'D:/workspace/task',
+    workspace_mode: 'task',
+  });
+  assert.deepEqual(invocation.capability_scope, {
+    tools: ['demo_tool'],
+  });
+  assert.equal(loopCalls.length, 1);
+  assert.equal(loopCalls[0].expertService, expertService);
+  assert.equal(loopCalls[0].roundInput.agent_invocation_context, invocation);
+  assert.equal(completePayload.message.content, 'runtime result');
+  assert.deepEqual(completePayload.message.metadata.tokens, {
+    prompt_tokens: 3,
+    completion_tokens: 4,
+    total_tokens: 7,
+  });
+}
+
+async function main() {
+  await testStreamChatUsesRootAgentRuntime();
+
+  console.log('ChatService AgentRuntime facade tests passed.');
+}
+
+main();

--- a/tests/test-turn-context-builder.mjs
+++ b/tests/test-turn-context-builder.mjs
@@ -112,6 +112,9 @@ function testBuildStreamTurnContext() {
     workdir: 'D:/workspace/task',
     workspace_mode: 'task',
   });
+  assert.deepEqual(turnContext.agent_invocation.capability_scope, {
+    tools: ['demo_tool'],
+  });
   assert.deepEqual(turnContext.toolContext, {
     user_id: 'user_1',
     expert_id: 'expert_1',


### PR DESCRIPTION
## Summary

- Add `AgentRuntime.runRoot()` as the root Agent lifecycle facade.
- Move the root chat streaming LLM/tool loop from `ChatService` into `AgentLoop.run()`.
- Route `ChatService.streamChat()` through `AgentRuntime -> AgentLoop` while keeping external behavior unchanged.
- Extend root turn context with tool capability scope.

## Not Included

- No DB schema changes.
- No `models/` changes.
- No `/api/assistants/call` changes.
- No AssistantManager changes.
- No Child Agent / `agent_delegate` wiring.
- No frontend changes.

## Verification

```powershell
node tests/test-agent-runtime.mjs
node tests/test-agent-loop.mjs
node tests/test-chat-service-agent-runtime-facade.mjs
node tests/test-turn-context-builder.mjs
node tests/test-agent-invocation-context.mjs
node tests/test-agent-definition-resolver.mjs
node tests/test-agent-access-policy.mjs
node tests/test-agent-delegation-service.mjs
npm.cmd run lint
git diff --check
```
