### PR TITLE
fix: upgrade-database.js 补 app_enterprise 建表迁移（标准管理缺表兜底）

### DIFF
--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -3863,6 +3863,33 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== standard-mgr: app_enterprise 建表（兜底） ====================
+  // 说明：app_enterprise 建表语句原本只存在于 apps/standard-mgr/migrations/install.js（app 安装迁移），
+  // 老库由早期 upgrade 升级而来、且 standard-mgr 早已注册时，install 迁移不会重跑，导致缺表。
+  // 此处补一条幂等建表迁移，须位于下方 FK 迁移之前（FK 依赖该表存在）。
+
+  {
+    name: 'app_enterprise create table',
+    check: async (conn) => await hasTable(conn, 'app_enterprise'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        CREATE TABLE IF NOT EXISTS app_enterprise (
+          id VARCHAR(32) PRIMARY KEY COMMENT '主键，Utils.newID(32)',
+          name VARCHAR(100) NOT NULL COMMENT '企业名称（如：吉利、小鹏、比亚迪）',
+          name_en VARCHAR(200) NULL COMMENT '企业英文名',
+          description TEXT NULL COMMENT '备注',
+          code_prefixes TEXT NULL COMMENT '标准编号前缀（逗号分隔，如 Q-JL,Q-JLY；用于企业标准识别与归属推断）',
+          is_active BIT(1) DEFAULT b'1' COMMENT '是否启用',
+          created_by VARCHAR(32) NULL COMMENT '创建人 users.id',
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY uk_app_enterprise_name (name)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='企业花名册（标准归属）'
+      `);
+      console.log('  ✓ Created app_enterprise table');
+    }
+  },
+
   // ==================== standard-mgr: app_standard.enterprise_id FK（兜底） ====================
 
   {


### PR DESCRIPTION
## 问题

服务器上使用「标准管理」报错：`Table 'touwaka_mate.app_enterprise' doesn't exist`。

**根因**：`scripts/upgrade-database.js` 中从未有创建 `app_enterprise` 表的迁移——只有 3869 行的「加外键」迁移（`ALTER TABLE app_standard ADD CONSTRAINT fk_standard_enterprise ... REFERENCES app_enterprise(id)`），该迁移假设表已存在，表缺失时直接报 `errno: 150` 失败且不会回头建表。`app_enterprise` 的建表语句只存在于 app 安装迁移 `apps/standard-mgr/migrations/install.js`，而老库中 standard-mgr 早已注册、install 迁移不会重跑，导致表一直缺失。

## 修复

在 `app_standard enterprise FK to app_enterprise` 迁移**之前**新增幂等建表迁移 `app_enterprise create table`（`CREATE TABLE IF NOT EXISTS`，DDL 与 install.js 保持一致）。此后任意环境执行 `node scripts/upgrade-database.js` 都会自动补建该表，外键迁移也能顺带通过。

## 验证

在本地容器（表已存在）执行 upgrade：新迁移正确识别为 `Skipped (already exists)`，`Failed: 0`，无副作用。缺失表的环境执行后会走 `up` 建表。

> 注：服务器上若急着恢复，可先直接执行 install.js 中 app_enterprise 的建表 SQL（无需重装 app；重装会因表名安全校验 `must start with app_standard_mgr_` 被拦，属另一个历史遗留问题）。