### PR TITLE
fix: 收口 contract-mgr-v2 / invoice-mgr / 文档对比 / outline / mini-app 本地修复

### DIFF
--- a/apps/contract-mgr-v2/manifest.json
+++ b/apps/contract-mgr-v2/manifest.json
@@ -234,10 +234,10 @@
         "type": "mcp",
         "mcp": {
           "server": "markitdown",
-          "tool": "submit_conversion_task",
+          "tool": "create_task",
           "params_mapping": {
-            "content": "file.base64",
-            "filename": "file.name"
+            "file_base64": "file.base64",
+            "file_name": "file.name"
           }
         }
       },
@@ -245,7 +245,7 @@
         "type": "mcp",
         "mcp": {
           "server": "markitdown",
-          "tool": "get_task",
+          "tool": "get_task_status",
           "hide_params_mapping": true
         },
         "judge_model_id": null,

--- a/apps/contract-mgr-v2/server/handlers/contracts.js
+++ b/apps/contract-mgr-v2/server/handlers/contracts.js
@@ -43,7 +43,7 @@ export async function post(ctx, deps) {
     }
 
     const service = new ContractV2Service(deps.db);
-    const contract = await service.createContract(ctx.request.body);
+    const contract = await service.createContract(ctx.request.body, ctx.state.session.id);
     ctx.success(contract);
   } catch (err) {
     logger.error(`[contract-mgr-v2] createContract error: ${err.message}`);

--- a/apps/contract-mgr-v2/server/handlers/contracts/versions/from-attachment.js
+++ b/apps/contract-mgr-v2/server/handlers/contracts/versions/from-attachment.js
@@ -1,4 +1,4 @@
-import ContractV2Service from '../../../../services/contract-v2.service.js';
+import ContractV2Service from '../../../services/contract-v2.service.js';
 
 // Handler 元数据：声明具名参数路径
 export const route = {

--- a/apps/contract-mgr-v2/server/handlers/shared.js
+++ b/apps/contract-mgr-v2/server/handlers/shared.js
@@ -1,0 +1,107 @@
+import logger from '../../../../lib/logger.js';
+
+export function splitIntoChunks(text, maxChars) {
+  if (!text || text.length <= maxChars) return text ? [text] : [];
+
+  const paragraphs = text.split('\n\n');
+  const chunks = [];
+  let current = '';
+
+  for (const para of paragraphs) {
+    if (current.length + para.length + 2 <= maxChars) {
+      current += (current ? '\n\n' : '') + para;
+    } else {
+      if (current) chunks.push(current);
+      if (para.length > maxChars) {
+        const lines = para.split('\n');
+        let lineChunk = '';
+        for (const line of lines) {
+          if (lineChunk.length + line.length + 1 <= maxChars) {
+            lineChunk += (lineChunk ? '\n' : '') + line;
+          } else {
+            if (lineChunk) chunks.push(lineChunk);
+            lineChunk = line;
+          }
+        }
+        current = lineChunk;
+      } else {
+        current = para;
+      }
+    }
+  }
+  if (current) chunks.push(current);
+
+  return chunks.length > 0 ? chunks : [text];
+}
+
+export function parseLlmResponse(response) {
+  const resultText = response.text || response.parsed || response;
+  if (typeof resultText === 'string') {
+    let text = resultText.trim();
+    if (text.startsWith('```')) {
+      text = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+    }
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+    return JSON.parse(jsonMatch[0]);
+  }
+  if (typeof resultText === 'object') return resultText;
+  return null;
+}
+
+export function extractKeyParts(text) {
+  const lines = text.split('\n');
+  const totalLines = lines.length;
+
+  const headEnd = Math.min(Math.floor(totalLines * 0.15), 200);
+  const head = lines.slice(0, headEnd).join('\n');
+
+  const tailStart = Math.max(totalLines - Math.min(Math.floor(totalLines * 0.1), 100), headEnd);
+  const tail = lines.slice(tailStart).join('\n');
+
+  const amountKeywords = ['金额', '总额', '合同金额', '价格', '价款', '人民币', 'RMB', '¥', '元'];
+  const amountLines = [];
+  for (let i = 0; i < totalLines; i++) {
+    if (amountKeywords.some(k => lines[i].includes(k))) {
+      const start = Math.max(0, i - 2);
+      const end = Math.min(totalLines, i + 3);
+      amountLines.push(...lines.slice(start, end));
+    }
+  }
+  const amountPart = [...new Set(amountLines)].join('\n');
+
+  return { head, tail, amountPart };
+}
+
+export function getAppConfig(app) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config || {};
+}
+
+export function getStepResource(app, stateName, fallback = {}) {
+  const config = getAppConfig(app);
+  return config?.step_resources?.[stateName] || fallback;
+}
+
+export function getPrompt(app, promptKey, fallback = null) {
+  const config = getAppConfig(app);
+  return config?.prompts?.[promptKey] || fallback;
+}
+
+export function buildLlmParams(stepConfig) {
+  return {
+    modelId: stepConfig.model_id || null,
+    temperature: stepConfig.temperature ?? 0.3,
+  };
+}
+
+export async function callLlmJson(services, systemPrompt, userPrompt, stepConfig = {}) {
+  return await services.llm.extractJson(systemPrompt, userPrompt, {
+    modelId: stepConfig.model_id || null,
+    temperature: stepConfig.temperature ?? 0.3,
+    defaultValue: null,
+  });
+}

--- a/apps/contract-mgr-v2/server/services/contract-v2.service.js
+++ b/apps/contract-mgr-v2/server/services/contract-v2.service.js
@@ -466,9 +466,15 @@ class ContractV2Service {
       return collection;
     }
 
-    const departmentId = await this.getUserDepartmentId(userId);
+    let departmentId = await this.getUserDepartmentId(userId);
     if (!departmentId) {
-      throw new Error('当前用户缺少 department_id，无法创建私有文档集合');
+      // 系统管理员允许无部门创建私有集合（department_id 无外键约束）
+      // 产品逻辑：管理员拥有全部权限，不应被组织数据配置卡住
+      const { isSystemAdmin } = await import('../../../../lib/permission-utils.js');
+      if (!(await isSystemAdmin(this.db, userId))) {
+        throw new Error('当前用户缺少 department_id，无法创建私有文档集合');
+      }
+      departmentId = 'sysadmin';
     }
 
     // 自动创建私有 collection，严格按照 document_collection 模型字段
@@ -1310,7 +1316,7 @@ ${fullText.substring(0, 8000)}`;
     });
 
     // 异步执行比对
-    const DocController = (await import('../../lib/doc-compare-executor.js')).default;
+    const DocController = (await import('../../../../lib/doc-compare-executor.js')).default;
     const executor = new DocController(this.db);
     setImmediate(() => executor.execute(runId));
 

--- a/apps/contract-mgr-v2/tick/index.js
+++ b/apps/contract-mgr-v2/tick/index.js
@@ -1,6 +1,6 @@
 import logger from '../../../lib/logger.js';
 import path from 'path';
-import { splitIntoChunks, getStepResource, getPrompt, callLlmJson } from '../handlers/shared.js';
+import { splitIntoChunks, getStepResource, getPrompt, callLlmJson } from '../server/handlers/shared.js';
 
 const MAX_LOG_STRING_LENGTH = parseInt(process.env.CONTRACT_MGR_V2_LOG_MAX_LENGTH || '1000', 10);
 const MAX_EXTRACT_TEXT_LENGTH = parseInt(process.env.CONTRACT_MGR_V2_EXTRACT_TEXT_MAX_LENGTH || '200000', 10);
@@ -63,6 +63,16 @@ function stringifyForLog(value, maxLength = MAX_LOG_STRING_LENGTH) {
     return truncateString(JSON.stringify(summarizeForLog(value)), maxLength);
   } catch (error) {
     return `[unserializable: ${error.message}]`;
+  }
+}
+
+function safeParseJson(value) {
+  if (!value) return null;
+  if (typeof value === 'object') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
   }
 }
 
@@ -320,7 +330,50 @@ ${taskInfo}
     if (!parsed.status) parsed.status = 'pending';
     
     if (parsed.status === 'completed') {
-      let ocrText = extractTextFromMcpResult(mcpResult);
+      // OCR 任务完成后，通过交付物协议获取真实文本：
+      // 1. list_deliverables 列出产物（primary markdown）
+      // 2. download_deliverable 下载并提取 content 文本
+      // 说明：get_task_status 只返回状态 JSON，不包含解析文本。
+      let ocrText = '';
+      try {
+        // OCR 交付物协议：list_deliverables -> download_deliverable
+        // 响应可能多层包装：{result:{content:"<json>"}} / {content:"<json>"} / 直接字符串
+        const unwrapContent = (input) => {
+          let cur = input;
+          for (let i = 0; i < 3 && cur && typeof cur === 'object'; i++) {
+            if (cur.result && typeof cur.result === 'object') { cur = cur.result; continue; }
+            if (typeof cur.content === 'string') {
+              const parsed = safeParseJson(cur.content);
+              if (parsed && typeof parsed === 'object') cur = parsed;
+            }
+            break;
+          }
+          return cur;
+        };
+
+        const deliverables = await services.callMcp(mcp.server, 'list_deliverables', { task_id: taskId });
+        const deliverablesObj = unwrapContent(deliverables);
+        const artifacts = (deliverablesObj && (deliverablesObj.artifacts || deliverablesObj.result?.artifacts)) || [];
+        const primary =
+          artifacts.find(a => a.is_default) ||
+          artifacts.find(a => a.artifact_type === 'markdown') ||
+          artifacts.find(a => a.role === 'primary') ||
+          artifacts[0];
+        if (primary?.download_key) {
+          const dl = await services.callMcp(mcp.server, 'download_deliverable', {
+            task_id: taskId,
+            download_key: primary.download_key,
+            include_content: true,
+          });
+          const dlObj = unwrapContent(dl);
+          ocrText = (dlObj && (dlObj.content || dlObj.text)) || extractTextFromMcpResult(dl);
+        } else {
+          logger.warn(`[tick] No downloadable deliverable for ${row.row_id}`);
+        }
+      } catch (dlErr) {
+        logger.warn(`[tick] OCR deliverable download failed for ${row.row_id}: ${dlErr.message}, falling back to status text`);
+      }
+      if (!ocrText) ocrText = extractTextFromMcpResult(mcpResult);
       ocrText = ocrText.replace(/\\n/g, '\n');
       
       await services.execute(`

--- a/apps/invoice-mgr/server/handlers/shared.js
+++ b/apps/invoice-mgr/server/handlers/shared.js
@@ -1,0 +1,52 @@
+import path from 'path';
+
+const ATTACHMENT_BASE_PATH = process.env.ATTACHMENT_BASE_PATH
+  || path.join(process.cwd(), 'data', 'attachments');
+
+export function resolveAttachmentPath(attachment) {
+  if (!attachment || !attachment.file_path) return null;
+
+  const basePath = path.resolve(path.normalize(ATTACHMENT_BASE_PATH));
+  let resolved;
+
+  if (path.isAbsolute(attachment.file_path)) {
+    resolved = path.resolve(path.normalize(attachment.file_path));
+  } else {
+    resolved = path.resolve(basePath, path.normalize(attachment.file_path));
+  }
+
+  const rel = path.relative(basePath, resolved);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+    return null;
+  }
+
+  return resolved;
+}
+
+export function getAppConfig(app) {
+  let config = app?.config;
+  if (typeof config === 'string') {
+    try { config = JSON.parse(config); } catch { config = {}; }
+  }
+  return config || {};
+}
+
+export function getStepResource(app, stateName, fallback = {}) {
+  const config = getAppConfig(app);
+  return config?.step_resources?.[stateName] || fallback;
+}
+
+export function parseLlmResponse(response) {
+  const resultText = response?.text || response?.parsed || response;
+  if (typeof resultText === 'string') {
+    let text = resultText.trim();
+    if (text.startsWith('```')) {
+      text = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+    }
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+    try { return JSON.parse(jsonMatch[0]); } catch { return null; }
+  }
+  if (typeof resultText === 'object') return resultText;
+  return null;
+}

