### PR TITLE
refactor: add child scoped tools adapter

### DIFF
--- a/lib/agent/expert-child-scoped-tools.js
+++ b/lib/agent/expert-child-scoped-tools.js
@@ -1,0 +1,61 @@
+/**
+ * Expert child scoped tools adapter.
+ *
+ * Produces LLM-visible tool definitions for a child expert by intersecting the
+ * child invocation's effective scope with the child expert's existing tools.
+ */
+
+function normalizeAllowedToolNames(effective_scope = {}) {
+  if (!Array.isArray(effective_scope.tools)) {
+    return [];
+  }
+
+  return [...new Set(effective_scope.tools
+    .filter(tool => typeof tool === 'string' && tool.trim())
+    .map(tool => tool.trim()))];
+}
+
+export function getToolDefinitionName(tool) {
+  return tool?.function?.name || tool?.name || null;
+}
+
+function buildChildToolContext({ invocation_context, session }) {
+  const user_id = invocation_context.principal_user_id;
+  const expert_id = invocation_context.callee_agent_id;
+
+  return {
+    user_id,
+    userId: user_id,
+    expert_id,
+    expertId: expert_id,
+    session,
+  };
+}
+
+export async function getExpertChildScopedTools({
+  expert_service,
+  invocation_context,
+  effective_scope = {},
+  session = null,
+} = {}) {
+  const allowedToolNames = normalizeAllowedToolNames(effective_scope);
+  if (allowedToolNames.length === 0) {
+    return [];
+  }
+
+  if (!expert_service?.toolManager || typeof expert_service.toolManager.getToolDefinitions !== 'function') {
+    throw new Error('expert_service.toolManager.getToolDefinitions is required');
+  }
+
+  const toolContext = buildChildToolContext({ invocation_context, session });
+  const allTools = await expert_service.toolManager.getToolDefinitions(toolContext);
+  const allowed = new Set(allowedToolNames);
+
+  return (Array.isArray(allTools) ? allTools : [])
+    .filter(tool => allowed.has(getToolDefinitionName(tool)));
+}
+
+export default {
+  getExpertChildScopedTools,
+  getToolDefinitionName,
+};

--- a/tests/test-expert-child-scoped-tools.mjs
+++ b/tests/test-expert-child-scoped-tools.mjs
@@ -1,0 +1,125 @@
+/**
+ * Tests for expert child scoped tool adapter.
+ *
+ * Usage:
+ *   node tests/test-expert-child-scoped-tools.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  getExpertChildScopedTools,
+  getToolDefinitionName,
+} from '../lib/agent/expert-child-scoped-tools.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createChildInvocation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_scoped_tools_parent',
+    principal_user_id: 'user_scoped_tools',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_scoped_tools',
+  });
+
+  return deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_scoped_tools_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+}
+
+function createTool(name) {
+  return {
+    type: 'function',
+    function: {
+      name,
+      description: `${name} tool`,
+      parameters: { type: 'object', properties: {} },
+    },
+  };
+}
+
+async function testFiltersToolsByEffectiveScope() {
+  const invocation_context = createChildInvocation();
+  const toolContextCalls = [];
+  const tools = [
+    createTool('execute'),
+    createTool('search'),
+    createTool('read_file'),
+    { name: 'legacy_shape_tool' },
+  ];
+  const session = { userId: 'user_scoped_tools' };
+  const expert_service = {
+    toolManager: {
+      async getToolDefinitions(context) {
+        toolContextCalls.push(context);
+        return tools;
+      },
+    },
+  };
+
+  const scopedTools = await getExpertChildScopedTools({
+    expert_service,
+    invocation_context,
+    effective_scope: { tools: ['search', 'legacy_shape_tool', 'missing_tool', 'search'] },
+    session,
+  });
+
+  assert.deepEqual(scopedTools, [
+    tools[1],
+    tools[3],
+  ]);
+  assert.deepEqual(toolContextCalls, [{
+    user_id: 'user_scoped_tools',
+    userId: 'user_scoped_tools',
+    expert_id: 'expert_child',
+    expertId: 'expert_child',
+    session,
+  }]);
+}
+
+async function testEmptyScopeDoesNotLoadToolDefinitions() {
+  let getToolDefinitionsCalled = false;
+  const scopedTools = await getExpertChildScopedTools({
+    expert_service: {
+      toolManager: {
+        async getToolDefinitions() {
+          getToolDefinitionsCalled = true;
+          return [createTool('search')];
+        },
+      },
+    },
+    invocation_context: createChildInvocation(),
+    effective_scope: {},
+  });
+
+  assert.deepEqual(scopedTools, []);
+  assert.equal(getToolDefinitionsCalled, false);
+}
+
+async function testRejectsMissingToolManagerWhenScopeRequestsTools() {
+  await assert.rejects(() => getExpertChildScopedTools({
+    expert_service: {},
+    invocation_context: createChildInvocation(),
+    effective_scope: { tools: ['search'] },
+  }), /toolManager\.getToolDefinitions is required/);
+}
+
+function testExtractsToolDefinitionName() {
+  assert.equal(getToolDefinitionName(createTool('search')), 'search');
+  assert.equal(getToolDefinitionName({ name: 'flat_tool' }), 'flat_tool');
+  assert.equal(getToolDefinitionName({}), null);
+}
+
+async function main() {
+  await testFiltersToolsByEffectiveScope();
+  await testEmptyScopeDoesNotLoadToolDefinitions();
+  await testRejectsMissingToolManagerWhenScopeRequestsTools();
+  testExtractsToolDefinitionName();
+
+  console.log('Expert child scoped tools tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add an internal expert child scoped tools adapter.
- Filter child expert tool definitions by `effective_scope.tools`.
- Keep empty or missing tool scope conservative: no tools are exposed.

## Boundaries

- No DB changes.
- No API changes.
- No `agent_delegate` exposure.
- No Child Agent connection from root chat.
- No ToolManager behavior change.
- No AssistantManager enhancement.

## Validation

- `node tests\test-expert-child-scoped-tools.mjs`
- `node tests\test-expert-child-agent-runner.mjs`
- `node tests\test-tool-definitions-contract.mjs`
- `node tests\test-child-run-projection.mjs`
- `node tests\test-child-agent-executor.mjs`
- `node tests\test-agent-delegation-service.mjs`
- `node tests\test-agent-runtime.mjs`
- `node tests\test-agent-invocation-context.mjs`
- `node tests\test-agent-loop.mjs`
- `node tests\test-chat-service-agent-runtime-facade.mjs`
- `node tests\test-turn-context-builder.mjs`
- `npm.cmd run lint`
- `git diff --check`
