### PR TITLE
docs: 修正 createStandard 版本唯一性校验注释

### DIFF
--- a/apps/standard-mgr/server/service.js
+++ b/apps/standard-mgr/server/service.js
@@ -2132,7 +2132,8 @@ class StandardMgrService {
 
     // ---- 2. 校验 document_id / revision 唯一性 ----
     // R17-3（一文档多版本）：允许同一 document_id 纳管多个版本（revision_id 不同）。
-    // 仅拒绝「同 document_id + 同 revision_id」的完全重复纳管。
+    // 每次纳管必须明确指定 revision_id；若未指定且该文档已有任意标准记录，则拒绝，
+    // 防止在不确定版本的情况下重复纳管。仅拒绝「同 document_id + 同 revision_id」的完全重复纳管。
     const AppStandard = this._appStandard();
     const existing = await AppStandard.findOne({
       where: { document_id },


### PR DESCRIPTION
修正 `apps/standard-mgr/server/service.js` 中 `createStandard` 关于版本唯一性校验的注释，使其与代码实际逻辑和 UI 行为一致。

## 背景

原注释：

```js
// R17-3（一文档多版本）：允许同一 document_id 纳管多个版本（revision_id 不同）。
// 仅拒绝「同 document_id + 同 revision_id」的完全重复纳管。
```

这段注释容易让人误解为：只要 `revision_id` 不同就可以随便纳管，甚至不传 `revision_id` 也能自动处理。

但实际上：

1. UI 上用户必须明确选择一个版本（`revision_id`）。
2. 后端代码在未传 `revision_id` 且该文档已有任意标准记录时，会返回 409。
3. 这是为了防止在版本不确定的情况下重复纳管。

## 修改后

```js
// R17-3（一文档多版本）：允许同一 document_id 纳管多个版本（revision_id 不同）。
// 每次纳管必须明确指定 revision_id；若未指定且该文档已有任意标准记录，则拒绝，
// 防止在不确定版本的情况下重复纳管。仅拒绝「同 document_id + 同 revision_id」的完全重复纳管。
```

仅注释改动，无代码逻辑变更。
