### PR TITLE
refactor: add child agent executor adapter

### DIFF
--- a/lib/agent/agent-delegation-service.js
+++ b/lib/agent/agent-delegation-service.js
@@ -1,8 +1,8 @@
 /**
  * Agent delegation service contract.
  *
- * This service prepares a child Agent run envelope. It does not execute the
- * child run yet; execution will be wired in later migration phases.
+ * This service prepares a child Agent run envelope. Child execution is explicit
+ * via delegateAndExecute() and requires a caller-provided executor adapter.
  */
 
 import {
@@ -106,6 +106,20 @@ export class AgentDelegationService {
     });
 
     return delegation;
+  }
+
+  async delegateAndExecute(input = {}, child_executor) {
+    if (!child_executor || typeof child_executor.execute !== 'function') {
+      throw new Error('child_executor.execute is required');
+    }
+
+    const delegation = await this.delegate(input);
+    const execution_result = await child_executor.execute(delegation);
+
+    return Object.freeze({
+      ...delegation,
+      execution_result,
+    });
   }
 
   async emit(type, invocation_context, payload = {}) {

--- a/lib/agent/child-agent-executor.js
+++ b/lib/agent/child-agent-executor.js
@@ -1,0 +1,53 @@
+/**
+ * Child Agent executor adapter.
+ *
+ * This adapter bridges an accepted delegation envelope to AgentRuntime.runChild().
+ * It deliberately does not resolve targets, widen capability scope, expose an
+ * LLM tool, or build child prompts by itself.
+ */
+
+function assertFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function assertDelegation(delegation) {
+  if (!delegation || typeof delegation !== 'object') {
+    throw new Error('delegation is required');
+  }
+  if (!delegation.child_invocation) {
+    throw new Error('delegation.child_invocation is required');
+  }
+  if (!delegation.callee_definition) {
+    throw new Error('delegation.callee_definition is required');
+  }
+}
+
+export class ChildAgentExecutor {
+  constructor({
+    agent_runtime,
+    run_child,
+  } = {}) {
+    if (!agent_runtime || typeof agent_runtime.runChild !== 'function') {
+      throw new Error('agent_runtime.runChild is required');
+    }
+    assertFunction(run_child, 'run_child');
+
+    this.agent_runtime = agent_runtime;
+    this.run_child = run_child;
+  }
+
+  async execute(delegation) {
+    assertDelegation(delegation);
+
+    return this.agent_runtime.runChild({
+      invocation_context: delegation.child_invocation,
+    }, ({ invocation_context }) => this.run_child({
+      ...delegation,
+      invocation_context,
+    }));
+  }
+}
+
+export default ChildAgentExecutor;

--- a/tests/test-agent-delegation-service.mjs
+++ b/tests/test-agent-delegation-service.mjs
@@ -142,11 +142,79 @@ async function testRejectsDelegationCycle() {
   }), /delegation cycle detected/);
 }
 
+async function testDelegateAndExecuteUsesExplicitExecutor() {
+  const service = new AgentDelegationService({
+    definition_resolver: {
+      async resolve() {
+        return createDefinition();
+      },
+    },
+  });
+  const executorCalls = [];
+
+  const result = await service.delegateAndExecute({
+    parent_invocation: createParentInvocation(),
+    target: { source_type: 'expert', agent_id: 'expert_child' },
+    task: 'Search the project',
+    caller_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    principal_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    workspace_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      document_retrieval: true,
+      can_use_skills: true,
+    },
+    requested_scope: { tools: ['search'] },
+  }, {
+    async execute(delegation) {
+      executorCalls.push(delegation);
+      return {
+        fullContent: 'Child result',
+        agent_invocation_context: delegation.child_invocation,
+      };
+    },
+  });
+
+  assert.equal(result.status, 'accepted');
+  assert.equal(result.execution_result.fullContent, 'Child result');
+  assert.equal(executorCalls.length, 1);
+  assert.equal(executorCalls[0].child_invocation.callee_agent_id, 'expert_child');
+  assert.deepEqual(executorCalls[0].effective_scope.tools, ['search']);
+}
+
+async function testDelegateAndExecuteRequiresExplicitExecutor() {
+  const service = new AgentDelegationService({
+    definition_resolver: {
+      async resolve() {
+        return createDefinition();
+      },
+    },
+  });
+
+  await assert.rejects(() => service.delegateAndExecute({
+    parent_invocation: createParentInvocation(),
+    target: { source_type: 'expert', agent_id: 'expert_child' },
+    task: 'Search the project',
+  }), /child_executor.execute is required/);
+}
+
 async function main() {
   await testDelegationBuildsChildRun();
   await testRejectsDeniedCapability();
   await testRejectsInactiveTarget();
   await testRejectsDelegationCycle();
+  await testDelegateAndExecuteUsesExplicitExecutor();
+  await testDelegateAndExecuteRequiresExplicitExecutor();
 
   console.log('Agent delegation service tests passed.');
 }

