### PR TITLE
fix: 标准管理 app_enterprise 表缺失自愈（建表兜底迁移）

### DIFF
--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -3863,6 +3863,32 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== standard-mgr: app_enterprise 建表兜底 ====================
+  // app_enterprise 建表已归入 app 自治迁移（apps/standard-mgr/migrations/install.js，commit 3f0ebd8）。
+  // 此处保留幂等兜底：旧库/备份恢复/半安装场景下表缺失时自动补齐（结构须与 install.js 保持一致），
+  // 否则下方 FK 兜底迁移会因引用不存在的表而失败。
+  {
+    name: 'app_enterprise create table (fallback)',
+    check: async (conn) => await hasTable(conn, 'app_enterprise'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        CREATE TABLE IF NOT EXISTS app_enterprise (
+          id VARCHAR(32) PRIMARY KEY COMMENT '主键，Utils.newID(32)',
+          name VARCHAR(100) NOT NULL COMMENT '企业名称（如：吉利、小鹏、比亚迪）',
+          name_en VARCHAR(200) NULL COMMENT '企业英文名',
+          description TEXT NULL COMMENT '备注',
+          code_prefixes TEXT NULL COMMENT '标准编号前缀（逗号分隔，如 Q-JL,Q-JLY；用于企业标准识别与归属推断）',
+          is_active BIT(1) DEFAULT b'1' COMMENT '是否启用',
+          created_by VARCHAR(32) NULL COMMENT '创建人 users.id',
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY uk_app_enterprise_name (name)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='企业花名册（标准归属）'
+      `);
+      console.log('  ✓ Created app_enterprise table (fallback)');
+    }
+  },
+
   // ==================== standard-mgr: app_standard.enterprise_id FK（兜底） ====================
 
   {


### PR DESCRIPTION
## 背景
点开「标准管理」应用报错：`Table 'touwaka_mate.app_enterprise' doesn't exist`。

## 根因
commit 3f0ebd8 将 app_enterprise 建表从平台升级脚本移入 app 自治迁移（install.js），该迁移仅在 app 安装时执行。旧库/备份恢复/半安装场景下表缺失时，平台升级脚本只剩 FK 兜底迁移（引用不存在的表，会失败），无人建表。

## 修复
1. 数据库层（已执行）：按 install.js 规范 DDL 补建 app_enterprise 表 + 补 fk_standard_enterprise 外键
2. 代码层（本 PR）：upgrade-database.js 增加幂等建表兜底迁移（CREATE TABLE IF NOT EXISTS，结构同 install.js），防止同类环境复发

## 验证
- upgrade-database.js 全量执行：0 applied / 120 skipped / 0 failed
- touwaka-mate 容器内跑 StandardMgrService.listEnterprises() / listStandards()：正常返回，无报错