### PR TITLE
fix: 文档平台审计 P0 修复（越权读、内部API身份、intake收敛、前端契约）

### DIFF
--- a/frontend/src/api/collections.ts
+++ b/frontend/src/api/collections.ts
@@ -48,17 +48,8 @@ export interface CollectionDocumentItem {
   ocr_status: string | null
   has_preview_result: boolean
   import_source?: string | null
-  source_system?: string
-  source_ref_id?: string
-  owner_id?: string
-  department_id?: string
-  visibility?: string
-  collection_id?: string | null
-  current_version_id?: string | null
-  ocr_task_id?: string | null
-  processing_error_code?: string | null
-  lifecycle_status?: string
-  metadata?: Record<string, unknown>
+  // 注意：仅声明后端 listCollectionDocuments 实际返回的字段；
+  // 文档层不存在 owner_id/visibility/metadata 等（task-20260814 审计 P0-4.1）
   [key: string]: unknown
 }
 

--- a/frontend/src/api/docs.ts
+++ b/frontend/src/api/docs.ts
@@ -49,32 +49,44 @@ export function getDocProcessingStatusTagType(status?: string | null): 'success'
 export interface DocDocument {
   id: string
   doc_type: 'knowledge' | 'contract' | 'department_doc' | 'standard'
-  source_system: string
-  source_ref_id: string
+  source_system: string | null
+  source_ref_id: string | null
   title: string
-  owner_id: string
-  department_id: string
-  visibility: 'private' | 'department' | 'public'
   collection_id: string | null
-  current_version_id: string | null
   current_revision_id: string | null
-  ocr_task_id?: string | null
   processing_status: DocProcessingStage | null
   processing_error_code: string | null
-  lifecycle_status: string
-  metadata: Record<string, unknown>
-  classification_json?: Array<{
-    document_id: string
-    title: string
-    confidence: number
-    reasons: string[]
-  }>
+  processing_error_message: string | null
+  processing_retry_count: number | null
+  processing_updated_at: string | null
+  current_stage_started_at: string | null
+  // 注意：后端 metadata 列为 TEXT，序列化后为 JSON 字符串，不是对象（task-20260814 审计 P0-4.1）
+  metadata: string | null
   created_at: string
   updated_at: string
+  // 列表接口增强字段（listDocuments / listCollectionDocuments 返回）
+  current_revision?: {
+    id: string
+    revision_no: number
+    revision_label: string | null
+  } | null
+  source_attachment?: {
+    id: string
+    file_name: string | null
+    mime_type: string
+    file_size: number
+    created_at: string
+  } | null
+  ocr_task_id?: string | null
+  ocr_status?: string | null
+  ocr_progress?: number | null
+  ocr_error_message?: string | null
+  has_preview_result?: boolean
 }
 
 export interface DocVersion {
   id: string
+  document_id?: string
   revision_no: number
   revision_label: string | null
   revision_status: DocRevisionStatus
@@ -150,7 +162,10 @@ export interface DocPermissions {
 
 export interface DocDiffStatus {
   revision_id: string
-  status: string
+  document_id: string
+  revision_no: number
+  diff_status: string | null
+  updated_at: string | null
 }
 
 export interface DocIntakeResult {
@@ -234,7 +249,6 @@ export interface DocResultDetail {
     error_code: string | null
     error_message: string | null
     import_source?: string | null
-    preview_markdown_content?: string | null
     // 新语义（推荐使用）
     preview_markdown_attachment: DocAttachmentInfo | null
     raw_markdown_attachment: DocAttachmentInfo | null
@@ -272,7 +286,7 @@ export interface SyncOcrResult {
 
 export interface DocChunk {
   id: string
-  version_id: string
+  revision_id: string
   outline_id: string | null
   title: string | null
   content: string | null

--- a/frontend/src/composables/useDocumentWorkspace.ts
+++ b/frontend/src/composables/useDocumentWorkspace.ts
@@ -27,8 +27,10 @@ export function useDocumentWorkspace(options: UseDocumentWorkspaceOptions) {
   const { currentResult, markdownPreview, processingErrorCode, processingErrorMessage, t } = options
 
   // Markdown 引用图片路径
+  // 注：后端不返回 preview_markdown_content（task-20260814 审计 P0-4.1 删除假字段），
+  // 图片路径解析只基于已加载的 markdownPreview 内容
   const markdownReferencedImagePaths = computed(() => {
-    const content = markdownPreview.value || currentResult.value?.ocr_result?.preview_markdown_content || ''
+    const content = markdownPreview.value || ''
     const pathSet = new Set<string>()
     if (!content) return pathSet
 

--- a/frontend/src/views/CollectionDetailView.vue
+++ b/frontend/src/views/CollectionDetailView.vue
@@ -517,12 +517,8 @@ async function onPreviewVersion(revisionId: string) {
 
 // 加载 Markdown 预览
 async function loadMarkdownPreview() {
-  const previewContent = docStore.currentResult?.ocr_result?.preview_markdown_content
-  if (previewContent) {
-    markdownPreview.value = previewContent
-    return
-  }
-
+  // 后端不返回 preview_markdown_content（task-20260814 审计 P0-4.1 删除假字段），
+  // 统一走附件内容接口获取预览 markdown
   const attachment = markdownAttachmentFromWorkspace.value
   if (!attachment?.id) {
     markdownPreview.value = ''

--- a/frontend/src/views/DocDetailView.vue
+++ b/frontend/src/views/DocDetailView.vue
@@ -217,12 +217,8 @@ async function onDeleteDocument() {
 }
 
 async function loadMarkdownPreview() {
-    const previewContent = docStore.currentResult?.ocr_result?.preview_markdown_content
-    if (previewContent) {
-      markdownPreview.value = previewContent
-      return
-    }
-
+    // 后端不返回 preview_markdown_content（task-20260814 审计 P0-4.1 删除假字段），
+    // 统一走附件内容接口获取预览 markdown
     const attachment = markdownAttachmentFromWorkspace.value
     if (!attachment?.id) {
       markdownPreview.value = ''

--- a/lib/collection-access-service.js
+++ b/lib/collection-access-service.js
@@ -66,10 +66,15 @@ class CollectionAccessService {
         department_scope: 'self_and_descendants',
         department_id: { [Op.in]: lineage },
       });
+      // self（含 scope 为空的存量数据，与 checkAccess() 的 `!collection.department_scope` 语义对齐）：
+      // 仅集合本部门可读。注意不能用 [Op.in]: ['self', null] —— SQL 的 IN (NULL) 不匹配 NULL。
       conditions.push({
         visibility: 'department',
-        department_scope: 'self',
         department_id: ownDeptId,
+        [Op.or]: [
+          { department_scope: 'self' },
+          { department_scope: null },
+        ],
       });
     }
 

--- a/lib/doc-access-service.js
+++ b/lib/doc-access-service.js
@@ -18,51 +18,33 @@
  * - document_retrieval tool: 文档检索 skill 的权限边界
  * - doc.controller: 文档列表/详情接口的权限控制
  */
-import logger from './logger.js';
 import { Op } from 'sequelize';
+import CollectionAccessService from './collection-access-service.js';
 
 class DocAccessService {
   constructor(db) {
     this.db = db;
+    // 权限语义单一实现：可见性判定统一委托 CollectionAccessService（集合层权威）。
+    // 历史实现自建部门可见性规则时遗漏 department_scope 判定，导致
+    // scope=self 的上游部门集合被下级部门用户越权读取（task-20260814 审计 P0-1.1）。
+    this.collectionAccessService = new CollectionAccessService(db);
   }
 
-  async getUserDepartmentLineage(userId) {
-    try {
-      const User = this.db.getModel('user');
-      const user = await User.findOne({
-        where: { id: userId },
-        attributes: ['department_id'],
-        raw: true,
-      });
-      if (!user?.department_id) return [];
-
-      const Department = this.db.getModel('department');
-      const dept = await Department.findOne({
-        where: { id: user.department_id },
-        attributes: ['id', 'path'],
-        raw: true,
-      });
-      if (!dept) return [user.department_id];
-
-      return dept.path.split('/').filter(Boolean);
-    } catch (error) {
-      logger.error('[DocAccess] getUserDepartmentLineage error:', error);
-      return [];
-    }
-  }
-
+  /**
+   * 获取用户可访问的集合 ID 列表
+   *
+   * 文档权限 = 所属集合权限。可见性规则唯一来源是
+   * CollectionAccessService.buildAccessibleCollectionsWhere()：
+   *   - owner（admin，任何 visibility）
+   *   - public
+   *   - department + department_scope='self'（仅集合本部门）
+   *   - department + department_scope='self_and_descendants'（集合部门及其下级）
+   */
   async getAccessibleCollectionIds(userId) {
-    const lineage = await this.getUserDepartmentLineage(userId);
-    const ownDeptId = lineage.length > 0 ? lineage[lineage.length - 1] : null;
-
+    const where = await this.collectionAccessService.buildAccessibleCollectionsWhere(userId);
     const DocCollection = this.db.getModel('document_collection');
-    const conditions = [{ owner_id: userId }, { visibility: 'public' }];
-    if (ownDeptId && lineage.length > 0) {
-      conditions.push({ visibility: 'department', department_id: { [Op.in]: lineage } });
-    }
-
     const collections = await DocCollection.findAll({
-      where: { [Op.or]: conditions },
+      where,
       attributes: ['id'],
       raw: true,
     });

--- a/server/controllers/doc.controller.js
+++ b/server/controllers/doc.controller.js
@@ -1982,108 +1982,42 @@ async createVersion(ctx) {
   async createIntake(ctx) {
     try {
       this.ensureModels();
+      this.ensureIntakeService();
+      this.ensureCollectionAccessService();
       const userId = ctx.state.session.id;
       const { app_id, collection_id, schema_id, attachments } = ctx.request.body;
 
+      // 参数契约快速失败（400），避免落入 service 的 500 路径
       if (!app_id) ctx.throw(400, 'app_id is required');
       if (!collection_id) ctx.throw(400, 'collection_id is required');
 
-      const DocumentCollection = this.db.getModel('document_collection');
-      const collection = await DocumentCollection.findByPk(collection_id);
-      if (!collection) ctx.throw(404, 'Collection not found');
-
-      const collectionAccess = new CollectionAccessService(this.db);
-      const canWrite = await collectionAccess.canWrite(collection_id, userId);
-      if (!canWrite) ctx.throw(403, 'Only the collection owner can create intake documents');
-
       const attachmentList = Array.isArray(attachments) ? attachments : [];
-      const attachmentIds = attachmentList.map(item => item?.id).filter(Boolean);
-      const uniqueAttachmentIds = [...new Set(attachmentIds)];
-      if (attachmentList.length > 0 && attachmentIds.length !== attachmentList.length) {
+      if (attachmentList.length > 0 && attachmentList.some(item => !item?.id)) {
         ctx.throw(400, 'attachments must contain valid attachment ids');
       }
 
-      if (uniqueAttachmentIds.length > 0) {
-        const Attachment = this.db.getModel('attachment');
-        const attachmentRows = await Attachment.findAll({
-          where: { id: uniqueAttachmentIds },
-          attributes: ['id', 'created_by'],
-          raw: true,
-        });
+      // 权限/集合存在性/附件归属校验 + 事务创建统一委托 DocumentIntakeService（单一实现）。
+      // 历史实现：controller 内联复制创建逻辑且 revision_status 用 'draft'，
+      // 与 service 的 'effective'（两态语义约定）漂移（task-20260814 审计 P0-3.1）。
+      await this.intakeService.validateIntakeRequest({
+        appId: app_id,
+        collectionId: collection_id,
+        // 与历史 controller 行为等价：附件 ID 去重后再做存在性/归属校验
+        attachmentIds: [...new Set(attachmentList.map(item => item.id).filter(Boolean))],
+        userId,
+        collectionAccessService: this.collectionAccessService,
+      });
 
-        if (attachmentRows.length !== uniqueAttachmentIds.length) {
-          ctx.throw(404, 'One or more attachments not found');
-        }
-
-        const deniedAttachment = attachmentRows.find(item => item.created_by !== userId);
-        if (deniedAttachment) {
-          ctx.throw(403, 'Attachment access denied');
-        }
-      }
-
-      const sourceRefId = Utils.newID();
-      const firstAttachment = attachmentList.length > 0 ? attachmentList[0] : null;
-      const intakeMetadata = JSON.stringify({
-        app_id,
-        schema_id: schema_id || null,
+      const result = await this.intakeService.createIntakeDocument({
+        appId: app_id,
+        collectionId: collection_id,
+        schemaId: schema_id,
         attachments: attachmentList,
+        userId,
       });
 
-      const documentId = Utils.newID();
-      const revisionId = Utils.newID();
-      const document = await this.db.sequelize.transaction(async (t) => {
-        const createdDocument = await this.models.DocDocument.create({
-          id: documentId,
-          collection_id,
-          doc_type: app_id.startsWith('contract') ? 'contract' : 'knowledge',
-          source_system: app_id,
-          source_ref_id: sourceRefId,
-          title: firstAttachment ? `Intake ${sourceRefId}` : `Document ${sourceRefId}`,
-          processing_status: 'pending_ocr',
-            current_revision_id: null,
-          metadata: intakeMetadata,
-        }, { transaction: t });
-
-        await this.models.DocVersion.create({
-          id: revisionId,
-          document_id: documentId,
-          revision_no: 1,
-          revision_label: 'v1',
-          revision_status: 'draft',
-          is_current: 1,
-          change_summary: 'Initial intake revision',
-          created_by: userId,
-        }, { transaction: t });
-
-          await createdDocument.update({
-            current_revision_id: revisionId,
-          }, { transaction: t });
-
-        if (attachmentList.length > 0) {
-          const Attachment = this.db.getModel('attachment');
-          for (const item of attachmentList) {
-            if (!item?.id) continue;
-            await Attachment.update({
-              source_tag: 'doc-platform',
-              source_id: revisionId,
-            }, {
-              where: { id: item.id },
-              transaction: t,
-            });
-          }
-        }
-
-        return createdDocument;
-      });
-
-      ctx.success({
-        document_id: document.id,
-        revision_id: revisionId,
-        processing_status: document.processing_status,
-        source_ref_id: sourceRefId,
-        attachment_count: attachmentList.length,
-      });
-      logger.info(`[Doc] createIntake: ${document.id} for app ${app_id}, collection ${collection_id}`);
+      ctx.success(result);
+      logger.info(`[Doc] createIntake: ${result.document_id} for app ${app_id}, collection ${collection_id}`);
     } catch (error) {
       logger.error('[Doc] createIntake error:', error);
       ctx.throw(error.status || 500, error.message);

--- a/server/controllers/internal-docs.controller.js
+++ b/server/controllers/internal-docs.controller.js
@@ -1,9 +1,12 @@
 /**
  * Internal Docs Controller - 内部文档 API 控制器
  *
- * 用于驻留进程/技能调用文档能力
- *
- * API 设计（按审计报告 P27）：
+ * === 身份与认证契约（task-20260814 审计 P0-2.1 收口）===
+ * 所有 /internal/docs/* 路由在路由层强制 requireAuth（JWT 认证，见 server/routes/internal.routes.js），
+ * 到达本控制器的请求必定携带合法用户 session。因此：
+ *   - 身份来源唯一：ctx.state.session.id，禁止从 body 读取 user_id（可被调用方伪造）。
+ *   - 删除历史遗留的“本地 IP 免认证”分支（isLocal）：它是死代码（被路由层拦截），
+ *     且会误导未来新增内部路由时误以为可以绕过认证。
  * - POST /internal/docs/intakes - 文档接入
  * - GET /internal/docs/:document_id/processing - 查询处理状态
  * - POST /internal/docs/recall - 文档召回
@@ -58,9 +61,9 @@ class InternalDocsController {
   }
 
   validateInternalAccess(ctx) {
-    const ip = ctx.ip || ctx.request.ip || '';
-    const isLocal = ip === '127.0.0.1' || ip === '::1' || ip.startsWith('::ffff:127.0.0.1');
-    return isLocal || ctx.state.session;
+    // 身份来源唯一：必须携带合法用户 session。
+    // 路由层 requireAuth 已保证无 token 请求被 401 拦截（server/routes/internal.routes.js）。
+    return Boolean(ctx.state.session && ctx.state.session.id);
   }
 
   async createIntake(ctx) {
@@ -72,7 +75,8 @@ class InternalDocsController {
 
       this.ensureIntakeService();
       this.ensureCollectionAccessService();
-      const userId = ctx.state.session?.id || ctx.request.body?.user_id;
+      // 身份固定为 session 用户（禁止 body 伪造 user_id）
+      const userId = ctx.state.session.id;
       const { app_id, collection_id, schema_id, attachments } = ctx.request.body;
 
       const { collection } = await this.intakeService.validateIntakeRequest({
@@ -107,7 +111,8 @@ class InternalDocsController {
       }
 
       const { document_id } = ctx.params;
-      const userId = ctx.state.session?.id || ctx.request.body?.user_id;
+      // 身份固定为 session 用户（禁止 body 伪造 user_id）
+      const userId = ctx.state.session.id;
 
       this.ensureDocAccessService();
       const canRead = await this.docAccessService.canRead(document_id, userId);
@@ -142,7 +147,8 @@ class InternalDocsController {
       }
 
       this.ensureRecallService();
-      const userId = ctx.state.session?.id || ctx.request.body?.user_id;
+      // 身份固定为 session 用户（禁止 body 伪造 user_id）
+      const userId = ctx.state.session.id;
       const { query, scope, doc_types, top_k, threshold } = ctx.request.body;
 
       const items = await this.recallService.recall(query, {
@@ -169,7 +175,8 @@ class InternalDocsController {
       }
 
       const { document_id } = ctx.params;
-      const userId = ctx.state.session?.id || ctx.request.body?.user_id;
+      // 身份固定为 session 用户（禁止 body 伪造 user_id）
+      const userId = ctx.state.session.id;
 
       this.ensureDocAccessService();
       const canRead = await this.docAccessService.canRead(document_id, userId);

--- a/tests/doc-access-permission.test.js
+++ b/tests/doc-access-permission.test.js
@@ -1,0 +1,216 @@
+/**
+ * 文档访问权限语义矩阵测试（task-20260814 审计 P0-1.1）
+ *
+ * 覆盖修复点：DocAccessService.getAccessibleCollectionIds 原先自建部门可见性规则，
+ * 遗漏 department_scope 判定，导致 scope=self 的上游部门集合被下级部门用户越权读取。
+ * 修复后委托 CollectionAccessService.buildAccessibleCollectionsWhere，语义唯一。
+ *
+ * 测试目标：
+ *   1. 语义正确性：部门可见性矩阵（self / self_and_descendants / public / owner）
+ *   2. 一致性：DocAccessService 与 CollectionAccessService 对同一矩阵给出相同结果
+ *
+ * 运行：node tests/doc-access-permission.test.js
+ * 前置：临时 stub 位于 lib/node_modules/sequelize（测试后删除）
+ */
+
+import { Op } from '../lib/node_modules/sequelize/index.js';
+import DocAccessService from '../lib/doc-access-service.js';
+import CollectionAccessService from '../lib/collection-access-service.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, name, detail = '') {
+  if (cond) {
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } else {
+    console.error(`  ❌ ${name} ${detail}`);
+  }
+}
+
+// ============================================================
+// 迷你 Sequelize where 求值器（仅支持本测试矩阵用到的操作符）
+// ============================================================
+
+function isPlainObject(v) {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function evaluateWhere(where, record) {
+  if (where == null) return true;
+
+  // 本层级 Symbol 操作符（Op.or / Op.and），与普通字段条件同时生效（AND 关系）
+  for (const sym of Object.getOwnPropertySymbols(where)) {
+    if (sym === Op.or) {
+      if (!where[sym].some(b => evaluateWhere(b, record))) return false;
+    } else if (sym === Op.and) {
+      if (!where[sym].every(b => evaluateWhere(b, record))) return false;
+    } else {
+      throw new Error(`Unsupported top-level operator: ${String(sym)}`);
+    }
+  }
+
+  // 普通字段条件
+  for (const [field, value] of Object.entries(where)) {
+    const recordValue = record[field];
+    if (isPlainObject(value)) {
+      const inKey = Object.getOwnPropertySymbols(value).find(s => s === Op.in);
+      if (inKey) {
+        if (!(Array.isArray(value[inKey]) && value[inKey].includes(recordValue))) return false;
+        continue;
+      }
+      const eqKey = Object.getOwnPropertySymbols(value).find(s => s === Op.eq);
+      if (eqKey) {
+        if (recordValue !== value[eqKey]) return false;
+        continue;
+      }
+      const likeKey = Object.getOwnPropertySymbols(value).find(s => s === Op.like);
+      if (likeKey) {
+        const pattern = String(value[likeKey]);
+        const re = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/%/g, '.*')}$`);
+        if (!re.test(String(recordValue ?? ''))) return false;
+        continue;
+      }
+      throw new Error(`Unsupported operator in where: ${Object.getOwnPropertySymbols(value).map(String).join(',')}`);
+    }
+    if (recordValue !== value) return false;
+  }
+  return true;
+}
+
+// ============================================================
+// Mock DB
+// ============================================================
+
+function makeDb({ users, departments, collections }) {
+  const models = {
+    user: {
+      findOne: async ({ where }) => {
+        const key = where.id || where.id;
+        const user = users.find(u => u.id === key);
+        return user ? { ...user } : null;
+      },
+    },
+    department: {
+      findOne: async ({ where }) => {
+        const dept = departments.find(d => d.id === where.id);
+        return dept ? { ...dept } : null;
+      },
+    },
+    document_collection: {
+      findAll: async ({ where }) => {
+        return collections.filter(c => evaluateWhere(where, c)).map(c => ({ ...c }));
+      },
+      findOne: async ({ where }) => {
+        const found = collections.find(c => evaluateWhere(where, c));
+        return found ? { ...found } : null;
+      },
+    },
+    document: {
+      findOne: async () => null,
+      findAll: async () => [],
+    },
+  };
+  return {
+    getModel: (name) => models[name],
+    sequelize: {},
+  };
+}
+
+// ============================================================
+// 测试矩阵
+// ============================================================
+
+async function run() {
+  console.log('\n[P0-1.1] 部门可见性语义矩阵（用户部门 B，path=/A/B）\n');
+
+  const departments = [
+    { id: 'deptA', path: '/deptA' },
+    { id: 'deptB', path: '/deptA/deptB' },
+    { id: 'deptC', path: '/deptC' },
+  ];
+
+  const users = [
+    { id: 'u1', department_id: 'deptB' },   // B 部门用户（A 的下级）
+    { id: 'u2', department_id: null },       // 无部门用户
+    { id: 'u3', department_id: 'deptA' },    // A 部门用户
+  ];
+
+  // 集合矩阵
+  const collections = [
+    { id: 'c1', owner_id: 'u1', visibility: 'private', department_id: 'deptB', department_scope: null },      // u1 私有
+    { id: 'c2', owner_id: 'u99', visibility: 'public', department_id: null, department_scope: null },          // 公共
+    { id: 'c3', owner_id: 'u99', visibility: 'department', department_id: 'deptA', department_scope: 'self' }, // A 本部门私有（上级）
+    { id: 'c4', owner_id: 'u99', visibility: 'department', department_id: 'deptB', department_scope: 'self' }, // B 本部门私有（本部门）
+    { id: 'c5', owner_id: 'u99', visibility: 'department', department_id: 'deptA', department_scope: 'self_and_descendants' }, // A 及下级
+    { id: 'c6', owner_id: 'u99', visibility: 'department', department_id: 'deptC', department_scope: 'self_and_descendants' }, // C 及下级（无关）
+    { id: 'c7', owner_id: 'u99', visibility: 'department', department_id: 'deptB', department_scope: null },   // B 部门、scope 为空（按 self）
+    { id: 'c8', owner_id: 'u99', visibility: 'department', department_id: 'deptA', department_scope: null },   // A 部门、scope 为空（按 self）
+    { id: 'c9', owner_id: 'u2', visibility: 'private', department_id: null, department_scope: null },          // u2 私有
+  ];
+
+  const db = makeDb({ users, departments, collections });
+  const docAccess = new DocAccessService(db);
+  const collectionAccess = new CollectionAccessService(db);
+
+  // ---- u1（B 部门，A 的下级）----
+  const u1Expected = new Set(['c1', 'c2', 'c4', 'c5', 'c7']); // owner/公共/本部门self/上级self_and_descendants
+  const u1Doc = new Set(await docAccess.getAccessibleCollectionIds('u1'));
+  const u1CollWhere = await collectionAccess.buildAccessibleCollectionsWhere('u1');
+  const u1Coll = new Set(collections.filter(c => evaluateWhere(u1CollWhere, c)).map(c => c.id));
+
+  assert(
+    JSON.stringify([...u1Doc].sort()) === JSON.stringify([...u1Expected].sort()),
+    `u1 可访问集合 === 期望集 ${JSON.stringify([...u1Expected].sort())}`,
+    `实际: ${JSON.stringify([...u1Doc].sort())}`
+  );
+  assert(!u1Doc.has('c3'), 'u1 不能读 A 部门 scope=self 的集合 c3（越权修复点）');
+  assert(!u1Doc.has('c6'), 'u1 不能读无关部门 C 的集合 c6');
+  assert(!u1Doc.has('c8'), 'u1 不能读 A 部门 scope 为空的集合 c8（空 scope 按 self）');
+  assert(
+    JSON.stringify([...u1Doc].sort()) === JSON.stringify([...u1Coll].sort()),
+    'u1：DocAccessService 与 CollectionAccessService 结果一致',
+    `doc=${JSON.stringify([...u1Doc].sort())} coll=${JSON.stringify([...u1Coll].sort())}`
+  );
+
+  // ---- u2（无部门）----
+  const u2Expected = new Set(['c2', 'c9']); // 只能看 public + 自己的私有集合
+  const u2Doc = new Set(await docAccess.getAccessibleCollectionIds('u2'));
+  const u2CollWhere = await collectionAccess.buildAccessibleCollectionsWhere('u2');
+  const u2Coll = new Set(collections.filter(c => evaluateWhere(u2CollWhere, c)).map(c => c.id));
+
+  assert(
+    JSON.stringify([...u2Doc].sort()) === JSON.stringify([...u2Expected].sort()),
+    `u2（无部门）可访问集合 === 期望集 ${JSON.stringify([...u2Expected].sort())}`,
+    `实际: ${JSON.stringify([...u2Doc].sort())}`
+  );
+  assert(
+    JSON.stringify([...u2Doc].sort()) === JSON.stringify([...u2Coll].sort()),
+    'u2：DocAccessService 与 CollectionAccessService 结果一致'
+  );
+
+  // ---- u3（A 部门，上级）----
+  const u3Expected = new Set(['c2', 'c3', 'c5', 'c8']); // public + A 本部门 self + A 及下级 self_and_descendants + A 空 scope
+  const u3Doc = new Set(await docAccess.getAccessibleCollectionIds('u3'));
+  const u3CollWhere = await collectionAccess.buildAccessibleCollectionsWhere('u3');
+  const u3Coll = new Set(collections.filter(c => evaluateWhere(u3CollWhere, c)).map(c => c.id));
+
+  assert(
+    JSON.stringify([...u3Doc].sort()) === JSON.stringify([...u3Expected].sort()),
+    `u3（A 部门）可访问集合 === 期望集 ${JSON.stringify([...u3Expected].sort())}`,
+    `实际: ${JSON.stringify([...u3Doc].sort())}`
+  );
+  assert(
+    JSON.stringify([...u3Doc].sort()) === JSON.stringify([...u3Coll].sort()),
+    'u3：DocAccessService 与 CollectionAccessService 结果一致'
+  );
+
+  console.log(`\n结果: ${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch((err) => {
+  console.error('测试执行失败:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #1049

## 变更摘要

基于文档平台代码审计（本地任务留痕 task-20260814-doc-platform-code-audit）修复 4 个 P0 问题。仅静态分析与代码修复，不做真实环境测试。

| 项 | 内容 | 类型 |
|----|------|------|
| P0-1 | `DocAccessService` 委托 `CollectionAccessService`，修复 `department_scope=self` 集合被下级部门越权读取；空 scope 语义与 `checkAccess()` 对齐 | 权限修复 |
| P0-2 | `InternalDocsController` 身份固定为 JWT session，删除 body user_id 伪造路径与 isLocal 死代码分支 | 安全修复 |
| P0-3 | `createIntake` 收敛为单一实现（委托 `DocumentIntakeService`），初始版本状态修正为 `effective` | 一致性 |
| P0-4 | 前端类型契约修复：`DocDocument`/`DocChunk`/`DocDiffStatus` 对齐后端真实字段，删除假字段与死代码路径 | 契约修复 |

## 验证

- 新增 `tests/doc-access-permission.test.js`：权限语义矩阵 9/9 通过（含越权修复点断言）
- 后端 6 文件 `node --check` 通过
- 前端 `vue-tsc --build` 0 错误；根 + 前端 `npm run lint` 通过

## 变更文件

- `lib/doc-access-service.js` / `lib/collection-access-service.js`
- `server/controllers/internal-docs.controller.js` / `server/controllers/doc.controller.js`
- `tests/doc-access-permission.test.js`（新增）
- `frontend/src/api/docs.ts` / `frontend/src/api/collections.ts`
- `frontend/src/views/DocDetailView.vue` / `frontend/src/views/CollectionDetailView.vue`
- `frontend/src/composables/useDocumentWorkspace.ts`

## 说明

- 存量 intake 文档初始版本可能为 `draft`（本次修复对齐为 `effective`）；平台读路径无按 effective 过滤逻辑，功能影响低，数据归正另行评估。
- 权限越权场景的真实数据冒烟测试不在本次范围。
