### PR TITLE
refactor: expose agent delegate control tools

### DIFF
--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -50,7 +50,7 @@ export class AgentLoop {
     this.generate_tool_call_summary = generate_tool_call_summary;
   }
 
-  async run(expertService, { modelConfig, thinkingConfig, tools, currentMessages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, request_id, onDelta, shouldStop, runtimeState = null }) {
+  async run(expertService, { modelConfig, thinkingConfig, tools, currentMessages, llmPayload, user_id, expert_id, taskContext, topic_id, task_id, session, request_id, onDelta, shouldStop, runtimeState = null, agent_invocation_context = null }) {
     const systemSettingService = getSystemSettingService(this.db);
     const MAX_TOOL_ROUNDS = expertService.expertConfig?.expert?.max_tool_rounds
       || await systemSettingService.getMaxToolRounds();
@@ -251,6 +251,7 @@ export class AgentLoop {
         session,
         expert_id,
         request_id,
+        agent_invocation_context,
         onDelta
       });
 

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -56,6 +56,9 @@ import { buildToolCallSnapshot } from './tool-call-snapshot-builder.js';
 import { buildStreamTurnContext, buildToolContext } from './chat/turn-context-builder.js';
 import AgentRuntime from './agent/agent-runtime.js';
 import AgentLoop from './agent/agent-loop.js';
+import AgentDefinitionResolver, { AGENT_SOURCE_TYPES } from './agent/agent-definition-resolver.js';
+import ExpertAgentDefinitionAdapter from './agent/expert-agent-definition-adapter.js';
+import { createInMemoryAgentDelegateControlRuntime } from './agent/agent-delegate-control-runtime.js';
 import Utils from './utils.js';
 import path from 'path';
 import { getWorkspaceRoot, getSkillsPath, getTaskWorkspaceAbsolutePath, getDefaultWorkspaceAbsolutePath, toLogicalWorkspacePath } from './paths.js';
@@ -76,6 +79,7 @@ class ChatService {
       save_llm_payload: (user_id, expert_id, payload) => this.saveLLMPayload(user_id, expert_id, payload),
       generate_tool_call_summary: toolCalls => this._generateToolCallSummary(toolCalls),
     });
+    this.agentDelegateControlRuntime = options.agentDelegateControlRuntime || null;
     this.Message = db.getModel('message');
     this.Topic = db.getModel('topic');
     this.ChatRequest = db.getModel('chat_request');
@@ -159,12 +163,31 @@ class ChatService {
     }
 
     logger.info(`[ChatService] 创建新的专家服务实例: ${expertId}`);
-    const service = new ExpertChatService(this.db, expertId, { assistantManager: this.assistantManager });
+    const service = new ExpertChatService(this.db, expertId, {
+      assistantManager: this.assistantManager,
+      agentDelegateControlRuntime: this.getAgentDelegateControlRuntime(),
+    });
     await service.initialize();
 
     this.expertServices.set(expertId, service);
     logger.info(`[ChatService] 专家服务实例已缓存: ${expertId}, 技能数: ${service.toolManager?.skills?.size || 0}`);
     return service;
+  }
+
+  getAgentDelegateControlRuntime() {
+    if (!this.agentDelegateControlRuntime) {
+      this.agentDelegateControlRuntime = createInMemoryAgentDelegateControlRuntime({
+        definition_resolver: new AgentDefinitionResolver({
+          [AGENT_SOURCE_TYPES.expert]: new ExpertAgentDefinitionAdapter(this.db),
+        }),
+        agent_runtime: this.agentRuntime,
+        agent_loop: this.agentLoop,
+        get_expert_service: expertId => this.getExpertService(expertId),
+        event_sink: this.agentRuntime.event_sink || null,
+      });
+    }
+
+    return this.agentDelegateControlRuntime;
   }
 
 /**
@@ -264,7 +287,7 @@ class ChatService {
    * 执行工具调用（私有方法）
    * @returns {Promise<Array>} 工具执行结果数组
    */
