### PR TITLE
feat-260829-01: erix-llm-kit ModelConfigProvider 适配器（MariaDB）

### DIFF
--- a/lib/llm-kit-adapters/README.md
+++ b/lib/llm-kit-adapters/README.md
@@ -1,0 +1,24 @@
+# erix-llm-kit 适配器（touwaka 项目侧）
+
+erix-llm-kit 的"驱动模型"：接口在库，DB 适配器在项目侧（ADR-001/002）。
+本目录是 touwaka 的 MariaDB 适配器实现。
+
+## 适配器清单
+
+| 文件 | 接口 | 后端 |
+|---|---|---|
+| `model-config-provider.js` | ModelConfigProvider | `ai_models` + `providers` 表（经 lib/db.js） |
+
+## 测试
+
+契约测试（接口兼容断言来自库的 `@erix/llm-kit/contract-tests`，当前用相对路径引用，
+待 `@erix/llm-kit` 发布到 Gitea npm registry 后换包导入）：
+
+```bash
+# 凭据：~/.config/mcp/creds/touwaka-test-db.json（600，不入库）
+#   { "host": "127.0.0.1", "port": 3306, "user": "eric", "password": "…", "database": "llm_kit_test" }
+node --test tests/llm-kit-adapters/
+```
+
+测试会在 `llm_kit_test` 库内建/删 `providers` 与 `ai_models` 两表（sequelize sync 真实模型定义），
+**不要**把凭据指向 touwaka_mate 生产库。

--- a/lib/llm-kit-adapters/model-config-provider.js
+++ b/lib/llm-kit-adapters/model-config-provider.js
@@ -1,0 +1,57 @@
+/**
+ * erix-llm-kit ModelConfigProvider 适配器 —— touwaka MariaDB 实现（项目侧"驱动"）
+ *
+ * 把 touwaka 的 ai_models + providers 两表（经 lib/db.js 的 getModelConfig join 查询）
+ * 映射为 erix-llm-kit 的 ModelConfigProvider 接口：
+ *
+ *   resolve(slot?) → ModelConfig { protocol, endpoint, model, apiKey,
+ *                                  contextWindowTokens, maxOutputTokens }
+ *
+ * slot 语义（touwaka 没有槽位概念，映射规则如下）：
+ *   - 缺省 / "default" → 默认文本模型（is_active + model_type='text'，created_at 最新，
+ *     与 lib/model-registry.js getDefaultTextModelConfig 同规则）
+ *   - 其他值 → 按 ai_model.id 精确查找；找不到/未激活 → 回落 default（ADR-001 回落语义）
+ *
+ * 注意：
+ *   - protocol 固定 "openai"（touwaka providers 均为 OpenAI 兼容端点；将来接 Anthropic
+ *     原生协议时需在 providers 表加 protocol 列——DB 字段变更属红线，届时先确认）
+ *   - apiKey 来自 providers.api_key（DB 即物化，等价 ADR-001 的间接引用物化）
+ *   - 不做缓存（ModelRegistry 已有缓存层；本适配器保持薄，每次 resolve 走 DB）
+ */
+
+const DEFAULT_SLOT = "default";
+
+function toModelConfig(row) {
+  if (!row) return null;
+  return {
+    protocol: "openai",
+    endpoint: row.base_url,
+    model: row.model_name,
+    apiKey: row.api_key ?? undefined,
+    contextWindowTokens: row.max_tokens ?? undefined,
+    maxOutputTokens: row.max_output_tokens ?? undefined,
+  };
+}
+
+export function createTouwakaModelConfigProvider({ db }) {
+  if (!db) throw new Error("[llm-kit-adapters] db 实例必填");
+
+  async function resolveDefault() {
+    const AiModel = db.getModel("ai_model");
+    const row = await AiModel.findOne({
+      where: { is_active: true, model_type: "text" },
+      order: [["created_at", "DESC"]],
+      raw: true,
+    });
+    if (!row) throw new Error("[llm-kit-adapters] 无可用默认文本模型（ai_models 表为空或全未激活）");
+    return toModelConfig(await db.getModelConfig(row.id));
+  }
+
+  return {
+    async resolve(slot) {
+      if (!slot || slot === DEFAULT_SLOT) return resolveDefault();
+      const config = toModelConfig(await db.getModelConfig(slot));
+      return config ?? resolveDefault();
+    },
+  };
+}

