### PR TITLE
refactor: enable agent child runner production startup

### DIFF
--- a/scripts/skills-data.json
+++ b/scripts/skills-data.json
@@ -267,6 +267,30 @@
       "user_invocable": true,
       "allowed_tools": null,
       "is_active": true
+    },
+    {
+      "id": "agent-child-runner",
+      "name": "Agent Child Runner",
+      "description": "Agent 子任务驻留执行器 - 管理 Child Agent 异步运行状态并回调主服务执行",
+      "version": "1.0.0",
+      "author": "System",
+      "tags": [
+        "agent",
+        "resident",
+        "internal"
+      ],
+      "source_type": "local",
+      "source_path": "skills/agent-child-runner",
+      "source_url": null,
+      "skill_md": "---\nname: agent-child-runner\ndescription: \"Internal resident worker for delegated child Agent runs.\"\nis_resident: 1\nuser-invocable: false\nallowed-tools: []\n---\n\n# Agent Child Runner\n\nInternal resident worker for asynchronous child Agent execution.\n\nThis skill is not intended to be exposed directly to the LLM. Root Agent control tools call it through `ResidentSkillManager.invokeByName()` using the `agent-child-runner` / `invoke` entrypoint.\n",
+      "security_score": 100,
+      "security_warnings": null,
+      "license": null,
+      "argument_hint": "",
+      "disable_model_invocation": true,
+      "user_invocable": false,
+      "allowed_tools": "[]",
+      "is_active": true
     }
   ],
   "tools": [
@@ -3369,6 +3393,45 @@
       },
       "script_path": "index.js",
       "is_resident": false
