### PR TITLE
fix: standard-mgr 锚点列表分页拉全，消除静默截断

### DIFF
--- a/apps/standard-mgr/frontend/components/AnchorPanel.vue
+++ b/apps/standard-mgr/frontend/components/AnchorPanel.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="sm-anchor-panel">
+    <el-alert
+      v-if="store.anchor_truncated"
+      :title="$t('apps.standardMgr.anchorsTruncated')"
+      type="warning"
+      :closable="false"
+      show-icon
+      class="sm-anchor-truncated-alert"
+    />
     <div class="sm-anchor-header">
       <h3>{{ $t('apps.standardMgr.anchors') }}</h3>
       <span class="sm-anchor-count">{{ $t('apps.standardMgr.anchorsCount', { count: anchors.length }) }}</span>
@@ -120,8 +128,11 @@ import { ref, computed, watch } from 'vue'
 import { CopyDocument, Plus } from '@element-plus/icons-vue'
 import { i18n } from '@/i18n'
 import { useToastStore } from '@/stores/toast'
+import { useStandardMgrStore } from '../stores/standardMgr'
 import TreeNodeView from './TreeNodeView.vue'
 import type { RefAnchor, RefStatus, AnchoredSection } from '../api/standard-mgr'
+
+const store = useStandardMgrStore()
 
 const props = defineProps<{
   anchors: RefAnchor[]
@@ -435,6 +446,7 @@ initExpand()
 
 <style scoped>
 .sm-anchor-panel { padding: 12px; }
+.sm-anchor-truncated-alert { margin-bottom: 12px; }
 .sm-anchor-header {
   display: flex; align-items: center; gap: 8px;
   margin-bottom: 12px; flex-wrap: wrap;

--- a/apps/standard-mgr/frontend/stores/standardMgr.ts
+++ b/apps/standard-mgr/frontend/stores/standardMgr.ts
@@ -53,11 +53,20 @@ interface TabCache {
   sections: AnchoredSection[]
   anchors: RefAnchor[]
   gaps: GapItem[]
+  anchor_truncated: boolean
 }
 
 let _tabSeq = 0
 function generateTabId(): string {
   return `tab_${Date.now()}_${++_tabSeq}`
+}
+
+const ANCHOR_PAGE_SIZE = 500
+const MAX_ANCHORS = 5000
+
+interface FetchAllAnchorsResult {
+  anchors: RefAnchor[]
+  truncated: boolean
 }
 
 // ============================================================
@@ -156,9 +165,44 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
   /** 确保缓存槽存在 */
   function ensureCache(standardId: string): TabCache {
     if (!tabCaches.value[standardId]) {
-      tabCaches.value[standardId] = { detail: null, sections: [], anchors: [], gaps: [] }
+      tabCaches.value[standardId] = {
+        detail: null,
+        sections: [],
+        anchors: [],
+        gaps: [],
+        anchor_truncated: false,
+      }
     }
     return tabCaches.value[standardId]
+  }
+
+  const anchor_truncated = computed(() => {
+    const id = activeStandardId.value
+    return id ? tabCaches.value[id]?.anchor_truncated ?? false : false
+  })
+
+  async function fetchAllAnchors(standardId: string): Promise<FetchAllAnchorsResult> {
+    const anchors: RefAnchor[] = []
+    let offset = 0
+
+    while (anchors.length < MAX_ANCHORS) {
+      const page = await listRefAnchors(standardId, {
+        limit: ANCHOR_PAGE_SIZE,
+        offset,
+      })
+      anchors.push(...page)
+
+      if (page.length < ANCHOR_PAGE_SIZE) {
+        return { anchors, truncated: false }
+      }
+
+      offset += page.length
+    }
+
+    console.warn(
+      `[standard-mgr] Anchor list for standard ${standardId} exceeded ${MAX_ANCHORS} records; truncating results`,
+    )
+    return { anchors: anchors.slice(0, MAX_ANCHORS), truncated: true }
   }
 
   /** R9-1: 打开/切换到标准。allowDuplicate=true 时总是新建页签 */
@@ -345,7 +389,10 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
     }
     if (cache.anchors.length === 0) {
       fetchTasks.push(
-        listRefAnchors(standardId, { limit: 500 }).then(a => { cache.anchors = a }).catch(err => {
+        fetchAllAnchors(standardId).then(({ anchors, truncated }) => {
+          cache.anchors = anchors
+          cache.anchor_truncated = truncated
+        }).catch(err => {
           useToastStore().error(err?.message || i18n.global.t('apps.standardMgr.loadAnchorsFailed'))
         })
       )
@@ -370,7 +417,10 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
       listAnchoredSections(standardId).then(s => { cache.sections = s }).catch(() => {
         cache.sections = []
       }),
-      listRefAnchors(standardId, { limit: 500 }).then(a => { cache.anchors = a }).catch(err => {
+      fetchAllAnchors(standardId).then(({ anchors, truncated }) => {
+        cache.anchors = anchors
+        cache.anchor_truncated = truncated
+      }).catch(err => {
         useToastStore().error(err?.message || i18n.global.t('apps.standardMgr.loadAnchorsFailed'))
       }),
     ])
@@ -386,7 +436,10 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
       listAnchoredSections(standardId).then(s => { cache.sections = s }).catch(() => {
         cache.sections = []
       }),
-      listRefAnchors(standardId, { limit: 500 }).then(a => { cache.anchors = a }).catch(err => {
+      fetchAllAnchors(standardId).then(({ anchors, truncated }) => {
+        cache.anchors = anchors
+        cache.anchor_truncated = truncated
+      }).catch(err => {
         useToastStore().error(err?.message || i18n.global.t('apps.standardMgr.loadAnchorsFailed'))
       }),
     ])
@@ -413,7 +466,9 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
   async function fetchRefAnchors(standardId: string) {
     try {
       const cache = ensureCache(standardId)
-      cache.anchors = await listRefAnchors(standardId, { limit: 500 })
+      const result = await fetchAllAnchors(standardId)
+      cache.anchors = result.anchors
+      cache.anchor_truncated = result.truncated
     } catch (err: any) {
       useToastStore().error(err?.message || i18n.global.t('apps.standardMgr.loadAnchorsFailed'))
     }
@@ -528,6 +583,7 @@ export const useStandardMgrStore = defineStore('standardMgr', () => {
     rebuildLoading,
     rebuildError,
     cleanProgress,
+    anchor_truncated,
     // R8-4: 页签状态
     openTabs,
     activeTabId,

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -1437,6 +1437,7 @@ export default {
       notCleanedHint: 'Click "Start Cleaning" to trigger',
       anchors: 'Reference Anchors',
       anchorsCount: '{count} items',
+      anchorsTruncated: 'Too many anchors, showing only the first 5,000',
       noAnchors: 'No anchor data',
       anchorValid: 'Valid',
       anchorSuspected: 'Suspected',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -1379,6 +1379,7 @@ export default {
       notCleanedHint: '点击"开始清洗"按钮触发',
       anchors: '引用锚点',
       anchorsCount: '{count} 条',
+      anchorsTruncated: '锚点过多，仅显示前 5000 条',
       noAnchors: '暂无锚点数据',
       anchorValid: '有效',
       anchorSuspected: '存疑',


### PR DESCRIPTION
审计遗留收尾（limit=500 硬编码）

## 内容
- store.fetchAllAnchors：循环分页拉取（500/页，安全上限 5000）
- loadTabData / refreshAnchors / refreshTabData / fetchRefAnchors 四处全部改用
- 超限时 AnchorPanel 顶部 el-alert「锚点过多，仅显示前 5000 条」

## 验证
与重洗 PR 试合并无冲突；合并后 vue-tsc 0 错误、vite build 通过