### PR TITLE
feat: 允许管理员修改用户名

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -309,10 +309,9 @@
               <el-input
                 v-model="userForm.username"
                 :placeholder="$t('settings.usernamePlaceholder')"
-                :disabled="!!editingUser"
                 @input="handleUsernameInput"
               />
-              <div v-if="!editingUser" class="el-form-item__tip">{{ $t('settings.usernameFormatHint') }}</div>
+              <div class="el-form-item__tip">{{ $t('settings.usernameFormatHint') }}</div>
             </el-form-item>
           </el-col>
           <el-col :span="12">
@@ -777,6 +776,7 @@ const saveUser = async () => {
     if (editingUser.value) {
       // 更新用户
       const updateData: UpdateUserRequest = {
+        username: userForm.username,
         email: userForm.email,
         nickname: userForm.nickname,
         gender: userForm.gender as import('@/types').UserGender || undefined,

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -285,25 +285,24 @@ class UserController {
         return;
       }
 
-      // 验证用户名格式（如果更新用户名）
+      // 验证用户名格式（如果更新用户名）：普通用户名或邮箱格式，与创建/注册规则一致
       if (updates.username) {
-        const usernameRegex = /^[a-zA-Z][a-zA-Z0-9_]{5,15}$/;
-        if (!usernameRegex.test(updates.username)) {
-          ctx.error('用户名格式不正确：需以字母开头，仅允许字母、数字、下划线，长度6-16位', 400);
+        if (!isValidUsername(updates.username)) {
+          ctx.error(usernameErrorHint(), 400);
           return;
         }
       }
 
       // 验证邮箱格式（如果更新邮箱）
       if (updates.email) {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(updates.email)) {
+        if (!EMAIL_REGEX.test(updates.email)) {
           ctx.error('邮箱格式不正确', 400);
           return;
         }
       }
 
-      // 检查用户名和邮箱唯一性
+      // 检查用户名和邮箱唯一性（含交叉冲突：邮箱格式用户名不能与现有用户 email 相同，
+      // 新 email 也不能与现有用户（邮箱格式）的 username 相同，避免登录 Op.or 命中歧义）
       if (updates.username || updates.email) {
         const { Op } = this.db;
         const existing = await this.User.findOne({
@@ -311,17 +310,19 @@ class UserController {
             [Op.or]: [
               updates.username ? { username: updates.username } : null,
               updates.email ? { email: updates.email } : null,
+              updates.username ? { email: updates.username } : null,
+              updates.email ? { username: updates.email } : null,
             ].filter(Boolean),
             id: { [Op.ne]: id },
           },
           raw: true,
         });
         if (existing) {
-          if (existing.username === updates.username) {
+          if (existing.username === updates.username || existing.email === updates.username) {
             ctx.error('用户名已存在', 409);
             return;
           }
-          if (existing.email === updates.email) {
+          if (existing.email === updates.email || existing.username === updates.email) {
             ctx.error('邮箱已存在', 409);
             return;
           }


### PR DESCRIPTION
Closes #1061

## 改动概览

允许管理员在编辑用户时修改用户名，规则与创建/注册（#1059）完全对齐。

### 后端 `server/controllers/user.controller.js` (`updateUser`)

- 用户名格式校验换用共享 `user-validation.service.js` 的 `isValidUsername`（支持邮箱格式用户名，此前是 #1059 遗留的旧正则）
- 邮箱校验换用共享 `EMAIL_REGEX`
- 唯一性检查补充**交叉冲突**：新用户名不能与现有用户 email 相同、新 email 不能与现有用户（邮箱格式）username 相同，避免登录 `Op.or` 命中歧义（与 createUser/register 一致）
- 权限不变：仅管理员可更新 username

### 前端 `frontend/src/views/SettingsView.vue`

- 编辑用户时 username 输入框**可编辑**（移除 `:disabled="!!editingUser"`）
- 用户名格式提示始终显示（编辑时也提示）
- `saveUser` 编辑分支提交 `username` 字段

## 验证

- 后端 `node --check` 通过
- 前端 `npm run type-check` 通过；`npm run lint` 0 errors
- `UpdateUserRequest` 类型已含 `username?: string`，无需改动

## 说明

- 用户管理 tab 仅管理员可见，普通用户无法触达
- 修改 username 后旧用户名不可登录、新用户名可登录（登录本就支持 username/email）