+    },
+    {
+      "id": "agent-child-runner-invoke",
+      "skill_id": "agent-child-runner",
+      "name": "invoke",
+      "description": "Agent Child Runner 驻留进程入口工具",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "start",
+              "status",
+              "result",
+              "events",
+              "cancel"
+            ],
+            "description": "操作类型"
+          },
+          "delegation": {
+            "type": "object",
+            "description": "已接受的 delegation envelope，用于 start"
+          },
+          "child_run_id": {
+            "type": "string",
+            "description": "Child run ID，用于 status/result/events/cancel"
+          },
+          "options": {
+            "type": "object",
+            "description": "运行选项，例如 session"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "script_path": "index.js",
+      "is_resident": true
     }
   ],
   "parameters": []

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -1097,6 +1097,62 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== Agent Child Runner 驻留技能注册 ====================
+  {
+    name: 'agent-child-runner.skill_registration',
+    check: async (conn) => {
+      const [rows] = await conn.execute(`
+        SELECT t.id
+        FROM skill_tools t
+        JOIN skills s ON s.id = t.skill_id
+        WHERE s.id = 'agent-child-runner'
+          AND t.id = 'agent-child-runner-invoke'
+          AND t.name = 'invoke'
+          AND t.script_path = 'index.js'
+          AND t.is_resident = 1
+      `);
+      return rows.length > 0;
+    },
+    migrate: async (conn) => {
+      await conn.execute(`
+        INSERT INTO skills (id, name, description, source_type, source_path, is_active, created_at, updated_at)
+        VALUES ('agent-child-runner', 'Agent Child Runner', 'Agent 子任务驻留执行器 - 管理 Child Agent 异步运行状态并回调主服务执行', 'local', 'skills/agent-child-runner', 1, NOW(), NOW())
+        ON DUPLICATE KEY UPDATE
+          name = VALUES(name),
+          description = VALUES(description),
+          source_type = VALUES(source_type),
+          source_path = VALUES(source_path),
+          is_active = VALUES(is_active),
+          updated_at = NOW()
+      `);
+      console.log('  ✓ Registered agent-child-runner skill');
+
+      await conn.execute(`
+        INSERT INTO skill_tools (id, skill_id, name, description, parameters, script_path, is_resident, created_at, updated_at)
+        VALUES (
+          'agent-child-runner-invoke',
+          'agent-child-runner',
+          'invoke',
+          'Agent Child Runner 驻留进程入口工具',
+          '{"type":"object","properties":{"action":{"type":"string","enum":["start","status","result","events","cancel"],"description":"操作类型"},"delegation":{"type":"object","description":"已接受的 delegation envelope，用于 start"},"child_run_id":{"type":"string","description":"Child run ID，用于 status/result/events/cancel"},"options":{"type":"object","description":"运行选项，例如 session"}},"required":["action"]}',
+          'index.js',
+          1,
+          NOW(),
+          NOW()
+        )
+        ON DUPLICATE KEY UPDATE
+          skill_id = VALUES(skill_id),
+          name = VALUES(name),
+          description = VALUES(description),
+          parameters = VALUES(parameters),
+          script_path = VALUES(script_path),
+          is_resident = VALUES(is_resident),
+          updated_at = NOW()
+      `);
+      console.log('  ✓ Registered agent-child-runner invoke tool (is_resident=1)');
+    }
+  },
+
   // ==================== MCP Stateless HTTP 传输支持 ====================
   {
     name: 'mcp_servers.add_stateless_http_transport',

--- a/server/controllers/internal.controller.js
+++ b/server/controllers/internal.controller.js
@@ -607,6 +607,13 @@ class InternalController {
         skill_id,
         tool_name,
         params,
+        {
+          userId: ctx.state.session?.id || ctx.state.session?.userId || '',
+          accessToken: ctx.state.session?.accessToken || '',
+          expertId: ctx.state.session?.expertId || '',
+          isAdmin: ctx.state.session?.isAdmin || false,
+          workingDirectory: ctx.state.session?.workingDirectory || '',
+        },
         timeout || 60000
       );
 

--- a/tests/test-agent-child-runner-production-registration.mjs
+++ b/tests/test-agent-child-runner-production-registration.mjs
@@ -1,0 +1,48 @@
+/**
+ * Static production registration checks for agent-child-runner.
+ *
+ * Usage:
+ *   node tests/test-agent-child-runner-production-registration.mjs
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+function testSkillsDataRegistersResidentRunner() {
+  const data = JSON.parse(fs.readFileSync('scripts/skills-data.json', 'utf8'));
+  const skill = data.skills.find(item => item.id === 'agent-child-runner');
+  const tool = data.tools.find(item => item.id === 'agent-child-runner-invoke');
+
+  assert.ok(skill, 'agent-child-runner skill should be present in skills-data.json');
+  assert.equal(skill.source_path, 'skills/agent-child-runner');
+  assert.equal(skill.user_invocable, false);
+  assert.equal(skill.disable_model_invocation, true);
+  assert.equal(skill.is_active, true);
+
+  assert.ok(tool, 'agent-child-runner-invoke tool should be present in skills-data.json');
+  assert.equal(tool.skill_id, 'agent-child-runner');
+  assert.equal(tool.name, 'invoke');
+  assert.equal(tool.script_path, 'index.js');
+  assert.equal(tool.is_resident, true);
+  assert.deepEqual(tool.parameters.required, ['action']);
+  assert.deepEqual(tool.parameters.properties.action.enum, ['start', 'status', 'result', 'events', 'cancel']);
+}
+
+function testUpgradeScriptRegistersResidentRunnerIdempotently() {
+  const source = fs.readFileSync('scripts/upgrade-database.js', 'utf8');
+
+  assert.match(source, /name:\s*'agent-child-runner\.skill_registration'/);
+  assert.match(source, /agent-child-runner-invoke/);
+  assert.match(source, /skills\/agent-child-runner/);
+  assert.match(source, /ON DUPLICATE KEY UPDATE/);
+  assert.match(source, /t\.is_resident = 1/);
+}
+
+function main() {
+  testSkillsDataRegistersResidentRunner();
+  testUpgradeScriptRegistersResidentRunnerIdempotently();
+
+  console.log('Agent child runner production registration tests passed.');
+}
+
+main();

--- a/tests/test-agent-child-runner-resident-process.mjs
+++ b/tests/test-agent-child-runner-resident-process.mjs
@@ -1,0 +1,238 @@
+/**
+ * Process-level test for agent-child-runner resident skill.
+ *
+ * Usage:
+ *   node tests/test-agent-child-runner-resident-process.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+function createDelegation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_process_parent',
+    principal_user_id: 'user_process',
+    agent_id: 'expert_parent',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_process_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return {
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  };
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function startInternalApiServer(calls) {
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (req.method !== 'POST' || req.url !== '/internal/agent/child-run/execute') {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ code: 404, message: 'not found' }));
+        return;
+      }
+
+      const body = await readRequestBody(req);
+      calls.push({
+        authorization: req.headers.authorization,
+        body,
+      });
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        code: 200,
+        message: 'success',
+        data: {
+          fullContent: 'resident child result',
+          received_run_id: body.delegation?.child_invocation?.run_id,
+          received_session_user: body.session?.userId,
+        },
+      }));
+    } catch (error) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ code: 500, message: error.message }));
+    }
+  });
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function waitForLine(proc, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for resident process stdout'));
+    }, timeoutMs);
+
+    function cleanup() {
+      clearTimeout(timeout);
+      proc.stdout.off('data', onData);
+      proc.off('exit', onExit);
+    }
+
+    function onExit(code) {
+      cleanup();
+      reject(new Error(`Resident process exited before response: ${code}`));
+    }
+
+    function onData(chunk) {
+      buffer += chunk.toString();
+      const index = buffer.indexOf('\n');
+      if (index === -1) {
+        return;
+      }
+
+      cleanup();
+      const line = buffer.slice(0, index).trim();
+      try {
+        resolve(JSON.parse(line));
+      } catch (error) {
+        reject(error);
+      }
+    }
+
+    proc.stdout.on('data', onData);
+    proc.on('exit', onExit);
+  });
+}
+
+async function sendCommand(proc, envelope) {
+  const responsePromise = waitForLine(proc);
+  proc.stdin.write(`${JSON.stringify(envelope)}\n`);
+  return await responsePromise;
+}
+
+async function waitForCompletedStatus(proc, childRunId) {
+  for (let i = 0; i < 20; i += 1) {
+    const response = await sendCommand(proc, {
+      command: 'invoke',
+      task_id: `status_${i}`,
+      params: {
+        action: 'status',
+        child_run_id: childRunId,
+      },
+    });
+    assert.equal(response.success, true);
+    if (response.result.status === 'completed') {
+      return response.result;
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+
+  throw new Error('Timed out waiting for completed resident child run');
+}
+
+async function testResidentProcessStartStatusResult() {
+  const calls = [];
+  const server = await startInternalApiServer(calls);
+  const address = server.address();
+  const apiBase = `http://127.0.0.1:${address.port}`;
+  const proc = spawn(process.execPath, ['data/skills/agent-child-runner/index.js'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      API_BASE: apiBase,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stderr = '';
+  proc.stderr.on('data', chunk => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    const ready = await waitForLine(proc);
+    assert.equal(ready.type, 'ready');
+    assert.equal(ready.name, 'agent-child-runner');
+
+    const session = {
+      userId: 'user_process',
+      accessToken: 'token_process',
+    };
+    const started = await sendCommand(proc, {
+      command: 'invoke',
+      task_id: 'start_1',
+      params: {
+        action: 'start',
+        delegation: createDelegation(),
+        options: { session },
+      },
+    });
+
+    assert.equal(started.success, true);
+    assert.equal(started.result.child_run_id, 'child_run_process_1');
+    assert.equal(started.result.status, 'queued');
+
+    const completed = await waitForCompletedStatus(proc, started.result.child_run_id);
+    assert.equal(completed.status, 'completed');
+
+    const result = await sendCommand(proc, {
+      command: 'invoke',
+      task_id: 'result_1',
+      params: {
+        action: 'result',
+        child_run_id: started.result.child_run_id,
+      },
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.result.result.fullContent, 'resident child result');
+    assert.equal(result.result.result.received_run_id, 'child_run_process_1');
+    assert.equal(result.result.result.received_session_user, 'user_process');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].authorization, 'Bearer token_process');
+  } finally {
+    proc.kill();
+    server.close();
+  }
+
+  assert.equal(stderr, '');
+}
+
+async function main() {
+  await testResidentProcessStartStatusResult();
+
+  console.log('Agent child runner resident process tests passed.');
+}
+
+main();

--- a/tests/test-internal-child-agent-run-controller.mjs
+++ b/tests/test-internal-child-agent-run-controller.mjs
@@ -113,9 +113,52 @@ async function testRejectsMissingDelegation() {
   assert.match(ctx.body.message, /delegation\.child_invocation\.run_id is required/);
 }
 
+async function testInvokeResidentToolPassesUserContextAndTimeout() {
+  const calls = [];
+  const controller = new InternalController(createDbStub());
+  controller.setResidentSkillManager({
+    async invokeByName(skillId, toolName, params, userContext, timeout) {
+      calls.push({ skillId, toolName, params, userContext, timeout });
+      return { ok: true };
+    },
+  });
+  const ctx = createCtx({
+    skill_id: 'agent-child-runner',
+    tool_name: 'invoke',
+    params: { action: 'status', child_run_id: 'child_1' },
+    timeout: 1234,
+  });
+  ctx.state.session = {
+    id: 'user_internal',
+    accessToken: 'token_internal',
+    expertId: 'expert_internal',
+    isAdmin: true,
+    workingDirectory: 'D:/work/task',
+  };
+
+  await controller.invokeResidentTool(ctx);
+
+  assert.equal(ctx.body.code, 200);
+  assert.equal(ctx.body.data.ok, true);
+  assert.deepEqual(calls, [{
+    skillId: 'agent-child-runner',
+    toolName: 'invoke',
+    params: { action: 'status', child_run_id: 'child_1' },
+    userContext: {
+      userId: 'user_internal',
+      accessToken: 'token_internal',
+      expertId: 'expert_internal',
+      isAdmin: true,
+      workingDirectory: 'D:/work/task',
+    },
+    timeout: 1234,
+  }]);
+}
+
 async function main() {
   await testExecuteChildAgentRunUsesChatService();
   await testRejectsMissingDelegation();
+  await testInvokeResidentToolPassesUserContextAndTimeout();
 
   console.log('Internal child Agent run controller tests passed.');
 }

--- a/tests/test-resident-skill-manager-agent-child-runner-integration.mjs
+++ b/tests/test-resident-skill-manager-agent-child-runner-integration.mjs
@@ -1,0 +1,204 @@
+/**
+ * Integration test for ResidentSkillManager discovering agent-child-runner.
+ *
+ * Usage:
+ *   node tests/test-resident-skill-manager-agent-child-runner-integration.mjs
+ */
+
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import ResidentSkillManager from '../lib/resident-skill-manager.js';
+import {
+  buildRootAgentInvocationContext,
+  deriveChildAgentInvocationContext,
+} from '../lib/agent/agent-invocation-context.js';
+
+const TOOL = Object.freeze({
+  id: 'agent-child-runner-invoke',
+  skill_id: 'agent-child-runner',
+  name: 'invoke',
+  description: 'Agent Child Runner 驻留进程入口工具',
+  script_path: 'index.js',
+  is_resident: true,
+});
+
+const SKILL = Object.freeze({
+  id: 'agent-child-runner',
+  name: 'Agent Child Runner',
+  source_path: 'skills/agent-child-runner',
+});
+
+function createDelegation() {
+  const parent = buildRootAgentInvocationContext({
+    run_id: 'root_run_manager_parent',
+    principal_user_id: 'user_manager',
+    agent_id: 'expert_parent',
+  });
+  const child = deriveChildAgentInvocationContext(parent, {
+    run_id: 'child_run_manager_1',
+    callee_agent_id: 'expert_child',
+    capability_scope: { tools: ['search'] },
+  });
+
+  return {
+    status: 'accepted',
+    parent_invocation: parent,
+    child_invocation: child,
+    callee_definition: {
+      agent_id: 'expert_child',
+      source_type: 'expert',
+      display_name: 'Child Expert',
+      execution_policy: { mode: 'llm' },
+    },
+    task: 'Search project',
+    requested_scope: { tools: ['search'] },
+    effective_scope: { tools: ['search'] },
+  };
+}
+
+function createDbStub() {
+  return {
+    getModel(name) {
+      if (name === 'skill_tool') {
+        return {
+          async findAll({ where }) {
+            return where?.is_resident ? [TOOL] : [];
+          },
+          async findOne({ where }) {
+            return where?.skill_id === TOOL.skill_id && where?.name === TOOL.name
+              ? TOOL
+              : null;
+          },
+        };
+      }
+      if (name === 'skill') {
+        return {
+          async findAll({ where }) {
+            return Array.isArray(where?.id) && where.id.includes(SKILL.id)
+              ? [SKILL]
+              : [];
+          },
+        };
+      }
+      if (name === 'system_setting') {
+        return {
+          async findOne() {
+            return null;
+          },
+        };
+      }
+      return {};
+    },
+  };
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function startInternalApiServer(calls) {
+  const server = http.createServer(async (req, res) => {
+    const body = await readRequestBody(req);
+    calls.push({ url: req.url, body });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      code: 200,
+      message: 'success',
+      data: {
+        fullContent: 'manager resident result',
+        received_run_id: body.delegation?.child_invocation?.run_id,
+      },
+    }));
+  });
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+async function waitForCompleted(manager, childRunId) {
+  for (let i = 0; i < 20; i += 1) {
+    const status = await manager.invokeByName('agent-child-runner', 'invoke', {
+      action: 'status',
+      child_run_id: childRunId,
+    }, {}, 5000);
+    if (status.status === 'completed') {
+      return status;
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+
+  throw new Error('Timed out waiting for ResidentSkillManager child run');
+}
+
+async function testResidentSkillManagerRunsAgentChildRunner() {
+  const calls = [];
+  const server = await startInternalApiServer(calls);
+  const address = server.address();
+  const originalApiBase = process.env.API_BASE;
+  process.env.API_BASE = `http://127.0.0.1:${address.port}`;
+
+  const manager = new ResidentSkillManager(createDbStub());
+  try {
+    await manager.initialize();
+    const status = manager.getStatus();
+    assert.equal(status.length, 1);
+    assert.equal(status[0].skill_id, 'agent-child-runner');
+    assert.equal(status[0].tool_name, 'invoke');
+    assert.equal(status[0].state, 'running');
+
+    const started = await manager.invokeByName('agent-child-runner', 'invoke', {
+      action: 'start',
+      delegation: createDelegation(),
+      options: {
+        session: {
+          userId: 'user_manager',
+          accessToken: 'token_manager',
+        },
+      },
+    }, {}, 5000);
+    assert.equal(started.child_run_id, 'child_run_manager_1');
+
+    const completed = await waitForCompleted(manager, started.child_run_id);
+    assert.equal(completed.status, 'completed');
+
+    const result = await manager.invokeByName('agent-child-runner', 'invoke', {
+      action: 'result',
+      child_run_id: started.child_run_id,
+    }, {}, 5000);
+    assert.equal(result.result.fullContent, 'manager resident result');
+    assert.equal(result.result.received_run_id, 'child_run_manager_1');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, '/internal/agent/child-run/execute');
+  } finally {
+    await manager.shutdown();
+    server.close();
+    if (originalApiBase === undefined) {
+      delete process.env.API_BASE;
+    } else {
+      process.env.API_BASE = originalApiBase;
+    }
+  }
+}
+
+async function main() {
+  await testResidentSkillManagerRunsAgentChildRunner();
+
+  console.log('ResidentSkillManager agent child runner integration tests passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- register `agent-child-runner` / `invoke` as an internal resident skill/tool in `scripts/upgrade-database.js`
- add the same resident skill/tool to `scripts/skills-data.json` for fresh initialization
- fix `/internal/resident/invoke` to pass `userContext` and `timeout` to `ResidentSkillManager.invokeByName()` in the correct argument positions
- add production-focused tests for static registration, real resident worker process execution, and `ResidentSkillManager` discovery/start/invoke integration

## Scope notes

- No DB schema changes.
- No `models/` changes.
- No `/api/assistants/call` changes.
- Child agents still do not inherit root delegate control tools by default.

## Validation

- `node tests/test-agent-child-runner-production-registration.mjs`
- `node tests/test-agent-child-runner-resident-process.mjs`
- `node tests/test-resident-skill-manager-agent-child-runner-integration.mjs`
- `node tests/test-internal-child-agent-run-controller.mjs`
- `node tests/test-agent-child-runner-worker.mjs`
- `node tests/test-agent-child-runner-skill-entry.mjs`
- `node tests/test-chat-service-agent-runtime-facade.mjs`
- `node tests/test-skill-parameters-schema-quality.mjs`
- `node tests/test-resident-child-run-scheduler.mjs`
- `node tests/test-agent-delegate-control-runtime.mjs`
- `node tests/test-agent-delegate-control-facade.mjs`
- `node tests/test-tool-manager-agent-delegate-control.mjs`
- `node tests/test-child-delegation-runtime-factory.mjs`
- `node tests/test-child-run-scheduler.mjs`
- `node tests/test-expert-child-agent-runner.mjs`
- `node tests/test-child-agent-executor.mjs`
- `node tests/test-tool-definitions-contract.mjs`
- `node tests/test-tool-manager-dispatch.mjs`
- `node tests/test-agent-loop.mjs`
- `node tests/test-agent-runtime.mjs`
- `npm.cmd run lint`
- `git diff --check`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('scripts/skills-data.json','utf8')); console.log('skills-data JSON parse passed')"`
- `node -e "await import('./scripts/upgrade-database.js').catch(err => { if (!/DB_USER/.test(err.message)) throw err; }); console.log('upgrade script import guard checked')"`
