### PR TITLE
refactor: add expert child agent runner

### DIFF
--- a/lib/agent/expert-child-agent-runner.js
+++ b/lib/agent/expert-child-agent-runner.js
@@ -1,0 +1,131 @@
+/**
+ * Expert child Agent runner.
+ *
+ * Maps a validated child delegation projection into the existing AgentLoop
+ * input shape. It intentionally stays internal: target resolution, policy
+ * checks, and tool exposure are owned by earlier delegation layers.
+ */
+
+import { buildStreamLlmPayload } from '../chat/turn-context-builder.js';
+
+function assertFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function assertDelegation(delegation) {
+  if (!delegation || typeof delegation !== 'object') {
+    throw new Error('delegation is required');
+  }
+  if (!delegation.callee_definition) {
+    throw new Error('delegation.callee_definition is required');
+  }
+  if (delegation.callee_definition.source_type !== 'expert') {
+    throw new Error('expert child runner only supports expert callee definitions');
+  }
+}
+
+function assertInvocationContext(invocation_context) {
+  if (!invocation_context || typeof invocation_context !== 'object') {
+    throw new Error('invocation_context is required');
+  }
+  if (!invocation_context.principal_user_id) {
+    throw new Error('invocation_context.principal_user_id is required');
+  }
+  if (!invocation_context.callee_agent_id) {
+    throw new Error('invocation_context.callee_agent_id is required');
+  }
+}
+
+function assertProjection(projection) {
+  if (!projection || typeof projection !== 'object') {
+    throw new Error('projection is required');
+  }
+  if (!Array.isArray(projection.messages) || projection.messages.length === 0) {
+    throw new Error('projection.messages is required');
+  }
+}
+
+function resolveEffectiveScope(delegation, invocation_context) {
+  const scope = delegation.effective_scope || invocation_context.capability_scope;
+  return scope && typeof scope === 'object' && !Array.isArray(scope) ? scope : {};
+}
+
+export class ExpertChildAgentRunner {
+  constructor({
+    agent_loop,
+    get_expert_service,
+    get_scoped_tools = async () => [],
+  } = {}) {
+    if (!agent_loop || typeof agent_loop.run !== 'function') {
+      throw new Error('agent_loop.run is required');
+    }
+    assertFunction(get_expert_service, 'get_expert_service');
+    assertFunction(get_scoped_tools, 'get_scoped_tools');
+
+    this.agent_loop = agent_loop;
+    this.get_expert_service = get_expert_service;
+    this.get_scoped_tools = get_scoped_tools;
+  }
+
+  async run({
+    delegation,
+    invocation_context,
+    projection,
+    session = null,
+    onDelta = null,
+    shouldStop = null,
+    runtimeState = null,
+  } = {}) {
+    assertDelegation(delegation);
+    assertInvocationContext(invocation_context);
+    assertProjection(projection);
+
+    const expertService = await this.get_expert_service(invocation_context.callee_agent_id);
+    if (!expertService || typeof expertService.getDefaultModelConfig !== 'function') {
+      throw new Error('expertService.getDefaultModelConfig is required');
+    }
+    if (typeof expertService.getThinkingConfig !== 'function') {
+      throw new Error('expertService.getThinkingConfig is required');
+    }
+
+    const modelConfig = expertService.getDefaultModelConfig();
+    const thinkingConfig = expertService.getThinkingConfig(modelConfig);
+    const effective_scope = resolveEffectiveScope(delegation, invocation_context);
+    const tools = await this.get_scoped_tools({
+      expert_service: expertService,
+      delegation,
+      invocation_context,
+      effective_scope,
+      session,
+    });
+    const scopedTools = Array.isArray(tools) ? tools : [];
+    const llmPayload = buildStreamLlmPayload({
+      modelConfig,
+      messages: projection.messages,
+      tools: scopedTools,
+    });
+
+    return this.agent_loop.run(expertService, {
+      modelConfig,
+      thinkingConfig,
+      tools: scopedTools,
+      currentMessages: projection.messages,
+      llmPayload,
+      user_id: invocation_context.principal_user_id,
+      expert_id: invocation_context.callee_agent_id,
+      taskContext: null,
+      topic_id: invocation_context.topic_id,
+      task_id: invocation_context.task_id,
+      session,
+      request_id: invocation_context.request_id || invocation_context.run_id,
+      onDelta,
+      shouldStop,
+      runtimeState,
+      agent_invocation_context: invocation_context,
+    });
+  }
+}
+
+export default ExpertChildAgentRunner;

