### PR TITLE
refactor: add child agent run projection

### DIFF
--- a/lib/agent/child-agent-executor.js
+++ b/lib/agent/child-agent-executor.js
@@ -3,8 +3,10 @@
  *
  * This adapter bridges an accepted delegation envelope to AgentRuntime.runChild().
  * It deliberately does not resolve targets, widen capability scope, expose an
- * LLM tool, or build child prompts by itself.
+ * LLM tool, or run an LLM by itself.
  */
+
+import { buildChildAgentRunProjection } from './child-run-projection.js';
 
 function assertFunction(value, name) {
   if (typeof value !== 'function') {
@@ -28,24 +30,29 @@ export class ChildAgentExecutor {
   constructor({
     agent_runtime,
     run_child,
+    projection_builder = buildChildAgentRunProjection,
   } = {}) {
     if (!agent_runtime || typeof agent_runtime.runChild !== 'function') {
       throw new Error('agent_runtime.runChild is required');
     }
     assertFunction(run_child, 'run_child');
+    assertFunction(projection_builder, 'projection_builder');
 
     this.agent_runtime = agent_runtime;
     this.run_child = run_child;
+    this.projection_builder = projection_builder;
   }
 
   async execute(delegation) {
     assertDelegation(delegation);
+    const projection = this.projection_builder(delegation);
 
     return this.agent_runtime.runChild({
       invocation_context: delegation.child_invocation,
     }, ({ invocation_context }) => this.run_child({
       ...delegation,
       invocation_context,
+      projection,
     }));
   }
 }

--- a/lib/agent/child-run-projection.js
+++ b/lib/agent/child-run-projection.js
@@ -1,0 +1,99 @@
+/**
+ * Child Agent run projection.
+ *
+ * Converts an accepted delegation envelope into LLM protocol messages for the
+ * child agent. Authorization identity stays in metadata, not in the prompt.
+ */
+
+function assertDelegation(delegation) {
+  if (!delegation || typeof delegation !== 'object') {
+    throw new Error('delegation is required');
+  }
+  if (!delegation.child_invocation) {
+    throw new Error('delegation.child_invocation is required');
+  }
+  if (!delegation.callee_definition) {
+    throw new Error('delegation.callee_definition is required');
+  }
+  if (!delegation.task || typeof delegation.task !== 'string') {
+    throw new Error('delegation.task is required');
+  }
+}
+
+function normalizeObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+function buildSystemContent(calleeDefinition) {
+  const displayName = calleeDefinition.display_name || calleeDefinition.agent_id || 'Child Agent';
+  const prompt = calleeDefinition.system_prompt || calleeDefinition.description || '';
+
+  return [
+    `You are ${displayName}.`,
+    prompt ? `Agent instructions:\n${prompt}` : null,
+    'You are running as a child agent. The next user message is a delegation package from the caller agent, not a direct human identity.',
+    'Work only within the provided task, expected output, and capability scope.',
+  ].filter(Boolean).join('\n\n');
+}
+
+function buildTaskPackage(delegation) {
+  const childInvocation = delegation.child_invocation;
+
+  return {
+    type: 'agent_delegation_task',
+    task: delegation.task,
+    input: delegation.input ?? {},
+    expected_output: delegation.expected_output ?? null,
+    caller_agent_id: childInvocation.caller_agent_id,
+    callee_agent_id: childInvocation.callee_agent_id,
+    parent_run_id: childInvocation.parent_run_id,
+    run_id: childInvocation.run_id,
+    capability_scope: normalizeObject(delegation.effective_scope || childInvocation.capability_scope),
+  };
+}
+
+function freezeProjection(projection) {
+  return Object.freeze({
+    ...projection,
+    messages: Object.freeze(projection.messages.map(message => Object.freeze({ ...message }))),
+    metadata: Object.freeze({ ...projection.metadata }),
+  });
+}
+
+export function buildChildAgentRunProjection(delegation) {
+  assertDelegation(delegation);
+
+  const childInvocation = delegation.child_invocation;
+  const calleeDefinition = delegation.callee_definition;
+  const taskPackage = buildTaskPackage(delegation);
+
+  return freezeProjection({
+    invocation_context: childInvocation,
+    messages: [
+      {
+        role: 'system',
+        content: buildSystemContent(calleeDefinition),
+      },
+      {
+        role: 'user',
+        content: JSON.stringify(taskPackage, null, 2),
+      },
+    ],
+    metadata: {
+      principal_user_id: childInvocation.principal_user_id,
+      caller_agent_id: childInvocation.caller_agent_id,
+      callee_agent_id: childInvocation.callee_agent_id,
+      parent_run_id: childInvocation.parent_run_id,
+      run_id: childInvocation.run_id,
+      delegation_depth: childInvocation.delegation_depth,
+      source_type: calleeDefinition.source_type || null,
+      effective_scope: normalizeObject(delegation.effective_scope || childInvocation.capability_scope),
+    },
+  });
+}
+
+export default {
+  buildChildAgentRunProjection,
+};

--- a/tests/test-child-agent-executor.mjs
+++ b/tests/test-child-agent-executor.mjs
@@ -68,6 +68,9 @@ async function testExecuteRunsChildThroughRuntime() {
   assert.equal(result.agent_invocation_context, delegation.child_invocation);
   assert.equal(executorInputs.length, 1);
   assert.equal(executorInputs[0].invocation_context, delegation.child_invocation);
+  assert.equal(executorInputs[0].projection.invocation_context, delegation.child_invocation);
+  assert.equal(executorInputs[0].projection.messages[0].role, 'system');
+  assert.equal(executorInputs[0].projection.messages[1].role, 'user');
   assert.equal(executorInputs[0].principal_user_id, undefined);
   assert.equal(executorInputs[0].child_invocation.principal_user_id, 'user_1');
   assert.equal(executorInputs[0].child_invocation.caller_agent_id, 'expert_parent');

--- a/tests/test-child-run-projection.mjs
+++ b/tests/test-child-run-projection.mjs
@@ -1,0 +1,110 @@
+/**
+ * Tests for child Agent run projection.
+ *
+ * Usage:
+ *   node tests/test-child-run-projection.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { buildChildAgentRunProjection } from '../lib/agent/child-run-projection.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation(overrides = {}) {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_projection_parent',
+    principal_user_id: 'user_projection',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_1',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_projection_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return {
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Research Child',
+      description: 'Research support.',
+      system_prompt: 'Be precise.',
+      model_config: {
+        primary_model: {
+          model_name: 'test-model',
+          api_key: 'secret_key_should_not_project',
+        },
+      },
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search the project',
+    input: { query: 'agent runtime' },
+    expected_output: 'Short summary',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+    ...overrides,
+  };
+}
+
+function testBuildsChildMessages() {
+  const projection = buildChildAgentRunProjection(createDelegation());
+
+  assert.equal(projection.invocation_context.callee_agent_id, 'expert_child');
+  assert.equal(projection.messages.length, 2);
+  assert.equal(projection.messages[0].role, 'system');
+  assert.match(projection.messages[0].content, /Research Child/);
+  assert.match(projection.messages[0].content, /Be precise/);
+  assert.equal(projection.messages[1].role, 'user');
+
+  const taskPackage = JSON.parse(projection.messages[1].content);
+  assert.equal(taskPackage.type, 'agent_delegation_task');
+  assert.equal(taskPackage.task, 'Search the project');
+  assert.deepEqual(taskPackage.input, { query: 'agent runtime' });
+  assert.equal(taskPackage.expected_output, 'Short summary');
+  assert.equal(taskPackage.caller_agent_id, 'expert_parent');
+  assert.equal(taskPackage.callee_agent_id, 'expert_child');
+  assert.equal(taskPackage.parent_run_id, 'root_run_projection_parent');
+  assert.equal(taskPackage.run_id, 'child_run_projection_1');
+  assert.deepEqual(taskPackage.capability_scope, { tools: ['search'] });
+}
+
+function testKeepsPrincipalInMetadataNotPrompt() {
+  const projection = buildChildAgentRunProjection(createDelegation());
+  const promptText = projection.messages.map(message => message.content).join('\n');
+
+  assert.equal(projection.metadata.principal_user_id, 'user_projection');
+  assert.equal(projection.metadata.caller_agent_id, 'expert_parent');
+  assert.equal(projection.metadata.callee_agent_id, 'expert_child');
+  assert.equal(promptText.includes('user_projection'), false);
+}
+
+function testDoesNotProjectSensitiveModelConfig() {
+  const projection = buildChildAgentRunProjection(createDelegation());
+  const promptText = projection.messages.map(message => message.content).join('\n');
+
+  assert.equal(promptText.includes('secret_key_should_not_project'), false);
+  assert.equal(promptText.includes('model_config'), false);
+}
+
+function testRejectsMissingTask() {
+  assert.throws(() => buildChildAgentRunProjection(createDelegation({
+    task: '',
+  })), /delegation.task is required/);
+}
+
+function main() {
+  testBuildsChildMessages();
+  testKeepsPrincipalInMetadataNotPrompt();
+  testDoesNotProjectSensitiveModelConfig();
+  testRejectsMissingTask();
+
+  console.log('Child run projection tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `buildChildAgentRunProjection(delegation)` to project an accepted child delegation into LLM protocol messages.
- Keep authorization identity in projection metadata instead of the prompt.
- Pass projection data from `ChildAgentExecutor.execute()` into the explicit `run_child` adapter.
- Add tests for child message roles, task package content, metadata handling, and sensitive model config exclusion.

## Not Included

- No `AgentLoop.run()` child execution.
- No real Child Expert runtime construction.
- No `agent_delegate` exposure.
- No ToolManager or AssistantManager changes.
- No DB/API/frontend changes.

## Verification

```powershell
node tests/test-child-run-projection.mjs
node tests/test-child-agent-executor.mjs
node tests/test-agent-delegation-service.mjs
node tests/test-agent-runtime.mjs
node tests/test-agent-loop.mjs
node tests/test-agent-invocation-context.mjs
node tests/test-agent-definition-resolver.mjs
node tests/test-agent-access-policy.mjs
node tests/test-chat-service-agent-runtime-facade.mjs
node tests/test-turn-context-builder.mjs
npm.cmd run lint
git diff --check
```
