### PR TITLE
feat-260829-02: erix-llm-kit TranscriptStore 适配器（MariaDB）

### DIFF
--- a/lib/llm-kit-adapters/README.md
+++ b/lib/llm-kit-adapters/README.md
@@ -8,6 +8,7 @@ erix-llm-kit 的"驱动模型"：接口在库，DB 适配器在项目侧（ADR-0
 | 文件 | 接口 | 后端 |
 |---|---|---|
 | `model-config-provider.js` | ModelConfigProvider | `ai_models` + `providers` 表（经 lib/db.js） |
+| `transcript-store.js` | TranscriptStore | `llm_kit_transcripts` 表（适配器内 Sequelize 模型） |
 
 ## 测试
 

--- a/lib/llm-kit-adapters/transcript-store.js
+++ b/lib/llm-kit-adapters/transcript-store.js
@@ -1,0 +1,156 @@
+import { DataTypes } from "sequelize";
+
+const MODEL_NAME = "llm_kit_transcript";
+const TABLE_NAME = "llm_kit_transcripts";
+
+function defineTranscriptModel(sequelize) {
+  return sequelize.models[MODEL_NAME] ?? sequelize.define(MODEL_NAME, {
+    run_id: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+      primaryKey: true,
+    },
+    round: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+    },
+    ts: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+    },
+    folded: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    messages: {
+      type: DataTypes.JSON,
+      allowNull: false,
+    },
+    folded_payload: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  }, {
+    tableName: TABLE_NAME,
+    timestamps: false,
+    freezeTableName: true,
+  });
+}
+
+function parseJsonColumn(value) {
+  if (typeof value === "string") return JSON.parse(value);
+  return value;
+}
+
+function toRecord(row) {
+  const record = {
+    round: row.round,
+    ts: row.ts,
+    folded: Boolean(row.folded),
+    messages: parseJsonColumn(row.messages),
+  };
+  const foldedPayload = parseJsonColumn(row.folded_payload);
+  if (foldedPayload !== null && foldedPayload !== undefined) {
+    record.foldedPayload = foldedPayload;
+  }
+  return record;
+}
+
+function blocksFor(content) {
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  return Array.isArray(content) ? content : [];
+}
+
+function blockText(block) {
+  if (!block || typeof block !== "object") return null;
+  if (block.type === "text") return String(block.text ?? "");
+  if (block.type === "tool_use") {
+    return `${block.name ?? ""}${JSON.stringify(block.input)}`;
+  }
+  if (block.type === "tool_result") return String(block.content ?? "");
+  return null;
+}
+
+function appendFragments(fragments, messages) {
+  for (const message of messages ?? []) {
+    for (const block of blocksFor(message?.content)) {
+      const text = blockText(block);
+      if (text !== null) fragments.push(text);
+    }
+  }
+}
+
+/**
+ * Create a MariaDB-backed TranscriptStore.
+ *
+ * The model is defined here but is not synchronized automatically. Call the
+ * returned store's sync() during application or test setup.
+ *
+ * @param {{db: {sequelize: import("sequelize").Sequelize}}} options
+ * @returns {{
+ *   appendRound: (runId:string, record:object) => Promise<void>,
+ *   load: (runId:string) => Promise<object[]>,
+ *   recall: (runId:string, fromRound?:number, toRound?:number, pattern?:string) => Promise<string>,
+ *   sync: (options?:object) => Promise<object>
+ * }}
+ */
+export function createTouwakaTranscriptStore({ db }) {
+  if (!db?.sequelize) throw new Error("[llm-kit-adapters] db 实例必填");
+
+  const Transcript = defineTranscriptModel(db.sequelize);
+
+  return {
+    async appendRound(runId, record) {
+      await Transcript.create({
+        run_id: runId,
+        round: record.round,
+        ts: record.ts,
+        folded: record.folded ?? false,
+        messages: record.messages,
+        folded_payload: record.foldedPayload ?? null,
+      });
+    },
+
+    async load(runId) {
+      const rows = await Transcript.findAll({
+        where: { run_id: runId },
+        order: [["round", "ASC"]],
+        raw: true,
+      });
+      return rows.map(toRecord);
+    },
+
+    async recall(runId, fromRound, toRound, pattern) {
+      const rows = await Transcript.findAll({
+        where: { run_id: runId },
+        order: [["round", "ASC"]],
+        raw: true,
+      });
+      const fragments = [];
+
+      for (const row of rows) {
+        if (fromRound !== undefined && row.round < fromRound) continue;
+        if (toRound !== undefined && row.round > toRound) continue;
+
+        appendFragments(fragments, parseJsonColumn(row.messages));
+        appendFragments(fragments, parseJsonColumn(row.folded_payload));
+      }
+
+      const selected = pattern === undefined
+        ? fragments
+        : fragments.filter((fragment) => fragment.includes(pattern));
+      return selected.join("\n");
+    },
+
+    async sync(options) {
+      return Transcript.sync(options);
+    },
+  };
+}

