### PR TITLE
fix: 设置页角色管理 tab 加载报 TDZ 错误（watch immediate 回调访问未初始化 const 函数） (#1068)

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -942,20 +942,9 @@ watch(userPage, () => {
 })
 
 // 监听用户管理 tab 切换
-watch(activeTab, (newTab) => {
-  if (newTab === 'user' && usersList.value.length === 0) {
-    loadUsers()
-  }
-  if (newTab === 'role' && rolesList.value.length === 0) {
-    loadRolesForManagement()
-  }
-  if (newTab === 'role' && allPermissions.value.length === 0) {
-    loadAllPermissions()
-  }
-  if (newTab === 'role' && allExperts.value.length === 0) {
-    loadAllExperts()
-  }
-}, { immediate: true })
+// 注意：此 watch 带 immediate:true 会立即执行回调，回调引用的 loadRolesForManagement /
+// loadAllPermissions / loadAllExperts 均为 const 声明的箭头函数（无提升），
+// 因此 watch 必须放在这些函数声明之后，否则触发 TDZ: "Cannot access 'me' before initialization"
 
 // 监听设置组切换（路由已处理 redirect，此处仅保留数据加载逻辑）
 
@@ -998,6 +987,25 @@ const loadAllExperts = async () => {
     toast.error(t('settings.loadExpertsFailed'))
   }
 }
+
+// 监听用户管理 tab 切换
+// 注意：此 watch 带 immediate:true 会立即执行回调，回调引用的 loadRolesForManagement /
+// loadAllPermissions / loadAllExperts 均为 const 声明的箭头函数（无提升），
+// 因此 watch 必须放在这些函数声明之后，否则触发 TDZ: "Cannot access 'me' before initialization"
+watch(activeTab, (newTab) => {
+  if (newTab === 'user' && usersList.value.length === 0) {
+    loadUsers()
+  }
+  if (newTab === 'role' && rolesList.value.length === 0) {
+    loadRolesForManagement()
+  }
+  if (newTab === 'role' && allPermissions.value.length === 0) {
+    loadAllPermissions()
+  }
+  if (newTab === 'role' && allExperts.value.length === 0) {
+    loadAllExperts()
+  }
+}, { immediate: true })
 
 // 选择角色
 const selectRole = async (role: Role) => {


### PR DESCRIPTION
Closes #1068

## 问题

访问「组织管理 → 角色管理」（`/organization/roles`）控制台报错：

```
ReferenceError: Cannot access 'me' before initialization
    at Fe.immediate (SettingsView-*.js:3:43849)
```

## 根因

`SettingsView.vue` 中 `watch(activeTab, ..., { immediate: true })` 的回调引用了 `loadRolesForManagement` / `loadAllPermissions` / `loadAllExperts`，但它们是 **const 箭头函数（无提升）且声明在 watch 之后**。immediate 立即执行回调 → TDZ。

## 修复

将 watch 移到 `loadAllExperts` 声明之后，immediate 语义不变（初始 tab 数据照常加载）。

## 验证

- 本地构建（vite 7.3.2 + vue 3.5.32）
- Playwright 实测 `/organization/roles`：console 0 错误
- 截图确认角色列表（平台管理员/专家创作者/普通用户）正常渲染
