### PR TITLE
fix: 组织架构职位成员按一人一职收敛（事务独占 + UserPicker 挂载显示）

### DIFF
--- a/frontend/src/components/common/UserPicker.vue
+++ b/frontend/src/components/common/UserPicker.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { userApi } from '@/api/services'
 import { useToastStore } from '@/stores/toast'
@@ -142,7 +142,7 @@ const loadUsers = async () => {
   try {
     const response = await userApi.getUsers({ size: 100 })
     users.value = response.items || []
-    
+
     // 如果有选中值，找到对应的用户
     if (props.modelValue) {
       selectedUser.value = users.value.find(u => u.id === props.modelValue) || null
@@ -154,6 +154,12 @@ const loadUsers = async () => {
     loading.value = false
   }
 }
+
+// 组件挂载时即加载用户列表，使触发按钮能正确显示当前已分配成员
+// （此前仅在打开弹窗时加载，刷新后职位卡片空白显示"选择人员"）
+onMounted(() => {
+  loadUsers()
+})
 
 // 打开弹窗
 const openModal = () => {

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -656,11 +656,30 @@ class UserController {
         }
       }
 
-      // 更新用户的组织信息
-      await this.User.update(
-        { department_id: department_id || null, position_id: position_id || null },
-        { where: { id } }
-      );
+      // 事务：职位独占 + 更新用户组织信息
+      // 产品语义：一个部门可有多人，但一个人只能任职一个部门（users.department_id 单字段，
+      // 直接覆盖即自动转移）；一个职位下目前只放一个人（分配时清空该职位其他成员）。
+      const transaction = await this.db.sequelize.transaction();
+      try {
+        // 分配职位时，先清空该职位其他成员的职位（保留其部门归属：仍是部门的人，只是无职位）
+        if (position_id) {
+          await this.User.update(
+            { position_id: null },
+            { where: { position_id, id: { [Op.ne]: id } }, transaction }
+          );
+        }
+
+        // 更新目标用户的组织信息
+        await this.User.update(
+          { department_id: department_id || null, position_id: position_id || null },
+          { where: { id }, transaction }
+        );
+
+        await transaction.commit();
+      } catch (err) {
+        await transaction.rollback();
+        throw err;
+      }
 
       ctx.success({ department_id, position_id }, '组织信息更新成功');
     } catch (error) {


### PR DESCRIPTION
## 背景

Issue #1072：组织架构「职位成员」存在多成员与前端单选 UI 的矛盾。

- 后端允许一个职位挂多个人，前端 `UserPicker` 单选且 `loadPositionUsers` 只取 `members[0]` → 职位有 ≥2 人时非首个成员刷新后不可见/不可管理
- `UserPicker` 挂载时不加载用户，刷新后职位卡片空白显示「选择人员」（实际已有成员）

## 目标产品语义（用户确认）

- 一个部门可以有多个人（`users.department_id` 多用户相同）
- 一个人只能任职一个部门（单字段，分配时自动转移）
- **一个职位下目前只放一个人**（前端单选控制，分配新人时职位原成员自动清出）

## 改动

1. **后端 `server/controllers/user.controller.js`** `updateUserOrganization`：
   - 事务内先清空该职位其他成员的 `position_id`（职位独占一人，保留其部门归属），再设置目标用户
   - 表结构不动，数据层保留多成员能力
2. **前端 `frontend/src/components/common/UserPicker.vue`**：
   - 组件挂载时即加载用户列表并按 `modelValue` 显示当前成员（修复刷新后卡片空白）

## 验证

- 后端 API：分配 A → members=[A]；再分配 B → 自动清出 A，members=[B]，A 保留部门、职位清空；清空操作 members=[]；跨部门转移自动生效
- 前端 Playwright：分配「测试B」到「文档整理员」→ 刷新页面 → 卡片直接显示「测试B」（修复前为空）
- 本地 vue-tsc + vite build 通过
