### PR TITLE
fix: 压缩 legacy 检查降频与 notes 策略可见性残余收敛

### DIFF
--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -520,6 +520,9 @@ class ChatService {
       onDelta?.({ type: 'start', request_id, message_id: `msg_${Utils.newID(10)}`, topic_id, is_new_topic: isNewTopic });
 
       // 5. 保存用户消息（request 级重试时复用已有 user message）
+      // 已知残余风险（低概率）：绑定发生在压缩锁之外。若并发回合正在执行 active topic 分裂，
+      // 本消息可能绑到正被归档的旧 topic 且不在其 carryMessageIds 内，从而落入 archived topic。
+      // getRecentMessages 跨 topic 取数保证上下文不受损，仅 recall topic/messages 统计暂时漏记。
       let userMessageId = existing_user_message_id;
       if (!skip_user_message_persist) {
         userMessageId = await this.saveUserMessageAndBindRequest(topic_id, user_id, content, expert_id, task_id, request_id);

--- a/lib/memory-system.js
+++ b/lib/memory-system.js
@@ -76,6 +76,10 @@ class MemorySystem {
     // WP-5: 总结调用计数
     this._summarizationCallCount = 0;
     this._compressionLocks = new Map();
+    // P18: legacy 通道低频闸门。现代路径下 legacy 消息通常为空，
+    // 上次检查低于 minMessages 时在间隔内跳过重复的 1000 条扫描，避免每轮固定 DB 开销。
+    this._legacyCheckState = new Map();
+    this._legacyCheckIntervalMs = options.legacyCheckIntervalMs ?? 60000;
   }
 
   /**
@@ -751,18 +755,39 @@ class MemorySystem {
         }));
       }
 
-      if (!activeCheck.needCompress || options.scope === 'both' || options.scope === 'legacy') {
-        results.push(await this._compressLegacyContext(userId, {
+      const legacyRequested = !activeCheck.needCompress || options.scope === 'both' || options.scope === 'legacy';
+      const legacyForce = force && !activeTopicId;
+      if (legacyRequested && this._shouldRunLegacyCheck(userId, legacyForce)) {
+        const legacyResult = await this._compressLegacyContext(userId, {
           contextSize,
           threshold,
           minMessages,
           maxMessages,
-          force: force && !activeTopicId,
-        }));
+          force: legacyForce,
+        });
+        this._recordLegacyCheckResult(userId, legacyResult);
+        results.push(legacyResult);
       }
 
       return this._combineCompressionResults(results);
     });
+  }
+
+  /**
+   * P18: legacy 通道低频闸门。上次检查结果低于 minMessages（现代路径的常态）时，
+   * 间隔期内跳过重查；legacy 消息真实存在并累积（belowMin=false）时保持每轮检查，
+   * 避免延迟清理。force 压缩不受闸门限制。
+   */
+  _shouldRunLegacyCheck(userId, force = false) {
+    if (force) return true;
+    const state = this._legacyCheckState.get(`${this.expertId}:${userId}`);
+    if (!state || !state.belowMin) return true;
+    return Date.now() - state.lastCheck >= this._legacyCheckIntervalMs;
+  }
+
+  _recordLegacyCheckResult(userId, result) {
+    const belowMin = result?.success === false && result?.reason === '消息不足';
+    this._legacyCheckState.set(`${this.expertId}:${userId}`, { lastCheck: Date.now(), belowMin });
   }
 
   async _compressLegacyContext(userId, options = {}) {

--- a/server/controllers/internal.controller.js
+++ b/server/controllers/internal.controller.js
@@ -174,8 +174,13 @@ class InternalController {
       // 获取模型配置
       const modelConfig = expertService.getDefaultModelConfig();
 
-      // 获取工具定义（包含 MCP 工具）
-      const toolContext = { user_id, expert_id };
+      // 获取工具定义（包含 MCP 工具）；携带策略信息以保证 notes.* 等策略门控工具可见性正确
+      const toolContext = {
+        user_id,
+        expert_id,
+        context_strategy: expertService.expertConfig?.expert?.context_strategy || 'full',
+        enable_notes: expertService.expertConfig?.psyche?.enable_notes !== false,
+      };
       const tools = await expertService.toolManager.getToolDefinitions(toolContext);
 
       logger.info(`[Internal API] 开始生成专家回复: model=${modelConfig.model_name}, tools=${tools.length}`);

--- a/server/tests/round01-context-foundations.test.js
+++ b/server/tests/round01-context-foundations.test.js
@@ -170,4 +170,31 @@ describe('round01 context compression foundations', () => {
     expect(calls.filter(call => call[0] === 'updateTopicMessageCount')).to.have.length(2);
     expect(calls.some(call => call[0] === 'commit')).to.equal(true);
   });
+
+  it('MemorySystem throttles legacy check after below-min result but not force', async () => {
+    let legacyQueries = 0;
+    const db = {
+      getUnarchivedMessages: async () => {
+        legacyQueries++;
+        return [];
+      },
+    };
+    const memorySystem = new MemorySystem(db, 'expert_1', {}, { legacyCheckIntervalMs: 60000 });
+
+    const first = await memorySystem.compressContext('user_1', { minMessages: 5 });
+    const second = await memorySystem.compressContext('user_1', { minMessages: 5 });
+
+    expect(first.success).to.equal(false);
+    expect(second.success).to.equal(false);
+    expect(legacyQueries).to.equal(1);
+
+    // force 压缩不受闸门限制
+    await memorySystem.compressContext('user_1', { minMessages: 5, force: true });
+    expect(legacyQueries).to.equal(2);
+
+    // 间隔期过后恢复检查
+    memorySystem._legacyCheckState.get('expert_1:user_1').lastCheck = Date.now() - 120000;
+    await memorySystem.compressContext('user_1', { minMessages: 5 });
+    expect(legacyQueries).to.equal(3);
+  });
 });


### PR DESCRIPTION
## 背景

#1037（上下文压缩与 recall 治理）合并后的残余项核查（round06 residual check）发现 5 个低危残余，本 PR 收敛其中需要代码处置的 3 项；另外 2 项（存量 notes 处置结论、deprecated 方法清理）以文档结论/延期决策关闭，不涉及代码。

## 变更内容

### 1. legacy 压缩检查降频（P18 收尾）

`MemorySystem.compressContext()` 在 active 通道未触发时，此前**每轮对话**都会执行 `_compressLegacyContext` → `getUnarchivedMessages(userId, 1000)`，现代路径（消息实时绑定 active Topic）下该查询恒返回空，属于每轮固定的无效 DB 开销。

- 新增 legacy 通道低频闸门：上次检查低于 `minMessages` 时，间隔期（默认 60s，`legacyCheckIntervalMs` 可配）内跳过扫描；
- legacy 消息真实累积（belowMin=false）时保持每轮检查，不延迟清理；
- `force` 压缩（反思强制触发）不受闸门限制；
- full / simple / minimal 三种上下文策略同时受益。

### 2. Internal API 工具定义补策略参数

`internal.controller.js` 获取工具定义时 `toolContext` 未携带 `context_strategy` / `enable_notes`，导致 minimal 策略专家走 Internal API 时 notes.* 工具被门控默认值（full）错误隐藏。按 `expert-child-scoped-tools.js` 的既有口径补传。

### 3. 分裂竞态已知风险显式化

`chat-service.js` 消息绑定处补注释：绑定发生在压缩锁之外，并发回合在 active topic 分裂事务进行中保存消息时，消息可能绑到正被归档的旧 topic（低概率；`getRecentMessages` 跨 topic 取数保证上下文不受损，仅 recall topic/messages 统计暂时漏记）。经评估不加锁：每消息一次额外状态查询的成本不抵低概率收益。

## 测试

- 新增回归用例 `throttles legacy check after below-min result but not force`（首查执行 → 闸内跳过 → force 直通 → 间隔后恢复）；
- 聚焦套件 28 passing：`round01-context-foundations` / `notes-governance` / `recall-postcheck` / `recall-optimization` / `context-budget`；
- `npm run lint` 通过；`git diff --check` 通过。

## 影响面

- 不改数据库字段、不改 API 契约、不改 SSE 协议；
- legacy 降频只减少查询频次，不改变压缩触发语义（force 与 legacy 消息真实累积场景行为不变）。
