### PR TITLE
refactor: add child run scheduler

### DIFF
--- a/lib/agent/child-run-scheduler.js
+++ b/lib/agent/child-run-scheduler.js
@@ -1,0 +1,214 @@
+/**
+ * Child run scheduler.
+ *
+ * In-memory async scheduler for delegated child Agent runs. It owns run state
+ * and cancellation flags, while actual child execution remains injected.
+ */
+
+const TERMINAL_STATUSES = Object.freeze([
+  'completed',
+  'failed',
+  'cancelled',
+]);
+
+function assertFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function assertDelegation(delegation) {
+  if (!delegation || typeof delegation !== 'object') {
+    throw new Error('delegation is required');
+  }
+  if (!delegation.child_invocation?.run_id) {
+    throw new Error('delegation.child_invocation.run_id is required');
+  }
+}
+
+function defaultIsCancelledError(error) {
+  return error?.message === 'Request aborted by user' || error?.name === 'AbortError';
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function buildRunSnapshot(record) {
+  return Object.freeze({
+    child_run_id: record.child_run_id,
+    parent_run_id: record.parent_run_id,
+    principal_user_id: record.principal_user_id,
+    caller_agent_id: record.caller_agent_id,
+    callee_agent_id: record.callee_agent_id,
+    status: record.status,
+    cancel_requested: record.cancel_requested,
+    queued_at: record.queued_at,
+    started_at: record.started_at,
+    completed_at: record.completed_at,
+    failed_at: record.failed_at,
+    cancelled_at: record.cancelled_at,
+    error: record.error,
+    has_result: record.result !== null,
+    event_count: record.events.length,
+  });
+}
+
+function buildResultSnapshot(record) {
+  return Object.freeze({
+    ...buildRunSnapshot(record),
+    result: record.result,
+    events: Object.freeze(record.events.map(event => Object.freeze({ ...event }))),
+  });
+}
+
+export class InMemoryChildRunScheduler {
+  constructor({
+    create_child_executor,
+    is_cancelled_error = defaultIsCancelledError,
+  } = {}) {
+    assertFunction(create_child_executor, 'create_child_executor');
+    assertFunction(is_cancelled_error, 'is_cancelled_error');
+
+    this.create_child_executor = create_child_executor;
+    this.is_cancelled_error = is_cancelled_error;
+    this.runs = new Map();
+  }
+
+  start(delegation, options = {}) {
+    assertDelegation(delegation);
+    const invocation = delegation.child_invocation;
+    const child_run_id = invocation.run_id;
+
+    if (this.runs.has(child_run_id)) {
+      throw new Error(`child run already scheduled: ${child_run_id}`);
+    }
+
+    const record = {
+      child_run_id,
+      parent_run_id: invocation.parent_run_id || null,
+      principal_user_id: invocation.principal_user_id,
+      caller_agent_id: invocation.caller_agent_id,
+      callee_agent_id: invocation.callee_agent_id,
+      status: 'queued',
+      cancel_requested: false,
+      queued_at: nowIso(),
+      started_at: null,
+      completed_at: null,
+      failed_at: null,
+      cancelled_at: null,
+      error: null,
+      result: null,
+      events: [],
+      completion_promise: null,
+    };
+
+    this.runs.set(child_run_id, record);
+    record.completion_promise = this.runRecord(record, delegation, options);
+
+    return buildRunSnapshot(record);
+  }
+
+  getStatus(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    return buildRunSnapshot(record);
+  }
+
+  getResult(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    if (record.status !== 'completed') {
+      throw new Error(`child run is not completed: ${record.status}`);
+    }
+
+    return buildResultSnapshot(record);
+  }
+
+  getEvents(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    return Object.freeze(record.events.map(event => Object.freeze({ ...event })));
+  }
+
+  cancel(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    if (TERMINAL_STATUSES.includes(record.status)) {
+      return buildRunSnapshot(record);
+    }
+
+    record.cancel_requested = true;
+    if (record.status === 'queued') {
+      record.status = 'cancelled';
+      record.cancelled_at = nowIso();
+      record.error = 'Request aborted by user';
+    }
+
+    return buildRunSnapshot(record);
+  }
+
+  async waitForCompletion(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    await record.completion_promise;
+    return buildRunSnapshot(record);
+  }
+
+  getRecord(child_run_id) {
+    const record = this.runs.get(child_run_id);
+    if (!record) {
+      throw new Error(`child run not found: ${child_run_id}`);
+    }
+    return record;
+  }
+
+  async runRecord(record, delegation, options) {
+    await Promise.resolve();
+    if (record.status === 'cancelled') {
+      return;
+    }
+
+    record.status = 'running';
+    record.started_at = nowIso();
+
+    const runtimeState = {};
+    const onDelta = event => {
+      record.events.push(event);
+      options.onDelta?.(event);
+    };
+    const shouldStop = () => record.cancel_requested || Boolean(options.shouldStop?.());
+
+    try {
+      const childExecutor = this.create_child_executor({
+        session: options.session ?? null,
+        onDelta,
+        shouldStop,
+        runtimeState,
+      });
+      if (!childExecutor || typeof childExecutor.execute !== 'function') {
+        throw new Error('create_child_executor must return child_executor.execute');
+      }
+
+      const result = await childExecutor.execute(delegation);
+      if (record.cancel_requested) {
+        record.status = 'cancelled';
+        record.cancelled_at = nowIso();
+        record.error = 'Request aborted by user';
+        return;
+      }
+
+      record.status = 'completed';
+      record.completed_at = nowIso();
+      record.result = result;
+    } catch (error) {
+      if (record.cancel_requested || this.is_cancelled_error(error)) {
+        record.status = 'cancelled';
+        record.cancelled_at = nowIso();
+      } else {
+        record.status = 'failed';
+        record.failed_at = nowIso();
+      }
+      record.error = error?.message || String(error);
+    }
+  }
+}
+
+export default {
+  InMemoryChildRunScheduler,
+};

--- a/tests/test-child-run-scheduler.mjs
+++ b/tests/test-child-run-scheduler.mjs
@@ -1,0 +1,200 @@
+/**
+ * Tests for child run scheduler.
+ *
+ * Usage:
+ *   node tests/test-child-run-scheduler.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { InMemoryChildRunScheduler } from '../lib/agent/child-run-scheduler.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation(runId = 'child_run_scheduler_1') {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_scheduler_parent',
+    principal_user_id: 'user_scheduler',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_scheduler',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: runId,
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return Object.freeze({
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    input: { query: 'agent runtime' },
+    expected_output: 'summary',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  });
+}
+
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitOneTurn() {
+  await Promise.resolve();
+}
+
+async function testStartsAndCompletesChildRun() {
+  const executorCalls = [];
+  const deltas = [];
+  const scheduler = new InMemoryChildRunScheduler({
+    create_child_executor: runOptions => ({
+      async execute(delegation) {
+        executorCalls.push({ delegation, runOptions });
+        runOptions.onDelta({ type: 'delta', content: 'hello' });
+        return {
+          fullContent: 'child result',
+          llmCallsCount: 1,
+          allToolCalls: [],
+        };
+      },
+    }),
+  });
+  const delegation = createDelegation();
+  const session = { userId: 'user_scheduler' };
+
+  const queued = scheduler.start(delegation, {
+    session,
+    onDelta: event => deltas.push(event),
+  });
+  assert.equal(queued.child_run_id, 'child_run_scheduler_1');
+  assert.equal(queued.parent_run_id, 'root_run_scheduler_parent');
+  assert.equal(queued.status, 'queued');
+  assert.equal(queued.has_result, false);
+
+  const finalStatus = await scheduler.waitForCompletion('child_run_scheduler_1');
+  assert.equal(finalStatus.status, 'completed');
+  assert.equal(finalStatus.has_result, true);
+  assert.equal(finalStatus.event_count, 1);
+  assert.equal(executorCalls.length, 1);
+  assert.equal(executorCalls[0].delegation, delegation);
+  assert.equal(executorCalls[0].runOptions.session, session);
+  assert.equal(executorCalls[0].runOptions.shouldStop(), false);
+  assert.deepEqual(deltas, [{ type: 'delta', content: 'hello' }]);
+
+  const result = scheduler.getResult('child_run_scheduler_1');
+  assert.equal(result.result.fullContent, 'child result');
+  assert.deepEqual(result.events, [{ type: 'delta', content: 'hello' }]);
+}
+
+async function testCancelsRunningChildRun() {
+  const entered = createDeferred();
+  const release = createDeferred();
+  let shouldStopFromRun = null;
+  const scheduler = new InMemoryChildRunScheduler({
+    create_child_executor: runOptions => ({
+      async execute() {
+        shouldStopFromRun = runOptions.shouldStop;
+        entered.resolve();
+        await release.promise;
+        if (runOptions.shouldStop()) {
+          throw new Error('Request aborted by user');
+        }
+        return { fullContent: 'should not complete', allToolCalls: [], llmCallsCount: 1 };
+      },
+    }),
+  });
+
+  scheduler.start(createDelegation('child_run_scheduler_cancel'));
+  await entered.promise;
+  assert.equal(scheduler.getStatus('child_run_scheduler_cancel').status, 'running');
+  assert.equal(shouldStopFromRun(), false);
+
+  const cancelling = scheduler.cancel('child_run_scheduler_cancel');
+  assert.equal(cancelling.cancel_requested, true);
+  assert.equal(cancelling.status, 'running');
+  assert.equal(shouldStopFromRun(), true);
+
+  release.resolve();
+  const finalStatus = await scheduler.waitForCompletion('child_run_scheduler_cancel');
+  assert.equal(finalStatus.status, 'cancelled');
+  assert.equal(finalStatus.error, 'Request aborted by user');
+  assert.throws(() => scheduler.getResult('child_run_scheduler_cancel'), /not completed: cancelled/);
+}
+
+async function testCapturesFailedChildRun() {
+  const scheduler = new InMemoryChildRunScheduler({
+    create_child_executor: () => ({
+      async execute() {
+        throw new Error('child exploded');
+      },
+    }),
+  });
+
+  scheduler.start(createDelegation('child_run_scheduler_failed'));
+  const finalStatus = await scheduler.waitForCompletion('child_run_scheduler_failed');
+
+  assert.equal(finalStatus.status, 'failed');
+  assert.equal(finalStatus.error, 'child exploded');
+  assert.equal(finalStatus.has_result, false);
+}
+
+async function testRejectsDuplicateRunIdAndUnknownRun() {
+  const scheduler = new InMemoryChildRunScheduler({
+    create_child_executor: () => ({
+      async execute() {
+        return { fullContent: 'ok', allToolCalls: [], llmCallsCount: 1 };
+      },
+    }),
+  });
+  const delegation = createDelegation('child_run_scheduler_duplicate');
+
+  scheduler.start(delegation);
+  assert.throws(() => scheduler.start(delegation), /already scheduled/);
+  assert.throws(() => scheduler.getStatus('missing_child_run'), /not found/);
+  await scheduler.waitForCompletion('child_run_scheduler_duplicate');
+}
+
+async function testCannotReadResultBeforeCompletion() {
+  const release = createDeferred();
+  const scheduler = new InMemoryChildRunScheduler({
+    create_child_executor: () => ({
+      async execute() {
+        await release.promise;
+        return { fullContent: 'ok', allToolCalls: [], llmCallsCount: 1 };
+      },
+    }),
+  });
+
+  scheduler.start(createDelegation('child_run_scheduler_pending'));
+  await waitOneTurn();
+  assert.throws(() => scheduler.getResult('child_run_scheduler_pending'), /not completed/);
+  release.resolve();
+  await scheduler.waitForCompletion('child_run_scheduler_pending');
+  assert.equal(scheduler.getResult('child_run_scheduler_pending').result.fullContent, 'ok');
+}
+
+async function main() {
+  await testStartsAndCompletesChildRun();
+  await testCancelsRunningChildRun();
+  await testCapturesFailedChildRun();
+  await testRejectsDuplicateRunIdAndUnknownRun();
+  await testCannotReadResultBeforeCompletion();
+
+  console.log('Child run scheduler tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add an internal in-memory child run scheduler.
- Support async child run start/status/result/events/cancel/wait operations.
- Keep child execution injected so the backend can later move to resident/MCP workers.

## Boundaries

- No DB changes.
- No API changes.
- No ToolManager registration.
- No `agent_delegate` exposure.
- No resident/MCP transport yet.

## Validation

- `node tests\test-child-run-scheduler.mjs`
- `node tests\test-child-delegation-runtime-factory.mjs`
- `node tests\test-expert-child-agent-runner.mjs`
- `node tests\test-expert-child-scoped-tools.mjs`
- `node tests\test-agent-delegation-service.mjs`
- `node tests\test-child-run-projection.mjs`
- `node tests\test-child-agent-executor.mjs`
- `node tests\test-agent-runtime.mjs`
- `node tests\test-agent-invocation-context.mjs`
- `node tests\test-agent-loop.mjs`
- `node tests\test-chat-service-agent-runtime-facade.mjs`
- `node tests\test-turn-context-builder.mjs`
- `node tests\test-tool-definitions-contract.mjs`
- `npm.cmd run lint`
- `git diff --check`
