### PR TITLE
refactor: add agent child runner worker

### DIFF
--- a/data/skills/agent-child-runner/SKILL.md
+++ b/data/skills/agent-child-runner/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: agent-child-runner
+description: "Internal resident worker for delegated child Agent runs."
+is_resident: 1
+user-invocable: false
+allowed-tools: []
+---
+
+# Agent Child Runner
+
+Internal resident worker for asynchronous child Agent execution.
+
+This skill is not intended to be exposed directly to the LLM. Root Agent control
+tools call it through `ResidentSkillManager.invokeByName()` using the
+`agent-child-runner` / `invoke` entrypoint.
+
+## Protocol
+
+Input is a JSON object with an `action` field:
+
+- `start`: accepts an accepted delegation envelope and returns a child run handle immediately.
+- `status`: returns the current child run status.
+- `result`: returns completed result and buffered events.
+- `events`: returns buffered child run events.
+- `cancel`: requests cancellation.
+
+The worker owns run state. Actual child Agent execution is delegated back to the
+main service through `/internal/agent/child-run/execute`, preserving the main
+process AgentLoop, ToolManager, and database service boundaries.

--- a/data/skills/agent-child-runner/index.js
+++ b/data/skills/agent-child-runner/index.js
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Agent child runner resident skill.
+ *
+ * Owns asynchronous child run state in a resident process. Actual child Agent
+ * execution is delegated back to the main service through an internal API so
+ * the main process keeps the canonical AgentLoop, ToolManager, and DB services.
+ */
+
+import { pathToFileURL } from 'url';
+import { AgentChildRunnerWorker } from '../../../lib/agent/agent-child-runner-worker.js';
+
+const API_BASE = process.env.API_BASE || 'http://localhost:3000';
+
+let buffer = '';
+
+function log(message, ...args) {
+  process.stderr.write(`[agent-child-runner] ${new Date().toISOString()} ${message}`);
+  if (args.length > 0) {
+    process.stderr.write(' ' + args.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : String(arg)).join(' '));
+  }
+  process.stderr.write('\n');
+}
+
+function sendResponse(data) {
+  process.stdout.write(JSON.stringify(data) + '\n');
+}
+
+function buildAuthHeaders(session = {}) {
+  const accessToken = session.accessToken || session.token || process.env.INTERNAL_TOKEN || '';
+  return accessToken
+    ? { Authorization: `Bearer ${accessToken}` }
+    : {};
+}
+
+async function executeChildRunViaInternalApi({
+  delegation,
+  session = null,
+}) {
+  const response = await fetch(`${API_BASE}/internal/agent/child-run/execute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...buildAuthHeaders(session || {}),
+    },
+    body: JSON.stringify({
+      delegation,
+      session,
+    }),
+  });
+
+  const text = await response.text();
+  let payload = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      throw new Error(`Invalid internal child run response: ${text.slice(0, 200)}`);
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(payload?.message || `HTTP ${response.status}: ${response.statusText}`);
+  }
+  if (payload && payload.code !== undefined && payload.code !== 200) {
+    throw new Error(payload.message || 'Internal child run failed');
+  }
+
+  return payload?.data ?? payload;
+}
+
+function createDefaultWorker() {
+  return new AgentChildRunnerWorker({
+    execute_child_run: executeChildRunViaInternalApi,
+  });
+}
+
+export function getTools() {
+  return [
+    {
+      name: 'invoke',
+      description: 'Agent child runner resident process entrypoint',
+      parameters: {
+        type: 'object',
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['start', 'status', 'result', 'events', 'cancel'],
+          },
+          delegation: {
+            type: 'object',
+          },
+          child_run_id: {
+            type: 'string',
+          },
+          options: {
+            type: 'object',
+          },
+        },
+        required: ['action'],
+      },
+      script_path: 'index.js',
+      is_resident: true,
+    },
+  ];
+}
+
+let worker = createDefaultWorker();
+
+function processCommand(command, params = {}) {
+  switch (command) {
+    case 'invoke':
+      return worker.handleAction(params);
+    case 'ping':
+      return {
+        pong: true,
+        runs: worker.runs.size,
+        timestamp: Date.now(),
+      };
+    case 'exit':
+      process.exit(0);
+      return null;
+    default:
+      return worker.handleAction({ action: command, ...params });
+  }
+}
+
+async function processCommandLine(line) {
+  let commandEnvelope;
+  try {
+    commandEnvelope = JSON.parse(line);
+  } catch (error) {
+    sendResponse({
+      task_id: null,
+      success: false,
+      error: `Invalid JSON: ${error.message}`,
+    });
+    return;
+  }
+
+  const { command = 'invoke', task_id, params = {} } = commandEnvelope;
+  try {
+    const result = await processCommand(command, params);
+    sendResponse({
+      task_id,
+      success: true,
+      result,
+    });
+  } catch (error) {
+    sendResponse({
+      task_id,
+      success: false,
+      error: error?.message || String(error),
+    });
+  }
+}
+
+async function main() {
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    buffer += chunk.toString();
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (line.trim()) {
+        processCommandLine(line).catch(error => {
+          log(`Command processing error: ${error.message}`);
+        });
+      }
+    }
+  });
+
+  process.stdin.on('end', () => process.exit(0));
+  process.on('SIGTERM', () => process.exit(0));
+  process.on('SIGINT', () => process.exit(0));
+
+  sendResponse({
+    type: 'ready',
+    name: 'agent-child-runner',
+    pid: process.pid,
+    timestamp: Date.now(),
+  });
+}
+
+export const __testing = {
+  createDefaultWorker,
+  executeChildRunViaInternalApi,
+  getWorker() {
+    return worker;
+  },
+  setWorker(nextWorker) {
+    worker = nextWorker;
+  },
+  processCommand,
+  processCommandLine,
+};
+
+function isMainModule() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  try {
+    return pathToFileURL(process.argv[1]).href === import.meta.url;
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  main().catch(error => {
+    log(`Fatal error: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/lib/agent/agent-child-runner-worker.js
+++ b/lib/agent/agent-child-runner-worker.js
@@ -1,0 +1,230 @@
+/**
+ * Resident child Agent runner worker.
+ *
+ * Owns child run records inside a resident process. The actual child execution
+ * is injected so the worker protocol stays independent from process bootstrapping.
+ */
+
+const TERMINAL_STATUSES = Object.freeze(['completed', 'failed', 'cancelled']);
+
+function assertFunction(value, name) {
+  if (typeof value !== 'function') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function assertChildRunId(child_run_id) {
+  if (typeof child_run_id !== 'string' || child_run_id.trim() === '') {
+    throw new Error('child_run_id is required');
+  }
+}
+
+function assertDelegation(delegation) {
+  if (!delegation?.child_invocation?.run_id) {
+    throw new Error('delegation.child_invocation.run_id is required');
+  }
+}
+
+function defaultIsCancelledError(error) {
+  return error?.message === 'Request aborted by user' || error?.name === 'AbortError';
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function freezeEvents(events) {
+  return Object.freeze(events.map(event => Object.freeze({ ...event })));
+}
+
+function buildRunSnapshot(record) {
+  return Object.freeze({
+    child_run_id: record.child_run_id,
+    parent_run_id: record.parent_run_id,
+    principal_user_id: record.principal_user_id,
+    caller_agent_id: record.caller_agent_id,
+    callee_agent_id: record.callee_agent_id,
+    status: record.status,
+    cancel_requested: record.cancel_requested,
+    queued_at: record.queued_at,
+    started_at: record.started_at,
+    completed_at: record.completed_at,
+    failed_at: record.failed_at,
+    cancelled_at: record.cancelled_at,
+    error: record.error,
+    has_result: record.result !== null,
+    event_count: record.events.length,
+  });
+}
+
+function buildResultSnapshot(record) {
+  return Object.freeze({
+    ...buildRunSnapshot(record),
+    result: record.result,
+    events: freezeEvents(record.events),
+  });
+}
+
+export class AgentChildRunnerWorker {
+  constructor({
+    execute_child_run,
+    is_cancelled_error = defaultIsCancelledError,
+  } = {}) {
+    assertFunction(execute_child_run, 'execute_child_run');
+    assertFunction(is_cancelled_error, 'is_cancelled_error');
+
+    this.execute_child_run = execute_child_run;
+    this.is_cancelled_error = is_cancelled_error;
+    this.runs = new Map();
+  }
+
+  handleAction(params = {}) {
+    switch (params.action) {
+      case 'start':
+        return this.start(params.delegation, params.options || {});
+      case 'status':
+        return this.getStatus(params.child_run_id);
+      case 'result':
+        return this.getResult(params.child_run_id);
+      case 'events':
+        return this.getEvents(params.child_run_id);
+      case 'cancel':
+        return this.cancel(params.child_run_id);
+      default:
+        throw new Error(`Unknown child runner action: ${params.action}`);
+    }
+  }
+
+  start(delegation, options = {}) {
+    assertDelegation(delegation);
+
+    const invocation = delegation.child_invocation;
+    const child_run_id = invocation.run_id;
+    if (this.runs.has(child_run_id)) {
+      throw new Error(`child run already exists: ${child_run_id}`);
+    }
+
+    const record = {
+      child_run_id,
+      parent_run_id: invocation.parent_run_id || null,
+      principal_user_id: invocation.principal_user_id || null,
+      caller_agent_id: invocation.caller_agent_id || null,
+      callee_agent_id: invocation.callee_agent_id || null,
+      status: 'queued',
+      cancel_requested: false,
+      queued_at: nowIso(),
+      started_at: null,
+      completed_at: null,
+      failed_at: null,
+      cancelled_at: null,
+      error: null,
+      result: null,
+      events: [],
+      completion_promise: null,
+    };
+
+    this.runs.set(child_run_id, record);
+    record.completion_promise = this.runRecord(record, delegation, options);
+
+    return buildRunSnapshot(record);
+  }
+
+  getStatus(child_run_id) {
+    return buildRunSnapshot(this.getRecord(child_run_id));
+  }
+
+  getResult(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    if (record.status !== 'completed') {
+      throw new Error(`child run is not completed: ${record.status}`);
+    }
+
+    return buildResultSnapshot(record);
+  }
+
+  getEvents(child_run_id) {
+    return freezeEvents(this.getRecord(child_run_id).events);
+  }
+
+  cancel(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    if (TERMINAL_STATUSES.includes(record.status)) {
+      return buildRunSnapshot(record);
+    }
+
+    record.cancel_requested = true;
+    if (record.status === 'queued') {
+      record.status = 'cancelled';
+      record.cancelled_at = nowIso();
+      record.error = 'Request aborted by user';
+    }
+
+    return buildRunSnapshot(record);
+  }
+
+  getRecord(child_run_id) {
+    assertChildRunId(child_run_id);
+    const record = this.runs.get(child_run_id);
+    if (!record) {
+      throw new Error(`child run not found: ${child_run_id}`);
+    }
+    return record;
+  }
+
+  async waitForCompletion(child_run_id) {
+    const record = this.getRecord(child_run_id);
+    await record.completion_promise;
+    return buildRunSnapshot(record);
+  }
+
+  async runRecord(record, delegation, options) {
+    await Promise.resolve();
+    if (record.status === 'cancelled') {
+      return;
+    }
+
+    record.status = 'running';
+    record.started_at = nowIso();
+
+    const runtimeState = {};
+    const onDelta = event => {
+      record.events.push(event);
+    };
+    const shouldStop = () => record.cancel_requested;
+
+    try {
+      const result = await this.execute_child_run({
+        delegation,
+        session: options.session ?? null,
+        onDelta,
+        shouldStop,
+        runtimeState,
+      });
+
+      if (record.cancel_requested) {
+        record.status = 'cancelled';
+        record.cancelled_at = nowIso();
+        record.error = 'Request aborted by user';
+        return;
+      }
+
+      record.status = 'completed';
+      record.completed_at = nowIso();
+      record.result = result;
+    } catch (error) {
+      if (record.cancel_requested || this.is_cancelled_error(error)) {
+        record.status = 'cancelled';
+        record.cancelled_at = nowIso();
+      } else {
+        record.status = 'failed';
+        record.failed_at = nowIso();
+      }
+
+      record.error = error?.message || String(error);
+    }
+  }
+}
+
+export default {
+  AgentChildRunnerWorker,
+};

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -62,6 +62,7 @@ import {
   createInMemoryAgentDelegateControlRuntime,
   createResidentAgentDelegateControlRuntime,
 } from './agent/agent-delegate-control-runtime.js';
+import { createExpertChildDelegationExecutor } from './agent/child-delegation-runtime-factory.js';
 import Utils from './utils.js';
 import path from 'path';
 import { getWorkspaceRoot, getSkillsPath, getTaskWorkspaceAbsolutePath, getDefaultWorkspaceAbsolutePath, toLogicalWorkspacePath } from './paths.js';
@@ -155,6 +156,20 @@ class ChatService {
     }
   }
 
+  setResidentSkillManager(residentSkillManager) {
+    if (this.residentSkillManager === residentSkillManager) {
+      return;
+    }
+
+    const hadRuntime = Boolean(this.agentDelegateControlRuntime);
+    this.residentSkillManager = residentSkillManager || null;
+    this.agentDelegateControlRuntime = null;
+
+    if (hadRuntime && this.expertServices.size > 0) {
+      this.clearExpertCache();
+    }
+  }
+
   /**
    * 获取或创建专家服务实例
    * @param {string} expertId - 专家ID
@@ -200,6 +215,22 @@ class ChatService {
     }
 
     return this.agentDelegateControlRuntime;
+  }
+
+  async executeChildDelegation(delegation, options = {}) {
+    const executor = createExpertChildDelegationExecutor({
+      agent_runtime: this.agentRuntime,
+      agent_loop: this.agentLoop,
+      get_expert_service: expertId => this.getExpertService(expertId),
+      run_options: {
+        session: options.session ?? null,
+        onDelta: options.onDelta ?? null,
+        shouldStop: options.shouldStop ?? null,
+        runtimeState: options.runtimeState ?? null,
+      },
+    });
+
+    return await executor.execute(delegation);
   }
 
 /**

--- a/server/controllers/internal.controller.js
+++ b/server/controllers/internal.controller.js
@@ -620,6 +620,41 @@ class InternalController {
   }
 
   /**
+   * POST /internal/agent/child-run/execute
+   * Resident child runner worker 回调主服务执行实际 Child Agent。
+   */
+  async executeChildAgentRun(ctx) {
+    try {
+      if (!this.validateInternalAccess(ctx)) {
+        ctx.status = 403;
+        ctx.error('无权访问内部 API', 403, { code: 'FORBIDDEN' });
+        return;
+      }
+
+      if (!this.chatService || typeof this.chatService.executeChildDelegation !== 'function') {
+        ctx.status = 503;
+        ctx.error('ChatService child delegation executor is not available', 503);
+        return;
+      }
+
+      const { delegation, session = null } = ctx.request.body || {};
+      if (!delegation?.child_invocation?.run_id) {
+        ctx.error('delegation.child_invocation.run_id is required', 400);
+        return;
+      }
+
+      const result = await this.chatService.executeChildDelegation(delegation, {
+        session: session || ctx.state.session || null,
+      });
+
+      ctx.success(result);
+    } catch (error) {
+      logger.error('Internal API execute child Agent run error:', error);
+      ctx.error(error.message || '执行 Child Agent 失败', 500);
+    }
+  }
+
+  /**
    * 设置 ResidentSkillManager 引用（在 server 初始化时调用）
    */
   setResidentSkillManager(manager) {

--- a/server/index.js
+++ b/server/index.js
@@ -382,6 +382,7 @@ class ApiServer {
     // 初始化驻留式技能管理器
     this.residentSkillManager = new ResidentSkillManager(this.db);
     await this.residentSkillManager.initialize();
+    this.chatService.setResidentSkillManager(this.residentSkillManager);
     this.mcpToolCaller = new McpToolCaller(this.db, {
       residentSkillManager: this.residentSkillManager,
     });

--- a/server/routes/internal.routes.js
+++ b/server/routes/internal.routes.js
@@ -1,21 +1,7 @@
 /**
- * Internal Routes - 内部 API 路由
+ * Internal Routes
  *
- * 用于驻留式技能调用，需要用户 JWT 认证
- *
- * API 设计：
- * - POST /internal/messages/insert - 插入消息并触发专家响应
- * - GET /internal/models/:model_id - 获取模型配置（含 Provider 信息）
- * - GET /internal/models/resolve?name=xxx - 通过名称解析模型 ID
- * - POST /internal/resident/invoke - 调用驻留式技能工具
- * - POST /internal/docs/intakes - 文档接入
- * - GET /internal/docs/:document_id/processing - 查询处理状态
- * - POST /internal/docs/recall - 文档召回
- * - GET /internal/docs/:document_id/revisions - 版本列表
- *
- * 安全策略：
- * - 必须提供有效的用户 JWT Token
- * - 注：当前实现为"JWT 认证即可"，未强制本地 IP 访问
+ * 用于驻留式技能和内部后台执行链路。所有路由都经过用户 JWT 认证。
  */
 
 import Router from '@koa/router';
@@ -29,39 +15,24 @@ import Router from '@koa/router';
  */
 export default function createInternalRoutes(controller, docsController, authMiddleware) {
   const router = new Router({
-    prefix: '/internal'
+    prefix: '/internal',
   });
 
-  // 所有 internal API 都需要用户认证
   const requireAuth = authMiddleware.authenticate();
 
-  // 消息插入 API
   router.post('/messages/insert', requireAuth, controller.insertMessage.bind(controller));
 
-  // 通过名称解析模型 ID（必须在 /:model_id 之前注册）
   router.get('/models/resolve', requireAuth, controller.resolveModelName.bind(controller));
-
-  // 获取模型配置 API
   router.get('/models/:model_id', requireAuth, controller.getModelConfig.bind(controller));
 
-  // 调用驻留式技能工具 API
   router.post('/resident/invoke', requireAuth, controller.invokeResidentTool.bind(controller));
+  router.post('/agent/child-run/execute', requireAuth, controller.executeChildAgentRun.bind(controller));
 
-  // 获取 MCP 配置 API（供驻留进程调用）
   router.post('/mcp/config', requireAuth, controller.getMcpConfig.bind(controller));
 
-  // ==================== 文档内部 API (P27) ====================
-
-  // 文档接入
   router.post('/docs/intakes', requireAuth, docsController.createIntake.bind(docsController));
-
-  // 查询处理状态
   router.get('/docs/:document_id/processing', requireAuth, docsController.getProcessingStatus.bind(docsController));
-
-  // 文档召回
   router.post('/docs/recall', requireAuth, docsController.recall.bind(docsController));
-
-  // 版本列表
   router.get('/docs/:document_id/revisions', requireAuth, docsController.listRevisions.bind(docsController));
 
   return router;

--- a/tests/test-agent-child-runner-skill-entry.mjs
+++ b/tests/test-agent-child-runner-skill-entry.mjs
@@ -1,0 +1,91 @@
+/**
+ * Tests for agent-child-runner resident skill entrypoint.
+ *
+ * Usage:
+ *   node tests/test-agent-child-runner-skill-entry.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { AgentChildRunnerWorker } from '../lib/agent/agent-child-runner-worker.js';
+import {
+  getTools,
+  __testing,
+} from '../data/skills/agent-child-runner/index.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_skill_entry_parent',
+    principal_user_id: 'user_skill_entry',
+    agent_id: 'expert_parent',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_skill_entry_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return {
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  };
+}
+
+async function testToolDefinition() {
+  const tools = getTools();
+
+  assert.equal(tools.length, 1);
+  assert.equal(tools[0].name, 'invoke');
+  assert.equal(tools[0].script_path, 'index.js');
+  assert.equal(tools[0].is_resident, true);
+  assert.deepEqual(tools[0].parameters.required, ['action']);
+}
+
+async function testProcessCommandDispatchesToWorker() {
+  const worker = new AgentChildRunnerWorker({
+    async execute_child_run() {
+      return { fullContent: 'done' };
+    },
+  });
+  const originalWorker = __testing.getWorker();
+  __testing.setWorker(worker);
+
+  try {
+    const started = __testing.processCommand('invoke', {
+      action: 'start',
+      delegation: createDelegation(),
+    });
+    const finalStatus = await worker.waitForCompletion(started.child_run_id);
+    const result = __testing.processCommand('invoke', {
+      action: 'result',
+      child_run_id: started.child_run_id,
+    });
+
+    assert.equal(finalStatus.status, 'completed');
+    assert.equal(result.result.fullContent, 'done');
+  } finally {
+    __testing.setWorker(originalWorker);
+  }
+}
+
+async function main() {
+  await testToolDefinition();
+  await testProcessCommandDispatchesToWorker();
+
+  console.log('Agent child runner skill entry tests passed.');
+}
+
+main();

--- a/tests/test-agent-child-runner-worker.mjs
+++ b/tests/test-agent-child-runner-worker.mjs
@@ -1,0 +1,144 @@
+/**
+ * Tests for resident child Agent runner worker.
+ *
+ * Usage:
+ *   node tests/test-agent-child-runner-worker.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { AgentChildRunnerWorker } from '../lib/agent/agent-child-runner-worker.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation(runId = 'child_run_worker_1') {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_worker_parent',
+    principal_user_id: 'user_worker',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_worker',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: runId,
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return Object.freeze({
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    input: { query: 'agent runtime' },
+    expected_output: 'summary',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  });
+}
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function testStartCompletesAndReturnsResult() {
+  const worker = new AgentChildRunnerWorker({
+    async execute_child_run(input) {
+      assert.equal(input.delegation.child_invocation.run_id, 'child_run_worker_1');
+      assert.deepEqual(input.session, { userId: 'user_worker' });
+      input.onDelta({ type: 'delta', content: 'done' });
+      return { fullContent: 'child result' };
+    },
+  });
+
+  const started = worker.handleAction({
+    action: 'start',
+    delegation: createDelegation(),
+    options: { session: { userId: 'user_worker' } },
+  });
+  assert.equal(started.status, 'queued');
+  assert.equal(started.child_run_id, 'child_run_worker_1');
+
+  const finalStatus = await worker.waitForCompletion(started.child_run_id);
+  assert.equal(finalStatus.status, 'completed');
+
+  const result = worker.handleAction({
+    action: 'result',
+    child_run_id: started.child_run_id,
+  });
+  assert.equal(result.result.fullContent, 'child result');
+  assert.deepEqual(result.events, [{ type: 'delta', content: 'done' }]);
+
+  const events = worker.handleAction({
+    action: 'events',
+    child_run_id: started.child_run_id,
+  });
+  assert.deepEqual(events, [{ type: 'delta', content: 'done' }]);
+}
+
+async function testCancelRunningRun() {
+  let releaseRun;
+  const enteredRun = new Promise(resolve => {
+    releaseRun = resolve;
+  });
+  const worker = new AgentChildRunnerWorker({
+    async execute_child_run(input) {
+      enteredRun.then(() => {});
+      await new Promise(resolve => {
+        releaseRun = resolve;
+      });
+      if (input.shouldStop()) {
+        throw new Error('Request aborted by user');
+      }
+      return { fullContent: 'unexpected' };
+    },
+  });
+
+  const started = worker.start(createDelegation('child_run_worker_cancel'));
+  await nextTick();
+  assert.equal(worker.getStatus(started.child_run_id).status, 'running');
+
+  const cancelled = worker.cancel(started.child_run_id);
+  assert.equal(cancelled.cancel_requested, true);
+  releaseRun();
+
+  const finalStatus = await worker.waitForCompletion(started.child_run_id);
+  assert.equal(finalStatus.status, 'cancelled');
+  assert.equal(finalStatus.error, 'Request aborted by user');
+}
+
+async function testFailedRunStatus() {
+  const worker = new AgentChildRunnerWorker({
+    async execute_child_run() {
+      throw new Error('child exploded');
+    },
+  });
+
+  const started = worker.start(createDelegation('child_run_worker_failed'));
+  const finalStatus = await worker.waitForCompletion(started.child_run_id);
+
+  assert.equal(finalStatus.status, 'failed');
+  assert.equal(finalStatus.error, 'child exploded');
+  assert.throws(() => worker.getResult(started.child_run_id), /child run is not completed: failed/);
+}
+
+function testRequiresExecutor() {
+  assert.throws(() => new AgentChildRunnerWorker(), /execute_child_run is required/);
+}
+
+async function main() {
+  await testStartCompletesAndReturnsResult();
+  await testCancelRunningRun();
+  await testFailedRunStatus();
+  testRequiresExecutor();
+
+  console.log('Agent child runner worker tests passed.');
+}
+
+main();

--- a/tests/test-chat-service-agent-runtime-facade.mjs
+++ b/tests/test-chat-service-agent-runtime-facade.mjs
@@ -7,6 +7,10 @@
 
 import assert from 'node:assert/strict';
 import ChatService from '../lib/chat-service.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
 
 function createDbStub() {
   return {
@@ -71,6 +75,37 @@ function createRuntimeStub(calls) {
       return executor({ invocation_context: input.invocation_context });
     },
   };
+}
+
+function createDelegation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_chat_service_parent',
+    principal_user_id: 'user_1',
+    agent_id: 'expert_parent',
+    topic_id: 'topic_1',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_chat_service_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['demo_tool'] },
+  });
+
+  return Object.freeze({
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Use demo tool',
+    input: {},
+    expected_output: 'answer',
+    requested_scope: { tools: ['demo_tool'] },
+    effective_scope: { tools: ['demo_tool'] },
+  });
 }
 
 async function testStreamChatUsesRootAgentRuntime() {
@@ -154,6 +189,55 @@ async function testStreamChatUsesRootAgentRuntime() {
   });
 }
 
+async function testChatServiceExecutesChildDelegation() {
+  const runtimeCalls = [];
+  const loopCalls = [];
+  const service = new ChatService(createDbStub(), {
+    agentRuntime: {
+      async runChild(input, executor) {
+        runtimeCalls.push(input);
+        const result = await executor({ invocation_context: input.invocation_context });
+        return {
+          ...result,
+          agent_invocation_context: input.invocation_context,
+        };
+      },
+    },
+    agentLoop: {
+      async run(expertService, input) {
+        loopCalls.push({ expertService, input });
+        input.onDelta?.({ type: 'delta', content: 'child' });
+        return {
+          fullContent: 'child result',
+          fullReasoningContent: '',
+          tokenUsage: null,
+          allToolCalls: [],
+          finalMessages: input.currentMessages,
+          llmCallsCount: 1,
+        };
+      },
+    },
+  });
+  const expertService = createExpertServiceStub();
+  service.getExpertService = async expertId => {
+    assert.equal(expertId, 'expert_child');
+    return expertService;
+  };
+  const deltaEvents = [];
+
+  const result = await service.executeChildDelegation(createDelegation(), {
+    session: { userId: 'user_1' },
+    onDelta: event => deltaEvents.push(event),
+  });
+
+  assert.equal(result.fullContent, 'child result');
+  assert.equal(result.agent_invocation_context.run_id, 'child_run_chat_service_1');
+  assert.equal(runtimeCalls.length, 1);
+  assert.equal(loopCalls.length, 1);
+  assert.equal(loopCalls[0].input.expert_id, 'expert_child');
+  assert.deepEqual(deltaEvents, [{ type: 'delta', content: 'child' }]);
+}
+
 function testChatServiceCanUseResidentDelegateRuntime() {
   const residentSkillManager = {
     async invokeByName() {
@@ -169,9 +253,29 @@ function testChatServiceCanUseResidentDelegateRuntime() {
   assert.equal(runtime.child_run_scheduler.resident_skill_manager, residentSkillManager);
 }
 
+function testChatServiceCanSetResidentDelegateRuntimeAfterConstruction() {
+  const residentSkillManager = {
+    async invokeByName() {
+      return {};
+    },
+  };
+  const service = new ChatService(createDbStub());
+
+  const inMemoryRuntime = service.getAgentDelegateControlRuntime();
+  assert.equal(inMemoryRuntime.child_run_scheduler.resident_skill_manager, undefined);
+
+  service.setResidentSkillManager(residentSkillManager);
+  const residentRuntime = service.getAgentDelegateControlRuntime();
+
+  assert.notEqual(residentRuntime, inMemoryRuntime);
+  assert.equal(residentRuntime.child_run_scheduler.resident_skill_manager, residentSkillManager);
+}
+
 async function main() {
   await testStreamChatUsesRootAgentRuntime();
+  await testChatServiceExecutesChildDelegation();
   testChatServiceCanUseResidentDelegateRuntime();
+  testChatServiceCanSetResidentDelegateRuntimeAfterConstruction();
 
   console.log('ChatService AgentRuntime facade tests passed.');
 }

--- a/tests/test-internal-child-agent-run-controller.mjs
+++ b/tests/test-internal-child-agent-run-controller.mjs
@@ -1,0 +1,123 @@
+/**
+ * Tests for internal child Agent run execution endpoint handler.
+ *
+ * Usage:
+ *   node tests/test-internal-child-agent-run-controller.mjs
+ */
+
+import assert from 'node:assert/strict';
+import InternalController from '../server/controllers/internal.controller.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDbStub() {
+  return {
+    getModel() {
+      return {};
+    },
+  };
+}
+
+function createDelegation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_internal_parent',
+    principal_user_id: 'user_internal',
+    agent_id: 'expert_parent',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_internal_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return {
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  };
+}
+
+function createCtx(body = {}) {
+  return {
+    ip: '127.0.0.1',
+    request: {
+      body,
+      headers: {},
+      ip: '127.0.0.1',
+    },
+    state: {
+      session: {
+        id: 'user_internal',
+        userId: 'user_internal',
+      },
+    },
+    success(data) {
+      this.body = { code: 200, message: 'success', data };
+    },
+    error(message, status = 500, extra = null) {
+      this.status = status;
+      this.body = { code: status, message, data: extra };
+    },
+  };
+}
+
+async function testExecuteChildAgentRunUsesChatService() {
+  const calls = [];
+  const controller = new InternalController(createDbStub(), {
+    chatService: {
+      async executeChildDelegation(delegation, options) {
+        calls.push({ delegation, options });
+        return { fullContent: 'done' };
+      },
+    },
+  });
+  const session = { id: 'user_internal', accessToken: 'token_1' };
+  const ctx = createCtx({
+    delegation: createDelegation(),
+    session,
+  });
+
+  await controller.executeChildAgentRun(ctx);
+
+  assert.equal(ctx.body.code, 200);
+  assert.equal(ctx.body.data.fullContent, 'done');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].delegation.child_invocation.run_id, 'child_run_internal_1');
+  assert.equal(calls[0].options.session, session);
+}
+
+async function testRejectsMissingDelegation() {
+  const controller = new InternalController(createDbStub(), {
+    chatService: {
+      async executeChildDelegation() {
+        throw new Error('unexpected');
+      },
+    },
+  });
+  const ctx = createCtx({});
+
+  await controller.executeChildAgentRun(ctx);
+
+  assert.equal(ctx.status, 400);
+  assert.match(ctx.body.message, /delegation\.child_invocation\.run_id is required/);
+}
+
+async function main() {
+  await testExecuteChildAgentRunUsesChatService();
+  await testRejectsMissingDelegation();
+
+  console.log('Internal child Agent run controller tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- add an `AgentChildRunnerWorker` run registry for resident child Agent execution
- add `data/skills/agent-child-runner` resident skill entrypoint with stdio invoke protocol
- add an internal `/internal/agent/child-run/execute` callback endpoint so the worker can ask the main service to execute the actual child Agent
- add `ChatService.executeChildDelegation()` and post-construction `setResidentSkillManager()` wiring
- inject `residentSkillManager` into `ChatService` after server resident manager initialization

## Scope notes

- No DB schema or model changes.
- No automatic DB registration for `agent-child-runner` yet.
- No `/api/assistants/call` changes.
- Child agents still do not inherit root delegate control tools by default.
- Production startup still requires a separately approved DB data registration for `agent-child-runner` / `invoke` with `is_resident=1`.

## Validation

- `node tests/test-agent-child-runner-worker.mjs`
- `node tests/test-agent-child-runner-skill-entry.mjs`
- `node tests/test-internal-child-agent-run-controller.mjs`
- `node tests/test-chat-service-agent-runtime-facade.mjs`
- `node tests/test-resident-child-run-scheduler.mjs`
- `node tests/test-agent-delegate-control-runtime.mjs`
- `node tests/test-agent-delegate-control-facade.mjs`
- `node tests/test-tool-manager-agent-delegate-control.mjs`
- `node tests/test-child-delegation-runtime-factory.mjs`
- `node tests/test-child-run-scheduler.mjs`
- `node tests/test-expert-child-agent-runner.mjs`
- `node -e "await import('./server/routes/internal.routes.js'); await import('./data/skills/agent-child-runner/index.js'); console.log('ESM import checks passed.')"`
- `node tests/test-tool-definitions-contract.mjs`
- `node tests/test-tool-manager-dispatch.mjs`
- `node tests/test-agent-loop.mjs`
- `node tests/test-agent-runtime.mjs`
- `npm.cmd run lint`
- `git diff --check`
