### PR TITLE
fix: 卸载/回滚一律不删除 app 目录

### DIFF
--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -551,23 +551,15 @@ class AppMarketService {
       logger.warn(`Failed to rollback DB records for ${appId}:`, err);
     }
     
-    // 3. 清理安装流程写入的文件（manifest.json + migrations/）
-    //    ⚠ 不能整目录删除：builtin app（仓库自带的 apps/*）含 frontend/、server/ 等源码，
-    //    整目录删除会导致重装后 runtime app 前端入口缺失、前端构建失败。
-    //    不再需要 APP_MARKET_PRESERVE_DIR（旧逻辑用于保护整目录不删，现已默认不删源码）。
+    // 3. 不删除 app 目录（含安装产物）
+    //    ⚠ 整目录删除会误删 builtin app（仓库自带的 apps/*）的 frontend/、server/ 等源码，
+    //    重装时 installApp 只重建 manifest.json + migrations，源码永久缺失导致前端构建失败。
+    //    故回滚一律保留目录。
     try {
-      for (const rel of ['manifest.json', 'migrations']) {
-        await fs.rm(path.join(appDir, rel), { recursive: true, force: true });
-      }
-      try {
-        const remaining = await fs.readdir(appDir);
-        if (remaining.length === 0) {
-          await fs.rmdir(appDir);
-        }
-      } catch { /* appDir 不存在等场景忽略 */ }
-      logger.info(`Rolled back app installation artifacts for ${appId}`);
-    } catch (err) {
-      logger.warn(`Failed to rollback app directory for ${appId}:`, err);
+      await fs.access(appDir);
+      logger.info(`Rollback preserved app directory for ${appId} (${appDir})`);
+    } catch {
+      logger.info(`Rollback: app directory not present for ${appId}`);
     }
     
     logger.info(`Installation rollback completed for ${appId}`);
@@ -918,26 +910,12 @@ class AppMarketService {
       await MiniAppRow.destroy({ where: { app_id: appId } });
     }
     
-    // 6. 删除安装流程写入的本地文件（manifest.json + migrations/）
-    //    ⚠ 不能整目录删除：builtin app（仓库自带的 apps/*）含 frontend/、server/ 等源码，
-    //    整目录删除会导致重装后 runtime app 前端入口（如 standard-mgr 的 frontend/views/AppRuntimeView.vue）
-    //    缺失、前端构建失败（ENOENT）。只清理安装产物，保留仓库源码。
+    // 6. 不删除 app 目录（含安装产物）
+    //    ⚠ 整目录删除会误删 builtin app（仓库自带的 apps/*）的 frontend/、server/ 等源码，
+    //    重装时 installApp 只重建 manifest.json + migrations，源码永久缺失导致前端构建失败。
+    //    故卸载一律保留目录（registry app 残留的安装产物可接受，以保护仓库源码为优先）。
     const appDir = path.join(this.appsDir, appId);
-    try {
-      for (const rel of ['manifest.json', 'migrations']) {
-        await fs.rm(path.join(appDir, rel), { recursive: true, force: true });
-      }
-      // 目录已空则清理（纯 registry app 场景），非空（builtin app 有源码）则保留
-      try {
-        const remaining = await fs.readdir(appDir);
-        if (remaining.length === 0) {
-          await fs.rmdir(appDir);
-        }
-      } catch { /* appDir 不存在等场景忽略 */ }
-      logger.info(`Removed app installation artifacts for ${appId}`);
-    } catch (error) {
-      logger.warn(`Failed to remove app files in ${appDir}:`, error);
-    }
+    logger.info(`App ${appId} uninstalled; directory preserved (${appDir})`);
     
     logger.info(`App ${appId} uninstalled successfully`);
     


### PR DESCRIPTION
## 变更

按需求收紧为最简策略：**卸载/回滚一律不删除 app 目录**（含 manifest.json、migrations/ 等安装产物也不删）。

## 背景

此前 `uninstallApp` / `rollbackInstall` 执行 `fs.rm(appDir, recursive)` 整目录删除，builtin app（仓库自带 apps/*）的 frontend/、server/ 源码被误删，重装只重建 manifest+migrations，前端入口文件缺失导致构建 ENOENT（#1081 曾改为只删安装产物，本次按用户要求进一步简化为不删目录）。

## 验证

- `node --check` / `npm run lint` 通过
- 无残留 `fs.rm(appDir)` 删除逻辑