### PR TITLE
fix: 收敛聊天消息状态与渲染稳定性

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -28,6 +28,7 @@
 |------|------|
 | [AI 调用规范](./llm-call-standards.md) | `LLMClient` / `InternalLLMService` / `EmbeddingClient` 等统一入口规则 |
 | [AI 架构方针](./ai-architecture-guidelines.md) | AI / LLM 架构原则与演进建议 |
+| [Chat 记忆边界](./chat-memory-boundaries.md) | Topic、Memory Summary、Psyche 的当前职责与后续边界 |
 | [Skill 开发指南](./skill-development-guide.md) | Skill 结构、实现方式、接入流程 |
 | [XLSX 公式处理](./xlsx-skill-formula-handling.md) | Excel 公式读取与计算处理说明 |
 

--- a/docs/development/chat-memory-boundaries.md
+++ b/docs/development/chat-memory-boundaries.md
@@ -1,0 +1,37 @@
+# Chat Memory Boundaries
+
+> Last updated: 2026-08-01
+
+本文记录当前聊天、Topic、历史压缩与 Psyche 的边界事实，避免继续沿用旧的 `topic_id IS NULL` 归档模型。
+
+## 当前事实
+
+- 在线聊天会获取或创建 active Topic。
+- user / tool / assistant 消息保存时会绑定当前 `topic_id`。
+- `topic_id = null` 只表示旧数据兼容、无话题上下文或特殊内部路径，不再表示“未归档”。
+- Topic 当前是产品侧 conversation segment，用于会话分段、展示、召回和归档状态管理。
+- 上下文组织策略当前有 `full` / `simple` / `minimal` 三种。
+- Psyche 是 `minimal` 策略的历史消息压缩/工作记忆机制，由反思链路更新并可替代原始 Messages 注入上下文。
+- Psyche 不等同于 Topic 摘要，也不是 Topic 的归档状态。
+
+## 禁止假设
+
+- 禁止把 `topic_id IS NULL` 当作待压缩消息集合的唯一来源。
+- 禁止把 `topic_id NOT NULL` 当作已压缩或已归档。
+- 禁止在未确认数据库方案前新增或重写历史压缩产物的字段语义。
+
+## 后续架构方向
+
+Topic / 普通历史摘要 / Psyche 应明确边界：
+
+- `Topic`：用户可理解的在线 conversation segment。
+- `普通历史摘要`：如果后续新增或保留 Memory Summary 命名，应作为非 Psyche 策略的历史压缩产物，记录 source message range、生成模型、版本和触发来源。
+- `Psyche`：`context_strategy = minimal` 的历史压缩类型，使用反思 LLM 更新工作记忆，并按 token 上限压缩自身。
+
+普通历史摘要是否需要独立落库仍未确认。涉及新增表、字段、索引或迁移脚本前，必须先获得 Eric 明确确认。
+
+## 当前实现建议
+
+- 修复注释和文档时，以“在线绑定 active Topic”为当前事实。
+- 压缩器继续保留兼容逻辑，但不要新增依赖 `topic_id IS NULL` 的主链路。
+- 如果需要重新设计压缩入口，先输出数据/API 方案，再进入数据库迁移流程。

--- a/docs/development/core-modules.md
+++ b/docs/development/core-modules.md
@@ -61,7 +61,7 @@ const messages = await memory.getRecentMessages(userId, 20);
 - 读取和归档对话历史
 - 提供上下文给 LLM
 
-⚠️ **注意**：消息存储由 `ChatService` 直接处理，`MemorySystem` 只负责读取和归档。
+⚠️ **注意**：消息存储由 `ChatService` 直接处理，`MemorySystem` 只负责读取和归档。当前在线消息会绑定 active Topic，`topic_id = null` 只用于旧数据兼容或无话题上下文，不能再作为“未压缩/未归档”的主语义。
 
 ---
 

--- a/frontend/src/components/AssistantMessage.vue
+++ b/frontend/src/components/AssistantMessage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="assistant-message">
+  <div ref="assistantMessageRef" class="assistant-message">
     <div
       v-if="message.role === 'assistant' && message.tool_calls"
       class="tool-calls-section"
@@ -71,18 +71,19 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ToolMessageCard from './ToolMessageCard.vue'
 import { useToolDataParser } from '@/composables/useToolDataParser'
 import { useMarkdownFormatter } from '@/composables/useMarkdownFormatter'
 import { formatRelativeTime } from '@/composables/useTimeFormatter'
 import type { ChatMessage } from './ChatWindow.vue'