--- a/tests/llm-kit-adapters/model-config-provider.contract.test.mjs
+++ b/tests/llm-kit-adapters/model-config-provider.contract.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * touwaka ModelConfigProvider 适配器 × erix-llm-kit 契约测试（真实 MariaDB）
+ *
+ * 在测试库（llm_kit_test）内用 sequelize sync 建出 providers / ai_models 两表的真实结构，
+ * 播种后跑库的 modelConfigProviderContract 全部断言。
+ *
+ * 凭据：~/.config/mcp/creds/touwaka-test-db.json（600，不入库）；缺失则 skip。
+ * 运行：node --test tests/llm-kit-adapters/
+ */
+
+import { test, after } from "node:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// logs/ 目录当前是 root 属主（容器残留），logger 写文件会 EACCES 掩盖真实错误。
+// 测试环境把 logger 降级为 console-only（在 db.connect() 之前补丁即可，logger 是模块级单例）。
+// TODO: sudo chown -R eric:eric logs/ 后可移除此补丁。
+import logger from "../../lib/logger.js";
+for (const m of ["info", "warn", "error", "debug"]) {
+  if (typeof logger[m] === "function") logger[m] = () => {};
+}
+
+import Database from "../../lib/db.js";
+import { createTouwakaModelConfigProvider } from "../../lib/llm-kit-adapters/model-config-provider.js";
+
+// TODO: @erix/llm-kit 发布到 Gitea npm registry 后改为包导入：
+//   import { modelConfigProviderContract } from "@erix/llm-kit/contract-tests";
+import { modelConfigProviderContract } from "../../../erix-llm-kit/test/contract/model-config-provider.js";
+
+const CREDS_PATH = join(homedir(), ".config/mcp/creds/touwaka-test-db.json");
+
+function loadCreds() {
+  try {
+    return JSON.parse(readFileSync(CREDS_PATH, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+const creds = loadCreds();
+
+let db = null;
+
+if (creds) {
+  db = new Database({
+    database: creds.database,
+    user: creds.user,
+    password: creds.password,
+    host: creds.host,
+    port: creds.port,
+  });
+
+  await db.connect();
+
+  // 真实模型定义 sync 建表（force 重建，保证干净的契约环境）
+  await db.models.provider.sync({ force: true });
+  await db.models.ai_model.sync({ force: true });
+
+  // 播种：两个 provider（不同 api_key），三个模型
+  await db.models.provider.bulkCreate([
+    { id: "p-main", name: "主网关", base_url: "http://127.0.0.1:8317/v1", api_key: "main-secret-key", is_active: true },
+    { id: "p-fold", name: "折叠专用", base_url: "http://127.0.0.1:8317/v1", api_key: "fold-secret-key", is_active: true },
+    { id: "p-off", name: "停用", base_url: "http://127.0.0.1:9/v1", api_key: "off-key", is_active: false },
+  ]);
+  await db.models.ai_model.bulkCreate([
+    // 默认文本模型（created_at 最新 → default slot 命中它）
+    { id: "m-default", name: "默认文本", model_name: "qwen3-default", model_type: "text", provider_id: "p-main", max_tokens: 131072, max_output_tokens: 8192, is_active: true, created_at: "2026-08-01 00:00:00", updated_at: "2026-08-01 00:00:00" },
+    // 命名槽位模型（slot = ai_model.id）
+    { id: "m-fold", name: "折叠", model_name: "qwen3-fold", model_type: "text", provider_id: "p-fold", max_tokens: 32768, max_output_tokens: 4096, is_active: true, created_at: "2026-07-01 00:00:00", updated_at: "2026-07-01 00:00:00" },
+    // 更老的默认候选（不应命中 default）
+    { id: "m-old", name: "旧模型", model_name: "qwen-old", model_type: "text", provider_id: "p-main", max_tokens: 8192, max_output_tokens: 2048, is_active: true, created_at: "2026-06-01 00:00:00", updated_at: "2026-06-01 00:00:00" },
+    // 非文本模型（不应命中 default）
+    { id: "m-emb", name: "嵌入", model_name: "bge-m3", model_type: "embedding", provider_id: "p-main", is_active: true, created_at: "2026-08-02 00:00:00", updated_at: "2026-08-02 00:00:00" },
+  ]);
+
+}
+
+after(async () => {
+  if (!db) return;
+
+  await db.models.ai_model.drop();
+  await db.models.provider.drop();
+  if (typeof db.close === "function") {
+    await db.close();
+  } else if (db.sequelize) {
+    await db.sequelize.close();
+  }
+});
+
+if (!creds) {
+  test("touwaka ModelConfigProvider 适配器契约（真实 MariaDB）", {
+    skip: `缺少凭据 ${CREDS_PATH}`,
+  }, () => {});
+} else {
+  const provider = createTouwakaModelConfigProvider({ db });
+  modelConfigProviderContract("touwaka ModelConfigProvider", async () => ({
+    provider,
+    slot: "m-fold",
+    expect: {
+      defaultModel: "qwen3-default",
+      slotModel: "qwen3-fold",
+      materializedKey: "fold-secret-key",
+    },
+  }));
+}


### PR DESCRIPTION
## 内容

erix-llm-kit 驱动模型的首个项目侧落地（ADR-001/002：接口在库、DB 适配器在项目侧）。

### 新增
- **`lib/llm-kit-adapters/model-config-provider.js`** — `createTouwakaModelConfigProvider({ db })`
  - slot 语义：`default` → 最新激活文本模型（与 ModelRegistry 同规则）；其他值 → 按 `ai_model.id` 查找，未知槽回落 default
  - apiKey 由 `providers.api_key` DB 物化（等价 ADR-001 间接引用物化）
  - protocol 固定 `openai`（将来接 Anthropic 原生协议需 providers 表加列，属 DB 红线变更，届时先确认）
- **`tests/llm-kit-adapters/`** — 契约测试：sequelize sync 真实模型建表 → 播种（含停用 provider/非文本/更老候选干扰项）→ 跑库的 4 条契约断言 → after 清理
- **`lib/llm-kit-adapters/README.md`** — 用法与测试说明

### 验证
- `node --test tests/llm-kit-adapters/`：4/4 绿（真实 MariaDB `llm_kit_test` 库），表已清理无残留
- `npm run lint` 通过

### 注意
- 契约套件当前相对路径引用 `erix-llm-kit/test/contract/`，待 `@erix/llm-kit` 发布 Gitea npm registry 后换包导入（文件内 TODO）
- 测试凭据 `~/.config/mcp/creds/touwaka-test-db.json`（600，不入库）
- `logs/` 目录 root 属主导致 logger EACCES，测试内临时降级（TODO：sudo chown 后移除补丁）