--- a/tests/test-expert-child-agent-runner.mjs
+++ b/tests/test-expert-child-agent-runner.mjs
@@ -1,0 +1,228 @@
+/**
+ * Tests for ExpertChildAgentRunner.
+ *
+ * Usage:
+ *   node tests/test-expert-child-agent-runner.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { ExpertChildAgentRunner } from '../lib/agent/expert-child-agent-runner.js';
+import { buildChildAgentRunProjection } from '../lib/agent/child-run-projection.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation(overrides = {}) {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_expert_runner_parent',
+    principal_user_id: 'user_expert_runner',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_1',
+    task_id: 'task_1',
+    request_id: 'request_parent',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_expert_runner_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return {
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Research Child',
+      system_prompt: 'Be precise.',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    input: { query: 'agent runtime' },
+    expected_output: 'summary',
+    requested_scope: { tools: ['search', 'write_file'] },
+    effective_scope: { tools: ['search'] },
+    ...overrides,
+  };
+}
+
+function createExpertService() {
+  const modelConfig = {
+    model_name: 'child-model',
+    provider_name: 'provider_1',
+    base_url: 'https://example.test/v1',
+    max_tokens: 4096,
+    max_output_tokens: 2048,
+  };
+
+  return {
+    getDefaultModelConfig() {
+      return modelConfig;
+    },
+    getThinkingConfig(inputModelConfig) {
+      return {
+        thinking: false,
+        reasoning: null,
+        reasoning_effort: null,
+        enable_thinking: false,
+        chat_template_kwargs: null,
+        model_name_seen: inputModelConfig.model_name,
+      };
+    },
+  };
+}
+
+async function testMapsProjectionToAgentLoopInput() {
+  const delegation = createDelegation();
+  const projection = buildChildAgentRunProjection(delegation);
+  const expertService = createExpertService();
+  const loopCalls = [];
+  const runner = new ExpertChildAgentRunner({
+    agent_loop: {
+      async run(service, input) {
+        loopCalls.push({ service, input });
+        return {
+          fullContent: 'child result',
+          llmCallsCount: 1,
+          allToolCalls: [],
+        };
+      },
+    },
+    get_expert_service: async expert_id => {
+      assert.equal(expert_id, 'expert_child');
+      return expertService;
+    },
+  });
+  const session = { userId: 'user_expert_runner' };
+  const deltas = [];
+  const onDelta = event => deltas.push(event);
+  const shouldStop = () => false;
+  const runtimeState = {};
+
+  const result = await runner.run({
+    delegation,
+    invocation_context: delegation.child_invocation,
+    projection,
+    session,
+    onDelta,
+    shouldStop,
+    runtimeState,
+  });
+
+  assert.equal(result.fullContent, 'child result');
+  assert.equal(loopCalls.length, 1);
+  assert.equal(loopCalls[0].service, expertService);
+  assert.deepEqual(loopCalls[0].input.currentMessages, projection.messages);
+  assert.deepEqual(loopCalls[0].input.llmPayload.messages, projection.messages);
+  assert.equal(loopCalls[0].input.llmPayload.model, 'child-model');
+  assert.equal(loopCalls[0].input.llmPayload._debug.tools_count, 0);
+  assert.equal(loopCalls[0].input.modelConfig.model_name, 'child-model');
+  assert.equal(loopCalls[0].input.thinkingConfig.model_name_seen, 'child-model');
+  assert.deepEqual(loopCalls[0].input.tools, []);
+  assert.equal(loopCalls[0].input.user_id, 'user_expert_runner');
+  assert.equal(loopCalls[0].input.expert_id, 'expert_child');
+  assert.equal(loopCalls[0].input.topic_id, 'topic_1');
+  assert.equal(loopCalls[0].input.task_id, 'task_1');
+  assert.equal(loopCalls[0].input.request_id, 'child_run_expert_runner_1');
+  assert.equal(loopCalls[0].input.session, session);
+  assert.equal(loopCalls[0].input.onDelta, onDelta);
+  assert.equal(loopCalls[0].input.shouldStop, shouldStop);
+  assert.equal(loopCalls[0].input.runtimeState, runtimeState);
+  assert.equal(loopCalls[0].input.agent_invocation_context, delegation.child_invocation);
+}
+
+async function testUsesScopedToolsWithEffectiveScope() {
+  const delegation = createDelegation({
+    effective_scope: { tools: ['search', 'read_file'] },
+  });
+  const projection = buildChildAgentRunProjection(delegation);
+  const expertService = createExpertService();
+  const tool = { type: 'function', function: { name: 'search' } };
+  const scopedToolCalls = [];
+  const loopCalls = [];
+  const runner = new ExpertChildAgentRunner({
+    agent_loop: {
+      async run(service, input) {
+        loopCalls.push({ service, input });
+        return { fullContent: 'ok', allToolCalls: [], llmCallsCount: 1 };
+      },
+    },
+    get_expert_service: async () => expertService,
+    get_scoped_tools: async input => {
+      scopedToolCalls.push(input);
+      return [tool];
+    },
+  });
+
+  await runner.run({
+    delegation,
+    invocation_context: delegation.child_invocation,
+    projection,
+  });
+
+  assert.equal(scopedToolCalls.length, 1);
+  assert.equal(scopedToolCalls[0].expert_service, expertService);
+  assert.equal(scopedToolCalls[0].delegation, delegation);
+  assert.equal(scopedToolCalls[0].invocation_context, delegation.child_invocation);
+  assert.deepEqual(scopedToolCalls[0].effective_scope, { tools: ['search', 'read_file'] });
+  assert.deepEqual(loopCalls[0].input.tools, [tool]);
+  assert.equal(loopCalls[0].input.llmPayload._debug.tools_count, 1);
+}
+
+async function testRejectsNonExpertCalleeDefinition() {
+  const delegation = createDelegation({
+    callee_definition: {
+      agent_id: 'assistant_child',
+      source_type: 'assistant',
+    },
+  });
+  const runner = new ExpertChildAgentRunner({
+    agent_loop: { run: async () => ({}) },
+    get_expert_service: async () => createExpertService(),
+  });
+
+  await assert.rejects(() => runner.run({
+    delegation,
+    invocation_context: delegation.child_invocation,
+    projection: {
+      messages: [{ role: 'user', content: 'hello' }],
+    },
+  }), /only supports expert/);
+}
+
+async function testDefaultsToNoTools() {
+  const delegation = createDelegation();
+  const projection = buildChildAgentRunProjection(delegation);
+  const loopCalls = [];
+  const runner = new ExpertChildAgentRunner({
+    agent_loop: {
+      async run(_service, input) {
+        loopCalls.push(input);
+        return { fullContent: 'ok', allToolCalls: [], llmCallsCount: 1 };
+      },
+    },
+    get_expert_service: async () => createExpertService(),
+  });
+
+  await runner.run({
+    delegation,
+    invocation_context: delegation.child_invocation,
+    projection,
+  });
+
+  assert.deepEqual(loopCalls[0].tools, []);
+  assert.equal(loopCalls[0].llmPayload._debug.tools_count, 0);
+}
+
+async function main() {
+  await testMapsProjectionToAgentLoopInput();
+  await testUsesScopedToolsWithEffectiveScope();
+  await testRejectsNonExpertCalleeDefinition();
+  await testDefaultsToNoTools();
+
+  console.log('Expert child agent runner tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add an internal `ExpertChildAgentRunner` adapter for expert-backed child runs.
- Map child projection messages into the existing `AgentLoop.run()` input shape.
- Keep tool scope explicit through injected `get_scoped_tools`, defaulting to no tools.

## Boundaries

- No DB changes.
- No `/api/assistants/call` changes.
- No root-callable `agent_delegate` tool exposure.
- No Child Agent connection from root chat yet.
- No `ToolManager` or `AssistantManager` enhancement.

## Validation

- `node tests\test-expert-child-agent-runner.mjs`
- `node tests\test-child-run-projection.mjs`
- `node tests\test-child-agent-executor.mjs`
- `node tests\test-agent-delegation-service.mjs`
- `node tests\test-agent-runtime.mjs`
- `node tests\test-agent-loop.mjs`
- `node tests\test-agent-invocation-context.mjs`
- `node tests\test-chat-service-agent-runtime-facade.mjs`
- `node tests\test-turn-context-builder.mjs`
- `npm.cmd run lint`
- `git diff --check`
