### PR TITLE
fix: 部署时前端 dist 有源码更新即重建（修复旧构建残留导致部署后前端不更新）

### DIFF
--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -51,7 +51,11 @@ services:
           npm install -g pptxgenjs
         fi
 
-        if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ]; then
+        # 前端构建：dist 缺失，或源码较 dist 有更新时重建
+        # （不能只看 dist 是否存在：旧构建残留会导致 git pull 新代码后前端不更新，
+        #   部署后仍加载旧 chunk 报 TDZ/MIME 错；用源码 mtime 与 dist/index.html 对比触发重建）
+        if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ] || \
+           [ -n "$(find /app/frontend/src /app/frontend/index.html /app/apps -type f \( -name '*.vue' -o -name '*.ts' -o -name '*.js' -o -name '*.html' -o -name '*.css' \) -newer /app/frontend/dist/index.html 2>/dev/null | head -1)" ]; then
           echo 'Building frontend...'
           cd /app/frontend
           npm ci --include=dev

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -56,7 +56,11 @@ services:
           npm install -g pptxgenjs
         fi
 
-        if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ]; then
+        # 前端构建：dist 缺失，或源码较 dist 有更新时重建
+        # （不能只看 dist 是否存在：旧构建残留会导致 git pull 新代码后前端不更新，
+        #   部署后仍加载旧 chunk 报 TDZ/MIME 错；用源码 mtime 与 dist/index.html 对比触发重建）
+        if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ] || \
+           [ -n "$(find /app/frontend/src /app/frontend/index.html /app/apps -type f \( -name '*.vue' -o -name '*.ts' -o -name '*.js' -o -name '*.html' -o -name '*.css' \) -newer /app/frontend/dist/index.html 2>/dev/null | head -1)" ]; then
           echo 'Building frontend...'
           cd /app/frontend
           npm ci --include=dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,11 @@ services:
           npm install -g pptxgenjs
         fi
 
-        if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ]; then
+        # 前端构建：dist 缺失，或源码较 dist 有更新时重建
+        # （不能只看 dist 是否存在：旧构建残留会导致 git pull 新代码后前端不更新，
+        #   部署后仍加载旧 chunk 报 TDZ/MIME 错；用源码 mtime 与 dist/index.html 对比触发重建）
+        if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ] || \
+           [ -n "$(find /app/frontend/src /app/frontend/index.html /app/apps -type f \( -name '*.vue' -o -name '*.ts' -o -name '*.js' -o -name '*.html' -o -name '*.css' \) -newer /app/frontend/dist/index.html 2>/dev/null | head -1)" ]; then
           echo 'Building frontend...'
           cd /app/frontend
           npm ci --include=dev


### PR DESCRIPTION
## 问题

生产环境 `git pull` 新代码并重启容器后，前端仍加载**旧构建产物**，报 TDZ 错误：
```
ReferenceError: Cannot access 'me' before initialization
    at Fe.immediate (SettingsView-Db_n2Zg6.js:...)
```
实测生产环境 `SettingsView-Db_n2Zg6.js`（旧版）存在、新版 404——前端从未被重新构建。

## 根因

docker-compose 启动逻辑：
```bash
if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ]; then
  ... npx vite build
fi
```
**只要 `dist` 目录存在（哪怕是旧构建），就永远跳过前端构建**。`git pull` 更新源码后，后端更新了，前端 dist 还是老的 → 旧 chunk 残留报错。

## 修复

构建条件改为：`dist 缺失` **或** `源码 mtime 新于 dist/index.html` 时触发重建：
```bash
if [ ! -d /app/frontend/dist ] || [ ! -f /app/frontend/dist/index.html ] || \
   [ -n "$(find /app/frontend/src /app/frontend/index.html /app/apps -type f \( -name '*.vue' -o -name '*.ts' -o -name '*.js' -o -name '*.html' -o -name '*.css' \) -newer /app/frontend/dist/index.html 2>/dev/null | head -1)" ]; then
  ... npx vite build
fi
```
这样每次部署新代码后重启容器，前端会跟随源码自动重建。已同步修改 `docker-compose.yml` / `docker-compose.standalone.yml` / `docker-compose.nas.yml`。

## 验证

- 4 个 compose 文件 `docker compose config` 语法全部通过
- 本机 dist 自洽：入口引用的 chunk 全部存在，`/personal`、`/system` 页面 Playwright 实测 console 0 错误

## 生产环境修复步骤

1. `git pull` 拉取本修复
2. 重启容器（触发前端重建）：
   ```bash
   docker compose -f docker-compose.<环境>.yml up -d --force-recreate app
   # 或：docker restart touwaka-mate
   ```
3. 确认构建日志出现 `Building frontend...`，验证页面加载新 chunk
