### PR TITLE
refactor: standard-mgr 企业维度收口为分类标签

### DIFF
--- a/apps/standard-mgr/migrations/install.js
+++ b/apps/standard-mgr/migrations/install.js
@@ -47,7 +47,7 @@ export default {
         standard_type VARCHAR(20) NOT NULL COMMENT '标准类型，当前取值 national/industry/enterprise/international，应用层校验，可扩展',
         standard_code VARCHAR(100) NOT NULL COMMENT '标准编号，如 GB/T 19001-2016',
         standard_name VARCHAR(500) NOT NULL COMMENT '标准名称',
-        enterprise_id VARCHAR(32) NULL COMMENT '归属企业；NULL=公共标准库（承接国家/行业/国际标准），企业表建立后迁移为企业记录',
+        enterprise_id VARCHAR(32) NULL COMMENT '归属企业分类标签；NULL=公共标准库（承接国家/行业/国际标准）',
         current_revision_id VARCHAR(32) NULL COMMENT '当前采用版本 document_revisions.id',
         is_active BIT(1) DEFAULT 1 COMMENT '是否启用',
         anchor_build_status ENUM('pending','processing','done','error') DEFAULT 'pending' COMMENT '引用清洗状态',

--- a/apps/standard-mgr/server/handlers/anchors.js
+++ b/apps/standard-mgr/server/handlers/anchors.js
@@ -29,7 +29,7 @@ export async function get(ctx, deps) {
       return;
     }
 
-    // R2-4 过渡策略：不过滤 enterprise_id
+    // 企业维度为分类标签，查询不按 enterprise_id 过滤。
     const standard = await service.getStandard(standard_id);
     if (!standard) {
       ctx.error('Standard not found', 404);

--- a/apps/standard-mgr/server/handlers/anchors/gaps.js
+++ b/apps/standard-mgr/server/handlers/anchors/gaps.js
@@ -27,7 +27,7 @@ export async function get(ctx, deps) {
       return;
     }
 
-    // R2-4 过渡策略：不过滤 enterprise_id
+    // 企业维度为分类标签，查询不按 enterprise_id 过滤。
     const standard = await service.getStandard(standard_id);
     if (!standard) {
       ctx.error('Standard not found', 404);

--- a/apps/standard-mgr/server/handlers/standards.js
+++ b/apps/standard-mgr/server/handlers/standards.js
@@ -1,7 +1,7 @@
 /**
  * standards handler
  *
- * GET  /api/apps/standard-mgr/standards — 列表（R2-4：忽略客户端 enterprise_id）
+ * GET  /api/apps/standard-mgr/standards — 列表（企业维度为分类标签，查询不按 enterprise_id 过滤）
  * GET  /api/apps/standard-mgr/standards/:standardId — 详情
  * POST /api/apps/standard-mgr/standards — 纳管新标准（P0-1：从文档平台纳管标准文档）
  *
@@ -26,8 +26,7 @@ export async function get(ctx, deps) {
     const userId = getUserId(ctx);
     const service = new StandardMgrService(deps.db);
 
-    // R2-4：在企业对象用户映射落地前，忽略客户端传入的 enterprise_id
-    // 统一按"不过滤"处理，由 getStandard/listStandards 内部按实际需求处理
+    // enterprise_id 仅作为标准归属的分类标签，不参与访问控制或查询过滤。
 
     if (ctx.params.standardId) {
       // 获取单个标准详情
@@ -43,7 +42,7 @@ export async function get(ctx, deps) {
     const standard_type = ctx.query.standard_type || null;
     const is_active = ctx.query.is_active !== undefined ? parseInt(ctx.query.is_active, 10) : undefined;
 
-    // R2-4 过渡策略：不过滤 enterprise_id，返回全部
+    // 企业维度为分类标签，查询不按 enterprise_id 过滤，返回全部标准。
     const standards = await service.listAllStandards({ standard_type, is_active });
     ctx.success(standards);
   } catch (err) {
@@ -60,6 +59,7 @@ export async function get(ctx, deps) {
  * - standard_type：national / industry / enterprise / international
  * - standard_code：标准编号，如 "GB/T 19001-2016"
  * - standard_name：标准名称
+ * - enterprise_id：可选的主机厂客户分类标签
  *
  * 校验：文档存在、processing_status 为 ready 或处理中状态、document_id 不重复；
  * 文档类型不限（contract / knowledge / department_doc / standard 均可），
@@ -67,7 +67,7 @@ export async function get(ctx, deps) {
  */
 export async function post(ctx, deps) {
   try {
-    // R2-4：纳管操作需要管理员权限
+    // 纳管操作需要管理员权限
     if (!ctx.state.session?.isAdmin) {
       ctx.error('需要管理员权限', 403);
       return;
@@ -155,12 +155,12 @@ export async function post(ctx, deps) {
 /**
  * PUT /api/apps/standard-mgr/standards/:standardId — 更新标准元数据
  *
- * 可更新字段：standard_name, standard_code, standard_type, is_active
- * 需要管理员权限（R2-4）。
+ * 可更新字段：standard_name, standard_code, standard_type, is_active, enterprise_id（分类标签）
+ * 需要管理员权限。
  */
 export async function put(ctx, deps) {
   try {
-    // R2-4：管理员权限校验
+    // 管理员权限校验
     if (!ctx.state.session?.isAdmin) {
       ctx.error('需要管理员权限', 403);
       return;

--- a/apps/standard-mgr/server/handlers/standards/build-status.js
+++ b/apps/standard-mgr/server/handlers/standards/build-status.js
@@ -6,7 +6,7 @@
  * 更新标准的锚点构建状态。
  * 当 status='done' 时自动触发 rebuildAnchoredSections 生成带锚点副本。
  *
- * 需要管理员权限（R2-4）。
+ * 需要管理员权限。
  */
 
 import StandardMgrService from '../../service.js';
@@ -22,7 +22,7 @@ export const route = {
 
 export async function post(ctx, deps) {
   try {
-    // R2-4：管理员权限校验
+    // 管理员权限校验
     if (!ctx.state.session?.isAdmin) {
       ctx.error('需要管理员权限', 403);
       return;

--- a/apps/standard-mgr/server/handlers/standards/find.js
+++ b/apps/standard-mgr/server/handlers/standards/find.js
@@ -20,7 +20,7 @@ export async function get(ctx, deps) {
     const userId = getUserId(ctx);
     const service = new StandardMgrService(deps.db);
 
-    // R2-4 过渡策略：忽略客户端传入的 enterprise_id
+    // enterprise_id 仅作为标准归属的分类标签，不参与访问控制或查询过滤。
     const standard_code = ctx.query.standard_code || null;
     const standard_name = ctx.query.standard_name || null;
 

--- a/apps/standard-mgr/server/handlers/write-anchor-result.js
+++ b/apps/standard-mgr/server/handlers/write-anchor-result.js
@@ -42,7 +42,7 @@ export async function post(ctx, deps) {
 
     const service = new StandardMgrService(deps.db);
 
-    // R2-4 过渡策略：忽略客户端传入的 enterprise_id
+    // 企业维度为分类标签，不承担权限隔离；引用写入仅校验 standard 实际存在。
     const result = await service.writeAnchorResult({
       ...body,
       user_id: userId,

--- a/apps/standard-mgr/server/service.js
+++ b/apps/standard-mgr/server/service.js
@@ -8,11 +8,10 @@
  * === 幂等键 ===
  * UNIQUE (source_revision_id, source_outline_id, occurrence_index)
  *
- * === 企业隔离（R2-4 过渡策略） ===
- * 企业对象与企业成员关系尚未建立。当前阶段：
- * - 忽略一切客户端/请求传入的 enterprise_id
- * - 查询不过滤（全部返回），写路径标准必须已在 app_standard 中存在
- * - 公共标准库：enterprise_id IS NULL；企业标准：留待企业表建立后迁移
+ * === 企业分类标签（正式设计） ===
+ * enterprise_id 标记标准归属的主机厂客户，用于分类展示与归属推断，不承担权限隔离。
+ * 平台为单租户供应商内部共用，查询不按 enterprise_id 过滤，标准统一可见。
+ * 标准创建/更新保留企业花名册存在性与启用状态校验；引用写入仅校验 standard 实际存在。
  *
  * === 状态管理 ===
  * 使用"status 列 + 常量 + 单点转换函数"模式，不引入状态机引擎。
@@ -388,7 +387,7 @@ class StandardMgrService {
    * 幂等键：(source_revision_id, source_outline_id, occurrence_index)
    * 同事务写：引用记录 + 带锚点副本 + 标准汇总计数
    *
-   * R2-4：忽略客户端传入的 enterprise_id（过渡策略）
+   * 企业维度为分类标签，不承担权限隔离；引用写入仅校验 standard 实际存在。
    * R2-5：修复 anchor_count、双重 rollback、人工治理字段
    * R2-9：状态转换校验改为真实规则
    *
@@ -464,8 +463,8 @@ class StandardMgrService {
     const standard = await AppStandard.findByPk(standard_id, { raw: true });
     if (!standard) throw new Error(`Standard not found: ${standard_id}`);
 
-    // R2-4 过渡策略：忽略客户端传入的 enterprise_id
-    // 仅校验 standard 实际存在，不校验企业归属（企业映射尚未建立）
+    // 企业维度为分类标签，不承担权限隔离。
+    // 此处仅校验 standard 实际存在，不校验企业归属权限。
 
     // R2-8/N8：目标文档权限校验从 warn 升级为阻断
     if (target_document_id && user_id) {
@@ -736,15 +735,14 @@ class StandardMgrService {
   }
 
   // ============================================================
-  // R2-4: 企业隔离查询（过渡策略）
+  // 企业分类标签查询（正式设计）
   //
-  // 在企业对象与企业成员关系落地前：
-  // - listAllStandards / getStandard / findStandards：不过滤 enterprise_id
-  // - 旧版 listStandards(enterpriseId) 保留但内部不再按 enterprise_id 过滤
+  // - listAllStandards / getStandard / findStandards：正式不按 enterprise_id 过滤
+  // - 平台为单租户供应商内部共用，enterprise_id 仅用于标准分类与展示
   // ============================================================
 
   /**
-   * 列出所有标准（过渡策略：不过滤企业）
+   * 列出所有标准（企业维度为分类标签，查询不按 enterprise_id 过滤）
    *
    * @param {object} [options]
    * @param {string} [options.standard_type]
@@ -792,16 +790,9 @@ class StandardMgrService {
   }
 
   /**
-   * 按企业查询标准列表（保留兼容，过渡策略下等同 listAllStandards）
-   */
-  async listStandards(enterpriseId, options = {}) {
-    return await this.listAllStandards(options);
-  }
-
-  /**
    * 获取单个标准详情
    *
-   * R2-4：不再按 enterprise_id 过滤；undefined 与 null 语义统一为"不过滤"
+   * 企业维度为分类标签，查询不按 enterprise_id 过滤。
    */
   async getStandard(standardId) {
     const AppStandard = this._appStandard();
@@ -915,7 +906,7 @@ class StandardMgrService {
   /**
    * 按标准编号/名称查找标准
    *
-   * R2-4 过渡策略：不过滤 enterprise_id
+   * 企业维度为分类标签，查询不按 enterprise_id 过滤。
    *
    * R17-1：编号匹配改为归一化模糊匹配（先 LIKE 精确，再内存归一化兜底）。
    *   根因：库内标准编号形态不统一（`QC-T 413` / `QC T 636-2000` / `QC/T 413-2002`），
@@ -1346,7 +1337,7 @@ class StandardMgrService {
    * 通道 1：已知标准化组织前缀 + 动态企业前缀
    *   - 企业前缀来自 app_enterprise.code_prefixes（如 Q-JL、Q-JLY、Q/JL、Q/JLY），
    *     支持连字符/斜杠形态，随企业花名册动态扩展
-   *   - 原 QJLY/QJL 硬编码保留作为兜底（企业表未配置时仍可用）
+   *   - 原 QJLY/QJL 硬编码保留作为兜底（企业花名册未配置前缀时仍可用）
    * 通道 2：通用形态兜底——大写前缀(1-6 字母) + 可选 [/或-]分段 + 数字主体(≥2 位)
    *
    * @param {string} text
@@ -2759,7 +2750,7 @@ class StandardMgrService {
    * R2-5: updateStandard — 更新标准元数据
    *
    * 可更新字段：standard_name, standard_code, standard_type, is_active, enterprise_id
-   * R11-5: 扩展 enterprise_id 用于人工修改企业归属
+   * R11-5: 扩展 enterprise_id 用于人工修改企业分类标签
    *
    * @param {string} standardId
    * @param {object} updates
@@ -3066,7 +3057,7 @@ class StandardMgrService {
 
     let standard_code = '';
     let standard_name = trimmed;
-    let matchedEnterprise = null; // { id, name } —— 前缀命中的企业归属
+    let matchedEnterprise = null; // { id, name } —— 前缀命中的企业分类标签
 
     // 1. 动态企业前缀优先（Q-JL、Q-JLY、Q/JL 等）
     //    必须放在通用 Q 形态之前：避免 "Q-JLY J7111029E" 被 /^(Q[/\s]*[\d.\-]+)/ 截成 "Q-"


### PR DESCRIPTION
Closes #1088（方案 A，已决策）

## 决策
平台使用者是一家供应商（同时供吉利/小鹏/特斯拉等主机厂），企业标准是各主机厂客户的文件、供应商内部合法共用，无企业外用户 → 企业维度 = 标准归属主机厂的分类标签，不做权限隔离。

## 内容
- service.js / handlers / migrations 中「R2-4 过渡策略」临时表述全部改为正式设计表述
- 删除无调用方的 `listStandards(enterpriseId)` 兼容死方法
- 保留：企业花名册、code_prefixes 编号提取、classify-preview 归属推断、左树企业分组

## 验证
node --check 全部通过；无运行时行为变化（纯语义收口 + 死代码删除）