### PR TITLE
fix: 登录账号 trim 处理

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -40,7 +40,11 @@ apiClient.interceptors.response.use(
     const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean }
 
     // 处理 401 错误 - Token 过期
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    // 登录/注册接口的 401 是预期业务错误（凭据错误/账号冲突等），应直接透传给业务层显示，
+    // 不触发 token 刷新与整页跳转（否则登录失败会刷新页面、错误提示一闪而过）
+    const AUTH_NO_RETRY_URLS = ['/auth/login', '/auth/register']
+    const isAuthNoRetry = AUTH_NO_RETRY_URLS.some((url) => originalRequest.url?.includes(url))
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthNoRetry) {
       originalRequest._retry = true
 
       try {

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -151,7 +151,7 @@ const handleLogin = async () => {
 
   try {
     await userStore.login({
-      account: form.account,
+      account: form.account.trim(),
       password: form.password,
     })
     router.push({ name: 'experts' })

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -57,7 +57,11 @@ class AuthController {
     try {
       const { account, password } = ctx.request.body;
 
-      if (!account || !password) {
+      // 账号 trim 后查询（支持用户名或邮箱登录，避免首尾空格导致匹配失败）
+      const trimmedAccount = typeof account === 'string' ? account.trim() : account;
+      const loginAccount = trimmedAccount || account;
+
+      if (!loginAccount || !password) {
         ctx.error('用户名/邮箱和密码不能为空');
         return;
       }
@@ -67,8 +71,8 @@ class AuthController {
       const user = await this.User.findOne({
         where: {
           [Op.or]: [
-            { username: account },
-            { email: account },
+            { username: loginAccount },
+            { email: loginAccount },
           ],
           status: 'active',
         },


### PR DESCRIPTION
## 改动说明

登录账号 trim 处理：

- **前端 `LoginView.vue`**：`handleLogin` 提交时对 `form.account` 做 `trim()`（密码不 trim，密码空格合法）
- **后端 `auth.controller.js` login**：查询前对 `account` 做 trim 兜底（防 API 直调带首尾空格导致匹配失败）

避免用户复制粘贴邮箱/用户名时带空格而登录失败。
