### PR TITLE
refactor: add agent delegate control facade

### DIFF
--- a/lib/agent/agent-delegate-control-facade.js
+++ b/lib/agent/agent-delegate-control-facade.js
@@ -1,0 +1,213 @@
+/**
+ * Agent delegation control facade.
+ *
+ * Internal, unregistered facade for the future agent_delegate tool surface.
+ * It delegates policy decisions to AgentDelegationService and execution state
+ * to ChildRunScheduler.
+ */
+
+export const AGENT_DELEGATE_TOOL_NAMES = Object.freeze({
+  START: 'agent_delegate_start',
+  STATUS: 'agent_delegate_status',
+  RESULT: 'agent_delegate_result',
+  CANCEL: 'agent_delegate_cancel',
+});
+
+function assertService(value, methodName, name) {
+  if (!value || typeof value[methodName] !== 'function') {
+    throw new Error(`${name}.${methodName} is required`);
+  }
+}
+
+function assertString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function normalizeObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function normalizeNullableString(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function buildStartToolDefinition() {
+  return {
+    type: 'function',
+    function: {
+      name: AGENT_DELEGATE_TOOL_NAMES.START,
+      description: 'Start an asynchronous child agent run for a delegated task.',
+      parameters: {
+        type: 'object',
+        properties: {
+          source_type: {
+            type: 'string',
+            enum: ['expert'],
+            description: 'Child agent source type. Only expert is supported in the current runtime.',
+          },
+          agent_id: {
+            type: 'string',
+            description: 'Target child agent id.',
+          },
+          task: {
+            type: 'string',
+            description: 'Delegated task for the child agent.',
+          },
+          input: {
+            type: 'object',
+            description: 'Structured task input for the child agent.',
+          },
+          expected_output: {
+            type: 'string',
+            description: 'Expected child output format or acceptance criteria.',
+          },
+          requested_scope: {
+            type: 'object',
+            description: 'Requested delegated capability scope.',
+          },
+        },
+        required: ['source_type', 'agent_id', 'task'],
+      },
+    },
+  };
+}
+
+function buildChildRunIdToolDefinition(name, description) {
+  return {
+    type: 'function',
+    function: {
+      name,
+      description,
+      parameters: {
+        type: 'object',
+        properties: {
+          child_run_id: {
+            type: 'string',
+            description: 'Child agent run id returned by agent_delegate_start.',
+          },
+        },
+        required: ['child_run_id'],
+      },
+    },
+  };
+}
+
+export function buildAgentDelegateControlToolDefinitions() {
+  return Object.freeze([
+    Object.freeze(buildStartToolDefinition()),
+    Object.freeze(buildChildRunIdToolDefinition(
+      AGENT_DELEGATE_TOOL_NAMES.STATUS,
+      'Get the current status of an asynchronous child agent run.',
+    )),
+    Object.freeze(buildChildRunIdToolDefinition(
+      AGENT_DELEGATE_TOOL_NAMES.RESULT,
+      'Read the completed result and events for a child agent run.',
+    )),
+    Object.freeze(buildChildRunIdToolDefinition(
+      AGENT_DELEGATE_TOOL_NAMES.CANCEL,
+      'Request cancellation for a running child agent run.',
+    )),
+  ]);
+}
+
+export class AgentDelegateControlFacade {
+  constructor({
+    delegation_service,
+    child_run_scheduler,
+  } = {}) {
+    assertService(delegation_service, 'delegate', 'delegation_service');
+    assertService(child_run_scheduler, 'start', 'child_run_scheduler');
+    assertService(child_run_scheduler, 'getStatus', 'child_run_scheduler');
+    assertService(child_run_scheduler, 'getResult', 'child_run_scheduler');
+    assertService(child_run_scheduler, 'cancel', 'child_run_scheduler');
+
+    this.delegation_service = delegation_service;
+    this.child_run_scheduler = child_run_scheduler;
+  }
+
+  getToolDefinitions() {
+    return buildAgentDelegateControlToolDefinitions();
+  }
+
+  async start(params = {}, context = {}) {
+    if (!context.parent_invocation) {
+      throw new Error('context.parent_invocation is required');
+    }
+    assertString(params.source_type, 'params.source_type');
+    assertString(params.agent_id, 'params.agent_id');
+    assertString(params.task, 'params.task');
+
+    const delegation = await this.delegation_service.delegate({
+      parent_invocation: context.parent_invocation,
+      target: {
+        source_type: params.source_type,
+        agent_id: params.agent_id,
+      },
+      task: params.task,
+      input: normalizeObject(params.input),
+      expected_output: normalizeNullableString(params.expected_output),
+      requested_scope: params.requested_scope ? normalizeObject(params.requested_scope) : null,
+      caller_scope: normalizeObject(context.caller_scope),
+      principal_scope: normalizeObject(context.principal_scope),
+      workspace_scope: normalizeObject(context.workspace_scope),
+      invocation_mode: 'llm',
+      source: 'agent_delegate',
+    });
+    const run = this.child_run_scheduler.start(delegation, {
+      session: context.session ?? null,
+    });
+
+    return Object.freeze({
+      child_run_id: run.child_run_id,
+      status: run.status,
+      run,
+    });
+  }
+
+  status(params = {}) {
+    assertString(params.child_run_id, 'params.child_run_id');
+    return this.child_run_scheduler.getStatus(params.child_run_id);
+  }
+
+  result(params = {}) {
+    assertString(params.child_run_id, 'params.child_run_id');
+    return this.child_run_scheduler.getResult(params.child_run_id);
+  }
+
+  cancel(params = {}) {
+    assertString(params.child_run_id, 'params.child_run_id');
+    return this.child_run_scheduler.cancel(params.child_run_id);
+  }
+
+  async handleToolCall(tool_name, params = {}, context = {}) {
+    try {
+      switch (tool_name) {
+        case AGENT_DELEGATE_TOOL_NAMES.START:
+          return { success: true, data: await this.start(params, context) };
+        case AGENT_DELEGATE_TOOL_NAMES.STATUS:
+          return { success: true, data: this.status(params) };
+        case AGENT_DELEGATE_TOOL_NAMES.RESULT:
+          return { success: true, data: this.result(params) };
+        case AGENT_DELEGATE_TOOL_NAMES.CANCEL:
+          return { success: true, data: this.cancel(params) };
+        default:
+          throw new Error(`Unknown agent delegate control tool: ${tool_name}`);
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error?.message || String(error),
+      };
+    }
+  }
+}
+
+export default {
+  AGENT_DELEGATE_TOOL_NAMES,
+  AgentDelegateControlFacade,
+  buildAgentDelegateControlToolDefinitions,
+};

--- a/tests/test-agent-delegate-control-facade.mjs
+++ b/tests/test-agent-delegate-control-facade.mjs
@@ -1,0 +1,221 @@
+/**
+ * Tests for internal agent delegate control facade.
+ *
+ * Usage:
+ *   node tests/test-agent-delegate-control-facade.mjs
+ */
+
+import assert from 'node:assert/strict';
+import {
+  AgentDelegateControlFacade,
+  AGENT_DELEGATE_TOOL_NAMES,
+  buildAgentDelegateControlToolDefinitions,
+} from '../lib/agent/agent-delegate-control-facade.js';
+import { AgentDelegationService } from '../lib/agent/agent-delegation-service.js';
+import { InMemoryChildRunScheduler } from '../lib/agent/child-run-scheduler.js';
+import { buildRootAgentInvocationContext } from '../lib/agent/agent-invocation-context.js';
+
+function createParentInvocation() {
+  return buildRootAgentInvocationContext({
+    run_id: 'root_run_delegate_control_parent',
+    principal_user_id: 'user_delegate_control',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_delegate_control',
+  });
+}
+
+function createDelegationService(events = []) {
+  return new AgentDelegationService({
+    definition_resolver: {
+      async resolve({ source_type, agent_id }) {
+        assert.equal(source_type, 'expert');
+        assert.equal(agent_id, 'expert_child');
+        return {
+          agent_id: 'expert_child',
+          source_type: 'expert',
+          display_name: 'Child Expert',
+          execution_policy: { mode: 'llm' },
+          capability_declarations: {
+            skills: [{ skill_id: 'skill_search', mark: 'search' }],
+          },
+          is_active: true,
+        };
+      },
+    },
+    event_sink: event => events.push(event),
+  });
+}
+
+function createFacade({ execute, events = [] } = {}) {
+  const scheduler = new InMemoryChildRunScheduler({
+    create_child_executor: runOptions => ({
+      async execute(delegation) {
+        return execute
+          ? execute(delegation, runOptions)
+          : {
+              fullContent: 'child result',
+              allToolCalls: [],
+              llmCallsCount: 1,
+              agent_invocation_context: delegation.child_invocation,
+            };
+      },
+    }),
+  });
+
+  return {
+    scheduler,
+    facade: new AgentDelegateControlFacade({
+      delegation_service: createDelegationService(events),
+      child_run_scheduler: scheduler,
+    }),
+  };
+}
+
+function createStartContext() {
+  return {
+    parent_invocation: createParentInvocation(),
+    caller_scope: {
+      tools: ['search', 'write_file'],
+      skills: ['search'],
+      can_use_skills: true,
+    },
+    principal_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      can_use_skills: true,
+    },
+    workspace_scope: {
+      tools: ['search'],
+      skills: ['search'],
+      can_use_skills: true,
+    },
+    session: { userId: 'user_delegate_control' },
+  };
+}
+
+function createStartParams(overrides = {}) {
+  return {
+    source_type: 'expert',
+    agent_id: 'expert_child',
+    task: 'Search project',
+    input: { query: 'agent runtime' },
+    expected_output: 'summary',
+    requested_scope: { tools: ['search'] },
+    ...overrides,
+  };
+}
+
+async function testStartStatusAndResultFlow() {
+  const events = [];
+  const { facade, scheduler } = createFacade({ events });
+
+  const started = await facade.start(createStartParams(), createStartContext());
+  assert.equal(started.child_run_id, started.run.child_run_id);
+  assert.equal(started.status, 'queued');
+  assert.equal(started.run.parent_run_id, 'root_run_delegate_control_parent');
+
+  const finalStatus = await scheduler.waitForCompletion(started.child_run_id);
+  assert.equal(finalStatus.status, 'completed');
+  assert.equal(facade.status({ child_run_id: started.child_run_id }).status, 'completed');
+
+  const result = facade.result({ child_run_id: started.child_run_id });
+  assert.equal(result.result.fullContent, 'child result');
+  assert.equal(result.result.agent_invocation_context.run_id, started.child_run_id);
+  assert.equal(events[0].type, 'delegation_created');
+}
+
+async function testHandleToolCallWrapsSuccessAndErrors() {
+  const { facade, scheduler } = createFacade();
+
+  const started = await facade.handleToolCall(
+    AGENT_DELEGATE_TOOL_NAMES.START,
+    createStartParams(),
+    createStartContext(),
+  );
+  assert.equal(started.success, true);
+  await scheduler.waitForCompletion(started.data.child_run_id);
+
+  const status = await facade.handleToolCall(AGENT_DELEGATE_TOOL_NAMES.STATUS, {
+    child_run_id: started.data.child_run_id,
+  });
+  assert.equal(status.success, true);
+  assert.equal(status.data.status, 'completed');
+
+  const result = await facade.handleToolCall(AGENT_DELEGATE_TOOL_NAMES.RESULT, {
+    child_run_id: started.data.child_run_id,
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.data.result.fullContent, 'child result');
+
+  const unknown = await facade.handleToolCall('unknown_tool', {}, {});
+  assert.equal(unknown.success, false);
+  assert.match(unknown.error, /Unknown agent delegate control tool/);
+}
+
+async function testCancelFlow() {
+  let release;
+  const entered = new Promise(resolve => {
+    release = resolve;
+  });
+  let continueRun;
+  const canContinue = new Promise(resolve => {
+    continueRun = resolve;
+  });
+  const { facade, scheduler } = createFacade({
+    execute: async (_delegation, runOptions) => {
+      release();
+      await canContinue;
+      if (runOptions.shouldStop()) {
+        throw new Error('Request aborted by user');
+      }
+      return { fullContent: 'late result', allToolCalls: [], llmCallsCount: 1 };
+    },
+  });
+
+  const started = await facade.start(createStartParams(), createStartContext());
+  await entered;
+  assert.equal(facade.status({ child_run_id: started.child_run_id }).status, 'running');
+
+  const cancelling = facade.cancel({ child_run_id: started.child_run_id });
+  assert.equal(cancelling.cancel_requested, true);
+  continueRun();
+
+  const finalStatus = await scheduler.waitForCompletion(started.child_run_id);
+  assert.equal(finalStatus.status, 'cancelled');
+  assert.match(finalStatus.error, /Request aborted/);
+}
+
+function testBuildsUnregisteredToolDefinitions() {
+  const definitions = buildAgentDelegateControlToolDefinitions();
+  const names = definitions.map(tool => tool.function.name);
+
+  assert.deepEqual(names, [
+    AGENT_DELEGATE_TOOL_NAMES.START,
+    AGENT_DELEGATE_TOOL_NAMES.STATUS,
+    AGENT_DELEGATE_TOOL_NAMES.RESULT,
+    AGENT_DELEGATE_TOOL_NAMES.CANCEL,
+  ]);
+  assert.deepEqual(definitions[0].function.parameters.required, ['source_type', 'agent_id', 'task']);
+  assert.equal(definitions[0].function.parameters.properties.requested_scope.type, 'object');
+  assert.deepEqual(definitions[1].function.parameters.required, ['child_run_id']);
+}
+
+async function testStartRejectsDeniedScope() {
+  const { facade } = createFacade();
+
+  await assert.rejects(() => facade.start(createStartParams({
+    requested_scope: { tools: ['write_file'] },
+  }), createStartContext()), /Requested capability denied/);
+}
+
+async function main() {
+  await testStartStatusAndResultFlow();
+  await testHandleToolCallWrapsSuccessAndErrors();
+  await testCancelFlow();
+  testBuildsUnregisteredToolDefinitions();
+  await testStartRejectsDeniedScope();
+
+  console.log('Agent delegate control facade tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add an internal, unregistered agent delegation control facade.
- Define start/status/result/cancel tool-shaped operations.
- Route start through `AgentDelegationService.delegate()` and scheduling through `ChildRunScheduler`.

## Boundaries

- No DB changes.
- No API changes.
- No ToolManager registration.
- No root-visible `agent_delegate` exposure.
- No resident/MCP transport yet.

## Validation

- `node tests\test-agent-delegate-control-facade.mjs`
- `node tests\test-child-run-scheduler.mjs`
- `node tests\test-agent-delegation-service.mjs`
- `node tests\test-child-delegation-runtime-factory.mjs`
- `node tests\test-expert-child-agent-runner.mjs`
- `node tests\test-expert-child-scoped-tools.mjs`
- `node tests\test-child-run-projection.mjs`
- `node tests\test-child-agent-executor.mjs`
- `node tests\test-agent-runtime.mjs`
- `node tests\test-agent-invocation-context.mjs`
- `node tests\test-agent-loop.mjs`
- `node tests\test-chat-service-agent-runtime-facade.mjs`
- `node tests\test-turn-context-builder.mjs`
- `node tests\test-tool-definitions-contract.mjs`
- `npm.cmd run lint`
- `git diff --check`
