### PR TITLE
fix: stabilize chat message query and rendering

### DIFF
--- a/docs/database/api-query-design.md
+++ b/docs/database/api-query-design.md
@@ -226,27 +226,33 @@ POST /api/topics/query
 }
 ```
 
-### 示例 4：嵌套关联查询
+### 示例 4：消息 JSON 查询
 
 ```json
 POST /api/messages/query
 {
-  "page": { "number": 1, "size": 50 },
   "filter": {
-    "topic_id": "topic-001",
-    "role_in": ["user", "assistant"],
-    "is_deleted": false
+    "expert_id": "expert-001",
+    "role": "assistant"
   },
-  "sort": [{ "field": "created_at", "order": "ASC" }],
-  "include": [
-    {
-      "model": "Topic",
-      "fields": ["id", "title"],
-      "include": ["Expert"]
-    }
-  ]
+  "sort": [
+    { "field": "created_at", "order": "asc" },
+    { "field": "id", "order": "asc" }
+  ],
+  "pagination": {
+    "page": 1,
+    "size": 30,
+    "window": "latest"
+  }
 }
 ```
+
+消息查询约束：
+
+- 复杂查询使用 `POST /api/messages/query`，不要把 filter / sort / pagination 拼到 URL。
+- `filter.expert_id` 必填；后端始终用当前登录用户作为 `user_id`，禁止前端传入用户 ID 决定查询归属。
+- 当前排序白名单仅允许 `created_at` 与 `id`；聊天窗口主链路按 `created_at asc, id asc` 返回老到新。
+- `pagination.window = "latest"` 表示从最新消息端取第 N 页，然后按展示顺序返回；旧 GET 入口仅作兼容。
 
 ---
 

--- a/docs/development/api-reference.md
+++ b/docs/development/api-reference.md
@@ -29,6 +29,26 @@
 | 方法 | 端点 | 描述 | 认证 |
 |------|------|------|------|
 | GET | `/api/messages?topic_id=` | 消息列表 | ✅ |
+| GET | `/api/messages/expert/:expertId` | 按专家加载消息列表（兼容入口） | ✅ |
+| POST | `/api/messages/query` | JSON 查询消息列表（推荐：filter/sort/pagination body） | ✅ |
+| GET | `/api/messages/expert/:expertId/since` | 按 live cursor 增量获取新消息 | ✅ |
+
+`POST /api/messages/query` 示例：
+
+```json
+{
+  "filter": { "expert_id": "expert-001" },
+  "sort": [
+    { "field": "created_at", "order": "asc" },
+    { "field": "id", "order": "asc" }
+  ],
+  "pagination": {
+    "page": 1,
+    "size": 30,
+    "window": "latest"
+  }
+}
+```
 
 ## 专家 API
 

--- a/docs/development/code-review-checklist.md
+++ b/docs/development/code-review-checklist.md
@@ -409,6 +409,19 @@ return await response.json()  // 错误！包含了 code/message 包装
 **请求参数规范**：
 - 使用 `page` 和 `size`（**不是** `page` 和 `pageSize`）
 - 示例：`GET /api/messages?expert_id=xxx&page=1&size=20`
+- 复杂列表查询应优先提供 `POST /query` JSON body，把 `filter`、`sort`、`pagination` 放在请求体中。
+- 消息主链路使用 `POST /api/messages/query`：
+  ```json
+  {
+    "filter": { "expert_id": "xxx" },
+    "sort": [
+      { "field": "created_at", "order": "asc" },
+      { "field": "id", "order": "asc" }
+    ],
+    "pagination": { "page": 1, "size": 30, "window": "latest" }
+  }
+  ```
+  后端必须使用排序字段白名单，当前消息查询只允许 `created_at` 和 `id`。
 
 **前端期望**：
 ```typescript

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -40,6 +40,8 @@ import type {
   UserOrganization,
   UpdateUserOrganizationRequest,
   ChatRequestStatus,
+  MessageQueryRequest,
+  MessageQueryResponse,
 } from '@/types'
 
 /**
@@ -80,10 +82,29 @@ export const topicApi = {
 
 // 消息相关 API
 export const messageApi = {
+  // JSON 查询入口：filter / sort / pagination 放在 body 中
+  queryMessages: (data: MessageQueryRequest) =>
+    apiRequest<MessageQueryResponse>(apiClient.post('/messages/query', data)),
+
   // 按 expert 加载消息列表（主要入口）
   // 一个 expert 对一个 user 只有一个连续的对话 session
-  getMessagesByExpert: (expert_id: string, params?: PaginationParams) =>
-    apiRequest<PaginatedResponse<Message>>(apiClient.get(`/messages/expert/${expert_id}`, { params })),
+  getMessagesByExpert: (expert_id: string, params?: PaginationParams) => {
+    const size = params?.size || params?.limit || params?.pageSize || 30
+    return messageApi.queryMessages({
+      filter: {
+        expert_id,
+      },
+      sort: [
+        { field: 'created_at', order: 'asc' },
+        { field: 'id', order: 'asc' },
+      ],
+      pagination: {
+        page: params?.page || 1,
+        size,
+        window: 'latest',
+      },
+    })
+  },
 
   // 获取消息列表（旧 API，按 topic，保留兼容）
   getMessages: (topic_id: string, params?: PaginationParams) =>

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -147,7 +147,13 @@ export const messageApi = {
 
   // 增量获取指定游标之后的消息
   getMessagesSince: (expert_id: string, params?: { after_message_id?: string; limit?: number }) =>
-    apiRequest<{ items: Message[]; latest_message_id: string | null; has_more: boolean }>(
+    apiRequest<{
+      items: Message[];
+      latest_message_id: string | null;
+      has_more: boolean;
+      cursor_initialized?: boolean;
+      anchor_found?: boolean;
+    }>(
       apiClient.get(`/messages/expert/${expert_id}/since`, { params })
     ),
 }

--- a/frontend/src/components/ChatWindow.vue
+++ b/frontend/src/components/ChatWindow.vue
@@ -18,14 +18,6 @@
     />
 
     <button
-      v-if="messageListRef?.showNewMessagesHint"
-      class="new-messages-hint"
-      @click="messageListRef?.handleScrollToBottom()"
-    >
-      {{ newMessagesHintText }}
-    </button>
-
-    <button
       v-if="messageListRef?.showScrollToBottom"
       class="scroll-to-bottom-btn"
       @click="messageListRef?.handleScrollToBottom()"
@@ -47,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, onUnmounted } from 'vue'
 import MessageList from './MessageList.vue'
 import ChatInputArea from './ChatInputArea.vue'
 import type { Message } from '@/types'
@@ -79,11 +71,6 @@ defineEmits<{
 }>()
 
 const messageListRef = ref<InstanceType<typeof MessageList> | null>(null)
-
-const newMessagesHintText = computed(() => {
-  const count = messageListRef.value?.pendingNewMessageCount ?? 0
-  return count > 1 ? `有 ${count} 条新消息` : '有新消息'
-})
 
 onUnmounted(() => {
   messageListRef.value?.cleanup()
@@ -158,23 +145,4 @@ defineExpose({
   transition: color 0.2s;
 }
 
-.new-messages-hint {
-  position: absolute;
-  bottom: 144px;
-  right: 24px;
-  z-index: 10;
-  padding: 8px 14px;
-  border: 1px solid var(--border-color, #dbe4ee);
-  border-radius: 999px;
-  background: var(--bg-primary, #fff);
-  color: var(--primary-color, #2196f3);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.new-messages-hint:hover {
-  background: var(--hover-bg, #f5faff);
-}
 </style>

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -86,8 +86,6 @@ const handleJumpToMessage = (messageId: string) => {
 const {
   messagesContainer,
   showScrollToBottom,
-  showNewMessagesHint,
-  pendingNewMessageCount,
   handleScroll,
   handleScrollToBottom,
   handleLoadMore,
@@ -105,8 +103,6 @@ defineExpose({
   handleScrollToBottom,
   messagesContainer,
   showScrollToBottom,
-  showNewMessagesHint,
-  pendingNewMessageCount,
   cleanup,
 })
 </script>

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -38,6 +38,8 @@
         <div class="thinking-indicator">{{ $t('chat.thinking') }}</div>
       </div>
     </div>
+
+    <div ref="bottomSentinel" class="bottom-sentinel" aria-hidden="true"></div>
   </div>
 </template>
 
@@ -85,6 +87,7 @@ const handleJumpToMessage = (messageId: string) => {
 
 const {
   messagesContainer,
+  bottomSentinel,
   showScrollToBottom,
   handleScroll,
   handleScrollToBottom,
@@ -102,6 +105,7 @@ defineExpose({
   scrollToBottom,
   handleScrollToBottom,
   messagesContainer,
+  bottomSentinel,
   showScrollToBottom,
   cleanup,
 })
@@ -205,5 +209,10 @@ defineExpose({
 .thinking-indicator {
   color: var(--text-secondary, #666);
   font-style: italic;
+}
+
+.bottom-sentinel {
+  width: 100%;
+  height: 1px;
 }
 </style>

--- a/frontend/src/composables/useChatSession.ts
+++ b/frontend/src/composables/useChatSession.ts
@@ -63,6 +63,7 @@ export function useChatSession(options: UseChatSessionOptions) {
 
   const connectToExpert = async (expert_id: string) => {
     console.log('[useChatSession] Connecting SSE for expert:', expert_id)
+    sseHandler.resetLiveState(expert_id, chatStore.getLatestServerMessageId())
 
     await rawConnect(expert_id, {
       timeout: 10000,
@@ -249,6 +250,7 @@ export function useChatSession(options: UseChatSessionOptions) {
     }
 
     await chatStore.setCurrentExpert(expertId)
+    sseHandler.resetLiveState(expertId, chatStore.getLatestServerMessageId())
     connectToExpert(expertId)
   }
 

--- a/frontend/src/composables/useSSEHandler.ts
+++ b/frontend/src/composables/useSSEHandler.ts
@@ -26,6 +26,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
   const lastKnownMessageId = ref<string | null>(null)
   const lastKnownSequence = ref<number>(0)
+  const activeExpertId = ref<string | null>(null)
 
   let contentBuffer = ''
   let reasoningBuffer = ''
@@ -46,6 +47,26 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
   const getStreamingAssistant = (): Message | undefined => {
     return chatStore.getStreamingAssistant()
+  }
+
+  const resetLiveState = (expertId: string, liveCursor: string | null = null) => {
+    activeExpertId.value = expertId || null
+    lastKnownMessageId.value = liveCursor
+    lastKnownSequence.value = 0
+    contentBuffer = ''
+    reasoningBuffer = ''
+    if (flushTimer) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+  }
+
+  const ensureExpertState = () => {
+    const expertId = options.getExpertId()
+    if (expertId && activeExpertId.value !== expertId) {
+      resetLiveState(expertId, chatStore.getLatestServerMessageId())
+    }
+    return expertId
   }
 
   const isManuallyStoppedRequest = (requestId?: string | null) => {
@@ -255,6 +276,8 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
   }
 
   const handleSSEEvent = async (event: SSEEvent) => {
+    const currentExpertId = ensureExpertState()
+
     if (event.event === 'heartbeat') {
       try {
         const data = JSON.parse(event.data)
@@ -274,13 +297,22 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
         }
 
         if (serverLatestMessageId && serverLatestMessageId !== lastKnownMessageId.value) {
-          const expertId = options.getExpertId()
+          const expertId = currentExpertId
           if (expertId) {
+            if (!lastKnownMessageId.value) {
+              lastKnownMessageId.value = serverLatestMessageId
+              return
+            }
+
             try {
               const result = await messageApi.getMessagesSince(expertId, {
                 after_message_id: lastKnownMessageId.value || undefined,
                 limit: 50,
               })
+
+              if (activeExpertId.value !== expertId) {
+                return
+              }
 
               if (result.items?.length) {
                 chatStore.mergeMessages(result.items.map(message => ({
@@ -309,6 +341,15 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
     try {
       const data = JSON.parse(event.data)
       const eventSequence = Number(data.sequence || event.id || 0)
+      if (event.event === 'connected') {
+        const expertId = currentExpertId
+        activeExpertId.value = expertId || null
+        lastKnownSequence.value = eventSequence || 0
+        lastKnownMessageId.value = data.latest_message_id || chatStore.getLatestServerMessageId()
+        console.log('[useSSEHandler] SSE connected:', data)
+        return
+      }
+
       if (eventSequence && eventSequence <= lastKnownSequence.value && event.event !== 'connected') {
         return
       }
@@ -317,10 +358,6 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
       }
 
       switch (event.event) {
-        case 'connected':
-          console.log('[useSSEHandler] SSE connected:', data)
-          break
-
         case 'start':
           console.log('[useSSEHandler] SSE start:', data)
           bindPendingAssistantToRequest(data.request_id)
@@ -574,6 +611,7 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
 
   return {
     lastKnownMessageId,
+    resetLiveState,
     handleSSEEvent,
     handleCompleteEvent,
     setSendingTimeoutProtection,

--- a/frontend/src/composables/useScrollManager.ts
+++ b/frontend/src/composables/useScrollManager.ts
@@ -5,7 +5,7 @@ export interface UseScrollManagerOptions {
   messages: Ref<ChatMessage[]>
   hasMoreMessages: Ref<boolean>
   isLoadingMore: Ref<boolean>
-  onLoadMore: () => void
+  onLoadMore: () => Promise<unknown> | unknown
 }
 
 export function useScrollManager(options: UseScrollManagerOptions) {
@@ -17,6 +17,30 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   const isLoadingTriggered = ref(false)
 
   let streamingScrollRaf: number | null = null
+
+  const triggerLoadMore = async () => {
+    if (!messagesContainer.value || isLoadingTriggered.value) return
+
+    isLoadingTriggered.value = true
+    scrollHeightBeforeLoad.value = messagesContainer.value.scrollHeight
+
+    try {
+      const oldLength = options.messages.value.length
+      await options.onLoadMore()
+      await nextTick()
+
+      if (!messagesContainer.value) return
+      if (options.messages.value.length > oldLength) {
+        const newScrollHeight = messagesContainer.value.scrollHeight
+        messagesContainer.value.scrollTop = newScrollHeight - scrollHeightBeforeLoad.value
+        isUserAtBottom.value = checkIsAtBottom()
+      }
+    } catch (error) {
+      console.warn('[useScrollManager] load more failed:', error)
+    } finally {
+      isLoadingTriggered.value = false
+    }
+  }
 
   const checkIsAtBottom = () => {
     if (!messagesContainer.value) return true
@@ -48,9 +72,7 @@ export function useScrollManager(options: UseScrollManagerOptions) {
     const { scrollTop } = messagesContainer.value
 
     if (scrollTop < 100 && !isLoadingTriggered.value) {
-      isLoadingTriggered.value = true
-      scrollHeightBeforeLoad.value = messagesContainer.value.scrollHeight
-      options.onLoadMore()
+      void triggerLoadMore()
     }
   }
 
@@ -62,9 +84,7 @@ export function useScrollManager(options: UseScrollManagerOptions) {
 
   const handleLoadMore = () => {
     if (!messagesContainer.value) return
-    scrollHeightBeforeLoad.value = messagesContainer.value.scrollHeight
-    isLoadingTriggered.value = true
-    options.onLoadMore()
+    void triggerLoadMore()
   }
 
   watch(
@@ -73,11 +93,7 @@ export function useScrollManager(options: UseScrollManagerOptions) {
       nextTick(() => {
         if (!messagesContainer.value || newLength === 0) return
 
-        if (isLoadingTriggered.value && options.isLoadingMore.value === false && newLength > (oldLength || 0)) {
-          const newScrollHeight = messagesContainer.value.scrollHeight
-          messagesContainer.value.scrollTop = newScrollHeight - scrollHeightBeforeLoad.value
-          isLoadingTriggered.value = false
-          isUserAtBottom.value = checkIsAtBottom()
+        if (isLoadingTriggered.value) {
           return
         }
 

--- a/frontend/src/composables/useScrollManager.ts
+++ b/frontend/src/composables/useScrollManager.ts
@@ -12,8 +12,6 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   const messagesContainer = ref<HTMLElement | null>(null)
   const isUserAtBottom = ref(true)
   const showScrollToBottom = ref(false)
-  const showNewMessagesHint = ref(false)
-  const pendingNewMessageCount = ref(0)
 
   const scrollHeightBeforeLoad = ref(0)
   const isLoadingTriggered = ref(false)
@@ -45,11 +43,6 @@ export function useScrollManager(options: UseScrollManagerOptions) {
     isUserAtBottom.value = checkIsAtBottom()
     showScrollToBottom.value = !isUserAtBottom.value
 
-    if (isUserAtBottom.value) {
-      showNewMessagesHint.value = false
-      pendingNewMessageCount.value = 0
-    }
-
     if (!options.hasMoreMessages.value || options.isLoadingMore.value) return
 
     const { scrollTop } = messagesContainer.value
@@ -65,8 +58,6 @@ export function useScrollManager(options: UseScrollManagerOptions) {
     isUserAtBottom.value = true
     scrollToBottom()
     showScrollToBottom.value = false
-    showNewMessagesHint.value = false
-    pendingNewMessageCount.value = 0
   }
 
   const handleLoadMore = () => {
@@ -94,16 +85,9 @@ export function useScrollManager(options: UseScrollManagerOptions) {
           if (oldLength === 0 || oldLength === undefined) {
             scrollToBottom()
             isUserAtBottom.value = true
-            showNewMessagesHint.value = false
-            pendingNewMessageCount.value = 0
           } else {
             if (isUserAtBottom.value) {
               scrollToBottom()
-              showNewMessagesHint.value = false
-              pendingNewMessageCount.value = 0
-            } else {
-              pendingNewMessageCount.value += Math.max(newLength - (oldLength || 0), 1)
-              showNewMessagesHint.value = true
             }
           }
           showScrollToBottom.value = !checkIsAtBottom()
@@ -138,8 +122,6 @@ export function useScrollManager(options: UseScrollManagerOptions) {
     messagesContainer,
     isUserAtBottom,
     showScrollToBottom,
-    showNewMessagesHint,
-    pendingNewMessageCount,
     scrollToBottom,
     handleScroll,
     handleScrollToBottom,

--- a/frontend/src/composables/useScrollManager.ts
+++ b/frontend/src/composables/useScrollManager.ts
@@ -10,42 +10,125 @@ export interface UseScrollManagerOptions {
 
 export function useScrollManager(options: UseScrollManagerOptions) {
   const messagesContainer = ref<HTMLElement | null>(null)
+  const bottomSentinel = ref<HTMLElement | null>(null)
   const isUserAtBottom = ref(true)
   const showScrollToBottom = ref(false)
 
-  const scrollHeightBeforeLoad = ref(0)
   const isLoadingTriggered = ref(false)
+  const historyAnchor = ref<{
+    messageId: string
+    offsetTop: number
+    scrollHeight: number
+  } | null>(null)
 
   let streamingScrollRaf: number | null = null
+  let bottomObserver: IntersectionObserver | null = null
 
-  const triggerLoadMore = async () => {
+  const setBottomState = (atBottom: boolean) => {
+    isUserAtBottom.value = atBottom
+    showScrollToBottom.value = !atBottom
+  }
+
+  const captureVisibleAnchor = () => {
+    const container = messagesContainer.value
+    if (!container) return null
+
+    const containerTop = container.getBoundingClientRect().top
+    const messageElements = Array.from(container.querySelectorAll<HTMLElement>('[data-message-id]'))
+    const firstVisible = messageElements.find((element) => {
+      const rect = element.getBoundingClientRect()
+      return rect.bottom >= containerTop
+    })
+
+    const messageId = firstVisible?.dataset.messageId
+    if (!firstVisible || !messageId) {
+      return {
+        messageId: '',
+        offsetTop: 0,
+        scrollHeight: container.scrollHeight,
+      }
+    }
+
+    return {
+      messageId,
+      offsetTop: firstVisible.getBoundingClientRect().top - containerTop,
+      scrollHeight: container.scrollHeight,
+    }
+  }
+
+  const restoreHistoryAnchor = () => {
+    const container = messagesContainer.value
+    const anchor = historyAnchor.value
+    if (!container || !anchor) return
+
+    if (anchor.messageId) {
+      const target = Array.from(container.querySelectorAll<HTMLElement>('[data-message-id]'))
+        .find((element) => element.dataset.messageId === anchor.messageId)
+      if (target) {
+        const containerTop = container.getBoundingClientRect().top
+        const currentOffsetTop = target.getBoundingClientRect().top - containerTop
+        container.scrollTop += currentOffsetTop - anchor.offsetTop
+        return
+      }
+    }
+
+    container.scrollTop = container.scrollHeight - anchor.scrollHeight
+  }
+
+  const releaseHistoryLoad = () => {
+    isLoadingTriggered.value = false
+    historyAnchor.value = null
+  }
+
+  const triggerLoadMore = () => {
     if (!messagesContainer.value || isLoadingTriggered.value) return
 
     isLoadingTriggered.value = true
-    scrollHeightBeforeLoad.value = messagesContainer.value.scrollHeight
+    historyAnchor.value = captureVisibleAnchor()
 
     try {
-      const oldLength = options.messages.value.length
-      await options.onLoadMore()
-      await nextTick()
-
-      if (!messagesContainer.value) return
-      if (options.messages.value.length > oldLength) {
-        const newScrollHeight = messagesContainer.value.scrollHeight
-        messagesContainer.value.scrollTop = newScrollHeight - scrollHeightBeforeLoad.value
-        isUserAtBottom.value = checkIsAtBottom()
-      }
+      const result = options.onLoadMore()
+      Promise.resolve(result).catch((error) => {
+        console.warn('[useScrollManager] load more failed:', error)
+        releaseHistoryLoad()
+      })
     } catch (error) {
       console.warn('[useScrollManager] load more failed:', error)
-    } finally {
-      isLoadingTriggered.value = false
+      releaseHistoryLoad()
     }
+
+    nextTick(() => {
+      if (isLoadingTriggered.value && !options.isLoadingMore.value) {
+        releaseHistoryLoad()
+      }
+    })
   }
 
   const checkIsAtBottom = () => {
     if (!messagesContainer.value) return true
     const { scrollTop, scrollHeight, clientHeight } = messagesContainer.value
     return scrollHeight - scrollTop - clientHeight < 100
+  }
+
+  const setupBottomObserver = () => {
+    bottomObserver?.disconnect()
+    bottomObserver = null
+
+    if (!messagesContainer.value || !bottomSentinel.value || typeof IntersectionObserver === 'undefined') {
+      setBottomState(checkIsAtBottom())
+      return
+    }
+
+    bottomObserver = new IntersectionObserver(
+      ([entry]) => {
+        setBottomState(entry?.isIntersecting || false)
+      },
+      {
+        root: messagesContainer.value,
+        threshold: 1,
+      }
+    )
+    bottomObserver.observe(bottomSentinel.value)
   }
 
   const scrollToBottom = (instant = false) => {
@@ -64,8 +147,9 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   const handleScroll = () => {
     if (!messagesContainer.value) return
 
-    isUserAtBottom.value = checkIsAtBottom()
-    showScrollToBottom.value = !isUserAtBottom.value
+    if (!bottomObserver) {
+      setBottomState(checkIsAtBottom())
+    }
 
     if (!options.hasMoreMessages.value || options.isLoadingMore.value) return
 
@@ -77,9 +161,8 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   }
 
   const handleScrollToBottom = () => {
-    isUserAtBottom.value = true
+    setBottomState(true)
     scrollToBottom()
-    showScrollToBottom.value = false
   }
 
   const handleLoadMore = () => {
@@ -94,23 +177,49 @@ export function useScrollManager(options: UseScrollManagerOptions) {
         if (!messagesContainer.value || newLength === 0) return
 
         if (isLoadingTriggered.value) {
+          if (newLength > (oldLength || 0)) {
+            restoreHistoryAnchor()
+            releaseHistoryLoad()
+            setBottomState(checkIsAtBottom())
+          }
           return
         }
 
         if (newLength > (oldLength || 0)) {
           if (oldLength === 0 || oldLength === undefined) {
             scrollToBottom()
-            isUserAtBottom.value = true
+            setBottomState(true)
           } else {
             if (isUserAtBottom.value) {
               scrollToBottom()
             }
           }
-          showScrollToBottom.value = !checkIsAtBottom()
+          if (!bottomObserver) {
+            setBottomState(checkIsAtBottom())
+          }
         }
       })
     },
     { immediate: true }
+  )
+
+  watch(
+    () => options.isLoadingMore.value,
+    (isLoadingMore, wasLoadingMore) => {
+      if (!isLoadingMore && wasLoadingMore && isLoadingTriggered.value) {
+        nextTick(() => {
+          releaseHistoryLoad()
+        })
+      }
+    }
+  )
+
+  watch(
+    [messagesContainer, bottomSentinel],
+    () => {
+      nextTick(setupBottomObserver)
+    },
+    { flush: 'post' }
   )
 
   watch(
@@ -128,6 +237,8 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   )
 
   const cleanup = () => {
+    bottomObserver?.disconnect()
+    bottomObserver = null
     if (streamingScrollRaf !== null) {
       cancelAnimationFrame(streamingScrollRaf)
       streamingScrollRaf = null
@@ -136,6 +247,7 @@ export function useScrollManager(options: UseScrollManagerOptions) {
 
   return {
     messagesContainer,
+    bottomSentinel,
     isUserAtBottom,
     showScrollToBottom,
     scrollToBottom,

--- a/frontend/src/composables/useToolDataParser.ts
+++ b/frontend/src/composables/useToolDataParser.ts
@@ -183,6 +183,7 @@ const addLineNumbers = (code: string): string => {
 const filterAssistantContent = (message: ChatMessage, allMessages: ChatMessage[]): string => {
   if (!message.content) return ''
   if (message.role !== 'assistant') return message.content
+  if (!message.request_id) return message.content
 
   const currentIndex = allMessages.findIndex(m => m.id === message.id)
   if (currentIndex === -1) return message.content
@@ -190,7 +191,7 @@ const filterAssistantContent = (message: ChatMessage, allMessages: ChatMessage[]
   const toolContexts: string[] = []
   for (let i = 0; i < currentIndex; i++) {
     const msg = allMessages[i]
-    if (msg && msg.role === 'tool') {
+    if (msg && msg.role === 'tool' && msg.request_id === message.request_id) {
       const context = getToolData(msg).context
       if (context && context.trim()) {
         toolContexts.push(context.trim())

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -21,6 +21,7 @@ export const useChatStore = defineStore('chat', () => {
   const userMessageForAssistant = reactive<Map<string, string>>(new Map())
   const manuallyStoppedRequestIds = reactive<Set<string>>(new Set())
   const currentStreamingMessageId = ref<string | null>(null)
+  const currentExpertGeneration = ref(0)
 
   const sortedMessages = computed(() => messages.value)
 
@@ -102,6 +103,17 @@ export const useChatStore = defineStore('chat', () => {
     return messages.value.find(m => m.role === 'assistant' && m.status === 'streaming')
   }
 
+  const isServerMessage = (message: Pick<Message, 'id'>) => {
+    return !!message.id && !message.id.startsWith('temp-')
+  }
+
+  const getLatestServerMessageId = (): string | null => {
+    const serverMessages = messages.value.filter(isServerMessage)
+    if (serverMessages.length === 0) return null
+    const sortedServerMessages = [...serverMessages].sort(compareMessages)
+    return sortedServerMessages[sortedServerMessages.length - 1]?.id || null
+  }
+
   const setCurrentStreaming = (messageId: string | null) => {
     currentStreamingMessageId.value = messageId
   }
@@ -159,17 +171,23 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   const loadMessagesByExpert = async (expert_id: string, page: number = 1, size: number = 30) => {
+    const generation = page === 1
+      ? currentExpertGeneration.value + 1
+      : currentExpertGeneration.value
+
     if (page === 1) {
       const hasStreamingMessage = messages.value.some(m => m.status === 'streaming')
       if (hasStreamingMessage) {
         return
       }
 
+      currentExpertGeneration.value = generation
       isLoading.value = true
       messages.value = []
       messageById.clear()
       requestToAssistantMessageId.clear()
       requestToUserMessageId.clear()
+      userMessageForAssistant.clear()
       currentExpertId.value = expert_id
     } else {
       isLoadingMore.value = true
@@ -178,6 +196,10 @@ export const useChatStore = defineStore('chat', () => {
 
     try {
       const response = await messageApi.getMessagesByExpert(expert_id, { page, size })
+      if (currentExpertId.value !== expert_id || currentExpertGeneration.value !== generation) {
+        return
+      }
+
       const items = response.items || []
 
       if (page === 1) {
@@ -190,11 +212,15 @@ export const useChatStore = defineStore('chat', () => {
       hasMoreMessages.value = items.length === size
       currentPage.value = page
     } catch (err) {
-      error.value = err instanceof Error ? err.message : 'Failed to load messages'
+      if (currentExpertId.value === expert_id && currentExpertGeneration.value === generation) {
+        error.value = err instanceof Error ? err.message : 'Failed to load messages'
+      }
       throw err
     } finally {
-      isLoading.value = false
-      isLoadingMore.value = false
+      if (currentExpertId.value === expert_id && currentExpertGeneration.value === generation) {
+        isLoading.value = false
+        isLoadingMore.value = false
+      }
     }
   }
 
@@ -214,6 +240,7 @@ export const useChatStore = defineStore('chat', () => {
     userMessageForAssistant.clear()
     currentPage.value = 1
     hasMoreMessages.value = true
+    currentExpertGeneration.value += 1
 
     if (expert_id) {
       await loadMessagesByExpert(expert_id, 1)
@@ -422,6 +449,7 @@ export const useChatStore = defineStore('chat', () => {
     requestToUserMessageId.clear()
     userMessageForAssistant.clear()
     currentStreamingMessageId.value = null
+    currentExpertGeneration.value += 1
     currentPage.value = 1
     hasMoreMessages.value = true
     error.value = null
@@ -518,6 +546,7 @@ export const useChatStore = defineStore('chat', () => {
     getAssistantMessageByRequestId,
     getUserMessageByRequestId,
     getStreamingAssistant,
+    getLatestServerMessageId,
     setCurrentStreaming,
     markRequestManuallyStopped,
     clearManuallyStoppedRequest,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -296,6 +296,35 @@ export interface PaginatedResponse<T> {
   }
 }
 
+export type MessageSortField = 'created_at' | 'id'
+export type SortOrder = 'asc' | 'desc'
+export type MessagePaginationWindow = 'latest' | 'absolute'
+
+export interface MessageQueryRequest {
+  filter: {
+    expert_id: string
+    topic_id?: string | null
+    role?: MessageRole
+  }
+  sort?: Array<{
+    field: MessageSortField
+    order: SortOrder
+  }>
+  pagination?: {
+    page?: number
+    size?: number
+    limit?: number
+    window?: MessagePaginationWindow
+  }
+}
+
+export interface MessageQueryResponse extends PaginatedResponse<Message> {
+  sort?: Array<{
+    field: MessageSortField
+    order: SortOrder
+  }>
+}
+
 // 聊天请求
 export interface ChatRequest {
   topic_id?: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -319,6 +319,7 @@ export interface MessageQueryRequest {
 }
 
 export interface MessageQueryResponse extends PaginatedResponse<Message> {
+  latest_message_id?: string | null
   sort?: Array<{
     field: MessageSortField
     order: SortOrder

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -563,7 +563,11 @@ class ChatService {
       });
 
       // 11. 异步反思和历史归档
-      expertService.performReflection(user_id, content, finalContent, topic_id).catch(err => logger.error('[ChatService] 反思失败:', err.message));
+      expertService.performReflection(user_id, content, finalContent, topic_id, {
+        assistant_message_id: assistantMessageId,
+        request_id,
+        expert_id,
+      }).catch(err => logger.error('[ChatService] 反思失败:', err.message));
       expertService.processHistoryIfNeeded(user_id, topic_id).catch(err => logger.error('[ChatService] 历史归档失败:', err.message));
       await this.updateTopicTimestamp(topic_id);
 
@@ -608,7 +612,7 @@ class ChatService {
    * @returns {Promise<object>} 响应结果
    */
   async chat(params) {
-    const { topic_id, user_id, expert_id, content, model_id, task_id, working_path, session } = params;
+    const { topic_id, user_id, expert_id, content, model_id, task_id, working_path, session, request_id = null } = params;
 
     try {
       // 1. 获取专家服务
@@ -763,7 +767,11 @@ class ChatService {
       );
 
       // 8. 异步执行反思
-      expertService.performReflection(user_id, content, response, topic_id).catch(err => {
+      expertService.performReflection(user_id, content, response, topic_id, {
+        assistant_message_id: assistantMessageId,
+        request_id,
+        expert_id,
+      }).catch(err => {
         logger.error('[ChatService] 反思失败:', err.message);
       });
 
@@ -2138,8 +2146,9 @@ search_chunks_in_document 在指定文档内无命中时，答案可能存在于
    * @param {string} triggerMessage - 触发消息（用户消息）
    * @param {string} myResponse - 我的回复（助手消息）
    * @param {string} topic_id - 话题ID（可选，用于话题分析）
+   * @param {object} options - 反思归属目标
    */
-  async performReflection(user_id, triggerMessage, myResponse, topic_id = null) {
+  async performReflection(user_id, triggerMessage, myResponse, topic_id = null, options = {}) {
     // P0: minimal 策略使用 Psyche Reflection，停用通用反思
     if (this.expertConfig?.expert?.context_strategy === 'minimal') {
       logger.debug(`[ExpertChatService] minimal 策略跳过通用反思（已由 Psyche Reflection 处理）`);
@@ -2183,8 +2192,13 @@ search_chunks_in_document 在指定文档内无命中时，答案可能存在于
       // P0 观测：记录反思来源（general = 通用反思，仅 full/simple 策略）
       logger.info(`[ExpertChatService] 反思完成 (source=general), 专家: ${this.expertId}, 策略: ${this.expertConfig?.expert?.context_strategy || 'full'}`);
 
-      // 更新最后一条消息的 inner_voice
-      await this.updateLastMessageInnerVoice(user_id, reflection);
+      await this.updateMessageInnerVoice({
+        user_id,
+        expert_id: options.expert_id || this.expertId,
+        request_id: options.request_id || null,
+        assistant_message_id: options.assistant_message_id || null,
+        innerVoice: reflection,
+      });
 
       // 处理关键词累积和话题分裂
       if (reflection.keywords && reflection.keywords.length > 0 && topic_id) {
@@ -2342,24 +2356,37 @@ search_chunks_in_document 在指定文档内无命中时，答案可能存在于
   }
 
   /**
-   * 更新最后一条消息的 Inner Voice
+   * 更新指定助手消息的 Inner Voice
    */
-  async updateLastMessageInnerVoice(user_id, innerVoice) {
-    // 获取最近的消息（assistant 角色）
-    const message = await this.Message.findOne({
-      where: {
-        user_id,
-        role: 'assistant',
-      },
-      order: [['created_at', 'DESC']],
-      raw: true,
-    });
+  async updateMessageInnerVoice({ user_id, expert_id, request_id = null, assistant_message_id, innerVoice }) {
+    if (!assistant_message_id) {
+      logger.warn('[ExpertChatService] 跳过反思回写：缺少 assistant_message_id');
+      return;
+    }
 
-    if (message) {
-      await this.Message.update(
-        { inner_voice: JSON.stringify(innerVoice) },
-        { where: { id: message.id } }
-      );
+    const where = {
+      id: assistant_message_id,
+      user_id,
+      expert_id,
+      role: 'assistant',
+    };
+
+    if (request_id) {
+      where.request_id = request_id;
+    }
+
+    const [affectedRows] = await this.Message.update(
+      { inner_voice: JSON.stringify(innerVoice) },
+      { where }
+    );
+
+    if (affectedRows === 0) {
+      logger.warn('[ExpertChatService] 反思回写目标不存在或归属不匹配:', {
+        assistant_message_id,
+        user_id,
+        expert_id,
+        request_id,
+      });
     }
   }
 

--- a/lib/psyche/reflection-service.js
+++ b/lib/psyche/reflection-service.js
@@ -84,6 +84,26 @@ export class ReflectionService {
     return result;
   }
 
+  _applyLookbackRounds(messages) {
+    if (!messages || messages.length === 0) return [];
+
+    const lookbackRounds = Math.max(1, parseInt(this.config.lookbackRounds, 10) || 4);
+    let userRoundsSeen = 0;
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.role === 'user') {
+        userRoundsSeen++;
+        if (userRoundsSeen === lookbackRounds) {
+          const result = messages.slice(i);
+          logger.info(`[ReflectionService] lookbackRounds=${lookbackRounds}: 消息从 ${messages.length} 条裁剪至 ${result.length} 条`);
+          return result;
+        }
+      }
+    }
+
+    return messages;
+  }
+
   /**
    * 估算 JSON 对象的 token 数
    * @param {Object} json - JSON 对象
@@ -141,35 +161,26 @@ export class ReflectionService {
    * @returns {Object} 反思结果，用于更新 Psyche
    */
   async reflect(currentPsyche, recentMessages, topics = [], options = {}) {
+    const lookbackMessages = this._applyLookbackRounds(recentMessages);
     // 使用滑动窗口：基于 token 数限制，从最早的消息开始移除，直到符合要求
     // 输入限制为反思 LLM 上下文的 85%，预留 15% 给输出和系统提示
-    const messagesToProcess = this._applySlidingWindow(recentMessages, currentPsyche, topics);
+    const messagesToProcess = this._applySlidingWindow(lookbackMessages, currentPsyche, topics);
     
-    if (messagesToProcess.length < recentMessages.length) {
-      logger.info(`[ReflectionService] 消息从 ${recentMessages.length} 条截断至 ${messagesToProcess.length} 条`);
+    if (messagesToProcess.length < lookbackMessages.length) {
+      logger.info(`[ReflectionService] 消息从 ${lookbackMessages.length} 条截断至 ${messagesToProcess.length} 条`);
     }
     
     const prompt = this._buildReflectionPrompt(currentPsyche, messagesToProcess, topics, {
       ...options,
-      originalMessageCount: recentMessages.length
+      originalMessageCount: recentMessages.length,
+      selectedMessageCount: messagesToProcess.length
     });
     
     try {
       logger.debug('[ReflectionService] 开始反思...');
-      // 使用 llmClient.call 方法，构造模型配置
-      const modelConfig = {
-        model_name: this.config.model,
-        base_url: this.llmClient.config?.expressiveModel?.base_url || 'https://api.openai.com/v1',
-        api_key: this.llmClient.config?.expressiveModel?.api_key || '',
-        max_output_tokens: this.config.maxTokens,
-        model_type: this.llmClient.config?.expressiveModel?.model_type || 'text',
-      };
-      
-      const response = await this.llmClient.call(
-        modelConfig,
+      const response = await this.llmClient.callReflective(
         [{ role: 'user', content: prompt }],
         {
-          temperature: this.config.temperature,
           max_output_tokens: this.config.maxTokens,
           response_format: { type: 'json_object' }
         }

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -47,6 +47,152 @@ class MessageController {
     };
   }
 
+  getMessageListAttributes() {
+    return [
+      'id', 'request_id', 'expert_id', 'user_id', 'topic_id', 'role', 'content', 'reasoning_content',
+      'prompt_tokens', 'completion_tokens',
+      'inner_voice', 'tool_calls', 'error_info', 'created_at', 'latency_ms'
+    ];
+  }
+
+  parsePositiveInt(value, fallback, max = 100) {
+    const parsed = parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+    return Math.min(parsed, max);
+  }
+
+  normalizeMessageSort(sort) {
+    const allowedSortFields = new Set(['created_at', 'id']);
+    const requestedSort = Array.isArray(sort) ? sort : [];
+    const normalized = [];
+
+    for (const item of requestedSort) {
+      const field = item?.field;
+      if (!allowedSortFields.has(field)) continue;
+      const order = String(item?.order || 'asc').toLowerCase() === 'desc' ? 'DESC' : 'ASC';
+      normalized.push([field, order]);
+    }
+
+    if (!normalized.some(([field]) => field === 'created_at')) {
+      normalized.push(['created_at', 'ASC']);
+    }
+    if (!normalized.some(([field]) => field === 'id')) {
+      normalized.push(['id', 'ASC']);
+    }
+
+    return normalized;
+  }
+
+  reverseSortOrder(order) {
+    return order.map(([field, direction]) => [field, direction === 'ASC' ? 'DESC' : 'ASC']);
+  }
+
+  buildMessageWhere(filter, userId) {
+    const where = {
+      user_id: userId,
+    };
+
+    if (filter.expert_id) {
+      where.expert_id = filter.expert_id;
+    }
+    if (filter.topic_id !== undefined) {
+      where.topic_id = filter.topic_id || null;
+    }
+    if (filter.role) {
+      const allowedRoles = new Set(['user', 'assistant', 'system', 'tool']);
+      if (allowedRoles.has(filter.role)) {
+        where.role = filter.role;
+      }
+    }
+
+    return where;
+  }
+
+  async queryMessagesByRequest(queryRequest, userId, fallbackExpertId = null) {
+    const filter = {
+      ...(queryRequest.filter || {}),
+    };
+    if (fallbackExpertId && !filter.expert_id) {
+      filter.expert_id = fallbackExpertId;
+    }
+
+    if (!filter.expert_id) {
+      return { error: '缺少 filter.expert_id 参数' };
+    }
+
+    const pagination = queryRequest.pagination || {};
+    const page = this.parsePositiveInt(pagination.page, 1, 100000);
+    const size = this.parsePositiveInt(pagination.size || pagination.limit, 30, 100);
+    const offset = (page - 1) * size;
+    const displayOrder = this.normalizeMessageSort(queryRequest.sort);
+    const pageWindow = pagination.window === 'absolute' ? 'absolute' : 'latest';
+    const queryOrder = pageWindow === 'latest' ? this.reverseSortOrder(displayOrder) : displayOrder;
+
+    const { count, rows } = await this.Message.findAndCountAll({
+      where: this.buildMessageWhere(filter, userId),
+      attributes: this.getMessageListAttributes(),
+      order: queryOrder,
+      limit: size,
+      offset,
+      raw: true,
+    });
+
+    const sortedRows = [...rows].sort((a, b) => {
+      for (const [field, direction] of displayOrder) {
+        const aValue = field === 'created_at' ? new Date(a[field]).getTime() : String(a[field] || '');
+        const bValue = field === 'created_at' ? new Date(b[field]).getTime() : String(b[field] || '');
+        if (aValue < bValue) return direction === 'ASC' ? -1 : 1;
+        if (aValue > bValue) return direction === 'ASC' ? 1 : -1;
+      }
+      return 0;
+    });
+
+    const pages = Math.ceil(count / size);
+
+    return {
+      data: {
+        items: sortedRows.map(m => this.formatMessage(m)),
+        sort: displayOrder.map(([field, direction]) => ({
+          field,
+          order: direction.toLowerCase(),
+        })),
+        pagination: {
+          page,
+          size,
+          total: count,
+          pages,
+          has_next: page < pages,
+          has_prev: page > 1,
+          window: pageWindow,
+        },
+      },
+    };
+  }
+
+  /**
+   * JSON 查询消息列表：filter / sort / pagination 均由 body 承载
+   */
+  async query(ctx) {
+    try {
+      const userId = ctx.state.session.id;
+      if (!userId) {
+        ctx.error('未登录', 401);
+        return;
+      }
+
+      const result = await this.queryMessagesByRequest(ctx.request.body || {}, userId);
+      if (result.error) {
+        ctx.error(result.error);
+        return;
+      }
+
+      ctx.success(result.data);
+    } catch (error) {
+      logger.error('Query messages error:', error);
+      ctx.error('查询消息失败', 500);
+    }
+  }
+
   /**
    * 按 expert + user 获取消息列表（主要入口）
    * 这是新的核心 API，用于加载某个 expert 与当前用户的对话历史
@@ -67,45 +213,24 @@ class MessageController {
         return;
       }
 
-      const page = parseInt(pageNumber);
-      const size = parseInt(pageSize);
-      const limit = size;
-      const offset = (page - 1) * limit;
-
-      // 先按时间倒序获取最近的消息，然后再反转成正序（最早的在前）
-      // 这样第1页返回的就是最近的50条消息
-      const { count, rows } = await this.Message.findAndCountAll({
-        where: {
-          expert_id: expertId,
-          user_id: userId,
-        },
-        attributes: [
-          'id', 'request_id', 'expert_id', 'user_id', 'topic_id', 'role', 'content', 'reasoning_content',
-          'prompt_tokens', 'completion_tokens',
-          'inner_voice', 'tool_calls', 'error_info', 'created_at', 'latency_ms'
+      const result = await this.queryMessagesByRequest({
+        filter: {},
+        sort: [
+          { field: 'created_at', order: 'asc' },
+          { field: 'id', order: 'asc' },
         ],
-        order: [['created_at', 'DESC']],  // 先倒序获取最新的
-        limit,
-        offset,
-        raw: true,
-      });
-
-      // 反转数组，使消息按时间正序返回（最早的在前，便于聊天界面显示）
-      const sortedRows = rows.reverse();
-
-      const pages = Math.ceil(count / size);
-
-      ctx.success({
-        items: sortedRows.map(m => this.formatMessage(m)),
         pagination: {
-          page,
-          size,
-          total: count,
-          pages,
-          has_next: page < pages,
-          has_prev: page > 1,
+          page: pageNumber,
+          size: pageSize,
+          window: 'latest',
         },
-      });
+      }, userId, expertId);
+      if (result.error) {
+        ctx.error(result.error);
+        return;
+      }
+
+      ctx.success(result.data);
     } catch (error) {
       console.error('Get messages by expert error:', error.stack || error);
       ctx.error('获取消息失败', 500);

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -148,10 +148,19 @@ class MessageController {
     });
 
     const pages = Math.ceil(count / size);
+    const latestRow = rows.reduce((latest, row) => {
+      if (!latest) return row;
+      const latestTime = new Date(latest.created_at).getTime();
+      const rowTime = new Date(row.created_at).getTime();
+      if (rowTime > latestTime) return row;
+      if (rowTime === latestTime && String(row.id).localeCompare(String(latest.id)) > 0) return row;
+      return latest;
+    }, null);
 
     return {
       data: {
         items: sortedRows.map(m => this.formatMessage(m)),
+        latest_message_id: latestRow?.id || null,
         sort: displayOrder.map(([field, direction]) => ({
           field,
           order: direction.toLowerCase(),
@@ -486,6 +495,29 @@ class MessageController {
       let anchorCreatedAt = null;
       let anchorId = null;
 
+      const getLatestMessageId = async () => {
+        const latest = await this.Message.findOne({
+          where: {
+            expert_id: expertId,
+            user_id: userId,
+          },
+          attributes: ['id'],
+          order: [['created_at', 'DESC'], ['id', 'DESC']],
+          raw: true,
+        });
+        return latest?.id || null;
+      };
+
+      if (!after_message_id) {
+        ctx.success({
+          items: [],
+          latest_message_id: await getLatestMessageId(),
+          has_more: false,
+          cursor_initialized: true,
+        });
+        return;
+      }
+
       if (after_message_id) {
         const anchor = await this.Message.findOne({
           where: {
@@ -497,10 +529,19 @@ class MessageController {
           raw: true,
         });
 
-        if (anchor) {
-          anchorCreatedAt = anchor.created_at;
-          anchorId = anchor.id;
+        if (!anchor) {
+          ctx.success({
+            items: [],
+            latest_message_id: await getLatestMessageId(),
+            has_more: false,
+            cursor_initialized: true,
+            anchor_found: false,
+          });
+          return;
         }
+
+        anchorCreatedAt = anchor.created_at;
+        anchorId = anchor.id;
       }
 
       const where = {
@@ -521,7 +562,7 @@ class MessageController {
       const rows = await this.Message.findAll({
         where,
         attributes: [
-          'id', 'expert_id', 'user_id', 'topic_id', 'role', 'content', 'reasoning_content',
+          'id', 'request_id', 'expert_id', 'user_id', 'topic_id', 'role', 'content', 'reasoning_content',
           'prompt_tokens', 'completion_tokens',
           'inner_voice', 'tool_calls', 'error_info', 'created_at', 'latency_ms'
         ],

--- a/server/controllers/stream.controller.js
+++ b/server/controllers/stream.controller.js
@@ -1109,10 +1109,30 @@ class StreamController {
     // 重要：设置 ctx.status 让 Koa 知道响应已处理
     ctx.status = 200;
 
+    let connectedLatestMessageId = this._getLatestCursor(expert_id, user_id).latest_message_id;
+    if (!connectedLatestMessageId) {
+      const latestMessage = await this.Message.findOne({
+        where: {
+          expert_id,
+          user_id,
+        },
+        order: [['created_at', 'DESC'], ['id', 'DESC']],
+        attributes: ['id'],
+        raw: true,
+      });
+      connectedLatestMessageId = latestMessage?.id || null;
+      this._updateLatestCursor(expert_id, user_id, connectedLatestMessageId);
+    }
+
     // 发送连接成功事件
     const connectedSequence = this._nextSequence(expert_id, user_id);
     ctx.res.write(`id: ${connectedSequence}\nevent: connected\n`);
-    ctx.res.write(`data: ${JSON.stringify({ status: 'connected', expert_id, sequence: connectedSequence })}\n\n`);
+    ctx.res.write(`data: ${JSON.stringify({
+      status: 'connected',
+      expert_id,
+      sequence: connectedSequence,
+      latest_message_id: connectedLatestMessageId,
+    })}\n\n`);
 
     // 存储连接到 Expert 的连接池
     if (!this.expertConnections.has(expert_id)) {
@@ -1141,7 +1161,7 @@ class StreamController {
               expert_id,
               user_id,
             },
-            order: [['created_at', 'DESC']],
+            order: [['created_at', 'DESC'], ['id', 'DESC']],
             attributes: ['id'],
             raw: true,
           });

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -12,6 +12,9 @@ import { authenticate, requireAdmin } from '../middlewares/auth.js';
 export default (controller) => {
   const router = new Router({ prefix: '/api/messages' });
 
+  // JSON 查询入口：filter / sort / pagination 均在 body 中
+  router.post('/query', authenticate(), controller.query.bind(controller));
+
   // 按 expert + user 获取消息列表（主要入口，需要认证）
   router.get('/expert/:expertId', authenticate(), controller.listByExpert.bind(controller));
 

--- a/tests/message-controller-query-json.test.js
+++ b/tests/message-controller-query-json.test.js
@@ -1,0 +1,175 @@
+/**
+ * MessageController JSON query tests.
+ *
+ * Run:
+ *   node tests/message-controller-query-json.test.js
+ */
+
+import MessageController from '../server/controllers/message.controller.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, name, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } else {
+    failed++;
+    console.error(`  ❌ ${name} ${detail}`);
+  }
+}
+
+function createCtx(body) {
+  return {
+    params: {},
+    query: {},
+    request: { body },
+    state: { session: { id: 'user-1' } },
+    body: null,
+    status: 200,
+    success(data) {
+      this.body = { code: 200, message: 'success', data };
+    },
+    error(message, status = 400) {
+      this.status = status;
+      this.body = { code: status, message, data: null };
+    },
+  };
+}
+
+function createController(rows) {
+  const calls = {
+    findAndCountAll: [],
+  };
+
+  const Message = {
+    async findAndCountAll(options) {
+      calls.findAndCountAll.push(options);
+      return {
+        count: 99,
+        rows,
+      };
+    },
+  };
+
+  const controller = new MessageController({
+    getModel(name) {
+      if (name !== 'message') throw new Error(`Unexpected model: ${name}`);
+      return Message;
+    },
+  });
+
+  return { controller, calls };
+}
+
+console.log('\n场景 1：POST /messages/query 使用 JSON filter/sort/pagination');
+{
+  const rows = [
+    {
+      id: 'msg-3',
+      request_id: 'req-3',
+      expert_id: 'expert-1',
+      user_id: 'user-1',
+      topic_id: null,
+      role: 'assistant',
+      content: 'third',
+      created_at: '2026-08-01T00:00:03.000Z',
+    },
+    {
+      id: 'msg-2',
+      request_id: 'req-2',
+      expert_id: 'expert-1',
+      user_id: 'user-1',
+      topic_id: null,
+      role: 'user',
+      content: 'second',
+      created_at: '2026-08-01T00:00:02.000Z',
+    },
+  ];
+
+  const { controller, calls } = createController(rows);
+  const ctx = createCtx({
+    filter: {
+      expert_id: 'expert-1',
+    },
+    sort: [
+      { field: 'created_at', order: 'asc' },
+      { field: 'id', order: 'asc' },
+    ],
+    pagination: {
+      page: 2,
+      size: 2,
+      window: 'latest',
+    },
+  });
+
+  await controller.query(ctx);
+
+  const query = calls.findAndCountAll[0];
+  assert(query.where.user_id === 'user-1', '查询限定当前用户');
+  assert(query.where.expert_id === 'expert-1', '查询使用 body.filter.expert_id');
+  assert(query.limit === 2, '查询使用 body.pagination.size');
+  assert(query.offset === 2, '查询使用 body.pagination.page 计算 offset');
+  assert(JSON.stringify(query.order) === JSON.stringify([['created_at', 'DESC'], ['id', 'DESC']]), 'latest 窗口内部从最新端取页');
+  assert(ctx.body.data.items[0].id === 'msg-2', '返回结果按 created_at/id 老到新排序');
+  assert(ctx.body.data.items[1].id === 'msg-3', '返回结果保留老到新顺序');
+  assert(ctx.body.data.pagination.window === 'latest', '响应返回分页窗口语义');
+}
+
+console.log('\n场景 2：缺少 filter.expert_id 会拒绝');
+{
+  const { controller, calls } = createController([]);
+  const ctx = createCtx({
+    filter: {},
+    pagination: { page: 1, size: 30 },
+  });
+
+  await controller.query(ctx);
+
+  assert(ctx.status === 400, '返回 400');
+  assert(calls.findAndCountAll.length === 0, '不执行数据库查询');
+}
+
+console.log('\n场景 3：GET /messages/expert/:expertId 复用 JSON 查询语义');
+{
+  const rows = [
+    {
+      id: 'msg-5',
+      request_id: 'req-5',
+      expert_id: 'expert-2',
+      user_id: 'user-1',
+      topic_id: null,
+      role: 'assistant',
+      content: 'newer',
+      created_at: '2026-08-01T00:00:05.000Z',
+    },
+    {
+      id: 'msg-4',
+      request_id: 'req-4',
+      expert_id: 'expert-2',
+      user_id: 'user-1',
+      topic_id: null,
+      role: 'user',
+      content: 'older',
+      created_at: '2026-08-01T00:00:04.000Z',
+    },
+  ];
+  const { controller, calls } = createController(rows);
+  const ctx = createCtx({});
+  ctx.params = { expertId: 'expert-2' };
+  ctx.query = { page: '1', size: '2' };
+
+  await controller.listByExpert(ctx);
+
+  const query = calls.findAndCountAll[0];
+  assert(query.where.expert_id === 'expert-2', 'GET 入口使用 path expertId 作为 filter.expert_id');
+  assert(JSON.stringify(query.order) === JSON.stringify([['created_at', 'DESC'], ['id', 'DESC']]), 'GET 入口使用 latest 窗口查询顺序');
+  assert(ctx.body.data.items[0].id === 'msg-4', 'GET 入口返回老到新');
+  assert(ctx.body.data.items[1].id === 'msg-5', 'GET 入口返回老到新稳定次序');
+}
+
+console.log(`\n完成：${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/message-controller-since-cursor.test.js
+++ b/tests/message-controller-since-cursor.test.js
@@ -1,0 +1,126 @@
+/**
+ * MessageController listSince cursor baseline tests.
+ *
+ * Run:
+ *   node tests/message-controller-since-cursor.test.js
+ */
+
+import MessageController from '../server/controllers/message.controller.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, name, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } else {
+    failed++;
+    console.error(`  ❌ ${name} ${detail}`);
+  }
+}
+
+function createCtx(query = {}) {
+  return {
+    params: { expertId: 'expert-1' },
+    query,
+    state: { session: { id: 'user-1' } },
+    body: null,
+    status: 200,
+    success(data) {
+      this.body = { code: 200, message: 'success', data };
+    },
+    error(message, status = 400) {
+      this.status = status;
+      this.body = { code: status, message, data: null };
+    },
+  };
+}
+
+function createController({ latestMessageId = 'msg-latest', anchor = null, rows = [] } = {}) {
+  const calls = {
+    findOne: [],
+    findAll: [],
+  };
+
+  const Message = {
+    async findOne(options) {
+      calls.findOne.push(options);
+      if (options?.where?.id) {
+        return anchor;
+      }
+      return latestMessageId ? { id: latestMessageId } : null;
+    },
+    async findAll(options) {
+      calls.findAll.push(options);
+      return rows;
+    },
+  };
+
+  const controller = new MessageController({
+    getModel(name) {
+      if (name !== 'message') throw new Error(`Unexpected model: ${name}`);
+      return Message;
+    },
+  });
+
+  return { controller, calls };
+}
+
+console.log('\n场景 1：空 after_message_id 只建立 live cursor 基线');
+{
+  const { controller, calls } = createController({ latestMessageId: 'msg-100' });
+  const ctx = createCtx();
+
+  await controller.listSince(ctx);
+
+  assert(ctx.body?.data?.items?.length === 0, '不返回历史消息');
+  assert(ctx.body?.data?.latest_message_id === 'msg-100', '返回当前最新消息作为基线');
+  assert(ctx.body?.data?.cursor_initialized === true, '标记 cursor 已初始化');
+  assert(calls.findAll.length === 0, '不执行增量列表查询');
+}
+
+console.log('\n场景 2：无效 anchor 不回退为全量旧历史');
+{
+  const { controller, calls } = createController({ latestMessageId: 'msg-200', anchor: null });
+  const ctx = createCtx({ after_message_id: 'missing-anchor' });
+
+  await controller.listSince(ctx);
+
+  assert(ctx.body?.data?.items?.length === 0, '不返回历史消息');
+  assert(ctx.body?.data?.latest_message_id === 'msg-200', '返回当前最新消息作为新基线');
+  assert(ctx.body?.data?.anchor_found === false, '标记 anchor 未找到');
+  assert(calls.findAll.length === 0, 'anchor 失效时不扫描消息列表');
+}
+
+console.log('\n场景 3：有效 anchor 才查询 anchor 之后的消息');
+{
+  const rows = [
+    {
+      id: 'msg-201',
+      request_id: 'req-1',
+      expert_id: 'expert-1',
+      user_id: 'user-1',
+      topic_id: null,
+      role: 'assistant',
+      content: 'hello',
+      created_at: '2026-08-01T00:00:01.000Z',
+    },
+  ];
+  const { controller, calls } = createController({
+    anchor: { id: 'msg-200', created_at: '2026-08-01T00:00:00.000Z' },
+    rows,
+  });
+  const ctx = createCtx({ after_message_id: 'msg-200' });
+
+  await controller.listSince(ctx);
+
+  assert(calls.findAll.length === 1, '执行增量列表查询');
+  assert(ctx.body?.data?.items?.length === 1, '返回 anchor 之后的消息');
+  assert(ctx.body?.data?.latest_message_id === 'msg-201', 'latest_message_id 指向返回批次最后一条');
+}
+
+console.log(`\n完成：${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/reflection-service-call-reflective.test.js
+++ b/tests/reflection-service-call-reflective.test.js
@@ -1,0 +1,99 @@
+/**
+ * ReflectionService reflective client routing test.
+ *
+ * Run:
+ *   node tests/reflection-service-call-reflective.test.js
+ */
+
+import { ReflectionService } from '../lib/psyche/reflection-service.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, name, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } else {
+    failed++;
+    console.error(`  ❌ ${name} ${detail}`);
+  }
+}
+
+console.log('\n场景 1：ReflectionService 走 llmClient.callReflective');
+
+let callReflectiveArgs = null;
+const llmClient = {
+  async call() {
+    throw new Error('ReflectionService must not call raw llmClient.call');
+  },
+  async callReflective(messages, options) {
+    callReflectiveArgs = { messages, options };
+    return {
+      content: JSON.stringify({
+        session_meta: { current_topic: '测试话题' },
+        methodology: { current_phase: 'observe' },
+        key_exchange: [],
+      }),
+    };
+  },
+};
+
+const service = new ReflectionService(llmClient, {
+  maxTokens: 1234,
+  reflectionContextSize: 4096,
+  inputTokenRatio: 0.5,
+});
+
+const reflection = await service.reflect(
+  { persona: 'tester' },
+  [
+    { role: 'user', content: '你好' },
+    { role: 'assistant', content: '你好，我在。' },
+  ],
+  [],
+  { userId: 'user-1', expertId: 'expert-1' }
+);
+
+assert(!!callReflectiveArgs, '调用 callReflective');
+assert(callReflectiveArgs.messages[0].role === 'user', '以 messages 格式发送 prompt');
+assert(callReflectiveArgs.options.max_output_tokens === 1234, '传递 max_output_tokens');
+assert(callReflectiveArgs.options.response_format?.type === 'json_object', '要求 JSON object 响应');
+assert(reflection.session_meta?.current_topic === '测试话题', '解析 reflective 响应 JSON');
+
+console.log('\n场景 2：lookbackRounds 按最近 user turn 裁剪反思窗口');
+
+callReflectiveArgs = null;
+const lookbackService = new ReflectionService(llmClient, {
+  lookbackRounds: 2,
+  maxTokens: 2000,
+  reflectionContextSize: 8192,
+  inputTokenRatio: 0.8,
+});
+
+await lookbackService.reflect(
+  { persona: 'tester' },
+  [
+    { role: 'user', content: '第一轮用户内容-应被裁剪' },
+    { role: 'assistant', content: '第一轮助手内容-应被裁剪' },
+    { role: 'user', content: '第二轮用户内容-应保留' },
+    { role: 'tool', content: '第二轮工具内容-应保留' },
+    { role: 'assistant', content: '第二轮助手内容-应保留' },
+    { role: 'user', content: '第三轮用户内容-应保留' },
+    { role: 'assistant', content: '第三轮助手内容-应保留' },
+  ],
+  [],
+  { userId: 'user-1', expertId: 'expert-1' }
+);
+
+const prompt = callReflectiveArgs.messages[0].content;
+assert(!prompt.includes('第一轮用户内容-应被裁剪'), '裁剪掉 lookback 之外的旧 user turn');
+assert(!prompt.includes('第一轮助手内容-应被裁剪'), '裁剪掉 lookback 之外的旧 assistant');
+assert(prompt.includes('第二轮用户内容-应保留'), '保留倒数第二个 user turn');
+assert(prompt.includes('第二轮工具内容-应保留'), '保留 lookback 范围内 tool 链');
+assert(prompt.includes('第三轮助手内容-应保留'), '保留最近 assistant');
+
+console.log(`\n完成：${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- add JSON-body message query support and move the chat list fetch path off URL query composition
- stabilize message pagination, live cursor handling, bottom navigation, and scroll restoration
- tighten assistant/tool rendering filters and route reflection calls through the unified reflective LLM path

## Validation

- `node tests/message-controller-query-json.test.js`
- `node tests/message-controller-since-cursor.test.js`
- `node tests/reflection-service-call-reflective.test.js`
- `npm.cmd run lint`
- `cd frontend && npm.cmd run type-check`
- `git diff --check`