--- a/apps/invoice-mgr/tick/index.js
+++ b/apps/invoice-mgr/tick/index.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import { pathToFileURL } from 'url';
 import logger from '../../../lib/logger.js';
-import { resolveAttachmentPath } from '../handlers/shared.js';
+import { resolveAttachmentPath } from '../server/handlers/shared.js';
 
 const APP_ID = 'invoice-mgr';
 const HANDLERS_DIR = path.join(process.cwd(), 'apps', APP_ID, 'handlers');

--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -27,6 +27,7 @@ services:
       - DATA_BASE_PATH=/app/data
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - APP_MARKET_PRESERVE_DIR=true
+      - ENABLE_CLOCK_CORE=1
     volumes:
       - ./:/app
       - node_modules:/app/node_modules

--- a/lib/doc-compare-executor.js
+++ b/lib/doc-compare-executor.js
@@ -75,7 +75,7 @@ class DocCompareExecutor {
 
       await run.update({
         status: 'completed',
-        summary_json: summary,
+        summary_json: JSON.stringify(summary),
         duration_ms: Date.now() - startTime,
       });
 
@@ -84,7 +84,7 @@ class DocCompareExecutor {
       logger.error(`[CompareExecutor] Run ${runId} failed:`, error);
       await run.update({
         status: 'failed',
-        summary_json: { error: error.message },
+        summary_json: JSON.stringify({ error: error.message }),
         duration_ms: Date.now() - startTime,
       });
     }

--- a/lib/document-outline-service.js
+++ b/lib/document-outline-service.js
@@ -460,7 +460,16 @@ class DocumentOutlineService {
     }
 
     if (outlines.length === 0 && text.length > 100) {
-      throw new Error('Outline extraction returned empty result for non-empty document');
+      // 降级策略：LLM 未提取出章节时，使用单条目兜底（整篇文档作为一个 outline），
+      // 保证后续管线（chunk 生成、版本对比）可继续，而非阻断整个文档处理
+      logger.warn(`[DocumentOutlineService] Revision ${revisionId}: empty outline, falling back to single-entry outline (全文)`);
+      outlines = [{
+        title: '全文',
+        description: '整篇文档（outline 提取降级）',
+        seq: 0,
+        from_line: 1,
+        to_line: totalLines,
+      }];
     }
 
     if (extractionMeta.failedChunks > 0) {

--- a/lib/internal-llm-service.js
+++ b/lib/internal-llm-service.js
@@ -80,7 +80,11 @@ class InternalLLMService {
     } else if (images && images.length > 0) {
       model = await modelRegistry.getDefaultVLModel();
     } else {
-      throw new Error('Either expertId, modelId, or images must be provided');
+      // 兜底：使用系统默认文本模型，避免未显式配置模型的调用直接失败
+      model = await modelRegistry.getDefaultTextModelConfig();
+      if (!model) {
+        throw new Error('Either expertId, modelId, or images must be provided');
+      }
     }
 
     let userContent;

--- a/server/services/mini-app.service.js
+++ b/server/services/mini-app.service.js
@@ -1176,6 +1176,20 @@ ${JSON.stringify(listB, null, 2)}
     return null;
   }
 
+  async getAppInitialState(appId) {
+    // autonomous app 的初始状态取自 manifest step_resources 的首个 key
+    // （安装时将 states 展开为 step_resources，顺序即状态机流转顺序）
+    try {
+      const app = await this.models.MiniApp.findByPk(appId);
+      const config = typeof app?.config === 'string' ? JSON.parse(app.config) : (app?.config || {});
+      const resources = config.step_resources || {};
+      const keys = Object.keys(resources);
+      return keys[0] || 'pending';
+    } catch {
+      return 'pending';
+    }
+  }
+
   async getAutonomousPrimaryConfig(appId) {
     const extConfigs = await this.extensionService.getExtensionConfigs(appId);
     return extConfigs?.find(c => c.type === 'primary') || null;


### PR DESCRIPTION
统一收口本地 `master` 上累积的跨模块修复与兼容性调整。

主要包含：
- contract-mgr-v2 的 markitdown MCP 协议对齐、import 路径修复、session 透传、管理员 department 兜底、OCR deliverable 下载协议。
- invoice-mgr 的 import 路径修复与 shared helper 迁移。
- `lib/doc-compare-executor.js`、`lib/document-outline-service.js`、`lib/internal-llm-service.js` 的序列化、降级与兜底策略。
- `mini-app.service.js` 新增 `getAppInitialState()`。
- NAS docker-compose 启用 `ENABLE_CLOCK_CORE=1`。

Closes #1043
