### PR TITLE
fix: transitionVersionStatus 补文档写权限校验（LEGACY-1）

### DIFF
--- a/server/controllers/doc.controller.js
+++ b/server/controllers/doc.controller.js
@@ -1150,8 +1150,10 @@ async createVersion(ctx) {
   async transitionVersionStatus(ctx) {
     try {
       this.ensureModels();
+      this.ensureDocAccessService();
       const { revisionId } = ctx.params;
       const { to_status } = ctx.request.body;
+      const userId = ctx.state.session.id;
 
       if (!to_status) ctx.throw(400, 'to_status is required');
 
@@ -1159,6 +1161,11 @@ async createVersion(ctx) {
         where: { id: revisionId },
       });
       if (!version) ctx.throw(404, 'Revision not found');
+
+      // LEGACY-1 修复：状态切换属写操作，补上与 updateRevisionLabel 一致的文档写权限校验，
+      // 避免任意已登录用户越权切换他人文档的版本状态（认证 ≠ 授权）
+      const canWrite = await this.docAccessService.canWrite(version.document_id, userId);
+      if (!canWrite) ctx.throw(403, 'Write access denied');
 
       this.validateTransition(version.revision_status, to_status);
 


### PR DESCRIPTION
## 背景

修复 PR #1028 审计（task-260801-01-1028-audit-fix）中记录的 **LEGACY-1 存量问题**：

`POST /api/docs/revisions/:revisionId/transition`（`transitionVersionStatus`）此前只做登录认证（`authenticate()`）与状态机合法性校验（`validateTransition`），**缺少文档写权限校验**。任意已登录用户只要获得 revisionId，即可越权切换他人文档的版本状态（如将 effective 改为 expired / archived，或将 draft 改为 effective），违反"认证不等于授权"约束。

## 修复内容

`server/controllers/doc.controller.js#transitionVersionStatus`：

- 新增 `ensureDocAccessService()` 初始化；
- 取 `userId = ctx.state.session.id`；
- 通过 `docAccessService.canWrite(version.document_id, userId)` 校验写权限，无权返回 403 `Write access denied`。

与同文件 `updateRevisionLabel` / `setCurrentVersion` / `createVersion` 的既有权限校验模式保持一致。

## 验证

- `node --check server/controllers/doc.controller.js`：通过
- `npm run lint`（buildPaginatedResponse 检查）：通过
- 改动范围：1 文件、+7 行

## 关联

- LEGACY-1 记录于 round01-audit（task-260801-01-1028-audit-fix，已归档）
- 无关联 Issue（按审计建议直接修复，未另建 issue）