--- a/tests/llm-kit-adapters/transcript-store.contract.test.mjs
+++ b/tests/llm-kit-adapters/transcript-store.contract.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * touwaka TranscriptStore 适配器 × erix-llm-kit 契约测试（真实 MariaDB）
+ *
+ * 在测试库（llm_kit_test）内用适配器定义的 Sequelize 模型建出
+ * llm_kit_transcripts 表，逐测试清空后跑库的 transcriptStoreContract 全部断言。
+ *
+ * 凭据：~/.config/mcp/creds/touwaka-test-db.json（600，不入库）；缺失则 skip。
+ * 运行：node --test tests/llm-kit-adapters/
+ */
+
+import { test, after } from "node:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// logs/ 目录当前是 root 属主（容器残留），logger 写文件会 EACCES 掩盖真实错误。
+// 测试环境把 logger 降级为 console-only（在 db.connect() 之前补丁即可，logger 是模块级单例）。
+// TODO: sudo chown -R eric:eric logs/ 后可移除此补丁。
+import logger from "../../lib/logger.js";
+for (const m of ["info", "warn", "error", "debug"]) {
+  if (typeof logger[m] === "function") logger[m] = () => {};
+}
+
+import Database from "../../lib/db.js";
+import { createTouwakaTranscriptStore } from "../../lib/llm-kit-adapters/transcript-store.js";
+
+// TODO: @erix/llm-kit 发布到 Gitea npm registry 后改为包导入：
+//   import { transcriptStoreContract } from "@erix/llm-kit/contract-tests";
+import { transcriptStoreContract } from "../../../erix-llm-kit/test/contract/transcript-store.js";
+
+const CREDS_PATH = join(homedir(), ".config/mcp/creds/touwaka-test-db.json");
+
+function loadCreds() {
+  try {
+    return JSON.parse(readFileSync(CREDS_PATH, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+const creds = loadCreds();
+
+let db = null;
+let Transcript = null;
+
+if (creds) {
+  db = new Database({
+    database: creds.database,
+    user: creds.user,
+    password: creds.password,
+    host: creds.host,
+    port: creds.port,
+  });
+
+  await db.connect();
+
+  const setupStore = createTouwakaTranscriptStore({ db });
+  Transcript = db.sequelize.models.llm_kit_transcript;
+  await setupStore.sync({ force: true });
+}
+
+after(async () => {
+  if (!db) return;
+
+  await Transcript.drop();
+  if (typeof db.close === "function") {
+    await db.close();
+  } else if (db.sequelize) {
+    await db.sequelize.close();
+  }
+});
+
+if (!creds) {
+  test("touwaka TranscriptStore 适配器契约（真实 MariaDB）", {
+    skip: `缺少凭据 ${CREDS_PATH}`,
+  }, () => {});
+} else {
+  transcriptStoreContract("touwaka TranscriptStore", async () => {
+    await Transcript.destroy({ truncate: true });
+    return createTouwakaTranscriptStore({ db });
+  });
+}


### PR DESCRIPTION
Closes #1092

## 内容

TranscriptStore（ADR-002）的 touwaka MariaDB 实现，驱动模型第二站。

### 新增
- **`lib/llm-kit-adapters/transcript-store.js`** — `createTouwakaTranscriptStore({ db })`
  - `appendRound / load / recall` 三方法 + 显式 `sync()`（不做自动建表）
  - 新表 `llm_kit_transcripts`：联合主键 (run_id, round)；ts VARCHAR(32) ISO 原样往返；messages/folded_payload JSON 列
  - sequelize 模型在适配器内 define，**不改 models/ 与 init-models.js**
  - recall 语义与库内置 memory store 逐行对齐（语料 = messages + foldedPayload，messages 在前，子串过滤）
  - 边界归一化：mysql2 JSON 字符串返回兼容、BOOLEAN/TINYINT(1) 读回转 boolean
- **`tests/llm-kit-adapters/transcript-store.contract.test.mjs`** — 接入库契约套件 8 条断言（真实 llm_kit_test 库；逐测试 TRUNCATE；after drop 清理）
- README 清单加一行

### 验证（主 agent 复跑）
- `node --test` 两个契约文件：**12/12 绿**（config 4 + transcript 8）
- 测试后 `SHOW TABLES` 无残留
- `npm run lint` 通过

### 红线确认
- 不改任何既有表结构；`llm_kit_transcripts` 生产库建表迁移另开任务
- 无密钥入库；测试凭据走 ~/.config/mcp/creds/