### PR TITLE
fix: app 升级后版本追踪落地，修复「更新」按钮永不消失

### DIFF
--- a/apps/index.json
+++ b/apps/index.json
@@ -12,7 +12,11 @@
       "description": "分析误工数据，按账号分类汇总直接工资和附加费",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["误工", "分析", "汇总"],
+      "tags": [
+        "误工",
+        "分析",
+        "汇总"
+      ],
       "path": "apps/downtime-analyzer",
       "manifest_url": "apps/downtime-analyzer/manifest.json"
     },
@@ -25,7 +29,12 @@
       "description": "上传合同文件，AI自动提取合同元数据，支持批量处理和确认入库",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["合同", "文档", "OCR", "AI提取"],
+      "tags": [
+        "合同",
+        "文档",
+        "OCR",
+        "AI提取"
+      ],
       "path": "apps/contract-mgr",
       "manifest_url": "apps/contract-mgr/manifest.json"
     },
@@ -38,7 +47,14 @@
       "description": "支持组织层级、多版本管理、AI问答的销售合同管理系统",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["合同", "文档", "OCR", "AI提取", "多版本", "组织管理"],
+      "tags": [
+        "合同",
+        "文档",
+        "OCR",
+        "AI提取",
+        "多版本",
+        "组织管理"
+      ],
       "path": "apps/contract-mgr-v2",
       "manifest_url": "apps/contract-mgr-v2/manifest.json"
     },
@@ -51,7 +67,13 @@
       "description": "上传发票文件，AI自动识别并结构化提取发票信息，支持去重入库",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["发票", "invoice", "OCR", "AI识别", "fapiao"],
+      "tags": [
+        "发票",
+        "invoice",
+        "OCR",
+        "AI识别",
+        "fapiao"
+      ],
       "path": "apps/invoice-mgr",
       "manifest_url": "apps/invoice-mgr/manifest.json"
     },
@@ -64,7 +86,12 @@
       "description": "上传图片，自动识别并提取文字内容（不保存原图）。",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["OCR", "文字识别", "VLM", "图片"],
+      "tags": [
+        "OCR",
+        "文字识别",
+        "VLM",
+        "图片"
+      ],
       "path": "apps/ocr-tool",
       "manifest_url": "apps/ocr-tool/manifest.json"
     },
@@ -77,7 +104,13 @@
       "description": "短阅读、加词与快速复习的一体化学习工作台",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["学习", "阅读", "生词", "复习", "AI学习"],
+      "tags": [
+        "学习",
+        "阅读",
+        "生词",
+        "复习",
+        "AI学习"
+      ],
       "path": "apps/els",
       "manifest_url": "apps/els/manifest.json"
     },
@@ -91,7 +124,13 @@
       "demo": true,
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["简历", "筛选", "招聘", "AI", "匹配"],
+      "tags": [
+        "简历",
+        "筛选",
+        "招聘",
+        "AI",
+        "匹配"
+      ],
       "path": "apps/resume-fast-screening",
       "manifest_url": "apps/resume-fast-screening/manifest.json"
     },
@@ -104,30 +143,68 @@
       "description": "批量上传 CSV，执行快速矢量化、规则驱动阶段识别与统计报告输出的分析工具",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["电流", "CSV", "阶段识别", "信号分析", "LLM", "报告"],