-import type { ToolCallData } from '@/composables/useToolDataParser'
+import type { ToolCallData, ToolContextIndex } from '@/composables/useToolDataParser'
 
 const props = defineProps<{
   message: ChatMessage
   allMessages: ChatMessage[]
+  toolContextIndex?: ToolContextIndex
 }>()
 
 defineEmits<{
@@ -95,6 +96,9 @@ const toolParser = useToolDataParser()
 const formatter = useMarkdownFormatter()
 
 const isReasoningExpanded = ref(false)
+const assistantMessageRef = ref<HTMLElement | null>(null)
+const isRenderVisible = ref(false)
+let visibilityObserver: IntersectionObserver | null = null
 
 const toggleReasoning = () => {
   isReasoningExpanded.value = !isReasoningExpanded.value
@@ -105,11 +109,13 @@ const parsedToolCalls = computed<ToolCallData[]>(() => {
 })
 
 const filteredContent = computed(() => {
-  return toolParser.filterAssistantContent(props.message, props.allMessages)
+  return toolParser.filterAssistantContent(props.message, props.allMessages, props.toolContextIndex)
 })
 
 const formattedHtml = computed(() => {
-  return formatter.formatStreamingMessage(props.message, filteredContent.value)
+  return formatter.formatStreamingMessage(props.message, filteredContent.value, {
+    renderMermaid: isRenderVisible.value,
+  })
 })
 
 const isRecovering = computed(() => props.message.metadata?.recovering === true)
@@ -125,6 +131,34 @@ const recoveringText = computed(() => {
 const formattedTime = computed(() => {
   if (!props.message.created_at) return ''
   return formatRelativeTime(props.message.created_at, t)
+})
+
+onMounted(() => {
+  if (!assistantMessageRef.value || typeof IntersectionObserver === 'undefined') {
+    isRenderVisible.value = true
+    return
+  }
+
+  visibilityObserver = new IntersectionObserver(
+    ([entry]) => {
+      if (entry?.isIntersecting) {
+        isRenderVisible.value = true
+        visibilityObserver?.disconnect()
+        visibilityObserver = null
+      }
+    },
+    {
+      root: null,
+      rootMargin: '240px 0px',
+      threshold: 0,
+    }
+  )
+  visibilityObserver.observe(assistantMessageRef.value)
+})
+
+onUnmounted(() => {
+  visibilityObserver?.disconnect()
+  visibilityObserver = null
 })
 </script>
 

--- a/frontend/src/components/MessageItem.vue
+++ b/frontend/src/components/MessageItem.vue
@@ -33,6 +33,7 @@
           v-if="message.role === 'assistant'"
           :message="message"
           :all-messages="allMessages"
+          :tool-context-index="toolContextIndex"
           @retry="$emit('retry', $event)"
           @jump-to-message="$emit('jumpToMessage', $event)"
         />
@@ -56,10 +57,12 @@ import AssistantMessage from './AssistantMessage.vue'
 import { useToolDataParser } from '@/composables/useToolDataParser'
 import { formatRelativeTime } from '@/composables/useTimeFormatter'
 import type { ChatMessage } from './ChatWindow.vue'
+import type { ToolContextIndex } from '@/composables/useToolDataParser'
 
 defineProps<{
   message: ChatMessage
   allMessages: ChatMessage[]
+  toolContextIndex?: ToolContextIndex
   expertAvatar?: string
   highlighted?: boolean
 }>()

--- a/frontend/src/components/MessageList.vue
+++ b/frontend/src/components/MessageList.vue
@@ -19,6 +19,7 @@
       :key="message.id"
       :message="message"
       :all-messages="messages"
+      :tool-context-index="toolContextIndex"
       :expert-avatar="expertAvatar"
       :highlighted="highlightedMessageId === message.id"
       @retry="$emit('retry', $event)"
@@ -47,6 +48,7 @@
 import { ref, computed } from 'vue'
 import MessageItem from './MessageItem.vue'
 import { useScrollManager } from '@/composables/useScrollManager'
+import { useToolDataParser, type ToolContextIndex } from '@/composables/useToolDataParser'
 import type { ChatMessage } from './ChatWindow.vue'
 
 const props = defineProps<{
@@ -63,7 +65,10 @@ const emit = defineEmits<{
 }>()
 
 const highlightedMessageId = ref<string | null>(null)
+const toolParser = useToolDataParser()
 let highlightTimer: ReturnType<typeof setTimeout> | null = null
+
+const toolContextIndex = computed<ToolContextIndex>(() => toolParser.buildToolContextIndex(props.messages))
 
 const handleJumpToMessage = (messageId: string) => {
   highlightedMessageId.value = messageId

--- a/frontend/src/composables/useMarkdownFormatter.ts
+++ b/frontend/src/composables/useMarkdownFormatter.ts
@@ -28,7 +28,7 @@ const FORMATTED_CACHE_MAX_SIZE = 256
 
 const formattedCache = new Map<string, string>()
 const messageHtmlCache = new Map<string, { cacheKey: string; html: string }>()
-const mermaidRenderedHtml = ref<Map<string, string>>(new Map())
+const mermaidRenderedHtml = ref<Map<string, { cacheKey: string; html: string }>>(new Map())
 const renderingMermaid = ref<Set<string>>(new Set())
 
 const escapeHtml = (text: string): string => {
@@ -213,7 +213,7 @@ const containsMermaid = (content: string): boolean => {
   return /```mermaid\s*[\s\S]*?```/i.test(content)
 }
 
-const renderMermaidAsync = async (message: ChatMessage, html: string) => {
+const renderMermaidAsync = async (message: ChatMessage, html: string, cacheKey: string) => {
   const messageId = message.id
 
   renderingMermaid.value.add(messageId)
@@ -229,11 +229,11 @@ const renderMermaidAsync = async (message: ChatMessage, html: string) => {
       keys.forEach(key => mermaidRenderedHtml.value.delete(key))
     }
 
-    mermaidRenderedHtml.value.set(messageId, renderedHtml)
+    mermaidRenderedHtml.value.set(messageId, { cacheKey, html: renderedHtml })
     mermaidRenderedHtml.value = new Map(mermaidRenderedHtml.value)
   } catch (error) {
     console.error('Mermaid rendering error:', error)
-    mermaidRenderedHtml.value.set(messageId, html)
+    mermaidRenderedHtml.value.set(messageId, { cacheKey, html })
     mermaidRenderedHtml.value = new Map(mermaidRenderedHtml.value)
   } finally {
     renderingMermaid.value.delete(messageId)
@@ -256,7 +256,11 @@ const limitMessageHtmlCache = () => {
   keys.forEach(key => messageHtmlCache.delete(key))
 }
 
-const formatStreamingMessage = (message: ChatMessage, filteredContent: string): string => {
+const formatStreamingMessage = (
+  message: ChatMessage,
+  filteredContent: string,
+  options: { renderMermaid?: boolean } = {}
+): string => {
   if (!message.content) return ''
 
   if (message.status === 'streaming') {
@@ -271,22 +275,26 @@ const formatStreamingMessage = (message: ChatMessage, filteredContent: string): 
   }
 
   const cachedRendered = mermaidRenderedHtml.value.get(message.id)
-  if (cachedRendered) {
-    messageHtmlCache.set(message.id, { cacheKey, html: cachedRendered })
+  if (cachedRendered?.cacheKey === cacheKey) {
+    messageHtmlCache.set(message.id, { cacheKey, html: cachedRendered.html })
     limitMessageHtmlCache()
-    return cachedRendered
+    return cachedRendered.html
   }
 
   const html = formatMessage(filteredContent)
 
   if (containsMermaid(filteredContent)) {
+    if (options.renderMermaid === false) {
+      return html
+    }
+
     if (renderingMermaid.value.has(message.id)) {
       messageHtmlCache.set(message.id, { cacheKey, html })
       limitMessageHtmlCache()
       return html
     }
 
-    renderMermaidAsync(message, html)
+    renderMermaidAsync(message, html, cacheKey)
 
     messageHtmlCache.set(message.id, { cacheKey, html })
     limitMessageHtmlCache()

--- a/frontend/src/composables/useSSEHandler.ts
+++ b/frontend/src/composables/useSSEHandler.ts
@@ -163,27 +163,10 @@ export function useSSEHandler(options: UseSSEHandlerOptions) {
       if (tempUserId && tempAssistant) {
         chatStore.removeMessage(tempAssistantId)
         chatStore.removeMessage(tempUserId)
-
-        for (const msg of newMessages) {
-          const existing = chatStore.getMessageById(msg.id)
-          if (existing) {
-            existing.content = msg.content
-            existing.reasoning_content = msg.reasoning_content
-            existing.tool_calls = msg.tool_calls
-            existing.status = 'completed'
-            existing.metadata = msg.metadata
-            existing.updated_at = msg.updated_at || msg.created_at
-          } else {
-            chatStore.addLocalMessage({ ...msg, status: 'completed' })
-          }
-        }
-        return true
-      } else {
-        for (const msg of newMessages) {
-          chatStore.addLocalMessage({ ...msg, status: 'completed' })
-        }
-        return true
       }
+
+      chatStore.mergeMessages(newMessages.map(msg => ({ ...msg, status: 'completed' })))
+      return true
     } catch (error) {
       console.error('[useSSEHandler] Failed to fetch messages from DB:', error)
       return false

--- a/frontend/src/composables/useScrollManager.ts
+++ b/frontend/src/composables/useScrollManager.ts
@@ -13,6 +13,7 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   const bottomSentinel = ref<HTMLElement | null>(null)
   const isUserAtBottom = ref(true)
   const showScrollToBottom = ref(false)
+  const followMode = ref(true)
 
   const isLoadingTriggered = ref(false)
   const historyAnchor = ref<{
@@ -22,11 +23,34 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   } | null>(null)
 
   let streamingScrollRaf: number | null = null
+  let resizeScrollRaf: number | null = null
   let bottomObserver: IntersectionObserver | null = null
+  let resizeObserver: ResizeObserver | null = null
 
-  const setBottomState = (atBottom: boolean) => {
+  const setBottomPresentation = (atBottom: boolean) => {
     isUserAtBottom.value = atBottom
     showScrollToBottom.value = !atBottom
+  }
+
+  const enterFollowMode = () => {
+    followMode.value = true
+    setBottomPresentation(true)
+  }
+
+  const leaveFollowMode = () => {
+    followMode.value = false
+    setBottomPresentation(false)
+  }
+
+  const scheduleFollowScroll = () => {
+    if (!followMode.value || resizeScrollRaf !== null) return
+
+    resizeScrollRaf = requestAnimationFrame(() => {
+      resizeScrollRaf = null
+      if (followMode.value) {
+        scrollToBottom(true)
+      }
+    })
   }
 
   const captureVisibleAnchor = () => {
@@ -115,13 +139,23 @@ export function useScrollManager(options: UseScrollManagerOptions) {
     bottomObserver = null
 
     if (!messagesContainer.value || !bottomSentinel.value || typeof IntersectionObserver === 'undefined') {
-      setBottomState(checkIsAtBottom())
+      if (checkIsAtBottom()) {
+        enterFollowMode()
+      } else if (!followMode.value) {
+        setBottomPresentation(false)
+      }
       return
     }
 
     bottomObserver = new IntersectionObserver(
       ([entry]) => {
-        setBottomState(entry?.isIntersecting || false)
+        if (entry?.isIntersecting) {
+          enterFollowMode()
+        } else if (followMode.value) {
+          scheduleFollowScroll()
+        } else {
+          setBottomPresentation(false)
+        }
       },
       {
         root: messagesContainer.value,
@@ -147,8 +181,10 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   const handleScroll = () => {
     if (!messagesContainer.value) return
 
-    if (!bottomObserver) {
-      setBottomState(checkIsAtBottom())
+    if (checkIsAtBottom()) {
+      enterFollowMode()
+    } else {
+      leaveFollowMode()
     }
 
     if (!options.hasMoreMessages.value || options.isLoadingMore.value) return
@@ -161,7 +197,7 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   }
 
   const handleScrollToBottom = () => {
-    setBottomState(true)
+    enterFollowMode()
     scrollToBottom()
   }
 
@@ -180,7 +216,11 @@ export function useScrollManager(options: UseScrollManagerOptions) {
           if (newLength > (oldLength || 0)) {
             restoreHistoryAnchor()
             releaseHistoryLoad()
-            setBottomState(checkIsAtBottom())
+            if (checkIsAtBottom()) {
+              enterFollowMode()
+            } else {
+              leaveFollowMode()
+            }
           }
           return
         }
@@ -188,14 +228,16 @@ export function useScrollManager(options: UseScrollManagerOptions) {
         if (newLength > (oldLength || 0)) {
           if (oldLength === 0 || oldLength === undefined) {
             scrollToBottom()
-            setBottomState(true)
+            enterFollowMode()
           } else {
-            if (isUserAtBottom.value) {
+            if (followMode.value) {
               scrollToBottom()
             }
           }
-          if (!bottomObserver) {
-            setBottomState(checkIsAtBottom())
+          if (checkIsAtBottom()) {
+            enterFollowMode()
+          } else if (!followMode.value) {
+            setBottomPresentation(false)
           }
         }
       })
@@ -222,10 +264,38 @@ export function useScrollManager(options: UseScrollManagerOptions) {
     { flush: 'post' }
   )
 
+  const setupResizeObserver = () => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+
+    if (!messagesContainer.value || typeof ResizeObserver === 'undefined') {
+      return
+    }
+
+    resizeObserver = new ResizeObserver(() => {
+      if (isLoadingTriggered.value && historyAnchor.value) {
+        restoreHistoryAnchor()
+        return
+      }
+      scheduleFollowScroll()
+    })
+
+    const observedElements = messagesContainer.value.querySelectorAll<HTMLElement>('[data-message-id]')
+    observedElements.forEach((element) => resizeObserver?.observe(element))
+  }
+
+  watch(
+    [messagesContainer, () => options.messages.value.length],
+    () => {
+      nextTick(setupResizeObserver)
+    },
+    { flush: 'post', immediate: true }
+  )
+
   watch(
     () => options.messages.value[options.messages.value.length - 1]?.content,
     () => {
-      if (isUserAtBottom.value) {
+      if (followMode.value) {
         if (streamingScrollRaf === null) {
           streamingScrollRaf = requestAnimationFrame(() => {
             streamingScrollRaf = null
@@ -239,9 +309,15 @@ export function useScrollManager(options: UseScrollManagerOptions) {
   const cleanup = () => {
     bottomObserver?.disconnect()
     bottomObserver = null
+    resizeObserver?.disconnect()
+    resizeObserver = null
     if (streamingScrollRaf !== null) {
       cancelAnimationFrame(streamingScrollRaf)
       streamingScrollRaf = null
+    }
+    if (resizeScrollRaf !== null) {
+      cancelAnimationFrame(resizeScrollRaf)
+      resizeScrollRaf = null
     }
   }
 

--- a/frontend/src/composables/useToolDataParser.ts
+++ b/frontend/src/composables/useToolDataParser.ts
@@ -30,6 +30,18 @@ type ParsedToolCallsRaw = ToolCallData | ToolCallData[] | null
 
 const parsedToolCallCache = new Map<string, { source: unknown; data: ParsedToolCallsRaw }>()
 const normalizedToolDataCache = new Map<string, { source: unknown; data: NormalizedToolData }>()
+let toolContextIndexCache = new WeakMap<ChatMessage[], ToolContextIndexCacheEntry>()
+
+interface ToolContextIndexCacheEntry {
+  length: number
+  last_message_id: string | null
+  index: ToolContextIndex
+}
+
+export interface ToolContextIndex {
+  messageIndexById: Map<string, number>
+  contextsByRequestId: Map<string, Array<{ index: number; context: string }>>
+}
 
 const parseToolCallsRaw = (message: ChatMessage): ParsedToolCallsRaw => {
   if (!message.tool_calls) return null
@@ -180,24 +192,59 @@ const addLineNumbers = (code: string): string => {
     .join('\n')
 }
 
-const filterAssistantContent = (message: ChatMessage, allMessages: ChatMessage[]): string => {
+const buildToolContextIndex = (allMessages: ChatMessage[]): ToolContextIndex => {
+  const messageIndexById = new Map<string, number>()
+  const contextsByRequestId = new Map<string, Array<{ index: number; context: string }>>()
+
+  allMessages.forEach((msg, index) => {
+    messageIndexById.set(msg.id, index)
+
+    if (msg.role !== 'tool' || !msg.request_id) return
+
+    const context = getToolData(msg).context?.trim()
+    if (!context) return
+
+    const contexts = contextsByRequestId.get(msg.request_id) || []
+    contexts.push({ index, context })
+    contextsByRequestId.set(msg.request_id, contexts)
+  })
+
+  return { messageIndexById, contextsByRequestId }
+}
+
+const getToolContextIndex = (allMessages: ChatMessage[]): ToolContextIndex => {
+  const lastMessage = allMessages[allMessages.length - 1]
+  const lastMessageId = lastMessage?.id || null
+  const cached = toolContextIndexCache.get(allMessages)
+  if (cached && cached.length === allMessages.length && cached.last_message_id === lastMessageId) {
+    return cached.index
+  }
+
+  const index = buildToolContextIndex(allMessages)
+  toolContextIndexCache.set(allMessages, {
+    length: allMessages.length,
+    last_message_id: lastMessageId,
+    index,
+  })
+  return index
+}
+
+const filterAssistantContent = (
+  message: ChatMessage,
+  allMessages: ChatMessage[],
+  prebuiltIndex?: ToolContextIndex
+): string => {
   if (!message.content) return ''
   if (message.role !== 'assistant') return message.content
   if (!message.request_id) return message.content
 
-  const currentIndex = allMessages.findIndex(m => m.id === message.id)
-  if (currentIndex === -1) return message.content
+  const index = prebuiltIndex || getToolContextIndex(allMessages)
+  const currentIndex = index.messageIndexById.get(message.id)
+  if (currentIndex === undefined) return message.content
 
-  const toolContexts: string[] = []
-  for (let i = 0; i < currentIndex; i++) {
-    const msg = allMessages[i]
-    if (msg && msg.role === 'tool' && msg.request_id === message.request_id) {
-      const context = getToolData(msg).context
-      if (context && context.trim()) {
-        toolContexts.push(context.trim())
-      }
-    }
-  }
+  const toolContexts = (index.contextsByRequestId.get(message.request_id) || [])
+    .filter(item => item.index < currentIndex)
+    .map(item => item.context)
 
   if (toolContexts.length === 0) return message.content
 
@@ -225,6 +272,7 @@ const filterAssistantContent = (message: ChatMessage, allMessages: ChatMessage[]
 const clearCaches = () => {
   parsedToolCallCache.clear()
   normalizedToolDataCache.clear()
+  toolContextIndexCache = new WeakMap<ChatMessage[], ToolContextIndexCacheEntry>()
 }
 
 let instance: ReturnType<typeof createInstance> | null = null
@@ -243,6 +291,7 @@ function createInstance() {
     formatToolArguments,
     formatToolResult,
     addLineNumbers,
+    buildToolContextIndex,
     filterAssistantContent,
     clearCaches,
   }

--- a/frontend/src/stores/chat-message-merge.d.ts
+++ b/frontend/src/stores/chat-message-merge.d.ts
@@ -1,0 +1,17 @@
+import type { Message } from '@/types'
+
+export function compareMessages(
+  a: Pick<Message, 'created_at' | 'id'>,
+  b: Pick<Message, 'created_at' | 'id'>
+): number
+
+export function normalizeStoredMessage(message: Message): Message
+
+export function mergeMessageData(current: Message, incoming: Message): Message
+
+export function mergeMessagesById(
+  currentMessages: Message[],
+  incomingMessages: Message[],
+  options?: { replace?: boolean }
+): Message[]
+

--- a/frontend/src/stores/chat-message-merge.js
+++ b/frontend/src/stores/chat-message-merge.js
@@ -1,0 +1,36 @@
+export const compareMessages = (a, b) => {
+  const timeDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  if (timeDiff !== 0) return timeDiff
+  return a.id.localeCompare(b.id)
+}
+
+export const normalizeStoredMessage = (message) => ({
+  ...message,
+  status: message.status || 'completed',
+})
+
+export const mergeMessageData = (current, incoming) => ({
+  ...current,
+  ...incoming,
+  status: incoming.status || current.status,
+  updated_at: incoming.updated_at || current.updated_at,
+})
+
+export const mergeMessagesById = (currentMessages, incomingMessages, options = {}) => {
+  const byId = new Map()
+
+  if (!options.replace) {
+    for (const current of currentMessages) {
+      byId.set(current.id, current)
+    }
+  }
+
+  for (const incoming of incomingMessages) {
+    const normalized = normalizeStoredMessage(incoming)
+    const current = byId.get(normalized.id)
+    byId.set(normalized.id, current ? mergeMessageData(current, normalized) : normalized)
+  }
+
+  return Array.from(byId.values()).sort(compareMessages)
+}
+

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -2,6 +2,7 @@ import { ref, computed, reactive } from 'vue'
 import { defineStore } from 'pinia'
 import { messageApi, topicApi } from '@/api/services'
 import type { Message, MessageStatus, Topic } from '@/types'
+import { compareMessages, mergeMessagesById } from './chat-message-merge.js'
 
 export const useChatStore = defineStore('chat', () => {
   const currentExpertId = ref<string | null>(null)
@@ -25,10 +26,9 @@ export const useChatStore = defineStore('chat', () => {
 
   const sortedMessages = computed(() => messages.value)
 
-  const compareMessages = (a: Pick<Message, 'created_at' | 'id'>, b: Pick<Message, 'created_at' | 'id'>) => {
-    const timeDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-    if (timeDiff !== 0) return timeDiff
-    return a.id.localeCompare(b.id)
+  const replaceMessagesById = (nextMessages: Message[]) => {
+    messages.value = mergeMessagesById([], nextMessages, { replace: true })
+    rebuildIndexes()
   }
 
   const indexMessage = (message: Message) => {
@@ -203,11 +203,10 @@ export const useChatStore = defineStore('chat', () => {
       const items = response.items || []
 
       if (page === 1) {
-        messages.value = [...items].sort(compareMessages)
+        replaceMessagesById(items)
       } else {
-        messages.value = [...items, ...messages.value].sort(compareMessages)
+        mergeMessages(items)
       }
-      rebuildIndexes()
 
       hasMoreMessages.value = items.length === size
       currentPage.value = page
@@ -274,12 +273,16 @@ export const useChatStore = defineStore('chat', () => {
     if (existingIndex >= 0) {
       const existing = messages.value[existingIndex]
       if (existing) {
-        unindexMessage(existing.id)
-        existing.content = content || existing.content
-        existing.status = message.status || existing.status
-        existing.updated_at = new Date().toISOString()
-        indexMessage(existing)
-        return existing
+        const updatedMessage: Message = {
+          ...existing,
+          ...message,
+          id: existing.id,
+          content: content || existing.content,
+          status: message.status || existing.status,
+          updated_at: new Date().toISOString()
+        }
+        replaceMessage(existing.id, updatedMessage)
+        return updatedMessage
       }
     }
 
@@ -337,9 +340,18 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   const updateMessageMetadata = (messageId: string, metadata: Message['metadata']) => {
-    const message = messageById.get(messageId)
-    if (message) {
-      message.metadata = { ...message.metadata, ...metadata }
+    const index = messages.value.findIndex(m => m.id === messageId)
+    if (index !== -1) {
+      const message = messages.value[index]
+      if (message) {
+        const newMessage: Message = {
+          ...message,
+          metadata: { ...message.metadata, ...metadata },
+          updated_at: new Date().toISOString()
+        }
+        messages.value.splice(index, 1, newMessage)
+        indexMessage(newMessage)
+      }
     }
   }
 
@@ -394,40 +406,23 @@ export const useChatStore = defineStore('chat', () => {
     if (index === -1) return
 
     const duplicateIndex = messages.value.findIndex((m, i) => i !== index && m.id === nextMessage.id)
-    if (duplicateIndex !== -1) {
-      unindexMessage(messages.value[duplicateIndex]!.id)
-      messages.value.splice(duplicateIndex, 1)
-    }
+    const removeIndexes = new Set([index])
+    if (duplicateIndex !== -1) removeIndexes.add(duplicateIndex)
 
     unindexMessage(messageId)
-    messages.value.splice(index, 1, nextMessage)
-    indexMessage(nextMessage)
+    if (duplicateIndex !== -1) {
+      unindexMessage(nextMessage.id)
+    }
+    messages.value = messages.value.filter((_, i) => !removeIndexes.has(i))
+    insertMessageSorted(nextMessage)
+    rebuildIndexes()
   }
 
   const mergeMessages = (incomingMessages: Message[]) => {
-    for (const incoming of incomingMessages) {
-      const index = messages.value.findIndex(m => m.id === incoming.id)
-      if (index !== -1) {
-        const current = messages.value[index]
-        if (current) {
-          unindexMessage(current.id)
-          const merged: Message = {
-            ...current,
-            ...incoming,
-            updated_at: incoming.updated_at || current.updated_at,
-          }
-          messages.value.splice(index, 1, merged)
-          indexMessage(merged)
-        }
-        continue
-      }
+    if (incomingMessages.length === 0) return
 
-      const newMsg: Message = {
-        ...incoming,
-        status: incoming.status || 'completed',
-      }
-      insertMessageSorted(newMsg)
-    }
+    messages.value = mergeMessagesById(messages.value, incomingMessages)
+    rebuildIndexes()
   }
 
   const removeMessage = (messageId: string) => {
@@ -435,6 +430,7 @@ export const useChatStore = defineStore('chat', () => {
     if (index >= 0) {
       unindexMessage(messageId)
       messages.value.splice(index, 1)
+      rebuildIndexes()
     }
     if (currentStreamingMessageId.value === messageId) {
       currentStreamingMessageId.value = null

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -803,7 +803,8 @@ class ChatService {
 
   /**
    * 保存用户消息
-   * 新消息的 topic_id 为 NULL（未归档状态），压缩时再分配 topic_id
+   * 当前在线对话会绑定 active Topic；topic_id 为 null 只表示兼容旧消息或无话题上下文。
+   * 不要再使用 topic_id NULL / NOT NULL 表达“未压缩/已归档”状态。
    * @param {string} topic_id - 话题ID
    * @param {string} user_id - 用户ID
    * @param {string} content - 消息内容
@@ -886,7 +887,8 @@ class ChatService {
 
   /**
    * 保存助手消息
-   * 新消息的 topic_id 为 NULL（未归档状态），压缩时再分配 topic_id
+   * 当前在线对话会绑定 active Topic；topic_id 为 null 只表示兼容旧消息或无话题上下文。
+   * 压缩摘要后续应使用独立 Memory Summary 概念承载，不复用 topic_id 归属。
    * @param {string} topic_id - 话题ID
    * @param {string} user_id - 用户ID
    * @param {string} content - 消息内容
@@ -983,7 +985,7 @@ class ChatService {
    * - 上下文构建时使用摘要，减少 token 消耗
    * - 通过 message-reader 技能可召回完整结果
    *
-   * @param {string} topic_id - 话题ID（用于关联，但消息 topic_id 为 NULL）
+   * @param {string} topic_id - 话题ID（当前在线工具消息同样绑定 active Topic）
    * @param {string} user_id - 用户ID
    * @param {object} toolResult - 工具执行结果
    * @param {string} expert_id - 专家ID（可选）
@@ -1555,8 +1557,9 @@ class ChatService {
    * 扫描并处理未回复的消息
    * 在服务启动时调用，处理之前失败的用户消息
    *
-   * 注意：新设计中消息的 topic_id 为 NULL（未归档状态），
-   * 所以使用 expert_id + user_id 来判断是否有回复
+   * 注意：在线消息当前会绑定 active Topic，但未回复扫描不能依赖 topic_id。
+   * 这里使用 expert_id + user_id + created_at 判断是否有后续 assistant 回复，
+   * 兼容旧的 topic_id 为空消息与当前 active Topic 消息。
    */
   async processUnrepliedMessages() {
     try {

--- a/lib/context-manager.js
+++ b/lib/context-manager.js
@@ -98,7 +98,8 @@ class ContextManager {
    * 2. Skills Info（可用技能描述）
    * 3. Task Context（任务工作空间上下文，如果有的话）
    * 4. Topic Summaries（话题总结，从 topics 表加载）
-   * 5. Unarchived Messages（未归档消息，topic_id IS NULL）
+   * 5. Recent / legacy unassigned messages（当前实现由 organizer 决定；
+   *    topic_id IS NULL 仅代表旧版未绑定 Topic 消息，不再代表完整待压缩集合）
    *
    * @param {MemorySystem} memorySystem - 记忆系统实例
    * @param {string} userId - 用户ID

--- a/lib/db.js
+++ b/lib/db.js
@@ -481,8 +481,10 @@ class Database {
   // ============================================
 
   /**
-   * 获取未归档消息（topic_id IS NULL）
-   * 用于上下文压缩前加载待压缩的消息
+   * 获取旧版未绑定 Topic 的消息（topic_id IS NULL）
+   *
+   * 注意：当前在线聊天消息会绑定 active Topic。这里仅保留给旧压缩路径和历史
+   * 数据兼容使用，不能代表“所有待压缩消息”。
    * @param {string} expertId - 专家ID
    * @param {string} userId - 用户ID
    * @param {number|null} limit - 数量限制（null 表示不限制）
@@ -493,7 +495,7 @@ class Database {
       where: {
         expert_id: expertId,
         user_id: userId,
-        topic_id: null,  // 未归档
+        topic_id: null,  // legacy unassigned messages only
       },
       attributes: ['id', 'role', 'content', 'inner_voice', 'tool_calls', 'created_at'],
       order: [['created_at', 'ASC']],  // 正序，便于压缩处理

--- a/lib/memory-system.js
+++ b/lib/memory-system.js
@@ -387,17 +387,17 @@ class MemorySystem {
    * @param {number} contextSize - 上下文大小（token）
    * @param {number} threshold - 阈值比例（默认 0.7）
    * @param {number} minMessages - 最小消息数（默认 5 条）
-   * @param {number} maxMessages - 最大未归档消息数（默认 50 条），超过此数量强制压缩
+   * @param {number} maxMessages - 最大 legacy unassigned 消息数（默认 50 条），超过此数量强制压缩
    * @returns {Promise<{needCompress: boolean, reason: string, tokenCount: number}>}
    */
   async shouldCompressContext(userId, contextSize = 128000, threshold = 0.7, minMessages = 5, maxMessages = 50) {
-    // 获取未归档消息
+    // 当前在线消息已绑定 active Topic。这里仅检查旧版未绑定 Topic 的消息。
     const unarchivedMessages = await this.getUnarchivedMessages(userId, 1000);
     
     if (unarchivedMessages.length < minMessages) {
       return {
         needCompress: false,
-        reason: `未归档消息不足 ${minMessages} 条`,
+        reason: `legacy unassigned 消息不足 ${minMessages} 条`,
         tokenCount: 0,
         messageCount: unarchivedMessages.length,
       };
@@ -423,7 +423,7 @@ class MemorySystem {
     if (unarchivedMessages.length >= maxMessages) {
       return {
         needCompress: true,
-        reason: `未归档消息数 ${unarchivedMessages.length} >= 最大值 ${maxMessages}`,
+        reason: `legacy unassigned 消息数 ${unarchivedMessages.length} >= 最大值 ${maxMessages}`,
         tokenCount: estimatedTokens,
         messageCount: unarchivedMessages.length,
       };
@@ -438,10 +438,13 @@ class MemorySystem {
   }
 
   /**
-   * 获取未归档消息
+   * 获取旧版未绑定 Topic 的消息
+   *
+   * 当前在线消息会绑定 active Topic；此方法保留用于旧压缩路径和历史数据兼容。
+   * 后续 Memory Summary 落库前，不要把这里的结果当作完整待压缩集合。
    * @param {string} userId - 用户ID
    * @param {number|null} limit - 数量限制（null 表示不限制）
-   * @returns {Promise<Array>} 未归档消息列表
+   * @returns {Promise<Array>} legacy unassigned 消息列表
    */
   async getUnarchivedMessages(userId, limit = null) {
     // null 表示不限制，传入一个大数值
@@ -470,7 +473,7 @@ class MemorySystem {
 
   /**
    * 压缩上下文（核心方法）
-   * 1. 获取未归档消息
+   * 1. 获取旧版未绑定 Topic 的消息
    * 2. 调用 LLM 识别话题
    * 3. 创建 Topic 并关联消息
    * 4. 更新用户信息
@@ -484,18 +487,18 @@ class MemorySystem {
       contextSize = 128000,
       threshold = 0.7,
       minMessages = 5,
-      maxMessages = 50,  // 最大未归档消息数，超过此数量强制压缩
+      maxMessages = 50,  // 最大 legacy unassigned 消息数，超过此数量强制压缩
       force = false,     // 强制压缩，跳过阈值检查
     } = options;
 
     logger.info(`[MemorySystem] 开始压缩上下文: expert=${this.expertId}, user=${userId}, force=${force}`);
 
     try {
-      // 1. 获取未归档消息
+      // 1. 获取旧版未绑定 Topic 的消息
       const unarchivedMessages = await this.getUnarchivedMessages(userId, 1000);
 
       if (unarchivedMessages.length < minMessages) {
-        logger.debug(`[MemorySystem] 未归档消息不足 ${minMessages} 条，跳过压缩`);
+        logger.debug(`[MemorySystem] legacy unassigned 消息不足 ${minMessages} 条，跳过压缩`);
         return { success: false, reason: '消息不足' };
       }
 
@@ -607,7 +610,7 @@ class MemorySystem {
   /**
    * 话题识别（LLM 调用）
    * 一次性识别所有话题，避免多次 LLM 调用
-   * @param {Array} messages - 未归档消息列表
+   * @param {Array} messages - legacy unassigned 消息列表
    * @returns {Promise<object>} 话题列表和用户信息
    */
   async identifyTopics(messages) {

--- a/tests/chat-message-merge.test.js
+++ b/tests/chat-message-merge.test.js
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import {
+  compareMessages,
+  mergeMessagesById,
+} from '../frontend/src/stores/chat-message-merge.js';
+
+const message = (overrides) => ({
+  id: 'msg-1',
+  expert_id: 'expert-1',
+  user_id: 'user-1',
+  role: 'assistant',
+  content: '',
+  status: 'completed',
+  created_at: '2026-08-01T00:00:00.000Z',
+  updated_at: '2026-08-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const run = () => {
+  console.log('\n场景 1：按 created_at + id 稳定排序');
+  const sorted = [
+    message({ id: 'msg-3', created_at: '2026-08-01T00:00:02.000Z' }),
+    message({ id: 'msg-1', created_at: '2026-08-01T00:00:01.000Z' }),
+    message({ id: 'msg-2', created_at: '2026-08-01T00:00:01.000Z' }),
+  ].sort(compareMessages);
+  assert.deepEqual(sorted.map(m => m.id), ['msg-1', 'msg-2', 'msg-3']);
+
+  console.log('场景 2：历史页前插时按 id 去重并保持老到新');
+  const mergedHistory = mergeMessagesById(
+    [
+      message({ id: 'msg-3', created_at: '2026-08-01T00:00:03.000Z', content: 'three' }),
+      message({ id: 'msg-4', created_at: '2026-08-01T00:00:04.000Z', content: 'four' }),
+    ],
+    [
+      message({ id: 'msg-1', created_at: '2026-08-01T00:00:01.000Z', content: 'one' }),
+      message({ id: 'msg-3', created_at: '2026-08-01T00:00:03.000Z', content: 'three updated' }),
+    ]
+  );
+  assert.deepEqual(mergedHistory.map(m => m.id), ['msg-1', 'msg-3', 'msg-4']);
+  assert.equal(mergedHistory.find(m => m.id === 'msg-3')?.content, 'three updated');
+
+  console.log('场景 3：since 重复返回同一服务端消息时只保留一份');
+  const mergedSince = mergeMessagesById(
+    [
+      message({ id: 'msg-1', created_at: '2026-08-01T00:00:01.000Z' }),
+      message({ id: 'msg-2', created_at: '2026-08-01T00:00:02.000Z' }),
+    ],
+    [
+      message({ id: 'msg-2', created_at: '2026-08-01T00:00:02.000Z', content: 'second reconcile' }),
+      message({ id: 'msg-3', created_at: '2026-08-01T00:00:03.000Z' }),
+    ]
+  );
+  assert.deepEqual(mergedSince.map(m => m.id), ['msg-1', 'msg-2', 'msg-3']);
+  assert.equal(mergedSince.filter(m => m.id === 'msg-2').length, 1);
+  assert.equal(mergedSince.find(m => m.id === 'msg-2')?.content, 'second reconcile');
+
+  console.log('场景 4：缺少 status 的服务端消息归一化为 completed');
+  const normalized = mergeMessagesById([], [
+    message({ id: 'msg-1', status: undefined }),
+  ]);
+  assert.equal(normalized[0]?.status, 'completed');
+};
+
+run();
+console.log('\nchat-message-merge tests passed');
+


### PR DESCRIPTION
## Summary

- 收敛聊天消息 store 的按服务端 id 幂等合并入口，并补充纯函数回归测试。
- 统一 SSE 数据库 reconcile 到 `chatStore.mergeMessages()`，减少历史查询、since 补偿、流式完成重复插入风险。
- 增加 ResizeObserver 粘底修正、工具上下文索引、Mermaid 可视区延迟渲染和内容 cache key 校验。
- 修正 Topic / Psyche / 历史压缩边界文档，明确 Psyche 是 minimal 策略下的历史消息压缩/工作记忆机制。

## Validation

- `node tests/chat-message-merge.test.js`
- `node tests/message-controller-query-json.test.js`
- `node tests/message-controller-since-cursor.test.js`
- `cd frontend && npm.cmd run type-check`
- `npm.cmd run lint`
- `cd frontend && npm.cmd run build`
- `git diff --check`

## Notes

- 前端生产构建已恢复稳定，`transforming...` 未再卡死。
- Vite 仍提示 `mermaid` / `echarts` / `export-report` 等大 chunk，已作为后续独立优化点记录。

Closes #1035
