### PR TITLE
fix: standard-mgr 重装被表名安全校验拦截，加 legacy 豁免

### DIFF
--- a/apps/standard-mgr/manifest.json
+++ b/apps/standard-mgr/manifest.json
@@ -7,6 +7,7 @@
   "type": "document",
   "author": "Touwaka Team",
   "license": "MIT",
+  "legacy_table_names": true,
   "runtime": {
     "frontend": {
       "entry": "frontend/views/AppRuntimeView.vue"

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -29,8 +29,15 @@ class AppMarketService {
   }
 
   validateTableName(tableName, appId, { legacy = false } = {}) {
-    // legacy 豁免：老 app（表名不带 appId 前缀，如 standard-mgr 的 app_standard/app_enterprise）
-    // 是历史遗留命名，重装时应放行（manifest.json 显式声明 legacy_table_names: true 才生效）
+    // 禁用词校验始终生效（安全红线，legacy 豁免也不例外）
+    const forbidden = ['users', 'roles', 'mini_app', 'mini_apps', 'attachment', 'knowledge', 'kb_'];
+    if (forbidden.some(f => tableName.toLowerCase().includes(f))) {
+      throw new Error(`Security: table ${tableName} contains forbidden keyword`);
+    }
+
+    // legacy 豁免：仅跳过前缀校验。老 app（表名不带 appId 前缀，如 standard-mgr 的
+    // app_standard/app_enterprise）是历史遗留命名，重装时应放行（manifest.json 显式声明
+    // legacy_table_names: true 才生效）
     if (legacy) {
       logger.warn(`Table name validation skipped for ${tableName} (legacy app ${appId})`);
       return tableName;
@@ -40,11 +47,6 @@ class AppMarketService {
     
     if (!tableName.startsWith(safePrefix)) {
       throw new Error(`Security: table ${tableName} must start with ${safePrefix}`);
-    }
-    
-    const forbidden = ['users', 'roles', 'mini_app', 'mini_apps', 'attachment', 'knowledge', 'kb_'];
-    if (forbidden.some(f => tableName.toLowerCase().includes(f))) {
-      throw new Error(`Security: table ${tableName} contains forbidden keyword`);
     }
     
     return tableName;

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -28,7 +28,14 @@ class AppMarketService {
     }
   }
 
-  validateTableName(tableName, appId) {
+  validateTableName(tableName, appId, { legacy = false } = {}) {
+    // legacy 豁免：老 app（表名不带 appId 前缀，如 standard-mgr 的 app_standard/app_enterprise）
+    // 是历史遗留命名，重装时应放行（manifest.json 显式声明 legacy_table_names: true 才生效）
+    if (legacy) {
+      logger.warn(`Table name validation skipped for ${tableName} (legacy app ${appId})`);
+      return tableName;
+    }
+
     const safePrefix = `app_${appId.replace(/-/g, '_')}_`;
     
     if (!tableName.startsWith(safePrefix)) {
@@ -429,8 +436,9 @@ class AppMarketService {
     
     // 4. 校验 extension_tables 表名
     if (manifest.extension_tables) {
+      const legacy = manifest.legacy_table_names === true;
       for (const table of manifest.extension_tables) {
-        this.validateTableName(table.name, appId);
+        this.validateTableName(table.name, appId, { legacy });
       }
     }
     


### PR DESCRIPTION
## 问题

standard-mgr 是历史遗留 app，extension_tables 表名（`app_standard`、`app_enterprise`、`app_standard_ref_anchor`、`app_standard_anchored_section`）不带 `app_standard_mgr_` 前缀。`installApp` 第 4 步 `validateTableName`（#647 引入的安全加固）强制校验所有 extension_tables 必须以 `app_<appId>_` 开头，导致 standard-mgr **卸载后无法重装**，报：

```
Installation failed: Security: table app_standard must start with app_standard_mgr_
```

## 修复

1. `server/services/app-market.service.js`：`validateTableName` 增加 `legacy` 选项（默认关闭），manifest 显式声明 `legacy_table_names: true` 的 app 跳过前缀校验（禁用词校验仍生效）
2. `apps/standard-mgr/manifest.json`：声明 `legacy_table_names: true`

## 验证

容器内实测：
- legacy 豁免放行 `app_standard` / `app_enterprise` ✅
- 非 legacy 仍拦截（`Security: table app_standard must start with app_standard_mgr_`）✅
- 合规表名正常通过 ✅
- legacy 下禁用词（users 等）仍拦截 ✅

## 备注

重装通过校验后，install.js 会执行 `CREATE TABLE IF NOT EXISTS` 自动补建 `app_enterprise` 等表（含此前缺表问题）。