### PR TITLE
feat: standard-mgr 清洗进度可见 + 增量清洗/断点续洗

### DIFF
--- a/apps/standard-mgr/frontend/api/standard-mgr.ts
+++ b/apps/standard-mgr/frontend/api/standard-mgr.ts
@@ -48,6 +48,20 @@ export type AnchorBuildStatus = 'pending' | 'processing' | 'done' | 'error'
 export type RefStatus = 'valid' | 'suspected' | 'gap' | 'invalid'
 export type RefSource = 'auto' | 'user_confirmed' | 'manual' | 'auto_backfill'
 
+export interface CleanProgress {
+  anchor_build_status: AnchorBuildStatus
+  total_sections: number
+  processed_sections: number
+  anchor_counts: {
+    valid: number
+    suspected: number
+    gap: number
+    invalid: number
+  }
+  last_anchor_build_at: string | null
+  last_anchor_build_error: string | null
+}
+
 export interface StandardItem {
   id: string
   document_id: string
@@ -356,6 +370,13 @@ export async function updateBuildStatus(
 export async function startCleaning(standardId: string): Promise<{ accepted: boolean; standard_id: string }> {
   return apiRequest<{ accepted: boolean; standard_id: string }>(
     apiClient.post(`${PREFIX}/standards/${standardId}/clean`),
+  )
+}
+
+/** 获取当前版本的锚点清洗进度 */
+export async function getCleanProgress(standardId: string): Promise<CleanProgress> {
+  return apiRequest<CleanProgress>(
+    apiClient.get(`${PREFIX}/standards/${standardId}/clean-progress`),
   )
 }
 

--- a/apps/standard-mgr/frontend/components/StandardDetailView.vue
+++ b/apps/standard-mgr/frontend/components/StandardDetailView.vue
@@ -30,6 +30,16 @@
         >
           {{ rebuildLoading ? $t('apps.standardMgr.rebuilding') : rebuildLabel }}
         </el-button>
+        <div v-if="standard.anchor_build_status === 'processing'" class="sm-clean-progress">
+          <el-progress :percentage="cleanProgressPercentage" :stroke-width="8" />
+          <span class="sm-clean-progress-text">
+            {{ $t('apps.standardMgr.cleanProgress', {
+              processed: cleanProgressProcessedSections,
+              total: cleanProgressTotalSections,
+              anchors: cleanProgressAnchorCount,
+            }) }}
+          </span>
+        </div>
         <el-button size="small" @click="openReferencedByDialog">
           {{ $t('apps.standardMgr.referencedBy', { n: referencedByTotal }) }}
         </el-button>
@@ -278,6 +288,7 @@ import type {
  EnterpriseItem,
  ReferencedByResult,
  RefStatus,
+ CleanProgress,
 } from '../api/standard-mgr'
 import { i18n } from '@/i18n'
 import { useToastStore } from '@/stores/toast'
@@ -290,6 +301,7 @@ const props = defineProps<{
   selectedAnchorId: string | null
   rebuildLoading: boolean
   rebuildError: string | null
+  cleanProgress: CleanProgress | null
   /** R11-5: 企业列表（用于编辑元数据时选择企业） */
   enterprises?: EnterpriseItem[]
   /** R21: 框选模式——正文中划选文字创建锚点 */
@@ -570,6 +582,21 @@ const rebuildLabel = computed(() => {
     ? i18n.global.t('apps.standardMgr.rebuild')
     : i18n.global.t('apps.standardMgr.rebuildAgain')
 })
+
+const cleanProgressProcessedSections = computed(() => props.cleanProgress?.processed_sections ?? 0)
+const cleanProgressTotalSections = computed(() => props.cleanProgress?.total_sections ?? 0)
+const cleanProgressAnchorCount = computed(() => {
+  const counts = props.cleanProgress?.anchor_counts
+  if (!counts) return 0
+  return counts.valid + counts.suspected + counts.gap + counts.invalid
+})
+const cleanProgressPercentage = computed(() => {
+  const total = cleanProgressTotalSections.value
+  if (total <= 0) return 0
+  return Math.min(100, Math.max(0, Math.round(
+    (cleanProgressProcessedSections.value / total) * 100,
+  )))
+})
 </script>
 
 <style scoped>
@@ -617,7 +644,22 @@ const rebuildLabel = computed(() => {
 .sm-detail-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
+}
+
+.sm-clean-progress {
+  display: flex;
+  flex: 1 1 240px;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 220px;
+  max-width: 360px;
+}
+
+.sm-clean-progress-text {
+  color: #606266;
+  font-size: 12px;
 }
 
 .sm-rebuild-error {

--- a/apps/standard-mgr/frontend/stores/standardMgr.ts
+++ b/apps/standard-mgr/frontend/stores/standardMgr.ts
@@ -21,6 +21,7 @@ import {
   listRefAnchors,
   listGaps,
   startCleaning,
+  getCleanProgress,
   writeAnchorResult,
   updateStandard,
   deleteStandard,
@@ -31,6 +32,7 @@ import {
   type GapItem,
   type AnchoredSection,
   type EnterpriseItem,
+  type CleanProgress,
 } from '../api/standard-mgr'
 import { useToastStore } from '@/stores/toast'
 import { i18n } from '@/i18n'
@@ -80,6 +82,7 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
   const selectedAnchorId = ref<string | null>(null)
   const rebuildLoading = ref(false)
   const rebuildError = ref<string | null>(null)
+  const cleanProgress = ref<CleanProgress | null>(null)
 
   // R11: 企业花名册
   const enterprises = ref<EnterpriseItem[]>([])
@@ -336,6 +339,15 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
     }
 
     await Promise.all(fetchTasks)
+    if (cache.detail?.anchor_build_status === 'processing') {
+      try {
+        cleanProgress.value = await getCleanProgress(standardId)
+      } catch (err: unknown) {
+        useToastStore().error(
+          err instanceof Error ? err.message : i18n.global.t('apps.standardMgr.loadDetailFailed'),
+        )
+      }
+    }
   }
 
   /** R21: 强制刷新锚点数据（新建/修改锚点后调用，绕开缓存） */
@@ -407,21 +419,23 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
    * 触发锚点清洗（调服务端 POST /clean）
    *
    * 流程：提交清洗任务 → 轮询等待完成 → 刷新数据
-   * 后端 15 分钟超时，前端最多等 120 轮（10 分钟）后报超时。
+   * 后端 30 分钟超时，前端最多等 360 轮（30 分钟）后报超时。
    */
   async function triggerRebuild(standardId: string) {
     rebuildLoading.value = true
     rebuildError.value = null
+    cleanProgress.value = null
     try {
       // 1. 提交清洗任务
       await startCleaning(standardId)
       await fetchStandardDetail(standardId)
 
       // 2. 轮询等待完成
-      const detail = await pollBuildStatus(standardId)
-      if (detail.anchor_build_status === 'error') {
-        rebuildError.value = detail.last_anchor_build_error || i18n.global.t('apps.standardMgr.cleanFailed')
+      const progress = await pollBuildStatus(standardId)
+      if (progress.anchor_build_status === 'error') {
+        rebuildError.value = progress.last_anchor_build_error || i18n.global.t('apps.standardMgr.cleanFailed')
         useToastStore().error(rebuildError.value!)
+        await fetchStandardDetail(standardId)
       } else {
         useToastStore().success(i18n.global.t('apps.standardMgr.cleanSuccess'))
         await refreshTabData(standardId)
@@ -438,13 +452,16 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
   }
 
   /** 轮询等待清洗完成 */
-  async function pollBuildStatus(standardId: string): Promise<StandardItem> {
-    const maxAttempts = 120 // 10 分钟
+  async function pollBuildStatus(standardId: string): Promise<CleanProgress> {
+    const maxAttempts = 360 // 30 分钟
     for (let i = 0; i < maxAttempts; i++) {
-      await new Promise(resolve => setTimeout(resolve, 5000))
-      const detail = await getStandard(standardId)
-      if (detail.anchor_build_status === 'done' || detail.anchor_build_status === 'error') {
-        return detail
+      if (i > 0) {
+        await new Promise(resolve => setTimeout(resolve, 5000))
+      }
+      const progress = await getCleanProgress(standardId)
+      cleanProgress.value = progress
+      if (progress.anchor_build_status === 'done' || progress.anchor_build_status === 'error') {
+        return progress
       }
     }
     throw new Error(i18n.global.t('apps.standardMgr.rebuildTimeout'))
@@ -497,6 +514,7 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
     selectedAnchorId,
     rebuildLoading,
     rebuildError,
+    cleanProgress,
     // R8-4: 页签状态
     openTabs,
     activeTabId,

--- a/apps/standard-mgr/frontend/views/AppRuntimeView.vue
+++ b/apps/standard-mgr/frontend/views/AppRuntimeView.vue
@@ -80,6 +80,7 @@
                     :selected-anchor-id="store.selectedAnchorId"
                     :rebuild-loading="store.rebuildLoading"
                     :rebuild-error="store.rebuildError"
+                    :clean-progress="store.cleanProgress"
                     :enterprises="store.enterprises"
                     :picking="pickingMode"
                     @anchor-click="handleAnchorClick"

--- a/apps/standard-mgr/server/handlers/standards/clean-progress.js
+++ b/apps/standard-mgr/server/handlers/standards/clean-progress.js
@@ -1,0 +1,45 @@
+/**
+ * standards/clean-progress handler
+ *
+ * GET /api/apps/standard-mgr/standards/:standardId/clean-progress
+ *
+ * 登录用户可查询当前版本的锚点清洗进度，无需管理员权限。
+ */
+
+import StandardMgrService from '../../service.js';
+import logger from '../../../../../lib/logger.js';
+
+function getUserId(ctx) {
+  return ctx.state.session?.id || ctx.state.user?.id || null;
+}
+
+export const route = {
+  path: '/standards/:standardId/clean-progress',
+};
+
+export async function get(ctx, deps) {
+  try {
+    if (!getUserId(ctx)) {
+      ctx.error('未登录', 401);
+      return;
+    }
+
+    const { standardId } = ctx.params;
+    if (!standardId) {
+      ctx.error('standardId is required', 400);
+      return;
+    }
+
+    const service = new StandardMgrService(deps.db);
+    const progress = await service.getCleanProgress(standardId);
+    if (!progress) {
+      ctx.error('Standard not found', 404);
+      return;
+    }
+
+    ctx.success(progress);
+  } catch (err) {
+    logger.error(`[standard-mgr] clean-progress error: ${err.message}`);
+    ctx.error(err.message, err.status || 500);
+  }
+}

--- a/apps/standard-mgr/server/service.js
+++ b/apps/standard-mgr/server/service.js
@@ -201,22 +201,95 @@ class StandardMgrService {
    *
    * @param {string} standardId
    * @param {string} revisionId - 限定版本范围（source_revision_id）
+   * @param {string[]} [outlineIds] - 仅删除指定章节；省略时保持历史上的全量删除行为
    * @returns {Promise<number>} 删除条数
    */
-  async deleteAutoRefAnchors(standardId, revisionId) {
+  async deleteAutoRefAnchors(standardId, revisionId, outlineIds) {
     const RefAnchor = this._refAnchor();
-    const deleted = await RefAnchor.destroy({
-      where: {
-        standard_id: standardId,
-        source_revision_id: revisionId,
-        source: [REF_SOURCE.AUTO, REF_SOURCE.AUTO_BACKFILL],
-      },
-    });
+    const where = {
+      standard_id: standardId,
+      source_revision_id: revisionId,
+      source: [REF_SOURCE.AUTO, REF_SOURCE.AUTO_BACKFILL],
+    };
+
+    if (outlineIds !== undefined) {
+      if (!Array.isArray(outlineIds)) {
+        throw new TypeError('outlineIds must be an array when provided');
+      }
+      if (outlineIds.length === 0) {
+        logger.info(
+          `[standard-mgr] deleteAutoRefAnchors: standard=${standardId} revision=${revisionId} ` +
+          'no sections require cleaning, deleted=0 rows'
+        );
+        return 0;
+      }
+      where.source_outline_id = { [Op.in]: outlineIds };
+    }
+
+    const deleted = await RefAnchor.destroy({ where });
     logger.info(
       `[standard-mgr] deleteAutoRefAnchors: standard=${standardId} revision=${revisionId} ` +
       `deleted=${deleted} rows`
     );
     return deleted;
+  }
+
+  /**
+   * 计算本次清洗要处理的章节，以及可以明确跳过的章节。
+   *
+   * 章节级副本只有在同一 revision 且 source_text_hash 与当前 outline 的
+   * text_hash 一致时才算完成。没有成功清洗时间时不信任任何历史数据，首次
+   * 清洗自然退化为全量；之后无副本、hash 变化的章节都视为新增/变更/上次
+   * 未完成，必须重新交给 agent。
+   */
+  async _getCleaningPlan(standardId, revisionId, lastAnchorBuildAt) {
+    const DocOutline = this.db.getModel('document_outline');
+    const AnchoredSection = this._anchoredSection();
+    const outlines = await DocOutline.findAll({
+      where: { revision_id: revisionId },
+      attributes: ['id', 'title', 'text_hash'],
+      order: [['seq', 'ASC']],
+      raw: true,
+    });
+
+    if (!lastAnchorBuildAt) {
+      return {
+        outlineIds: outlines.map(outline => outline.id),
+        skippedSections: [],
+      };
+    }
+
+    const anchoredSections = await AnchoredSection.findAll({
+      where: {
+        standard_id: standardId,
+        revision_id: revisionId,
+      },
+      attributes: ['outline_id', 'source_text_hash'],
+      raw: true,
+    });
+    const anchoredByOutline = new Map(
+      anchoredSections.map(section => [section.outline_id, section])
+    );
+    const outlineIds = [];
+    const skippedSections = [];
+
+    for (const outline of outlines) {
+      const anchored = anchoredByOutline.get(outline.id);
+      // anchored_section 只有成功生成过副本才存在；没有它表示新章节或上次
+      // 清洗在写出该章节副本前中断。hash 不一致则说明正文已变更，旧 auto
+      // 锚点对应的是旧文本，也必须删除后重洗。只有 hash 一致的副本可复用。
+      const isCompleted = Boolean(anchored) && anchored.source_text_hash === outline.text_hash;
+      if (isCompleted) {
+        skippedSections.push({
+          outline_id: outline.id,
+          title: outline.title || '',
+        });
+      } else {
+        outlineIds.push(outline.id);
+      }
+    }
+
+    return { outlineIds, skippedSections };
   }
 
   // ============================================================
@@ -764,6 +837,79 @@ class StandardMgrService {
     }
 
     return standard;
+  }
+
+  /**
+   * 获取标准当前版本的锚点清洗进度。
+   *
+   * processed_sections 按当前 revision 的 ref_anchor 去重统计；这样清洗中的
+   * 新写入会立即反映出来，同时不会把历史版本的锚点混入当前进度。
+   */
+  async getCleanProgress(standardId) {
+    const AppStandard = this._appStandard();
+    const standard = await AppStandard.findByPk(standardId, {
+      attributes: [
+        'anchor_build_status',
+        'current_revision_id',
+        'last_anchor_build_at',
+        'last_anchor_build_error',
+      ],
+      raw: true,
+    });
+
+    if (!standard) return null;
+
+    const progress = {
+      anchor_build_status: standard.anchor_build_status,
+      total_sections: 0,
+      processed_sections: 0,
+      anchor_counts: {
+        valid: 0,
+        suspected: 0,
+        gap: 0,
+        invalid: 0,
+      },
+      last_anchor_build_at: standard.last_anchor_build_at,
+      last_anchor_build_error: standard.last_anchor_build_error,
+    };
+
+    const revisionId = standard.current_revision_id;
+    if (!revisionId) return progress;
+
+    const DocOutline = this.db.getModel('document_outline');
+    const RefAnchor = this._refAnchor();
+    const refWhere = {
+      standard_id: standardId,
+      source_revision_id: revisionId,
+    };
+
+    const [totalSections, processedSections, groupedCounts] = await Promise.all([
+      DocOutline.count({ where: { revision_id: revisionId } }),
+      RefAnchor.count({
+        where: refWhere,
+        distinct: true,
+        col: 'source_outline_id',
+      }),
+      RefAnchor.findAll({
+        where: refWhere,
+        attributes: [
+          'status',
+          [this.db.sequelize.fn('COUNT', this.db.sequelize.col('id')), 'count'],
+        ],
+        group: ['status'],
+        raw: true,
+      }),
+    ]);
+
+    progress.total_sections = Number(totalSections) || 0;
+    progress.processed_sections = Number(processedSections) || 0;
+    for (const row of groupedCounts) {
+      if (Object.prototype.hasOwnProperty.call(progress.anchor_counts, row.status)) {
+        progress.anchor_counts[row.status] = Number(row.count) || 0;
+      }
+    }
+
+    return progress;
   }
 
   /**
@@ -1801,7 +1947,7 @@ class StandardMgrService {
    *   3. 生成后台任务长期 token（防止工具回调 401）
    *   4. 异步执行清洗会话（_runCleaningAsync）：
    *      - 查找锚点清洗专家
-   *      - 清理 auto 记录（deleteAutoRefAnchors）
+   *      - 按章节 hash 计算增量清洗范围并清理对应 auto 记录（deleteAutoRefAnchors）
    *      - 创建 Topic
    *      - 构造开工消息（buildCleanMessage）
    *      - 驱动 agent（streamChat，带超时）
@@ -1888,6 +2034,7 @@ class StandardMgrService {
       documentId,
       revisionId,
       modelId: appModelId,
+      lastAnchorBuildAt: standard.last_anchor_build_at,
     }).catch(err => {
       logger.error(`[standard-mgr] runCleaningPipeline async error for ${standardId}: ${err.message}`);
     });
@@ -2066,7 +2213,16 @@ class StandardMgrService {
   /**
    * 异步清洗会话（内部实现，编排在 runCleaningPipeline 中声明）
    */
-  async _runCleaningAsync({ chatService, userId, session, standardId, documentId, revisionId, modelId = null }) {
+  async _runCleaningAsync({
+    chatService,
+    userId,
+    session,
+    standardId,
+    documentId,
+    revisionId,
+    modelId = null,
+    lastAnchorBuildAt = null,
+  }) {
     let expertId = null;
 
     try {
@@ -2083,21 +2239,39 @@ class StandardMgrService {
         `[standard-mgr] 开始清洗: standard=${standardId} doc=${documentId} revision=${revisionId} expert=${expertId}`
       );
 
-      // ── 2. 清空 auto 记录（R15-6），manual/user_confirmed 永久保留 ──
-      const deletedCount = await this.deleteAutoRefAnchors(standardId, revisionId);
-      logger.info(`[standard-mgr] 清洗前置清理: 删除 ${deletedCount} 条 auto 记录`);
+      // ── 2. 计算增量范围并清理对应 auto 记录（R15-6） ──
+      // manual/user_confirmed 永久保留；未变章节连同已有副本一起跳过。
+      const cleaningPlan = await this._getCleaningPlan(
+        standardId,
+        revisionId,
+        lastAnchorBuildAt,
+      );
+      const deletedCount = await this.deleteAutoRefAnchors(
+        standardId,
+        revisionId,
+        cleaningPlan.outlineIds,
+      );
+      logger.info(
+        `[standard-mgr] 清洗前置清理: sections=${cleaningPlan.outlineIds.length} ` +
+        `skipped=${cleaningPlan.skippedSections.length} deleted=${deletedCount} auto rows`
+      );
 
       // ── 3. 创建会话 ──
       const topicId = await chatService.createNewTopic(userId, expertId, `标准清洗 — ${standardId}`, null);
 
       // ── 4. 构造开工消息 ──
-      const content = buildCleanMessage(documentId, revisionId, standardId);
+      const content = buildCleanMessage(
+        documentId,
+        revisionId,
+        standardId,
+        cleaningPlan.skippedSections,
+      );
 
       // ── 5. 驱动 AgentLoop（带超时） ──
       const result = await new Promise((resolve) => {
         let settled = false;
         const timeoutId = setTimeout(() => {
-          if (!settled) { settled = true; resolve({ ok: false, error: '清洗超时（15 分钟）' }); }
+          if (!settled) { settled = true; resolve({ ok: false, error: '清洗超时（30 分钟）' }); }
         }, CLEAN_TIMEOUT_MS);
 
         chatService.streamChat(
@@ -3035,12 +3209,24 @@ class StandardMgrService {
 /**
  * R17-1：构造清洗开工消息（原位于 handlers/standards/clean.js，随编排收编迁入 service）
  */
-function buildCleanMessage(documentId, revisionId, standardId) {
+function buildCleanMessage(documentId, revisionId, standardId, skippedSections = []) {
+  const skippedSectionText = skippedSections.length > 0
+    ? skippedSections
+      .map(section => `- outline_id=${section.outline_id}，title=${section.title || '（无标题）'}`)
+      .join('\n')
+    : '- 无（首次清洗或没有可跳过的已完成章节）';
+
   return `请对以下标准文档执行完整的引用清洗（含外部引用和内部交叉引用）。
 
 文档 ID: ${documentId}
 版本 ID: ${revisionId}
 标准 ID: ${standardId}
+
+### 增量/断点续洗
+以下章节的 text_hash 与已落库的锚点副本一致，表示它们已完成处理。请跳过这些章节：
+${skippedSectionText}
+跳过章节不得调用 read_section_context、list_section_references 或 write_anchor_result。
+除上述章节外，其余章节必须按下面的阶段 2 逐批读取并写入；没有锚点副本或 hash 不一致的章节是本次需要处理的范围。
 
 请按以下流程执行：
 

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1424,7 +1424,7 @@ export default {
       rebuildAnchorCopy: 'Rebuild Anchor Sections',
       rebuilding: 'Rebuilding...',
       rebuildSuccess: 'Cleaning completed',
-      rebuildTimeout: 'Cleaning timeout (over 10 min)',
+      rebuildTimeout: 'Cleaning timeout (over 30 min)',
       rebuildFailed: 'Failed to trigger cleaning',
       rebuildNoPermission: 'Admin permission required',
       notCleaned: 'This standard has not been cleaned',
@@ -1521,6 +1521,7 @@ export default {
       cleanSuccess: 'Cleaning completed',
       cleanFailed: 'Cleaning failed',
       cleaningStarted: 'Cleaning submitted, will auto-update when done',
+      cleanProgress: 'Processed {processed}/{total} sections · {anchors} anchors',
       // R8-1 Doc platform selector
       selectFromPlatform: 'Select from Document Platform',
       uploadNewFile: 'Upload New File',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1366,7 +1366,7 @@ export default {
       rebuildAnchorCopy: '重建锚点副本',
       rebuilding: '重建中...',
       rebuildSuccess: '重建完成',
-      rebuildTimeout: '重建超时（超过 10 分钟）',
+      rebuildTimeout: '清洗超时（超过 30 分钟）',
       rebuildFailed: '触发清洗失败',
       rebuildNoPermission: '需要管理员权限',
       notCleaned: '该标准尚未清洗',
@@ -1463,6 +1463,7 @@ export default {
       cleanSuccess: '清洗完成',
       cleanFailed: '清洗失败',
       cleaningStarted: '清洗任务已提交，完成后自动更新',
+      cleanProgress: '已处理 {processed}/{total} 章节 · 锚点 {anchors} 条',
       // R8-1 文档平台选择
       selectFromPlatform: '从文档平台选择',
       uploadNewFile: '上传新文件',


### PR DESCRIPTION
Closes #1086

## 内容
- 新增 GET /standards/:id/clean-progress：total_sections / processed_sections / 各状态锚点计数 / 最近错误
- 前端轮询改为进度端点，上限对齐后端 30 分钟（360×5s），processing 时显示 el-progress「已处理 x/y 章节 · 锚点 n 条」
- 增量清洗：按 document_outline.text_hash 对比副本表 source_text_hash，仅重洗 新章节+hash 变化+未完成 章节；只删这些章节的 auto 记录；未变章节写入开工消息跳过清单
- 首次清洗自然退化为全量；writeAnchorResult 幂等语义不变

## 验证
- node --check 通过；与 #1087 试合并无冲突；合并后 vue-tsc 0 错误、vite build 通过