### PR TITLE
fix: 组织架构清空职位人员不保存

### DIFF
--- a/frontend/src/components/settings/OrganizationTab.vue
+++ b/frontend/src/components/settings/OrganizationTab.vue
@@ -281,7 +281,12 @@ const handlePositionUserChange = async (position: Position, user: UserListItem |
       positionUserMap.value.set(position.id, user.id)
       await organizationApi.updateUserOrganization(user.id, { department_id: selectedDepartment.value?.id || null, position_id: position.id })
     } else {
+      // 清空选择：需要把当前分配用户的组织信息一并移除（仅删本地 map 不调 API 会"看起来没保存"）
+      const currentUserId = positionUserMap.value.get(position.id)
       positionUserMap.value.delete(position.id)
+      if (currentUserId) {
+        await organizationApi.updateUserOrganization(currentUserId, { department_id: null, position_id: null })
+      }
     }
     toast.success(t('settings.assignSuccess'))
   } catch (error: unknown) {


### PR DESCRIPTION
Closes #1070

## 改动
`frontend/src/components/settings/OrganizationTab.vue` — `handlePositionUserChange()` 清空分支：

- 原：只 `positionUserMap.delete()` 更新本地显示，不调 API → 清空不落库，刷新后人员仍在
- 改：取出当前分配用户，调用 `updateUserOrganization(currentUserId, { department_id: null, position_id: null })` 真正清除

## 验证
浏览器实测（测试实例 http://10.41.24.109:3998）：
1. 选「测试用户」到 IT总监 → picker 显示员工、数据库落库
2. 点"无"清空 → picker 回到占位符、数据库 department_id/position_id 置 NULL
