### PR TITLE
fix: stop-bleeding phase fixes (A1-A4 + round02)

### DIFF
--- a/frontend/src/components/contract-v2/ContractDetail.vue
+++ b/frontend/src/components/contract-v2/ContractDetail.vue
@@ -240,9 +240,9 @@ async function handleSetCurrent(revisionId: string) {
       type: 'warning',
     })
   } catch {
+    // 用户取消确认，正常行为
     return
   }
-
   try {
     await store.setDocRevisionCurrent(revisionId)
     await loadDocRevisions()

--- a/frontend/src/views/CollectionSettingsView.vue
+++ b/frontend/src/views/CollectionSettingsView.vue
@@ -140,7 +140,7 @@ async function loadData() {
     const tree = await departmentApi.getDepartmentTree()
     departmentTree.value = tree || []
   } catch {
-    ElMessage.error(t('common.error'))
+    ElMessage.error(t('docs.workspace.settings.loadDepartmentsFailed'))
   }
 }
 


### PR DESCRIPTION
﻿## 变更内容
- A1: Provider 管理接口补全认证与管理员权限校验
- A2+A3: 修复 getAvailableResources 退役模型访问和 getDefaultStepResources ESM require 问题
- A4: 前端关键路径静默 catch 添加用户可见错误反馈
- round02: 修复函数闭合错误、Provider 读权限收口、handleSetCurrent 取消误报回归

## 关联 Issue
Closes #1030
