### PR TITLE
feat: 平台通用系统账户 system-bot（后台任务身份）

### DIFF
--- a/apps/standard-mgr/server/service.js
+++ b/apps/standard-mgr/server/service.js
@@ -22,6 +22,7 @@ import logger from '../../../lib/logger.js';
 import Utils from '../../../lib/utils.js';
 import jwt from 'jsonwebtoken';
 import DocAccessService from '../../../lib/doc-access-service.js';
+import { getSystemUserSession } from '../../../lib/system-account.js';
 import { Op } from 'sequelize';
 
 // R18-2: 清洗总超时 15→30 分钟（长标准 + 读写交替策略下 15 分钟偏紧）
@@ -2074,7 +2075,7 @@ class StandardMgrService {
    * 解析后台锚点清洗使用的用户会话。
    *
    * @param {string|null} createdBy - 纳管标准的创建人
-   * @returns {Promise<{id: string, roles: string[], isAdmin: boolean}>}
+   * @returns {Promise<{id: string, roles: string[], isAdmin: boolean, isSystem?: boolean}>}
    */
   async _buildOnboardCleaningSession(createdBy) {
     const User = this.db.getModel('user');
@@ -2091,37 +2092,10 @@ class StandardMgrService {
     }
 
     if (!user || user.status !== 'active') {
-      const adminAssignments = await UserRole.findAll({
-        attributes: ['user_id'],
-        include: [
-          {
-            model: Role,
-            as: 'role',
-            where: { mark: 'admin' },
-            attributes: [],
-            required: true,
-          },
-          {
-            model: User,
-            as: 'user',
-            where: { status: 'active' },
-            attributes: [],
-            required: true,
-          },
-        ],
-        order: [['user_id', 'ASC']],
-        limit: 1,
-        raw: true,
-      });
-      const fallbackUserId = adminAssignments[0]?.user_id;
-      if (!fallbackUserId) {
-        throw new Error('没有可用于后台锚点清洗的活动管理员用户');
-      }
       logger.info(
-        `[standard-mgr] created_by=${createdBy || 'unknown'} unavailable, ` +
-        `using active admin user=${fallbackUserId} for onboard cleaning`
+        `[standard-mgr] 创建人不可用，使用系统账户，原触发人=${createdBy || 'unknown'}`
       );
-      user = { id: fallbackUserId, status: 'active' };
+      return getSystemUserSession(this.db);
     }
 
     const roleRecords = await UserRole.findAll({

--- a/lib/system-account.js
+++ b/lib/system-account.js
@@ -1,0 +1,87 @@
+/**
+ * Platform system account helpers.
+ *
+ * The shared `system-bot` account is reserved for platform-owned background
+ * work. It is created by the database initialization/upgrade scripts with an
+ * `inactive` status and a random password, so it cannot log in normally.
+ * Internal task JWTs may still authenticate it because the auth middleware
+ * only rejects banned/disabled users.
+ */
+
+export const SYSTEM_USER_USERNAME = 'system-bot';
+
+function getModel(db, modelName) {
+  if (!db || typeof db.getModel !== 'function') {
+    throw new Error(`无法读取系统账户：数据库模型 ${modelName} 不可用`);
+  }
+
+  const Model = db.getModel(modelName);
+  if (!Model) {
+    throw new Error(`无法读取系统账户：数据库模型 ${modelName} 不可用`);
+  }
+  return Model;
+}
+
+/**
+ * Find the platform system user.
+ *
+ * Run scripts/upgrade-database.js before using this helper when the account
+ * is missing; this helper deliberately does not create users at runtime.
+ */
+export async function ensureSystemUser(db) {
+  const User = getModel(db, 'user');
+  if (typeof User.findOne !== 'function') {
+    throw new Error('无法读取系统账户：数据库模型 user 不支持查询');
+  }
+  const user = await User.findOne({
+    where: { username: SYSTEM_USER_USERNAME },
+    attributes: ['id', 'status'],
+    raw: true,
+  });
+
+  if (!user?.id) {
+    throw new Error(
+      `系统账户 ${SYSTEM_USER_USERNAME} 不存在，请先运行 scripts/upgrade-database.js`,
+    );
+  }
+
+  return user;
+}
+
+/**
+ * Return the session shape used by chat/tool execution for system work.
+ *
+ * The system account intentionally has no role assignment. Rejecting an
+ * accidental admin assignment prevents the account from gaining capabilities
+ * through the roles array even though isAdmin is explicitly false.
+ */
+export async function getSystemUserSession(db) {
+  const user = await ensureSystemUser(db);
+  const UserRole = getModel(db, 'user_role');
+  const Role = getModel(db, 'role');
+  if (typeof UserRole.findAll !== 'function') {
+    throw new Error('无法读取系统账户：数据库模型 user_role 不支持查询');
+  }
+  const roleRecords = await UserRole.findAll({
+    where: { user_id: user.id },
+    include: [{
+      model: Role,
+      as: 'role',
+      attributes: ['mark'],
+    }],
+    raw: true,
+    nest: true,
+  });
+  const roles = [...new Set(roleRecords.map(record => record.role?.mark).filter(Boolean))];
+
+  if (roles.includes('admin')) {
+    throw new Error(`系统账户 ${SYSTEM_USER_USERNAME} 不得分配 admin 角色`);
+  }
+
+  return {
+    id: user.id,
+    roles,
+    isAdmin: false,
+    isSystem: true,
+  };
+}

--- a/scripts/init-database.js
+++ b/scripts/init-database.js
@@ -20,6 +20,8 @@ dotenv.config();
 import mysql from 'mysql2/promise';
 import Utils from '../lib/utils.js';
 import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+import { SYSTEM_USER_USERNAME } from '../lib/system-account.js';
 
 const DB_CONFIG = {
   host: process.env.DB_HOST || 'localhost',
@@ -664,6 +666,9 @@ async function checkForeignKeyExists(connection, tableName, constraintName) {
 async function getInitialData() {
   // 创建默认密码哈希
   const defaultPassword = await bcrypt.hash('password123', 10);
+  // system-bot 禁止正常登录，使用随机密码并通过 inactive 状态锁定登录。
+  const systemPassword = crypto.randomBytes(48).toString('hex');
+  const systemPasswordHash = await bcrypt.hash(systemPassword, 12);
 
   // 生成Provider ID（使用newID）
   const providerIds = {
@@ -702,8 +707,16 @@ async function getInitialData() {
       { id: modelIds.llama3, name: 'Llama 3.1', model_name: 'llama3.1', provider_id: providerIds.ollama, max_tokens: 4096, cost_per_1k_input: 0, cost_per_1k_output: 0 },
     ],
     users: [
-      { id: Utils.newID(20), username: 'admin', email: 'admin@example.com', password_hash: defaultPassword, nickname: '管理员' },
-      { id: Utils.newID(20), username: 'test', email: 'test@example.com', password_hash: defaultPassword, nickname: '测试用户' },
+      { id: Utils.newID(20), username: 'admin', email: 'admin@example.com', password_hash: defaultPassword, nickname: '管理员', status: 'active' },
+      { id: Utils.newID(20), username: 'test', email: 'test@example.com', password_hash: defaultPassword, nickname: '测试用户', status: 'active' },
+      {
+        id: Utils.newID(20),
+        username: SYSTEM_USER_USERNAME,
+        email: null,
+        password_hash: systemPasswordHash,
+        nickname: '系统机器人',
+        status: 'inactive',
+      },
     ],
     roles: [
       { id: roleIds.admin, mark: 'admin', name: '平台管理员', description: '拥有所有权限', level: 'admin', is_system: true },
@@ -811,12 +824,12 @@ async function initDatabase() {
     for (const u of data.users) {
       await connection.execute(
         `INSERT INTO users (id, username, email, password_hash, nickname, status)
-         VALUES (?, ?, ?, ?, ?, 'active')
+         VALUES (?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE nickname=VALUES(nickname)`,
-        [u.id, u.username, u.email, u.password_hash, u.nickname]
+        [u.id, u.username, u.email, u.password_hash, u.nickname, u.status || 'active']
       );
     }
-    console.log(`  - ${data.users.length} users (default password: password123)`);
+    console.log(`  - ${data.users.length} users (admin/test default password: password123; system-bot login disabled)`);
 
     // 技能数据通过 init-skills-from-json.js 导入
     console.log('  - 技能数据请运行 init-skills-from-json.js 导入');

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -18,6 +18,9 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import Utils from '../lib/utils.js';
+import { SYSTEM_USER_USERNAME } from '../lib/system-account.js';
 
 const DB_CONFIG = {
   host: process.env.DB_HOST || 'localhost',
@@ -3911,9 +3914,36 @@ const MIGRATIONS = [
     }
   },
 
-
-  // 不硬编码在迁移脚本中，保持迁移脚本无业务数据。
-
+  // ==================== 平台系统账户 ====================
+  // system-bot 是所有应用可复用的平台后台任务身份，不属于 standard-mgr。
+  // 设为 inactive 可阻止正常登录；随机密码用于避免任何可猜测的登录凭据。
+  // 清洗链路只需认证身份，不需要角色，因此不分配 admin/creator/user 角色。
+  {
+    name: 'create platform system user',
+    check: async (conn) => {
+      const [rows] = await conn.execute(
+        'SELECT 1 FROM users WHERE username = ? LIMIT 1',
+        [SYSTEM_USER_USERNAME],
+      );
+      return rows.length > 0;
+    },
+    migrate: async (conn) => {
+      const randomPassword = crypto.randomBytes(48).toString('hex');
+      const passwordHash = await bcrypt.hash(randomPassword, 12);
+      await conn.execute(
+        `INSERT INTO users (id, username, email, password_hash, nickname, status)
+         VALUES (?, ?, NULL, ?, ?, 'inactive')
+         ON DUPLICATE KEY UPDATE username = VALUES(username)`,
+        [
+          Utils.newID(20),
+          SYSTEM_USER_USERNAME,
+          passwordHash,
+          '系统机器人',
+        ],
+      );
+      console.log(`  ✓ Created platform system user: ${SYSTEM_USER_USERNAME}`);
+    }
+  },
 
 ];
 


### PR DESCRIPTION
Closes #1089

## 背景
纳管后自动清洗在创建人不可用时借用「第一个 active admin」身份签 4h JWT，系统行为记在不知情 admin 头上，审计失真。

## 方案（已决策：平台通用）
- 新建平台通用系统账户 `system-bot`：`inactive` + 随机 bcrypt 密码 → 无法登录；认证中间件只拒 disabled/banned → 内部 task JWT 可用（已核实 server/middlewares/auth.js:110）
- `lib/system-account.js`：`getSystemUserSession(db)` 供所有 app 后台任务复用，返回 `{ id, roles, isAdmin: false, isSystem: true }`
- init-database seed + upgrade-database 幂等迁移双路径创建
- standard-mgr：创建人不可用 → 系统账户接管，日志记录原触发人

## 验证
- node --check 全部通过；升级脚本幂等（已存在则跳过）

## 部署注意
合并后需在环境执行一次 `node scripts/upgrade-database.js`（或重启服务走启动迁移链路）创建 system-bot 账户