### PR TITLE
feat-260829-03: TranscriptStore 表 v2 + OpenAI↔canonical 转换器（epic #1094 阶段 1）

### DIFF
--- a/lib/llm-kit-adapters/README.md
+++ b/lib/llm-kit-adapters/README.md
@@ -8,7 +8,8 @@ erix-llm-kit 的"驱动模型"：接口在库，DB 适配器在项目侧（ADR-0
 | 文件 | 接口 | 后端 |
 |---|---|---|
 | `model-config-provider.js` | ModelConfigProvider | `ai_models` + `providers` 表（经 lib/db.js） |
-| `transcript-store.js` | TranscriptStore | `llm_kit_transcripts` 表（适配器内 Sequelize 模型） |
+| `transcript-store.js` | TranscriptStore | `llm_kit_transcripts` 表（可通过 `tableName` 指定其他表，适配器内 Sequelize 模型） |
+| `message-converter.js` | OpenAI ↔ canonical 双向转换 | 纯函数，无 DB 依赖 |
 
 ## 测试
 
@@ -20,6 +21,9 @@ erix-llm-kit 的"驱动模型"：接口在库，DB 适配器在项目侧（ADR-0
 #   { "host": "127.0.0.1", "port": 3306, "user": "eric", "password": "…", "database": "llm_kit_test" }
 node --test tests/llm-kit-adapters/
 ```
+
+契约测试使用默认的 `llm_kit_transcripts` 表；元数据测试使用独立的
+`llm_kit_transcripts_meta_test` 表，因此可以在 Node.js 测试默认并发下安全运行。
 
 测试会在 `llm_kit_test` 库内建/删 `providers` 与 `ai_models` 两表（sequelize sync 真实模型定义），
 **不要**把凭据指向 touwaka_mate 生产库。

--- a/lib/llm-kit-adapters/message-converter.js
+++ b/lib/llm-kit-adapters/message-converter.js
@@ -1,0 +1,394 @@
+/**
+ * Convert legacy messages rows to and from the erix-llm-kit canonical format.
+ * This module intentionally has no database dependency.
+ */
+
+const META_FIELDS = [
+  ["topic_id", "topicId"],
+  ["user_id", "userId"],
+  ["expert_id", "expertId"],
+  ["model_name", "modelName"],
+  ["provider_name", "providerName"],
+  ["latency_ms", "latencyMs"],
+  ["is_deleted", "isDeleted"],
+];
+
+function hasValue(value) {
+  return value !== null && value !== undefined;
+}
+
+function isNonEmpty(value) {
+  return hasValue(value) && String(value).length > 0;
+}
+
+function parseJson(value) {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function asText(value) {
+  if (typeof value === "string") return value;
+  if (!hasValue(value)) return "";
+  return JSON.stringify(value);
+}
+
+function toIsoTimestamp(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isNaN(date.getTime())) return date.toISOString();
+  return hasValue(value) ? String(value) : undefined;
+}
+
+function compareValues(left, right) {
+  if (left === right) return 0;
+  if (!hasValue(left)) return -1;
+  if (!hasValue(right)) return 1;
+
+  const leftDate = new Date(left).getTime();
+  const rightDate = new Date(right).getTime();
+  if (!Number.isNaN(leftDate) && !Number.isNaN(rightDate) && leftDate !== rightDate) {
+    return leftDate - rightDate;
+  }
+  return String(left).localeCompare(String(right));
+}
+
+function compareRows(left, right) {
+  const createdAtOrder = compareValues(left?.created_at, right?.created_at);
+  if (createdAtOrder !== 0) return createdAtOrder;
+  if (left?.id === right?.id) return 0;
+  if (!hasValue(left?.id)) return -1;
+  if (!hasValue(right?.id)) return 1;
+  return String(left.id).localeCompare(String(right.id));
+}
+
+function textBlocksForContent(content) {
+  if (!isNonEmpty(content)) return [];
+  return [{ type: "text", text: String(content) }];
+}
+
+function auxiliaryBlocksForRow(row) {
+  const blocks = [];
+  if (isNonEmpty(row?.reasoning_content)) {
+    blocks.push({
+      type: "raw",
+      protocol: "touwaka",
+      payload: { kind: "reasoning", text: asText(row.reasoning_content) },
+    });
+  }
+  if (isNonEmpty(row?.inner_voice)) {
+    blocks.push({
+      type: "raw",
+      protocol: "touwaka",
+      payload: { kind: "inner_voice", text: asText(row.inner_voice) },
+    });
+  }
+  return blocks;
+}
+
+function toolUseBlocksForRow(row) {
+  const toolCalls = parseJson(row?.tool_calls);
+  if (!Array.isArray(toolCalls)) return [];
+
+  return toolCalls.map((toolCall) => {
+    const rawArguments = toolCall?.function?.arguments;
+    try {
+      return {
+        type: "tool_use",
+        id: toolCall?.id,
+        name: toolCall?.function?.name,
+        input: JSON.parse(rawArguments === undefined ? "{}" : rawArguments),
+      };
+    } catch {
+      return {
+        type: "raw",
+        protocol: "openai",
+        payload: toolCall,
+      };
+    }
+  });
+}
+
+function rowToCanonicalMessage(row) {
+  const role = row?.role === "tool" ? "user" : row?.role;
+  const content = role === "assistant"
+    ? [
+      ...textBlocksForContent(row?.content),
+      ...toolUseBlocksForRow(row),
+      ...auxiliaryBlocksForRow(row),
+    ]
+    : row?.role === "tool"
+      ? [{
+        type: "tool_result",
+        tool_use_id: row?.tool_call_id,
+        content: asText(row?.content),
+        ...(hasValue(row?.is_error) ? { is_error: Boolean(row.is_error) } : {}),
+      }, ...auxiliaryBlocksForRow(row)]
+      : [
+        ...textBlocksForContent(row?.content),
+        ...auxiliaryBlocksForRow(row),
+      ];
+
+  return { role, content };
+}
+
+function setIfPresent(target, key, value) {
+  if (hasValue(value)) target[key] = value;
+}
+
+function mergeRoundMeta(meta, row, isAssistant) {
+  for (const [columnName, metaKey] of META_FIELDS.slice(0, 3)) {
+    if (hasValue(row?.[columnName])) meta[metaKey] = row[columnName];
+  }
+
+  if (!isAssistant) {
+    if (!hasValue(meta.errorInfo) && hasValue(row?.error_info)) {
+      meta.errorInfo = parseJson(row.error_info);
+    }
+    if (!hasValue(meta.isDeleted) && hasValue(row?.is_deleted)) {
+      meta.isDeleted = row.is_deleted;
+    }
+    return;
+  }
+
+  for (const [columnName, metaKey] of META_FIELDS.slice(3, 6)) {
+    if (hasValue(row?.[columnName])) meta[metaKey] = row[columnName];
+  }
+  if (hasValue(row?.error_info)) meta.errorInfo = parseJson(row.error_info);
+  if (hasValue(row?.is_deleted)) meta.isDeleted = row.is_deleted;
+  if (hasValue(row?.prompt_tokens)
+    && hasValue(row?.completion_tokens)
+    && hasValue(row?.cost)) {
+    meta.usage = {
+      prompt_tokens: row.prompt_tokens,
+      completion_tokens: row.completion_tokens,
+      cost: row.cost,
+    };
+  }
+}
+
+function createRecord(round, row) {
+  const meta = {};
+  mergeRoundMeta(meta, row, row?.role === "assistant");
+  return {
+    round,
+    ts: toIsoTimestamp(row?.created_at),
+    folded: false,
+    messages: [],
+    meta,
+  };
+}
+
+function appendRowToRecord(record, row) {
+  mergeRoundMeta(record.meta, row, row?.role === "assistant");
+  record.messages.push(rowToCanonicalMessage(row));
+}
+
+/**
+ * Convert legacy messages rows to a canonical transcript.
+ *
+ * @param {string} requestId
+ * @param {object[]} rows
+ * @returns {{runId:string, records:object[]}}
+ */
+export function legacyRowsToTranscript(requestId, rows) {
+  const records = [];
+  let currentRecord = null;
+  let nextRound = 1;
+  let hasAssistant = false;
+
+  const sortedRows = [...(rows ?? [])].sort(compareRows);
+  for (const row of sortedRows) {
+    if (row?.role === "assistant") {
+      currentRecord = createRecord(nextRound, row);
+      nextRound += 1;
+      hasAssistant = true;
+      records.push(currentRecord);
+      appendRowToRecord(currentRecord, row);
+      continue;
+    }
+
+    if (!currentRecord || (!hasAssistant && row?.role === "user" && currentRecord.round !== 0)) {
+      currentRecord = createRecord(0, row);
+      records.push(currentRecord);
+    }
+
+    appendRowToRecord(currentRecord, row);
+  }
+
+  return { runId: requestId, records };
+}
+
+function blocksForCanonicalContent(content) {
+  if (typeof content === "string") {
+    return content.length > 0 ? [{ type: "text", text: content }] : [];
+  }
+  return Array.isArray(content) ? content : [];
+}
+
+function recordBaseFields(record, role) {
+  const fields = {};
+  const meta = record?.meta ?? {};
+
+  for (const [columnName, metaKey] of META_FIELDS.slice(0, 3)) {
+    setIfPresent(fields, columnName, meta[metaKey]);
+  }
+  if (role === "assistant") {
+    for (const [columnName, metaKey] of META_FIELDS.slice(3, 6)) {
+      setIfPresent(fields, columnName, meta[metaKey]);
+    }
+  }
+  setIfPresent(fields, "is_deleted", meta.isDeleted);
+  setIfPresent(fields, "error_info", meta.errorInfo);
+  if (role === "assistant" && meta.usage && typeof meta.usage === "object") {
+    for (const key of ["prompt_tokens", "completion_tokens", "cost"]) {
+      setIfPresent(fields, key, meta.usage[key]);
+    }
+  }
+  setIfPresent(fields, "created_at", record?.ts);
+  return fields;
+}
+
+function appendRawFields(row, block) {
+  if (block?.protocol === "touwaka" && block.payload?.kind === "reasoning") {
+    row.reasoning_content = asText(block.payload.text);
+  } else if (block?.protocol === "touwaka" && block.payload?.kind === "inner_voice") {
+    row.inner_voice = asText(block.payload.text);
+  }
+}
+
+function toolCallFromBlock(block) {
+  if (block?.type === "tool_use") {
+    return {
+      id: block.id,
+      type: "function",
+      function: {
+        name: block.name,
+        arguments: JSON.stringify(block.input ?? {}),
+      },
+    };
+  }
+  if (block?.type === "raw" && block.protocol === "openai") return block.payload ?? null;
+  return null;
+}
+
+function assistantMessageToLegacyRows(record, message) {
+  const row = {
+    role: "assistant",
+    content: "",
+    ...recordBaseFields(record, "assistant"),
+  };
+  const toolCalls = [];
+
+  for (const block of blocksForCanonicalContent(message?.content)) {
+    if (block?.type === "text") {
+      row.content += asText(block.text);
+      continue;
+    }
+
+    const toolCall = toolCallFromBlock(block);
+    if (toolCall !== null) {
+      toolCalls.push(toolCall);
+      continue;
+    }
+
+    appendRawFields(row, block);
+  }
+
+  if (toolCalls.length > 0) row.tool_calls = toolCalls;
+  return [row];
+}
+
+function toolResultToLegacyRow(record, block) {
+  const row = {
+    role: "tool",
+    content: asText(block?.content),
+    tool_call_id: block?.tool_use_id,
+    ...recordBaseFields(record, "tool"),
+  };
+  if (hasValue(block?.is_error)) row.is_error = Boolean(block.is_error);
+  return row;
+}
+
+function userLikeMessageToLegacyRows(record, message, role) {
+  const rows = [];
+  let text = "";
+  let auxiliaryRow = null;
+  let emitted = false;
+
+  const flushText = () => {
+    if (text.length === 0 && !auxiliaryRow) return;
+    rows.push({
+      role,
+      content: text,
+      ...recordBaseFields(record, role),
+      ...(auxiliaryRow ?? {}),
+    });
+    text = "";
+    auxiliaryRow = null;
+    emitted = true;
+  };
+
+  for (const block of blocksForCanonicalContent(message?.content)) {
+    if (block?.type === "text") {
+      text += asText(block.text);
+      continue;
+    }
+    if (block?.type === "tool_result") {
+      flushText();
+      rows.push(toolResultToLegacyRow(record, block));
+      emitted = true;
+      continue;
+    }
+
+    const toolCall = toolCallFromBlock(block);
+    if (toolCall !== null) {
+      auxiliaryRow ??= { tool_calls: [] };
+      auxiliaryRow.tool_calls.push(toolCall);
+      continue;
+    }
+
+    if (block?.type === "raw") {
+      auxiliaryRow ??= {};
+      appendRawFields(auxiliaryRow, block);
+    }
+  }
+
+  flushText();
+  if (!emitted) {
+    rows.push({
+      role,
+      content: "",
+      ...recordBaseFields(record, role),
+    });
+  }
+  if (auxiliaryRow?.tool_calls?.length === 0) {
+    delete auxiliaryRow.tool_calls;
+  }
+  return rows;
+}
+
+/**
+ * Convert canonical transcript records to legacy-shaped message rows.
+ *
+ * @param {object[]} records
+ * @returns {object[]}
+ */
+export function canonicalToLegacyMessages(records) {
+  const rows = [];
+  const sourceRecords = Array.isArray(records) ? records : records?.records ?? [];
+  for (const record of sourceRecords) {
+    for (const message of record?.messages ?? []) {
+      if (message?.role === "assistant") {
+        rows.push(...assistantMessageToLegacyRows(record, message));
+      } else if (message?.role === "system") {
+        rows.push(...userLikeMessageToLegacyRows(record, message, "system"));
+      } else {
+        rows.push(...userLikeMessageToLegacyRows(record, message, "user"));
+      }
+    }
+  }
+  return rows;
+}

--- a/lib/llm-kit-adapters/transcript-store.js
+++ b/lib/llm-kit-adapters/transcript-store.js
@@ -1,10 +1,29 @@
 import { DataTypes } from "sequelize";
 
-const MODEL_NAME = "llm_kit_transcript";
-const TABLE_NAME = "llm_kit_transcripts";
+const DEFAULT_MODEL_NAME = "llm_kit_transcript";
+const DEFAULT_TABLE_NAME = "llm_kit_transcripts";
 
-function defineTranscriptModel(sequelize) {
-  return sequelize.models[MODEL_NAME] ?? sequelize.define(MODEL_NAME, {
+const META_COLUMNS = [
+  ["topicId", "topic_id"],
+  ["userId", "user_id"],
+  ["expertId", "expert_id"],
+  ["modelName", "model_name"],
+  ["providerName", "provider_name"],
+  ["usage", "usage"],
+  ["latencyMs", "latency_ms"],
+  ["errorInfo", "error_info"],
+  ["isDeleted", "is_deleted"],
+];
+
+function modelNameForTable(tableName) {
+  return tableName === DEFAULT_TABLE_NAME
+    ? DEFAULT_MODEL_NAME
+    : `${DEFAULT_MODEL_NAME}_${tableName}`;
+}
+
+function defineTranscriptModel(sequelize, tableName) {
+  const modelName = modelNameForTable(tableName);
+  return sequelize.models[modelName] ?? sequelize.define(modelName, {
     run_id: {
       type: DataTypes.STRING(128),
       allowNull: false,
@@ -32,15 +51,62 @@ function defineTranscriptModel(sequelize) {
       type: DataTypes.JSON,
       allowNull: true,
     },
+    topic_id: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+    },
+    user_id: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+    },
+    expert_id: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+    },
+    model_name: {
+      type: DataTypes.STRING(128),
+      allowNull: true,
+    },
+    provider_name: {
+      type: DataTypes.STRING(128),
+      allowNull: true,
+    },
+    usage: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
+    latency_ms: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    error_info: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
+    is_deleted: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
     created_at: {
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
   }, {
-    tableName: TABLE_NAME,
+    tableName,
     timestamps: false,
     freezeTableName: true,
+    indexes: [
+      {
+        name: "idx_llm_kit_transcripts_topic_id",
+        fields: ["topic_id"],
+      },
+      {
+        name: "idx_llm_kit_transcripts_user_id",
+        fields: ["user_id"],
+      },
+    ],
   });
 }
 
@@ -61,6 +127,39 @@ function toRecord(row) {
     record.foldedPayload = foldedPayload;
   }
   return record;
+}
+
+function metaToColumns(meta = {}) {
+  const columns = {};
+  for (const [metaKey, columnName] of META_COLUMNS) {
+    if (metaKey === "isDeleted") {
+      columns[columnName] = meta[metaKey] ?? false;
+    } else {
+      columns[columnName] = meta[metaKey] ?? null;
+    }
+  }
+  return columns;
+}
+
+function rowToMeta(row) {
+  const meta = {};
+  for (const [metaKey, columnName] of META_COLUMNS) {
+    if (metaKey === "isDeleted") {
+      meta[metaKey] = Boolean(row[columnName]);
+    } else if (metaKey === "usage" || metaKey === "errorInfo") {
+      meta[metaKey] = parseJsonColumn(row[columnName]);
+    } else {
+      meta[metaKey] = row[columnName];
+    }
+  }
+  return meta;
+}
+
+function toRecordWithMeta(row) {
+  return {
+    ...toRecord(row),
+    meta: rowToMeta(row),
+  };
 }
 
 function blocksFor(content) {
@@ -93,21 +192,26 @@ function appendFragments(fragments, messages) {
  * The model is defined here but is not synchronized automatically. Call the
  * returned store's sync() during application or test setup.
  *
- * @param {{db: {sequelize: import("sequelize").Sequelize}}} options
+ * @param {{
+ *   db: {sequelize: import("sequelize").Sequelize},
+ *   tableName?: string
+ * }} options
  * @returns {{
- *   appendRound: (runId:string, record:object) => Promise<void>,
+ *   appendRound: (runId:string, record:object, meta?:object) => Promise<void>,
  *   load: (runId:string) => Promise<object[]>,
+ *   loadWithMeta: (runId:string) => Promise<object[]>,
+ *   findByTopic: (topicId:string, options?:{limit?:number}) => Promise<object[]>,
  *   recall: (runId:string, fromRound?:number, toRound?:number, pattern?:string) => Promise<string>,
  *   sync: (options?:object) => Promise<object>
  * }}
  */
-export function createTouwakaTranscriptStore({ db }) {
+export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAME }) {
   if (!db?.sequelize) throw new Error("[llm-kit-adapters] db 实例必填");
 
-  const Transcript = defineTranscriptModel(db.sequelize);
+  const Transcript = defineTranscriptModel(db.sequelize, tableName);
 
   return {
-    async appendRound(runId, record) {
+    async appendRound(runId, record, meta) {
       await Transcript.create({
         run_id: runId,
         round: record.round,
@@ -115,6 +219,7 @@ export function createTouwakaTranscriptStore({ db }) {
         folded: record.folded ?? false,
         messages: record.messages,
         folded_payload: record.foldedPayload ?? null,
+        ...metaToColumns(meta ?? record.meta),
       });
     },
 
@@ -125,6 +230,28 @@ export function createTouwakaTranscriptStore({ db }) {
         raw: true,
       });
       return rows.map(toRecord);
+    },
+
+    async loadWithMeta(runId) {
+      const rows = await Transcript.findAll({
+        where: { run_id: runId },
+        order: [["round", "ASC"]],
+        raw: true,
+      });
+      return rows.map(toRecordWithMeta);
+    },
+
+    async findByTopic(topicId, options = {}) {
+      const query = {
+        where: { topic_id: topicId },
+        order: [["run_id", "ASC"], ["round", "ASC"]],
+        raw: true,
+      };
+      if (Number.isInteger(options?.limit) && options.limit >= 0) {
+        query.limit = options.limit;
+      }
+      const rows = await Transcript.findAll(query);
+      return rows.map(toRecordWithMeta);
     },
 
     async recall(runId, fromRound, toRound, pattern) {

--- a/tests/llm-kit-adapters/message-converter.test.mjs
+++ b/tests/llm-kit-adapters/message-converter.test.mjs
@@ -1,0 +1,227 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  canonicalToLegacyMessages,
+  legacyRowsToTranscript,
+} from "../../lib/llm-kit-adapters/message-converter.js";
+
+test("普通对话按 created_at/id 排序并生成 round 0 种子记录", () => {
+  const { runId, records } = legacyRowsToTranscript("request-1", [
+    { id: "b", role: "user", content: "", created_at: "2026-08-29T00:00:02.000Z" },
+    { id: "a", role: "user", content: "先提供上下文", created_at: "2026-08-29T00:00:01.000Z" },
+    { id: "c", role: "assistant", content: "收到", created_at: "2026-08-29T00:00:03.000Z" },
+  ]);
+
+  assert.equal(runId, "request-1");
+  assert.deepEqual(records.map((record) => record.round), [0, 1]);
+  assert.deepEqual(records[0].messages, [
+    { role: "user", content: [{ type: "text", text: "先提供上下文" }] },
+    { role: "user", content: [] },
+  ]);
+  assert.deepEqual(records[1].messages, [
+    { role: "assistant", content: [{ type: "text", text: "收到" }] },
+  ]);
+  assert.equal(records[0].ts, "2026-08-29T00:00:01.000Z");
+});
+
+test("多轮 tool_calls、tool 结果和非法 arguments 都能转换", () => {
+  const invalidCall = {
+    id: "call-invalid",
+    type: "function",
+    function: { name: "broken", arguments: "{oops" },
+  };
+  const { records } = legacyRowsToTranscript("request-2", [
+    {
+      id: "u1",
+      role: "user",
+      content: "执行任务",
+      created_at: "2026-08-29T00:01:00.000Z",
+    },
+    {
+      id: "a1",
+      role: "assistant",
+      content: "开始",
+      tool_calls: JSON.stringify([
+        {
+          id: "call-valid",
+          type: "function",
+          function: { name: "search", arguments: '{"query":"touwaka"}' },
+        },
+        invalidCall,
+      ]),
+      created_at: "2026-08-29T00:01:01.000Z",
+    },
+    {
+      id: "t1",
+      role: "tool",
+      tool_call_id: "call-valid",
+      content: "命中结果",
+      created_at: "2026-08-29T00:01:02.000Z",
+    },
+    {
+      id: "a2",
+      role: "assistant",
+      content: null,
+      tool_calls: [{ id: "call-next", function: { name: "done", arguments: "{}" } }],
+      created_at: "2026-08-29T00:01:03.000Z",
+    },
+  ]);
+
+  assert.equal(records.length, 3);
+  assert.deepEqual(records[1].messages[1], {
+    role: "user",
+    content: [{
+      type: "tool_result",
+      tool_use_id: "call-valid",
+      content: "命中结果",
+    }],
+  });
+  assert.deepEqual(records[1].messages[0].content, [
+    { type: "text", text: "开始" },
+    { type: "tool_use", id: "call-valid", name: "search", input: { query: "touwaka" } },
+    { type: "raw", protocol: "openai", payload: invalidCall },
+  ]);
+  assert.deepEqual(records[2].messages[0].content, [
+    { type: "tool_use", id: "call-next", name: "done", input: {} },
+  ]);
+
+  const restored = canonicalToLegacyMessages(records);
+  assert.deepEqual(
+    restored.find((row) => row.role === "assistant" && row.tool_calls?.length === 2).tool_calls[1],
+    invalidCall,
+  );
+});
+
+test("reasoning、inner_voice、usage 和业务元数据进入同一轮", () => {
+  const { records } = legacyRowsToTranscript("request-3", [
+    {
+      id: "a1",
+      role: "assistant",
+      content: "回答",
+      reasoning_content: "先思考",
+      inner_voice: "保持谨慎",
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      cost: "0.012300",
+      topic_id: "topic-1",
+      user_id: "user-1",
+      expert_id: "expert-1",
+      model_name: "model-1",
+      provider_name: "provider-1",
+      latency_ms: 321,
+      error_info: '{"kind":"none"}',
+      is_deleted: false,
+      created_at: "2026-08-29T00:02:00.000Z",
+    },
+  ]);
+
+  assert.deepEqual(records[0].meta, {
+    topicId: "topic-1",
+    userId: "user-1",
+    expertId: "expert-1",
+    modelName: "model-1",
+    providerName: "provider-1",
+    latencyMs: 321,
+    isDeleted: false,
+    errorInfo: { kind: "none" },
+    usage: { prompt_tokens: 10, completion_tokens: 5, cost: "0.012300" },
+  });
+  assert.deepEqual(records[0].messages[0].content, [
+    { type: "text", text: "回答" },
+    { type: "raw", protocol: "touwaka", payload: { kind: "reasoning", text: "先思考" } },
+    { type: "raw", protocol: "touwaka", payload: { kind: "inner_voice", text: "保持谨慎" } },
+  ]);
+
+  const incompleteUsage = legacyRowsToTranscript("request-3b", [{
+    role: "assistant",
+    content: "缺少 cost",
+    prompt_tokens: 1,
+    completion_tokens: 2,
+    created_at: "2026-08-29T00:02:01.000Z",
+  }]);
+  assert.equal(Object.hasOwn(incompleteUsage.records[0].meta, "usage"), false);
+});
+
+test("孤儿 tool 行归入 round 0", () => {
+  const { records } = legacyRowsToTranscript("request-4", [{
+    id: "tool-1",
+    role: "tool",
+    tool_call_id: "missing-assistant",
+    content: "孤儿结果",
+    created_at: "2026-08-29T00:03:00.000Z",
+  }]);
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].round, 0);
+  assert.deepEqual(records[0].messages[0], {
+    role: "user",
+    content: [{
+      type: "tool_result",
+      tool_use_id: "missing-assistant",
+      content: "孤儿结果",
+    }],
+  });
+});
+
+test("legacy → canonical → legacy 保留关键字段", () => {
+  const legacyRows = [
+    {
+      id: "u1",
+      role: "user",
+      content: "问题",
+      topic_id: "topic-roundtrip",
+      user_id: "user-roundtrip",
+      created_at: "2026-08-29T00:04:00.000Z",
+    },
+    {
+      id: "a1",
+      role: "assistant",
+      content: "我来处理",
+      tool_calls: [{
+        id: "call-1",
+        type: "function",
+        function: { name: "lookup", arguments: '{"id":42}' },
+      }],
+      reasoning_content: "分析参数",
+      inner_voice: "需要核实",
+      prompt_tokens: 12,
+      completion_tokens: 8,
+      cost: 0.25,
+      topic_id: "topic-roundtrip",
+      user_id: "user-roundtrip",
+      expert_id: "expert-roundtrip",
+      model_name: "model-roundtrip",
+      provider_name: "provider-roundtrip",
+      latency_ms: 88,
+      error_info: { retryable: true },
+      is_deleted: false,
+      created_at: "2026-08-29T00:04:01.000Z",
+    },
+    {
+      id: "t1",
+      role: "tool",
+      tool_call_id: "call-1",
+      content: "结果",
+      created_at: "2026-08-29T00:04:02.000Z",
+    },
+  ];
+
+  const transcript = legacyRowsToTranscript("request-roundtrip", legacyRows);
+  const restored = canonicalToLegacyMessages(transcript.records);
+  const restoredAssistant = restored.find((row) => row.role === "assistant");
+  const restoredTool = restored.find((row) => row.role === "tool");
+
+  assert.equal(restored.find((row) => row.role === "user").content, "问题");
+  assert.equal(restoredAssistant.content, "我来处理");
+  assert.deepEqual(restoredAssistant.tool_calls, legacyRows[1].tool_calls);
+  assert.equal(restoredAssistant.reasoning_content, "分析参数");
+  assert.equal(restoredAssistant.inner_voice, "需要核实");
+  assert.equal(restoredAssistant.prompt_tokens, 12);
+  assert.equal(restoredAssistant.completion_tokens, 8);
+  assert.equal(restoredAssistant.cost, 0.25);
+  assert.equal(restoredAssistant.topic_id, "topic-roundtrip");
+  assert.deepEqual(restoredAssistant.error_info, { retryable: true });
+  assert.equal(restoredTool.tool_call_id, "call-1");
+  assert.equal(restoredTool.content, "结果");
+});

--- a/tests/llm-kit-adapters/transcript-store-meta.test.mjs
+++ b/tests/llm-kit-adapters/transcript-store-meta.test.mjs
@@ -1,0 +1,149 @@
+import { test, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// logs/ 目录当前是 root 属主，避免 logger 写文件的权限错误掩盖数据库测试结果。
+import logger from "../../lib/logger.js";
+for (const method of ["info", "warn", "error", "debug"]) {
+  if (typeof logger[method] === "function") logger[method] = () => {};
+}
+
+import Database from "../../lib/db.js";
+import { createTouwakaTranscriptStore } from "../../lib/llm-kit-adapters/transcript-store.js";
+
+const CREDS_PATH = join(homedir(), ".config/mcp/creds/touwaka-test-db.json");
+const TABLE_NAME = "llm_kit_transcripts_meta_test";
+const MODEL_NAME = `llm_kit_transcript_${TABLE_NAME}`;
+
+function loadCreds() {
+  try {
+    return JSON.parse(readFileSync(CREDS_PATH, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+const creds = loadCreds();
+let db = null;
+let Transcript = null;
+
+if (creds) {
+  db = new Database({
+    database: creds.database,
+    user: creds.user,
+    password: creds.password,
+    host: creds.host,
+    port: creds.port,
+  });
+
+  await db.connect();
+  const setupStore = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
+  Transcript = db.sequelize.models[MODEL_NAME];
+  await setupStore.sync({ force: true });
+}
+
+after(async () => {
+  if (!db) return;
+
+  await Transcript.drop();
+  if (typeof db.close === "function") {
+    await db.close();
+  } else if (db.sequelize) {
+    await db.sequelize.close();
+  }
+});
+
+if (!creds) {
+  test("touwaka TranscriptStore v2 元数据（真实 MariaDB）", {
+    skip: `缺少凭据 ${CREDS_PATH}`,
+  }, () => {});
+} else {
+  beforeEach(async () => {
+    await Transcript.destroy({ truncate: true });
+  });
+
+  test("appendRound 写入并由 loadWithMeta 读回元数据", async () => {
+    const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
+    const meta = {
+      topicId: "topic-meta",
+      userId: "user-meta",
+      expertId: "expert-meta",
+      modelName: "model-meta",
+      providerName: "provider-meta",
+      usage: { prompt_tokens: 10, completion_tokens: 5, cost: 0.1 },
+      latencyMs: 123,
+      errorInfo: { retryable: true },
+      isDeleted: false,
+    };
+
+    await store.appendRound("run-meta", {
+      round: 1,
+      ts: "2026-08-29T10:00:00.000Z",
+      messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }],
+    }, meta);
+
+    const loaded = await store.loadWithMeta("run-meta");
+    assert.deepEqual(loaded[0].meta, meta);
+  });
+
+  test("load 保持纯净，不返回 meta", async () => {
+    const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
+    await store.appendRound("run-clean", {
+      round: 1,
+      ts: "2026-08-29T10:01:00.000Z",
+      messages: [{ role: "user", content: [{ type: "text", text: "clean" }] }],
+    }, {
+      topicId: "topic-clean",
+      userId: "user-clean",
+      isDeleted: true,
+    });
+
+    const [loaded] = await store.load("run-clean");
+    assert.deepEqual(loaded, {
+      round: 1,
+      ts: "2026-08-29T10:01:00.000Z",
+      folded: false,
+      messages: [{ role: "user", content: [{ type: "text", text: "clean" }] }],
+    });
+    assert.equal(Object.hasOwn(loaded, "meta"), false);
+  });
+
+  test("findByTopic 过滤、按 run_id/round 排序并支持 limit", async () => {
+    const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
+    const record = (round, text) => ({
+      round,
+      ts: `2026-08-29T10:0${round}:00.000Z`,
+      messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+    });
+
+    await store.appendRound("run-b", record(1, "b"), {
+      topicId: "topic-target",
+      userId: "user-target",
+    });
+    await store.appendRound("run-a", record(3, "a3"), {
+      topicId: "topic-target",
+      userId: "user-target",
+    });
+    await store.appendRound("run-a", record(1, "a1"), {
+      topicId: "topic-target",
+      userId: "user-target",
+    });
+    await store.appendRound("run-z", record(1, "other"), {
+      topicId: "topic-other",
+      userId: "user-other",
+    });
+
+    const found = await store.findByTopic("topic-target");
+    assert.deepEqual(found.map((item) => item.messages[0].content[0].text), ["a1", "a3", "b"]);
+    assert.deepEqual(found.map((item) => item.meta.topicId), [
+      "topic-target",
+      "topic-target",
+      "topic-target",
+    ]);
+
+    const limited = await store.findByTopic("topic-target", { limit: 2 });
+    assert.deepEqual(limited.map((item) => item.messages[0].content[0].text), ["a1", "a3"]);
+  });
+}


### PR DESCRIPTION
Refs #1094（阶段 1/5）

## 内容
- **表 v2**：llm_kit_transcripts 扩展业务列（topic_id/user_id 索引、usage JSON 等 9 列），替代 messages 表业务职能的设计落地
- **适配器扩展**：appendRound(runId, record, meta?)、loadWithMeta、findByTopic；契约纯净性不变（load/recall 无 meta）
- **message-converter.js**：legacy 行 ↔ canonical 双向纯函数（分轮规则/raw 块降级/usage 聚合），阶段 2 迁移脚本与阶段 4 读路径的公共件
- **测试**：converter 单测 + meta 真实库测试；修复了两 DB 测试文件共享物理表的并发缺陷（tableName 隔离）

## 验证（主 agent 复跑）
- 默认并发 3 连跑 20/20 绿（config 契约 4 + transcript 契约 8 + converter/meta 8）
- npm run lint 通过

## 范围确认
不改任何调用方/models//迁移脚本；阶段 2（迁移脚本 + upgrades 表）另起 PR