### PR TITLE
refactor: add resident child run scheduler

### DIFF
--- a/lib/agent/agent-delegate-control-facade.js
+++ b/lib/agent/agent-delegate-control-facade.js
@@ -157,7 +157,7 @@ export class AgentDelegateControlFacade {
       invocation_mode: 'llm',
       source: 'agent_delegate',
     });
-    const run = this.child_run_scheduler.start(delegation, {
+    const run = await this.child_run_scheduler.start(delegation, {
       session: context.session ?? null,
     });
 
@@ -168,19 +168,19 @@ export class AgentDelegateControlFacade {
     });
   }
 
-  status(params = {}) {
+  async status(params = {}) {
     assertString(params.child_run_id, 'params.child_run_id');
-    return this.child_run_scheduler.getStatus(params.child_run_id);
+    return await this.child_run_scheduler.getStatus(params.child_run_id);
   }
 
-  result(params = {}) {
+  async result(params = {}) {
     assertString(params.child_run_id, 'params.child_run_id');
-    return this.child_run_scheduler.getResult(params.child_run_id);
+    return await this.child_run_scheduler.getResult(params.child_run_id);
   }
 
-  cancel(params = {}) {
+  async cancel(params = {}) {
     assertString(params.child_run_id, 'params.child_run_id');
-    return this.child_run_scheduler.cancel(params.child_run_id);
+    return await this.child_run_scheduler.cancel(params.child_run_id);
   }
 
   async handleToolCall(tool_name, params = {}, context = {}) {
@@ -189,11 +189,11 @@ export class AgentDelegateControlFacade {
         case AGENT_DELEGATE_TOOL_NAMES.START:
           return { success: true, data: await this.start(params, context) };
         case AGENT_DELEGATE_TOOL_NAMES.STATUS:
-          return { success: true, data: this.status(params) };
+          return { success: true, data: await this.status(params) };
         case AGENT_DELEGATE_TOOL_NAMES.RESULT:
-          return { success: true, data: this.result(params) };
+          return { success: true, data: await this.result(params) };
         case AGENT_DELEGATE_TOOL_NAMES.CANCEL:
-          return { success: true, data: this.cancel(params) };
+          return { success: true, data: await this.cancel(params) };
         default:
           throw new Error(`Unknown agent delegate control tool: ${tool_name}`);
       }

--- a/lib/agent/agent-delegate-control-runtime.js
+++ b/lib/agent/agent-delegate-control-runtime.js
@@ -9,6 +9,7 @@ import { AgentDelegationService } from './agent-delegation-service.js';
 import { AgentDelegateControlFacade } from './agent-delegate-control-facade.js';
 import { InMemoryChildRunScheduler } from './child-run-scheduler.js';
 import { createExpertChildDelegationExecutor } from './child-delegation-runtime-factory.js';
+import { ResidentChildRunScheduler } from './resident-child-run-scheduler.js';
 
 function assertFunction(value, name) {
   if (typeof value !== 'function') {
@@ -64,6 +65,45 @@ export function createInMemoryAgentDelegateControlRuntime({
   });
 }
 
+export function createResidentAgentDelegateControlRuntime({
+  definition_resolver,
+  resident_skill_manager,
+  event_sink = null,
+  max_delegation_depth = 2,
+  skill_id,
+  tool_name,
+  timeout_ms,
+  poll_interval_ms,
+  wait_timeout_ms,
+} = {}) {
+  assertObject(definition_resolver, 'definition_resolver');
+
+  const delegation_service = new AgentDelegationService({
+    definition_resolver,
+    event_sink,
+    max_delegation_depth,
+  });
+  const child_run_scheduler = new ResidentChildRunScheduler({
+    resident_skill_manager,
+    skill_id,
+    tool_name,
+    timeout_ms,
+    poll_interval_ms,
+    wait_timeout_ms,
+  });
+  const control_facade = new AgentDelegateControlFacade({
+    delegation_service,
+    child_run_scheduler,
+  });
+
+  return Object.freeze({
+    delegation_service,
+    child_run_scheduler,
+    control_facade,
+  });
+}
+
 export default {
   createInMemoryAgentDelegateControlRuntime,
+  createResidentAgentDelegateControlRuntime,
 };

--- a/lib/agent/resident-child-run-scheduler.js
+++ b/lib/agent/resident-child-run-scheduler.js
@@ -1,0 +1,124 @@
+/**
+ * Resident child run scheduler adapter.
+ *
+ * Bridges the ChildRunScheduler contract to a resident worker. The worker is
+ * expected to implement a single invoke-style tool that accepts an action.
+ */
+
+const DEFAULT_SKILL_ID = 'agent-child-runner';
+const DEFAULT_TOOL_NAME = 'invoke';
+const DEFAULT_TIMEOUT_MS = 120000;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_WAIT_TIMEOUT_MS = 10 * 60 * 1000;
+const TERMINAL_STATUSES = Object.freeze(['completed', 'failed', 'cancelled']);
+
+function assertResidentSkillManager(value) {
+  if (!value || typeof value.invokeByName !== 'function') {
+    throw new Error('resident_skill_manager.invokeByName is required');
+  }
+}
+
+function assertChildRunId(child_run_id) {
+  if (typeof child_run_id !== 'string' || child_run_id.trim() === '') {
+    throw new Error('child_run_id is required');
+  }
+}
+
+function assertDelegation(delegation) {
+  if (!delegation?.child_invocation?.run_id) {
+    throw new Error('delegation.child_invocation.run_id is required');
+  }
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export class ResidentChildRunScheduler {
+  constructor({
+    resident_skill_manager,
+    skill_id = DEFAULT_SKILL_ID,
+    tool_name = DEFAULT_TOOL_NAME,
+    timeout_ms = DEFAULT_TIMEOUT_MS,
+    poll_interval_ms = DEFAULT_POLL_INTERVAL_MS,
+    wait_timeout_ms = DEFAULT_WAIT_TIMEOUT_MS,
+  } = {}) {
+    assertResidentSkillManager(resident_skill_manager);
+
+    this.resident_skill_manager = resident_skill_manager;
+    this.skill_id = skill_id;
+    this.tool_name = tool_name;
+    this.timeout_ms = timeout_ms;
+    this.poll_interval_ms = poll_interval_ms;
+    this.wait_timeout_ms = wait_timeout_ms;
+  }
+
+  async start(delegation, options = {}) {
+    assertDelegation(delegation);
+    return await this.invoke('start', {
+      delegation,
+      options: {
+        session: options.session ?? null,
+      },
+    }, options);
+  }
+
+  async getStatus(child_run_id) {
+    assertChildRunId(child_run_id);
+    return await this.invoke('status', { child_run_id });
+  }
+
+  async getResult(child_run_id) {
+    assertChildRunId(child_run_id);
+    return await this.invoke('result', { child_run_id });
+  }
+
+  async getEvents(child_run_id) {
+    assertChildRunId(child_run_id);
+    return await this.invoke('events', { child_run_id });
+  }
+
+  async cancel(child_run_id) {
+    assertChildRunId(child_run_id);
+    return await this.invoke('cancel', { child_run_id });
+  }
+
+  async waitForCompletion(child_run_id, options = {}) {
+    assertChildRunId(child_run_id);
+
+    const timeoutMs = options.timeout_ms ?? this.wait_timeout_ms;
+    const pollIntervalMs = options.poll_interval_ms ?? this.poll_interval_ms;
+    const startedAt = Date.now();
+
+    while (true) {
+      const status = await this.getStatus(child_run_id);
+      if (TERMINAL_STATUSES.includes(status.status)) {
+        return status;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`Timed out waiting for child run: ${child_run_id}`);
+      }
+
+      await delay(pollIntervalMs);
+    }
+  }
+
+  async invoke(action, payload = {}, options = {}) {
+    return await this.resident_skill_manager.invokeByName(
+      this.skill_id,
+      this.tool_name,
+      {
+        action,
+        ...payload,
+      },
+      {
+        session: options.session ?? null,
+      },
+      options.timeout_ms ?? this.timeout_ms,
+    );
+  }
+}
+
+export default {
+  ResidentChildRunScheduler,
+};

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -58,7 +58,10 @@ import AgentRuntime from './agent/agent-runtime.js';
 import AgentLoop from './agent/agent-loop.js';
 import AgentDefinitionResolver, { AGENT_SOURCE_TYPES } from './agent/agent-definition-resolver.js';
 import ExpertAgentDefinitionAdapter from './agent/expert-agent-definition-adapter.js';
-import { createInMemoryAgentDelegateControlRuntime } from './agent/agent-delegate-control-runtime.js';
+import {
+  createInMemoryAgentDelegateControlRuntime,
+  createResidentAgentDelegateControlRuntime,
+} from './agent/agent-delegate-control-runtime.js';
 import Utils from './utils.js';
 import path from 'path';
 import { getWorkspaceRoot, getSkillsPath, getTaskWorkspaceAbsolutePath, getDefaultWorkspaceAbsolutePath, toLogicalWorkspacePath } from './paths.js';
@@ -80,6 +83,7 @@ class ChatService {
       generate_tool_call_summary: toolCalls => this._generateToolCallSummary(toolCalls),
     });
     this.agentDelegateControlRuntime = options.agentDelegateControlRuntime || null;
+    this.residentSkillManager = options.residentSkillManager || null;
     this.Message = db.getModel('message');
     this.Topic = db.getModel('topic');
     this.ChatRequest = db.getModel('chat_request');
@@ -176,15 +180,23 @@ class ChatService {
 
   getAgentDelegateControlRuntime() {
     if (!this.agentDelegateControlRuntime) {
-      this.agentDelegateControlRuntime = createInMemoryAgentDelegateControlRuntime({
-        definition_resolver: new AgentDefinitionResolver({
-          [AGENT_SOURCE_TYPES.expert]: new ExpertAgentDefinitionAdapter(this.db),
-        }),
-        agent_runtime: this.agentRuntime,
-        agent_loop: this.agentLoop,
-        get_expert_service: expertId => this.getExpertService(expertId),
-        event_sink: this.agentRuntime.event_sink || null,
+      const definition_resolver = new AgentDefinitionResolver({
+        [AGENT_SOURCE_TYPES.expert]: new ExpertAgentDefinitionAdapter(this.db),
       });
+
+      this.agentDelegateControlRuntime = this.residentSkillManager
+        ? createResidentAgentDelegateControlRuntime({
+            definition_resolver,
+            resident_skill_manager: this.residentSkillManager,
+            event_sink: this.agentRuntime.event_sink || null,
+          })
+        : createInMemoryAgentDelegateControlRuntime({
+            definition_resolver,
+            agent_runtime: this.agentRuntime,
+            agent_loop: this.agentLoop,
+            get_expert_service: expertId => this.getExpertService(expertId),
+            event_sink: this.agentRuntime.event_sink || null,
+          });
     }
 
     return this.agentDelegateControlRuntime;

--- a/tests/test-agent-delegate-control-facade.mjs
+++ b/tests/test-agent-delegate-control-facade.mjs
@@ -116,9 +116,9 @@ async function testStartStatusAndResultFlow() {
 
   const finalStatus = await scheduler.waitForCompletion(started.child_run_id);
   assert.equal(finalStatus.status, 'completed');
-  assert.equal(facade.status({ child_run_id: started.child_run_id }).status, 'completed');
+  assert.equal((await facade.status({ child_run_id: started.child_run_id })).status, 'completed');
 
-  const result = facade.result({ child_run_id: started.child_run_id });
+  const result = await facade.result({ child_run_id: started.child_run_id });
   assert.equal(result.result.fullContent, 'child result');
   assert.equal(result.result.agent_invocation_context.run_id, started.child_run_id);
   assert.equal(events[0].type, 'delegation_created');
@@ -174,9 +174,9 @@ async function testCancelFlow() {
 
   const started = await facade.start(createStartParams(), createStartContext());
   await entered;
-  assert.equal(facade.status({ child_run_id: started.child_run_id }).status, 'running');
+  assert.equal((await facade.status({ child_run_id: started.child_run_id })).status, 'running');
 
-  const cancelling = facade.cancel({ child_run_id: started.child_run_id });
+  const cancelling = await facade.cancel({ child_run_id: started.child_run_id });
   assert.equal(cancelling.cancel_requested, true);
   continueRun();
 

--- a/tests/test-agent-delegate-control-runtime.mjs
+++ b/tests/test-agent-delegate-control-runtime.mjs
@@ -10,7 +10,10 @@ import { AgentRuntime } from '../lib/agent/agent-runtime.js';
 import {
   AGENT_DELEGATE_TOOL_NAMES,
 } from '../lib/agent/agent-delegate-control-facade.js';
-import { createInMemoryAgentDelegateControlRuntime } from '../lib/agent/agent-delegate-control-runtime.js';
+import {
+  createInMemoryAgentDelegateControlRuntime,
+  createResidentAgentDelegateControlRuntime,
+} from '../lib/agent/agent-delegate-control-runtime.js';
 import { buildRootAgentInvocationContext } from '../lib/agent/agent-invocation-context.js';
 
 function createTool(name) {
@@ -204,8 +207,64 @@ function testRuntimeRequiresCompositionDependencies() {
   }), /get_expert_service is required/);
 }
 
+async function testResidentRuntimeUsesResidentScheduler() {
+  const calls = [];
+  const runtime = createResidentAgentDelegateControlRuntime({
+    definition_resolver: {
+      async resolve() {
+        return {
+          agent_id: 'expert_child',
+          source_type: 'expert',
+          display_name: 'Resident Child',
+          execution_policy: { mode: 'llm' },
+          capability_declarations: {
+            skills: [{ skill_id: 'skill_search', mark: 'search' }],
+          },
+          is_active: true,
+        };
+      },
+    },
+    resident_skill_manager: {
+      async invokeByName(skillId, toolName, params, userContext, timeoutMs) {
+        calls.push({ skillId, toolName, params, userContext, timeoutMs });
+        return {
+          child_run_id: params.child_run_id || params.delegation.child_invocation.run_id,
+          status: params.action === 'start' ? 'queued' : 'running',
+        };
+      },
+    },
+    timeout_ms: 1234,
+  });
+
+  const started = await runtime.control_facade.handleToolCall(
+    AGENT_DELEGATE_TOOL_NAMES.START,
+    {
+      source_type: 'expert',
+      agent_id: 'expert_child',
+      task: 'Search project',
+      requested_scope: { tools: ['search'] },
+    },
+    createStartContext(),
+  );
+  assert.equal(started.success, true);
+  assert.equal(started.data.child_run_id, started.data.run.child_run_id);
+
+  const status = await runtime.control_facade.handleToolCall(
+    AGENT_DELEGATE_TOOL_NAMES.STATUS,
+    { child_run_id: started.data.child_run_id },
+    createStartContext(),
+  );
+  assert.equal(status.success, true);
+  assert.equal(status.data.status, 'running');
+  assert.deepEqual(calls.map(call => call.params.action), ['start', 'status']);
+  assert.equal(calls[0].skillId, 'agent-child-runner');
+  assert.equal(calls[0].toolName, 'invoke');
+  assert.equal(calls[0].timeoutMs, 1234);
+}
+
 async function main() {
   await testRuntimeStartsAndCompletesChildRunEndToEnd();
+  await testResidentRuntimeUsesResidentScheduler();
   testRuntimeRequiresCompositionDependencies();
 
   console.log('Agent delegate control runtime tests passed.');

--- a/tests/test-chat-service-agent-runtime-facade.mjs
+++ b/tests/test-chat-service-agent-runtime-facade.mjs
@@ -154,8 +154,24 @@ async function testStreamChatUsesRootAgentRuntime() {
   });
 }
 
+function testChatServiceCanUseResidentDelegateRuntime() {
+  const residentSkillManager = {
+    async invokeByName() {
+      return {};
+    },
+  };
+  const service = new ChatService(createDbStub(), {
+    residentSkillManager,
+  });
+
+  const runtime = service.getAgentDelegateControlRuntime();
+
+  assert.equal(runtime.child_run_scheduler.resident_skill_manager, residentSkillManager);
+}
+
 async function main() {
   await testStreamChatUsesRootAgentRuntime();
+  testChatServiceCanUseResidentDelegateRuntime();
 
   console.log('ChatService AgentRuntime facade tests passed.');
 }

--- a/tests/test-resident-child-run-scheduler.mjs
+++ b/tests/test-resident-child-run-scheduler.mjs
@@ -1,0 +1,147 @@
+/**
+ * Tests for resident child run scheduler adapter.
+ *
+ * Usage:
+ *   node tests/test-resident-child-run-scheduler.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { ResidentChildRunScheduler } from '../lib/agent/resident-child-run-scheduler.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_resident_parent',
+    principal_user_id: 'user_resident',
+    agent_id: 'expert_parent',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_resident_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return Object.freeze({
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    input: { query: 'agent runtime' },
+    expected_output: 'summary',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  });
+}
+
+function createResidentSkillManager(handler) {
+  const calls = [];
+
+  return {
+    calls,
+    async invokeByName(skillId, toolName, params, userContext, timeoutMs) {
+      calls.push({ skillId, toolName, params, userContext, timeoutMs });
+      return await handler(params);
+    },
+  };
+}
+
+async function testForwardsSchedulerActionsToResidentWorker() {
+  const resident = createResidentSkillManager(async params => ({
+    child_run_id: params.child_run_id || params.delegation.child_invocation.run_id,
+    status: params.action === 'cancel' ? 'cancelled' : 'running',
+  }));
+  const scheduler = new ResidentChildRunScheduler({
+    resident_skill_manager: resident,
+    skill_id: 'agent-child-runner',
+    tool_name: 'invoke',
+    timeout_ms: 3210,
+  });
+  const session = { userId: 'user_resident' };
+
+  const started = await scheduler.start(createDelegation(), { session });
+  const status = await scheduler.getStatus(started.child_run_id);
+  const cancelled = await scheduler.cancel(started.child_run_id);
+
+  assert.equal(started.child_run_id, 'child_run_resident_1');
+  assert.equal(status.status, 'running');
+  assert.equal(cancelled.status, 'cancelled');
+  assert.deepEqual(resident.calls.map(call => call.params.action), ['start', 'status', 'cancel']);
+  assert.equal(resident.calls[0].skillId, 'agent-child-runner');
+  assert.equal(resident.calls[0].toolName, 'invoke');
+  assert.equal(resident.calls[0].params.delegation.child_invocation.run_id, 'child_run_resident_1');
+  assert.deepEqual(resident.calls[0].params.options, { session });
+  assert.deepEqual(resident.calls[0].userContext, { session });
+  assert.equal(resident.calls[0].timeoutMs, 3210);
+}
+
+async function testReadsResultAndEvents() {
+  const resident = createResidentSkillManager(async params => {
+    if (params.action === 'result') {
+      return {
+        child_run_id: params.child_run_id,
+        status: 'completed',
+        result: { fullContent: 'done' },
+      };
+    }
+    if (params.action === 'events') {
+      return [{ type: 'delta', content: 'done' }];
+    }
+    return { child_run_id: params.child_run_id, status: 'completed' };
+  });
+  const scheduler = new ResidentChildRunScheduler({
+    resident_skill_manager: resident,
+  });
+
+  const result = await scheduler.getResult('child_run_resident_result');
+  const events = await scheduler.getEvents('child_run_resident_result');
+
+  assert.equal(result.result.fullContent, 'done');
+  assert.deepEqual(events, [{ type: 'delta', content: 'done' }]);
+  assert.deepEqual(resident.calls.map(call => call.params.action), ['result', 'events']);
+}
+
+async function testWaitForCompletionPollsResidentStatus() {
+  let statusCalls = 0;
+  const resident = createResidentSkillManager(async params => {
+    assert.equal(params.action, 'status');
+    statusCalls += 1;
+    return {
+      child_run_id: params.child_run_id,
+      status: statusCalls < 2 ? 'running' : 'completed',
+    };
+  });
+  const scheduler = new ResidentChildRunScheduler({
+    resident_skill_manager: resident,
+    poll_interval_ms: 0,
+    wait_timeout_ms: 1000,
+  });
+
+  const finalStatus = await scheduler.waitForCompletion('child_run_resident_wait');
+
+  assert.equal(finalStatus.status, 'completed');
+  assert.equal(statusCalls, 2);
+}
+
+function testRejectsMissingResidentManager() {
+  assert.throws(() => new ResidentChildRunScheduler(), /resident_skill_manager\.invokeByName is required/);
+}
+
+async function main() {
+  await testForwardsSchedulerActionsToResidentWorker();
+  await testReadsResultAndEvents();
+  await testWaitForCompletionPollsResidentStatus();
+  testRejectsMissingResidentManager();
+
+  console.log('Resident child run scheduler tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- add `ResidentChildRunScheduler` to bridge child run control actions to `ResidentSkillManager.invokeByName`
- add resident delegate control runtime factory and let `ChatService` select it when `residentSkillManager` is injected
- make delegate control facade status/result/cancel async-compatible while preserving the in-memory scheduler path
- cover resident scheduler, runtime selection, and facade/tool-manager compatibility with tests

## Scope notes

- No DB schema or model changes.
- No `/api/assistants/call` changes.
- No resident skill DB registration or real `agent-child-runner` worker implementation in this PR.
- Child agents still do not inherit root delegate control tools by default.

## Validation

- `node tests/test-resident-child-run-scheduler.mjs`
- `node tests/test-agent-delegate-control-runtime.mjs`
- `node tests/test-agent-delegate-control-facade.mjs`
- `node tests/test-tool-manager-agent-delegate-control.mjs`
- `node tests/test-chat-service-agent-runtime-facade.mjs`
- `node tests/test-tool-definitions-contract.mjs`
- `node tests/test-tool-manager-dispatch.mjs`
- `node tests/test-turn-context-builder.mjs`
- `node tests/test-agent-loop.mjs`
- `node tests/test-child-run-scheduler.mjs`
- `node tests/test-child-delegation-runtime-factory.mjs`
- `node tests/test-agent-delegation-service.mjs`
- `node tests/test-expert-child-agent-runner.mjs`
- `node tests/test-expert-child-scoped-tools.mjs`
- `node tests/test-child-run-projection.mjs`
- `node tests/test-child-agent-executor.mjs`
- `node tests/test-agent-runtime.mjs`
- `node tests/test-agent-invocation-context.mjs`
- `node tests/test-agent-definition-resolver.mjs`
- `npm.cmd run lint`
- `git diff --check`
