### PR TITLE
fix: 修复 current-feature-analyzer 前端 echarts/exceljs 模块解析失败

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -12,7 +12,9 @@
       "vue": ["./node_modules/vue"],
       "pinia": ["./node_modules/pinia"],
       "element-plus": ["./node_modules/element-plus"],
-      "@element-plus/icons-vue": ["./node_modules/@element-plus/icons-vue"]
+      "@element-plus/icons-vue": ["./node_modules/@element-plus/icons-vue"],
+      "echarts/*": ["./node_modules/echarts/*"],
+      "exceljs": ["./node_modules/exceljs"]
     }
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,9 +28,11 @@ export default defineConfig(({ command }) => ({
       'vue': fileURLToPath(new URL('./node_modules/vue', import.meta.url)),
       'pinia': fileURLToPath(new URL('./node_modules/pinia', import.meta.url)),
       'element-plus': fileURLToPath(new URL('./node_modules/element-plus', import.meta.url)),
-      '@element-plus/icons-vue': fileURLToPath(new URL('./node_modules/@element-plus/icons-vue', import.meta.url))
+      '@element-plus/icons-vue': fileURLToPath(new URL('./node_modules/@element-plus/icons-vue', import.meta.url)),
+      'echarts': fileURLToPath(new URL('./node_modules/echarts', import.meta.url)),
+      'exceljs': fileURLToPath(new URL('./node_modules/exceljs', import.meta.url))
     },
-    dedupe: ['vue', 'pinia', 'element-plus', '@element-plus/icons-vue'],
+    dedupe: ['vue', 'pinia', 'element-plus', '@element-plus/icons-vue', 'echarts', 'exceljs'],
   },
   server: {
     host: true,  // 监听所有网络接口（包括 localhost 和 127.0.0.1）


### PR DESCRIPTION
修复 `apps/current-feature-analyzer/frontend/` 下组件在 `npm run build` 阶段无法解析 `echarts/*` 和 `exceljs` 的问题。

改动：
- `frontend/tsconfig.app.json` 补充 `echarts/*` 与 `exceljs` 的 `compilerOptions.paths` 映射。
- `frontend/vite.config.ts` 补充 `echarts` 与 `exceljs` 的 `resolve.alias` 和 `dedupe`。

验证：
- `cd frontend && npm run build` 已通过。

Closes #1045