--- a/tests/test-child-agent-executor.mjs
+++ b/tests/test-child-agent-executor.mjs
@@ -1,0 +1,115 @@
+/**
+ * Tests for ChildAgentExecutor.
+ *
+ * Usage:
+ *   node tests/test-child-agent-executor.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { AgentRuntime } from '../lib/agent/agent-runtime.js';
+import { ChildAgentExecutor } from '../lib/agent/child-agent-executor.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_executor_parent',
+    principal_user_id: 'user_1',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_1',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_executor_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return Object.freeze({
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    input: { query: 'agent' },
+    expected_output: 'summary',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  });
+}
+
+async function testExecuteRunsChildThroughRuntime() {
+  const events = [];
+  const delegation = createDelegation();
+  const executorInputs = [];
+  const executor = new ChildAgentExecutor({
+    agent_runtime: new AgentRuntime({
+      event_sink: event => events.push(event),
+    }),
+    run_child: async input => {
+      executorInputs.push(input);
+      return {
+        fullContent: 'Child result',
+        llmCallsCount: 1,
+        allToolCalls: [],
+      };
+    },
+  });
+
+  const result = await executor.execute(delegation);
+
+  assert.equal(result.fullContent, 'Child result');
+  assert.equal(result.agent_invocation_context, delegation.child_invocation);
+  assert.equal(executorInputs.length, 1);
+  assert.equal(executorInputs[0].invocation_context, delegation.child_invocation);
+  assert.equal(executorInputs[0].principal_user_id, undefined);
+  assert.equal(executorInputs[0].child_invocation.principal_user_id, 'user_1');
+  assert.equal(executorInputs[0].child_invocation.caller_agent_id, 'expert_parent');
+  assert.deepEqual(executorInputs[0].effective_scope, { tools: ['search'] });
+  assert.deepEqual(events.map(event => event.type), [
+    'agent_run_created',
+    'agent_run_started',
+    'agent_run_completed',
+  ]);
+  assert.equal(events[0].parent_run_id, delegation.parent_invocation.run_id);
+  assert.equal(events[0].caller_agent_id, 'expert_parent');
+  assert.equal(events[0].callee_agent_id, 'expert_child');
+}
+
+async function testExecutePropagatesFailureAsRuntimeEvent() {
+  const events = [];
+  const executor = new ChildAgentExecutor({
+    agent_runtime: new AgentRuntime({
+      event_sink: event => events.push(event),
+    }),
+    run_child: async () => {
+      throw new Error('child failed');
+    },
+  });
+
+  await assert.rejects(() => executor.execute(createDelegation()), /child failed/);
+  assert.equal(events.at(-1).type, 'agent_run_failed');
+  assert.equal(events.at(-1).payload.error, 'child failed');
+}
+
+function testRejectsMissingRunChild() {
+  assert.throws(() => new ChildAgentExecutor({
+    agent_runtime: new AgentRuntime(),
+  }), /run_child is required/);
+}
+
+async function main() {
+  await testExecuteRunsChildThroughRuntime();
+  await testExecutePropagatesFailureAsRuntimeEvent();
+  testRejectsMissingRunChild();
+
+  console.log('Child agent executor tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `ChildAgentExecutor` as an explicit adapter from accepted delegation envelopes to `AgentRuntime.runChild()`.
- Add `AgentDelegationService.delegateAndExecute(input, child_executor)` for explicit child execution.
- Keep `delegate()` behavior unchanged: it only prepares the child invocation and effective scope.
- Add tests for executor lifecycle, failure propagation, explicit executor requirement, and effective scope passthrough.

## Not Included

- No `agent_delegate` tool exposure.
- No ToolManager changes.
- No AssistantManager changes.
- No child prompt construction.
- No automatic execution from `delegate()`.
- No DB/API/frontend changes.

## Verification

```powershell
node tests/test-child-agent-executor.mjs
node tests/test-agent-delegation-service.mjs
node tests/test-agent-runtime.mjs
node tests/test-agent-loop.mjs
node tests/test-agent-invocation-context.mjs
node tests/test-agent-definition-resolver.mjs
node tests/test-agent-access-policy.mjs
node tests/test-chat-service-agent-runtime-facade.mjs
node tests/test-turn-context-builder.mjs
npm.cmd run lint
git diff --check
```