-  async _executeTools(expertService, { collectedToolCalls, user_id, taskContext, topic_id, task_id, session, expert_id, request_id, onDelta }) {
+  async _executeTools(expertService, { collectedToolCalls, user_id, taskContext, topic_id, task_id, session, expert_id, request_id, agent_invocation_context, onDelta }) {
     return await expertService.handleToolCalls(
       collectedToolCalls,
       user_id,
@@ -280,7 +303,8 @@ class ChatService {
         await this.saveToolMessage(topic_id, user_id, toolResult, expert_id, task_id, request_id);
         onDelta?.({ type: 'tool_result', result: toolResult });
       },
-      session
+      session,
+      agent_invocation_context
     );
   }
 
@@ -396,7 +420,12 @@ class ChatService {
       const startTime = Date.now();
       const modelConfig = model_id ? await this.getModelConfig(model_id) : expertService.getDefaultModelConfig();
       const thinkingConfig = expertService.getThinkingConfig(modelConfig);
-      const toolContext = buildToolContext({ user_id, expert_id, session });
+      const toolContext = buildToolContext({
+        user_id,
+        expert_id,
+        session,
+        agent_invocation: { delegation_depth: 0 },
+      });
       const tools = await expertService.toolManager.getToolDefinitions(toolContext);
 
       const turnContext = buildStreamTurnContext({
@@ -1580,6 +1609,7 @@ class ExpertChatService {
     this.expertId = expertId;
     this.expertName = '';  // 专家名称，用于日志
     this.assistantManager = options.assistantManager || null;
+    this.agentDelegateControlRuntime = options.agentDelegateControlRuntime || null;
     this.Message = db.getModel('message');
     this.Topic = db.getModel('topic');
 
@@ -1640,7 +1670,9 @@ class ExpertChatService {
     this.reflectiveMind = new ReflectiveMind(soul, this.llmClient);
 
     // 6. 初始化工具管理器
-    this.toolManager = new ToolManager(this.db, this.expertId);
+    this.toolManager = new ToolManager(this.db, this.expertId, {
+      agentDelegateControlRuntime: this.agentDelegateControlRuntime,
+    });
     await this.toolManager.initialize();
 
     // 8. 初始化 Recall 策略（Phase 3）
@@ -2037,7 +2069,7 @@ search_chunks_in_document 在指定文档内无命中时，答案可能存在于
    * @param {Function} onToolComplete - 单个工具执行完成回调 (result) => void
    * @param {object} session - 用户会话对象（包含 accessToken, isAdmin, roles 等）
    */
-  async handleToolCalls(toolCalls, user_id, access_token = null, taskContext = null, topic_id = null, onToolComplete = null, session = null) {
+  async handleToolCalls(toolCalls, user_id, access_token = null, taskContext = null, topic_id = null, onToolComplete = null, session = null, agent_invocation_context = null) {
     const context = {
       expert_id: this.expertId,
       user_id,
@@ -2046,6 +2078,7 @@ search_chunks_in_document 在指定文档内无命中时，答案可能存在于
       memorySystem: this.memorySystem,
       taskContext,  // 传递任务上下文（包含工作空间路径）
       session,  // 直接传递 session 对象，toolManager 从中读取权限信息
+      agent_invocation: agent_invocation_context,
     };
 
     return await this.toolManager.executeToolCalls(toolCalls, context, onToolComplete);

--- a/lib/chat/turn-context-builder.js
+++ b/lib/chat/turn-context-builder.js
@@ -7,8 +7,8 @@
 
 import { buildRootAgentInvocationContext } from '../agent/agent-invocation-context.js';
 
-export function buildToolContext({ user_id, expert_id, session }) {
-  return { user_id, expert_id, session };
+export function buildToolContext({ user_id, expert_id, session, agent_invocation = null }) {
+  return { user_id, expert_id, session, agent_invocation };
 }
 
 export function buildStreamLlmPayload({ modelConfig, messages, tools }) {
@@ -49,7 +49,6 @@ export function buildStreamTurnContext({
   messages,
   tools,
 }) {
-  const toolContext = buildToolContext({ user_id, expert_id, session });
   const llmPayload = buildStreamLlmPayload({ modelConfig, messages, tools });
   const agentInvocation = buildRootAgentInvocationContext({
     principal_user_id: user_id,
@@ -66,6 +65,12 @@ export function buildStreamTurnContext({
     capability_scope: {
       tools: getToolNames(tools),
     },
+  });
+  const toolContext = buildToolContext({
+    user_id,
+    expert_id,
+    session,
+    agent_invocation: agentInvocation,
   });
 
   return {

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -25,6 +25,9 @@ import DocumentAtomicTools from './document-atomic-tools.js';
 import DocumentHandleStore, { HANDLE_TYPE } from './document-handle-store.js';
 import DocAccessService from './doc-access-service.js';
 import { summarizeToolParamsForLog } from './tool-log-sanitizer.js';
+import {
+  AGENT_DELEGATE_TOOL_NAMES,
+} from './agent/agent-delegate-control-facade.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -899,6 +902,8 @@ class ToolManager {
     this._configLoader = null;
     this._docRetrievalService = null;
     this._docAccessService = null;
+    this.agentDelegateControlRuntime = options.agentDelegateControlRuntime || null;
+    this.agentDelegateControlFacade = options.agentDelegateControlFacade || null;
   }
 
   /**
@@ -1083,6 +1088,10 @@ class ToolManager {
       definitions.push(llmTool);
     }
 
+    if (this.shouldExposeAgentDelegateControlTools(context)) {
+      definitions.push(...this.getAgentDelegateControlFacade().getToolDefinitions());
+    }
+
     // 添加所有技能工具
     for (const skill of this.skills.values()) {
       const tools = this.skillLoader.getToolDefinitions(skill);
@@ -1254,6 +1263,40 @@ class ToolManager {
     return `Assistant/${toolId}`;
   }
 
+  formatAgentDelegateControlToolDisplay(toolId) {
+    return `AgentDelegation/${toolId}`;
+  }
+
+  getAgentDelegateControlFacade() {
+    return this.agentDelegateControlFacade || this.agentDelegateControlRuntime?.control_facade || null;
+  }
+
+  isAgentDelegateControlTool(toolId) {
+    return Object.values(AGENT_DELEGATE_TOOL_NAMES).includes(toolId);
+  }
+
+  isRootAgentToolContext(context = {}) {
+    const invocation = context.agent_invocation || context.agent_invocation_context;
+    return invocation?.delegation_depth === 0;
+  }
+
+  shouldExposeAgentDelegateControlTools(context = {}) {
+    return Boolean(this.getAgentDelegateControlFacade()) && this.isRootAgentToolContext(context);
+  }
+
+  buildAgentDelegateControlContext(context = {}) {
+    const parentInvocation = context.agent_invocation || context.agent_invocation_context;
+    const inheritedScope = parentInvocation?.capability_scope || {};
+
+    return {
+      parent_invocation: parentInvocation,
+      caller_scope: context.caller_scope || inheritedScope,
+      principal_scope: context.principal_scope || inheritedScope,
+      workspace_scope: context.workspace_capability_scope || context.delegation_workspace_scope || inheritedScope,
+      session: context.session ?? null,
+    };
+  }
+
   /**
    * 记录工具执行入口日志。
    * @param {string} display - 已按实际分派路线计算的显示名称
@@ -1310,6 +1353,21 @@ class ToolManager {
       const display = this.formatBuiltinToolDisplay(toolId, builtinTool);
       this.logToolExecution(display, toolId, params);
       return await this.executeBuiltinTool(toolId, params, context, display);
+    }
+
+    if (this.isAgentDelegateControlTool(toolId)) {
+      const display = this.formatAgentDelegateControlToolDisplay(toolId);
+      this.logToolExecution(display, toolId, params);
+
+      const facade = this.getAgentDelegateControlFacade();
+      if (!facade) {
+        return { success: false, error: 'Agent delegate control runtime is not configured' };
+      }
+      if (!this.isRootAgentToolContext(context)) {
+        return { success: false, error: 'Agent delegate control tools are only available to root agent runs' };
+      }
+
+      return await facade.handleToolCall(toolId, params, this.buildAgentDelegateControlContext(context));
     }
 
     // 检查是否是 MCP 工具（工具名以 mcp_ 开头）

--- a/tests/test-chat-service-agent-runtime-facade.mjs
+++ b/tests/test-chat-service-agent-runtime-facade.mjs
@@ -16,7 +16,7 @@ function createDbStub() {
   };
 }
 
-function createExpertServiceStub() {
+function createExpertServiceStub(toolContextCalls = []) {
   const modelConfig = {
     model_name: 'test-model',
     provider_name: 'test-provider',
@@ -50,7 +50,8 @@ function createExpertServiceStub() {
       };
     },
     toolManager: {
-      async getToolDefinitions() {
+      async getToolDefinitions(context) {
+        toolContextCalls.push(context);
         return [{ type: 'function', function: { name: 'demo_tool' } }];
       },
     },
@@ -75,6 +76,7 @@ function createRuntimeStub(calls) {
 async function testStreamChatUsesRootAgentRuntime() {
   const runtimeCalls = [];
   const loopCalls = [];
+  const toolContextCalls = [];
   const service = new ChatService(createDbStub(), {
     agentRuntime: createRuntimeStub(runtimeCalls),
     agentLoop: {
@@ -95,7 +97,7 @@ async function testStreamChatUsesRootAgentRuntime() {
       },
     },
   });
-  const expertService = createExpertServiceStub();
+  const expertService = createExpertServiceStub(toolContextCalls);
 
   service.getExpertService = async () => expertService;
   service._prepareTaskContext = async () => ({
@@ -125,6 +127,8 @@ async function testStreamChatUsesRootAgentRuntime() {
   });
 
   assert.equal(runtimeCalls.length, 1);
+  assert.equal(toolContextCalls.length, 1);
+  assert.equal(toolContextCalls[0].agent_invocation.delegation_depth, 0);
   const invocation = runtimeCalls[0].invocation_context;
   assert.equal(invocation.principal_user_id, 'user_1');
   assert.equal(invocation.caller_agent_id, null);

--- a/tests/test-tool-manager-agent-delegate-control.mjs
+++ b/tests/test-tool-manager-agent-delegate-control.mjs
@@ -1,0 +1,258 @@
+/**
+ * Tests for ToolManager agent delegate control tool exposure and dispatch.
+ *
+ * Usage:
+ *   node tests/test-tool-manager-agent-delegate-control.mjs
+ */
+
+import assert from 'node:assert/strict';
+import ToolManager from '../lib/tool-manager.js';
+import { AgentRuntime } from '../lib/agent/agent-runtime.js';
+import {
+  AGENT_DELEGATE_TOOL_NAMES,
+  buildAgentDelegateControlToolDefinitions,
+} from '../lib/agent/agent-delegate-control-facade.js';
+import { createInMemoryAgentDelegateControlRuntime } from '../lib/agent/agent-delegate-control-runtime.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createRootInvocation() {
+  return buildRootAgentInvocationContext({
+    run_id: 'root_run_tool_manager_delegate',
+    principal_user_id: 'user_delegate_tool',
+    agent_id: 'expert_parent',
+    capability_scope: {
+      tools: ['search', AGENT_DELEGATE_TOOL_NAMES.START],
+    },
+  });
+}
+
+function createChildInvocation() {
+  return deriveChildAgentInvocationContext(createRootInvocation(), {
+    run_id: 'child_run_tool_manager_delegate',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+}
+
+function createFacade(calls = []) {
+  return {
+    getToolDefinitions() {
+      return buildAgentDelegateControlToolDefinitions();
+    },
+    async handleToolCall(tool_name, params, context) {
+      calls.push({ tool_name, params, context });
+      return {
+        success: true,
+        data: {
+          routed: tool_name,
+          context,
+        },
+      };
+    },
+  };
+}
+
+function getToolNames(tools) {
+  return tools.map(tool => tool.function?.name || tool.name);
+}
+
+function createExpertService() {
+  return {
+    getDefaultModelConfig() {
+      return {
+        model_name: 'child-model',
+        provider_name: 'provider_1',
+        base_url: 'https://example.test/v1',
+        max_tokens: 4096,
+        max_output_tokens: 1024,
+      };
+    },
+    getThinkingConfig() {
+      return {
+        thinking: false,
+        reasoning: null,
+        reasoning_effort: null,
+        enable_thinking: false,
+        chat_template_kwargs: null,
+      };
+    },
+    toolManager: {
+      async getToolDefinitions() {
+        return [{
+          type: 'function',
+          function: {
+            name: 'search',
+            description: 'Search tool',
+            parameters: { type: 'object', properties: {} },
+          },
+        }];
+      },
+    },
+  };
+}
+
+async function testExposesControlToolsOnlyForRootContext() {
+  const manager = new ToolManager(null, 'expert_parent', {
+    agentDelegateControlFacade: createFacade(),
+  });
+
+  const rootTools = await manager.getToolDefinitions({
+    agent_invocation: createRootInvocation(),
+  });
+  const childTools = await manager.getToolDefinitions({
+    agent_invocation: createChildInvocation(),
+  });
+
+  assert.ok(getToolNames(rootTools).includes(AGENT_DELEGATE_TOOL_NAMES.START));
+  assert.ok(getToolNames(rootTools).includes(AGENT_DELEGATE_TOOL_NAMES.STATUS));
+  assert.equal(getToolNames(childTools).includes(AGENT_DELEGATE_TOOL_NAMES.START), false);
+}
+
+async function testDoesNotExposeControlToolsWithoutRuntime() {
+  const manager = new ToolManager(null, 'expert_parent');
+  const tools = await manager.getToolDefinitions({
+    agent_invocation: createRootInvocation(),
+  });
+
+  assert.equal(getToolNames(tools).includes(AGENT_DELEGATE_TOOL_NAMES.START), false);
+}
+
+async function testDispatchesControlToolWithParentInvocationAndScopes() {
+  const calls = [];
+  const manager = new ToolManager(null, 'expert_parent', {
+    agentDelegateControlFacade: createFacade(calls),
+  });
+  const rootInvocation = createRootInvocation();
+  const session = { userId: 'user_delegate_tool' };
+
+  const result = await manager.executeTool(
+    AGENT_DELEGATE_TOOL_NAMES.START,
+    {
+      source_type: 'expert',
+      agent_id: 'expert_child',
+      task: 'Search project',
+      requested_scope: { tools: ['search'] },
+    },
+    {
+      agent_invocation: rootInvocation,
+      session,
+    },
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].tool_name, AGENT_DELEGATE_TOOL_NAMES.START);
+  assert.equal(calls[0].context.parent_invocation, rootInvocation);
+  assert.deepEqual(calls[0].context.caller_scope, rootInvocation.capability_scope);
+  assert.deepEqual(calls[0].context.principal_scope, rootInvocation.capability_scope);
+  assert.deepEqual(calls[0].context.workspace_scope, rootInvocation.capability_scope);
+  assert.equal(calls[0].context.session, session);
+}
+
+async function testRejectsControlToolExecutionForChildContext() {
+  const manager = new ToolManager(null, 'expert_child', {
+    agentDelegateControlFacade: createFacade(),
+  });
+
+  const result = await manager.executeTool(
+    AGENT_DELEGATE_TOOL_NAMES.STATUS,
+    { child_run_id: 'child_run_1' },
+    { agent_invocation: createChildInvocation() },
+  );
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /only available to root agent runs/);
+}
+
+async function testRejectsControlToolExecutionWithoutRuntime() {
+  const manager = new ToolManager(null, 'expert_parent');
+
+  const result = await manager.executeTool(
+    AGENT_DELEGATE_TOOL_NAMES.STATUS,
+    { child_run_id: 'child_run_1' },
+    { agent_invocation: createRootInvocation() },
+  );
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /runtime is not configured/);
+}
+
+async function testToolManagerRunsControlRuntimeEndToEnd() {
+  const loopCalls = [];
+  const controlRuntime = createInMemoryAgentDelegateControlRuntime({
+    definition_resolver: {
+      async resolve() {
+        return {
+          agent_id: 'expert_child',
+          source_type: 'expert',
+          display_name: 'Child Expert',
+          system_prompt: 'Search carefully.',
+          execution_policy: { mode: 'llm' },
+          capability_declarations: {
+            skills: [{ skill_id: 'skill_search', mark: 'search' }],
+          },
+          is_active: true,
+        };
+      },
+    },
+    agent_runtime: new AgentRuntime(),
+    agent_loop: {
+      async run(expertService, input) {
+        loopCalls.push({ expertService, input });
+        return {
+          fullContent: 'child result',
+          allToolCalls: [],
+          llmCallsCount: 1,
+        };
+      },
+    },
+    get_expert_service: async () => createExpertService(),
+  });
+  const manager = new ToolManager(null, 'expert_parent', {
+    agentDelegateControlRuntime: controlRuntime,
+  });
+  const rootInvocation = createRootInvocation();
+
+  const startResult = await manager.executeTool(
+    AGENT_DELEGATE_TOOL_NAMES.START,
+    {
+      source_type: 'expert',
+      agent_id: 'expert_child',
+      task: 'Search project',
+      requested_scope: { tools: ['search'] },
+    },
+    {
+      agent_invocation: rootInvocation,
+      session: { userId: 'user_delegate_tool' },
+    },
+  );
+  assert.equal(startResult.success, true);
+
+  await controlRuntime.child_run_scheduler.waitForCompletion(startResult.data.child_run_id);
+  const result = await manager.executeTool(
+    AGENT_DELEGATE_TOOL_NAMES.RESULT,
+    { child_run_id: startResult.data.child_run_id },
+    { agent_invocation: rootInvocation },
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(result.data.result.fullContent, 'child result');
+  assert.equal(loopCalls.length, 1);
+  assert.deepEqual(loopCalls[0].input.tools.map(tool => tool.function.name), ['search']);
+}
+
+async function main() {
+  await testExposesControlToolsOnlyForRootContext();
+  await testDoesNotExposeControlToolsWithoutRuntime();
+  await testDispatchesControlToolWithParentInvocationAndScopes();
+  await testRejectsControlToolExecutionForChildContext();
+  await testRejectsControlToolExecutionWithoutRuntime();
+  await testToolManagerRunsControlRuntimeEndToEnd();
+
+  console.log('ToolManager agent delegate control tests passed.');
+}
+
+main();

--- a/tests/test-turn-context-builder.mjs
+++ b/tests/test-turn-context-builder.mjs
@@ -46,6 +46,7 @@ function testBuildToolContext() {
     user_id: 'user_1',
     expert_id: 'expert_1',
     session,
+    agent_invocation: null,
   });
 }
 
@@ -119,6 +120,7 @@ function testBuildStreamTurnContext() {
     user_id: 'user_1',
     expert_id: 'expert_1',
     session,
+    agent_invocation: turnContext.agent_invocation,
   });
   assert.equal(turnContext.roundInput.modelConfig, modelConfig);
   assert.equal(turnContext.roundInput.thinkingConfig, thinkingConfig);


### PR DESCRIPTION
## Summary

- Expose agent delegate control tools through ToolManager for root Agent turns.
- Route `agent_delegate_start/status/result/cancel` execution to the agent delegate control runtime.
- Pass Agent invocation context from root chat through tool definition lookup and tool execution.

## Boundaries

- No DB changes.
- No API/frontend changes.
- Child Agent tool lookups do not receive delegate control tools by default.
- No resident/MCP scheduler backend yet.

## Validation

- `node tests\test-tool-manager-agent-delegate-control.mjs`
- `node tests\test-tool-definitions-contract.mjs`
- `node tests\test-tool-manager-dispatch.mjs`
- `node tests\test-turn-context-builder.mjs`
- `node tests\test-chat-service-agent-runtime-facade.mjs`
- `node tests\test-agent-loop.mjs`
- `node tests\test-agent-delegate-control-runtime.mjs`
- `node tests\test-agent-delegate-control-facade.mjs`
- `node tests\test-child-run-scheduler.mjs`
- `node tests\test-child-delegation-runtime-factory.mjs`
- `node tests\test-agent-delegation-service.mjs`
- `node tests\test-expert-child-agent-runner.mjs`
- `node tests\test-expert-child-scoped-tools.mjs`
- `node tests\test-child-run-projection.mjs`
- `node tests\test-child-agent-executor.mjs`
- `node tests\test-agent-runtime.mjs`
- `node tests\test-agent-invocation-context.mjs`
- `node tests\test-agent-definition-resolver.mjs`
- `npm.cmd run lint`
- `git diff --check`
