### PR TITLE
refactor: add child agent runtime contract

### DIFF
--- a/lib/agent/agent-runtime.js
+++ b/lib/agent/agent-runtime.js
@@ -2,8 +2,8 @@
  * Agent runtime facade.
  *
  * Phase A keeps the existing root chat LLM loop intact and wraps it with the
- * shared Agent invocation/event boundary. Child execution is intentionally not
- * wired here yet.
+ * shared Agent invocation/event boundary. Child runs use the same lifecycle
+ * facade, but delegation/tool wiring stays outside this module.
  */
 
 import { buildAgentEvent } from './agent-event.js';
@@ -30,6 +30,41 @@ function buildCompletionPayload(result = {}) {
   };
 }
 
+function assertExecutor(executor) {
+  if (typeof executor !== 'function') {
+    throw new Error('executor is required');
+  }
+}
+
+function attachInvocationContext(result, invocation_context) {
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    return {
+      ...result,
+      agent_invocation_context: invocation_context,
+    };
+  }
+
+  return {
+    result,
+    agent_invocation_context: invocation_context,
+  };
+}
+
+function assertChildInvocationContext(invocation_context) {
+  if (!invocation_context || typeof invocation_context !== 'object') {
+    throw new Error('child invocation_context is required');
+  }
+  if (!invocation_context.parent_run_id) {
+    throw new Error('child invocation_context.parent_run_id is required');
+  }
+  if (!invocation_context.caller_agent_id) {
+    throw new Error('child invocation_context.caller_agent_id is required');
+  }
+  if (!Number.isInteger(invocation_context.delegation_depth) || invocation_context.delegation_depth < 1) {
+    throw new Error('child invocation_context.delegation_depth must be at least 1');
+  }
+}
+
 export class AgentRuntime {
   constructor({
     event_sink = null,
@@ -40,12 +75,21 @@ export class AgentRuntime {
   }
 
   async runRoot(input = {}, executor) {
-    if (typeof executor !== 'function') {
-      throw new Error('executor is required');
-    }
-
+    assertExecutor(executor);
     const invocation_context = input.invocation_context || buildRootAgentInvocationContext(input);
 
+    return this.runWithContext(invocation_context, executor);
+  }
+
+  async runChild(input = {}, executor) {
+    assertExecutor(executor);
+    const invocation_context = input.invocation_context || input.child_invocation;
+    assertChildInvocationContext(invocation_context);
+
+    return this.runWithContext(invocation_context, executor);
+  }
+
+  async runWithContext(invocation_context, executor) {
     await this.emit('agent_run_created', invocation_context, {
       source: invocation_context.source,
     });
@@ -55,17 +99,7 @@ export class AgentRuntime {
       const result = await executor({ invocation_context });
       await this.emit('agent_run_completed', invocation_context, buildCompletionPayload(result));
 
-      if (result && typeof result === 'object' && !Array.isArray(result)) {
-        return {
-          ...result,
-          agent_invocation_context: invocation_context,
-        };
-      }
-
-      return {
-        result,
-        agent_invocation_context: invocation_context,
-      };
+      return attachInvocationContext(result, invocation_context);
     } catch (error) {
       const eventType = this.is_cancelled_error(error) ? 'agent_run_cancelled' : 'agent_run_failed';
       await this.emit(eventType, invocation_context, {

--- a/tests/test-agent-runtime.mjs
+++ b/tests/test-agent-runtime.mjs
@@ -7,6 +7,10 @@
 
 import assert from 'node:assert/strict';
 import { AgentRuntime } from '../lib/agent/agent-runtime.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
 
 async function testRunRootWrapsExecutorResult() {
   const events = [];
@@ -96,10 +100,70 @@ async function testRunRootEmitsCancelled() {
   assert.equal(events[2].type, 'agent_run_cancelled');
 }
 
+async function testRunChildWrapsExecutorResult() {
+  const events = [];
+  const runtime = new AgentRuntime({
+    event_sink: event => events.push(event),
+  });
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_runtime_child_parent',
+    principal_user_id: 'user_child',
+    agent_id: 'expert_parent',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_runtime_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  const result = await runtime.runChild({
+    invocation_context: child,
+  }, async ({ invocation_context }) => {
+    assert.equal(invocation_context.parent_run_id, parent.run_id);
+    assert.equal(invocation_context.principal_user_id, 'user_child');
+    assert.equal(invocation_context.caller_agent_id, 'expert_parent');
+    assert.equal(invocation_context.callee_agent_id, 'expert_child');
+    assert.equal(invocation_context.delegation_depth, 1);
+
+    return {
+      fullContent: 'Child done',
+      allToolCalls: [],
+      llmCallsCount: 1,
+    };
+  });
+
+  assert.equal(result.fullContent, 'Child done');
+  assert.equal(result.agent_invocation_context, child);
+  assert.deepEqual(events.map(event => event.type), [
+    'agent_run_created',
+    'agent_run_started',
+    'agent_run_completed',
+  ]);
+  assert.equal(events[0].parent_run_id, parent.run_id);
+  assert.equal(events[0].caller_agent_id, 'expert_parent');
+  assert.equal(events[0].callee_agent_id, 'expert_child');
+  assert.equal(events[2].payload.llm_calls_count, 1);
+}
+
+async function testRunChildRejectsRootInvocation() {
+  const runtime = new AgentRuntime();
+  const root = buildRootAgentInvocationContext({
+    run_id: 'root_run_runtime_not_child',
+    principal_user_id: 'user_root',
+    agent_id: 'expert_root',
+  });
+
+  await assert.rejects(() => runtime.runChild({
+    invocation_context: root,
+  }, async () => ({ fullContent: 'should not run' })), /parent_run_id is required/);
+}
+
 async function main() {
   await testRunRootWrapsExecutorResult();
   await testRunRootEmitsFailure();
   await testRunRootEmitsCancelled();
+  await testRunChildWrapsExecutorResult();
+  await testRunChildRejectsRootInvocation();
 
   console.log('Agent runtime tests passed.');
 }


### PR DESCRIPTION
## Summary

- Add `AgentRuntime.runChild()` as the child run lifecycle facade.
- Reuse the same Agent run lifecycle used by root runs.
- Require child invocation contexts to include `parent_run_id`, `caller_agent_id`, and `delegation_depth >= 1`.
- Extend runtime tests for child run result passthrough, event fields, and root-context rejection.

## Not Included

- No `agent_delegate` tool exposure.
- No automatic child execution from `AgentDelegationService`.
- No AssistantManager changes.
- No ToolManager changes.
- No DB/API/frontend changes.

## Verification

```powershell
node tests/test-agent-runtime.mjs
node tests/test-agent-loop.mjs
node tests/test-agent-delegation-service.mjs
node tests/test-agent-invocation-context.mjs
node tests/test-agent-definition-resolver.mjs
node tests/test-agent-access-policy.mjs
node tests/test-chat-service-agent-runtime-facade.mjs
node tests/test-turn-context-builder.mjs
npm.cmd run lint
git diff --check
```