+      "tags": [
+        "电流",
+        "CSV",
+        "阶段识别",
+        "信号分析",
+        "LLM",
+        "报告"
+      ],
       "path": "apps/current-feature-analyzer",
       "manifest_url": "apps/current-feature-analyzer/manifest.json"
     },
     {
       "id": "standard-mgr",
       "name": "标准管理",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "icon": "📐",
       "type": "document",
       "description": "标准文档纳管、引用清洗与锚点定位",
       "author": "Touwaka Team",
       "license": "MIT",
-      "tags": ["标准", "文档", "引用", "锚点", "合规"],
+      "tags": [
+        "标准",
+        "文档",
+        "引用",
+        "锚点",
+        "合规"
+      ],
       "path": "apps/standard-mgr",
       "manifest_url": "apps/standard-mgr/manifest.json"
     }
   ],
   "categories": [
-    { "id": "document", "name": "文档管理", "icon": "📄", "description": "文档上传、OCR识别、数据提取" },
-    { "id": "workflow", "name": "流程审批", "icon": "🔄", "description": "审批流程、状态流转" },
-    { "id": "data", "name": "数据管理", "icon": "📊", "description": "结构化数据管理" },
-    { "id": "utility", "name": "实用工具", "icon": "🔧", "description": "各类实用小工具" },
-    { "id": "workflow", "name": "工作流", "icon": "🔄", "description": "流程审批、状态流转、智能匹配" }
+    {
+      "id": "document",
+      "name": "文档管理",
+      "icon": "📄",
+      "description": "文档上传、OCR识别、数据提取"
+    },
+    {
+      "id": "workflow",
+      "name": "流程审批",
+      "icon": "🔄",
+      "description": "审批流程、状态流转"
+    },
+    {
+      "id": "data",
+      "name": "数据管理",
+      "icon": "📊",
+      "description": "结构化数据管理"
+    },
+    {
+      "id": "utility",
+      "name": "实用工具",
+      "icon": "🔧",
+      "description": "各类实用小工具"
+    },
+    {
+      "id": "workflow",
+      "name": "工作流",
+      "icon": "🔄",
+      "description": "流程审批、状态流转、智能匹配"
+    }
   ],
   "metadata": {
     "total_apps": 9,

--- a/docs/apps/app-generation-guide.md
+++ b/docs/apps/app-generation-guide.md
@@ -494,7 +494,7 @@ apps/{appId}/
 - `up()` 全部幂等：建表用 `CREATE TABLE IF NOT EXISTS`；数据迁移用带条件的 `UPDATE`（条件不满足时影响 0 行），禁止“仅首装才能跑”的写法；
 - `check()` 返回 `true` 的条件 = 表不齐（首装）**或**存在待迁移的历史数据（升级）。表已存在且无待迁移数据时返回 `false`，升级时自然跳过；
 - 数据迁移与汇总计数重算都放在 `up()` 内完成，**禁止依赖“手动跑一次脚本”的体外迁移**——app 的数据演进必须随升级按钮自动发生；
-- 需要发布数据迁移时，同步递增 `manifest.json` 的 `version` 并写 `changelog`，应用市场按版本差显示「更新」按钮。
+- 需要发布数据迁移时，同步递增 `manifest.json` 的 `version` 并写 `changelog`，应用市场按版本差显示「更新」按钮（本地已装版本记录在 `mini_apps.config._registry_version`，安装/升级时由平台自动写入，app 无需关心）。
 
 参考实现：`apps/standard-mgr/migrations/install.js`（首装建 4 张表；升级路径检测并迁移历史回填数据 valid→suspected，随后按实况重算汇总计数）。
 

--- a/frontend/src/components/AppMarketPanel.vue
+++ b/frontend/src/components/AppMarketPanel.vue
@@ -381,8 +381,8 @@ onMounted(() => {
   checkUpdates()
 })
 
-// 安装/卸载后已安装列表变化 → 重新检查更新
-watch(() => props.installedApps, () => { checkUpdates() })
+// 安装/卸载后已安装列表变化 → 重新检查更新（按内容比较，避免数组引用变化导致的重复请求）
+watch(() => props.installedApps.join(','), () => { checkUpdates() })
 </script>
 
 <style scoped>

--- a/server/services/app-market.service.js
+++ b/server/services/app-market.service.js
@@ -494,10 +494,13 @@ class AppMarketService {
         handlerIdMap = result.handlerIdMap;
       }
 
-      // 10. 插入数据库（extension_tables 存入 config）
+      // 10. 插入数据库（extension_tables 存入 config；
+      // _registry_version 记录本次安装的 registry 版本，供 checkUpdate 判更新——
+      // mini_apps.revision 是 INTEGER 无法存语义化版本号，故放 config JSON）
       const config = {
         ...manifest.config,
-        extension_tables: manifest.extension_tables || []
+        extension_tables: manifest.extension_tables || [],
+        _registry_version: manifest.version || null
       };
       await this.installAppMetadata(manifest, userId, visibility, config);
 
@@ -938,8 +941,18 @@ class AppMarketService {
     }
     
     const manifest = await this.fetchManifest(appId);
-    const localVersion = app.getDataValue ? app.getDataValue('revision') : (app.revision || 1);
-    
+
+    // 本地版本：优先取 config._registry_version（安装/升级时写入的 registry 语义化版本），
+    // 老数据没有该字段时回退 revision（恒为 1，升级一次后自愈）
+    const rawConfig = app.getDataValue ? app.getDataValue('config') : app.config;
+    let cfg = rawConfig;
+    if (typeof rawConfig === 'string') {
+      try { cfg = JSON.parse(rawConfig); } catch { cfg = null; }
+    }
+    const trackedVersion = cfg && cfg._registry_version;
+    const localVersion = trackedVersion
+      || (app.getDataValue ? app.getDataValue('revision') : (app.revision || 1));
+
     return {
       has_update: this.compareVersion(manifest.version, localVersion.toString()) > 0,
       local_version: localVersion.toString(),


### PR DESCRIPTION
## 背景

PR #1083 合并后做升级链路 e2e 验收时发现平台级 bug：**升级成功后「更新」按钮永不消失**。

根因：`installApp` 写库时硬编码 `revision: 1`，而 `mini_apps.revision` 是 INTEGER 无法存语义化版本号，`checkUpdate` 拿 registry 的 `manifest.version`（如 1.1.0）和本地 revision（1）比较 → 永远 `has_update: true`。

## 修复

- `installApp`：安装/升级时把 `manifest.version` 写入 `mini_apps.config._registry_version`（不动表结构）
- `checkUpdate`：优先读 `config._registry_version`；老数据无该字段回退 `revision`（升级一次后自愈）
- `AppMarketPanel.vue`：watch 改为按 `installedApps.join(',')` 内容比较，避免数组引用变化导致的重复 check-update 请求
- `apps/index.json`：standard-mgr 卡片版本同步 1.1.0
- 文档补充 `_registry_version` 约定

## 验证（真机 e2e）

- 升级前：standard-mgr 显示「有更新」+「更新」按钮 → 点击 → confirm 显示 changelog → 升级 200 OK
- 升级中：服务端日志 `Migration migrations/install.js executed (up)`，种子遗留数据（auto_backfill+valid）自动迁移为 suspected + 计数重算正确（有效0/存疑1/needs_review=1）
- 升级后：`check-update` 返回 `has_update: false, local_version: 1.1.0`，UI 徽章与按钮消失；发票管理/OCR 工具仍正常显示「有更新」（它们确实未升级）
- 管理页渲染、删除确认对话框（无人工修正时正确不显示警告行）、UI 删除级联清理均验证通过
