### PR TITLE
feat: erix-agent@0.2.0 集成适配——契约测试换包导入 + TranscriptStore run state/checkpoint 契约

### DIFF
--- a/lib/llm-kit-adapters/README.md
+++ b/lib/llm-kit-adapters/README.md
@@ -13,13 +13,13 @@ erix-llm-kit 的"驱动模型"：接口在库，DB 适配器在项目侧（ADR-0
 
 ## 测试
 
-契约测试（接口兼容断言来自库的 `@erix/llm-kit/contract-tests`，当前用相对路径引用，
-待 `@erix/llm-kit` 发布到 Gitea npm registry 后换包导入）：
+契约测试消费已发布的 `erix-agent@0.2.0` 包，通过
+`erix-agent/contract-tests` 导入接口兼容断言：
 
 ```bash
 # 凭据：~/.config/mcp/creds/touwaka-test-db.json（600，不入库）
 #   { "host": "127.0.0.1", "port": 3306, "user": "eric", "password": "…", "database": "llm_kit_test" }
-node --test tests/llm-kit-adapters/
+node --test tests/llm-kit-adapters/*.test.mjs
 ```
 
 契约测试使用默认的 `llm_kit_transcripts` 表；元数据测试使用独立的

--- a/lib/llm-kit-adapters/transcript-store.js
+++ b/lib/llm-kit-adapters/transcript-store.js
@@ -2,6 +2,7 @@ import { DataTypes } from "sequelize";
 
 const DEFAULT_MODEL_NAME = "llm_kit_transcript";
 const DEFAULT_TABLE_NAME = "llm_kit_transcripts";
+const RUN_STATE_TABLE_NAME = "llm_kit_run_state";
 
 const META_COLUMNS = [
   ["topicId", "topic_id"],
@@ -115,6 +116,12 @@ function parseJsonColumn(value) {
   return value;
 }
 
+function isMissingRunStateTableError(error) {
+  return [error, error?.parent, error?.original].some((candidate) => (
+    candidate?.code === "ER_NO_SUCH_TABLE" || candidate?.errno === 1146
+  ));
+}
+
 function toRecord(row) {
   const record = {
     round: row.round,
@@ -202,6 +209,10 @@ function appendFragments(fragments, messages) {
  *   loadWithMeta: (runId:string) => Promise<object[]>,
  *   findByTopic: (topicId:string, options?:{limit?:number}) => Promise<object[]>,
  *   recall: (runId:string, fromRound?:number, toRound?:number, pattern?:string) => Promise<string>,
+ *   markRunState: (runId:string, state:string) => Promise<void>,
+ *   saveCheckpoint: (runId:string, checkpoint:object) => Promise<void>,
+ *   appendCheckpoint: (runId:string, checkpoint:object) => Promise<void>,
+ *   loadLatestCheckpoint: (runId:string) => Promise<object|undefined>,
  *   sync: (options?:object) => Promise<object>
  * }}
  */
@@ -209,6 +220,52 @@ export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAM
   if (!db?.sequelize) throw new Error("[llm-kit-adapters] db 实例必填");
 
   const Transcript = defineTranscriptModel(db.sequelize, tableName);
+  const runStateQuery = async (sql, replacements) => {
+    try {
+      return await db.sequelize.query(sql, { replacements });
+    } catch (error) {
+      if (isMissingRunStateTableError(error)) {
+        throw new Error(
+          `[llm-kit-adapters] ${RUN_STATE_TABLE_NAME} 表不存在，请先运行 scripts/upgrade-database.js`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  };
+
+  const markRunState = async (runId, state) => {
+    await runStateQuery(`
+      INSERT INTO ${RUN_STATE_TABLE_NAME} (run_id, state, updated_at)
+      VALUES (?, ?, CURRENT_TIMESTAMP)
+      ON DUPLICATE KEY UPDATE
+        state = VALUES(state),
+        updated_at = CURRENT_TIMESTAMP
+    `, [runId, state]);
+  };
+
+  const saveCheckpoint = async (runId, checkpoint) => {
+    await runStateQuery(`
+      INSERT INTO ${RUN_STATE_TABLE_NAME} (run_id, checkpoint, updated_at)
+      VALUES (?, ?, CURRENT_TIMESTAMP)
+      ON DUPLICATE KEY UPDATE
+        checkpoint = VALUES(checkpoint),
+        updated_at = CURRENT_TIMESTAMP
+    `, [runId, JSON.stringify(checkpoint)]);
+  };
+
+  const loadLatestCheckpoint = async (runId) => {
+    const [rows] = await runStateQuery(`
+      SELECT checkpoint
+      FROM ${RUN_STATE_TABLE_NAME}
+      WHERE run_id = ?
+      LIMIT 1
+    `, [runId]);
+    const checkpoint = rows[0]?.checkpoint;
+    return checkpoint === null || checkpoint === undefined
+      ? undefined
+      : parseJsonColumn(checkpoint);
+  };
 
   return {
     async appendRound(runId, record, meta) {
@@ -275,6 +332,15 @@ export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAM
         : fragments.filter((fragment) => fragment.includes(pattern));
       return selected.join("\n");
     },
+
+    markRunState,
+    saveCheckpoint,
+
+    async appendCheckpoint(runId, checkpoint) {
+      await saveCheckpoint(runId, checkpoint);
+    },
+
+    loadLatestCheckpoint,
 
     async sync(options) {
       return Transcript.sync(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "docx": "^9.6.1",
         "dotenv": "^16.6.1",
         "echarts": "^5.5.0",
+        "erix-agent": "^0.2.0",
         "exceljs": "^4.4.0",
         "hyperformula": "^2.7.0",
         "jsonwebtoken": "^9.0.3",
@@ -2259,6 +2260,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/erix-agent": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/erix-agent/-/erix-agent-0.2.0.tgz",
+      "integrity": "sha512-Wkv085/APx63MrQL28HK7957jLHeDvGq3KtvbltUNkTyICp/1EJrmWoDlz2Hv8im49WUGilIg3c8UWBg0QlpQA==",
+      "license": "UNLICENSED",
+      "bin": {
+        "erix": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/es-define-property": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "docx": "^9.6.1",
     "dotenv": "^16.6.1",
     "echarts": "^5.5.0",
+    "erix-agent": "^0.2.0",
     "exceljs": "^4.4.0",
     "hyperformula": "^2.7.0",
     "jsonwebtoken": "^9.0.3",

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -3945,6 +3945,24 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== erix-agent TranscriptStore run state ====================
+  {
+    name: 'llm_kit_run_state table create',
+    check: async (conn) => await hasTable(conn, 'llm_kit_run_state'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        CREATE TABLE IF NOT EXISTS llm_kit_run_state (
+          run_id VARCHAR(128) NOT NULL,
+          state VARCHAR(32) NULL,
+          checkpoint JSON NULL,
+          updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          PRIMARY KEY (run_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+      `);
+      console.log('  ✓ Created llm_kit_run_state table');
+    }
+  },
+
 ];
 
 /**

--- a/tests/llm-kit-adapters/model-config-provider.contract.test.mjs
+++ b/tests/llm-kit-adapters/model-config-provider.contract.test.mjs
@@ -1,5 +1,5 @@
 /**
- * touwaka ModelConfigProvider 适配器 × erix-llm-kit 契约测试（真实 MariaDB）
+ * touwaka ModelConfigProvider 适配器 × erix-agent 契约测试（真实 MariaDB）
  *
  * 在测试库（llm_kit_test）内用 sequelize sync 建出 providers / ai_models 两表的真实结构，
  * 播种后跑库的 modelConfigProviderContract 全部断言。
@@ -24,9 +24,7 @@ for (const m of ["info", "warn", "error", "debug"]) {
 import Database from "../../lib/db.js";
 import { createTouwakaModelConfigProvider } from "../../lib/llm-kit-adapters/model-config-provider.js";
 
-// TODO: @erix/llm-kit 发布到 Gitea npm registry 后改为包导入：
-//   import { modelConfigProviderContract } from "@erix/llm-kit/contract-tests";
-import { modelConfigProviderContract } from "../../../erix-llm-kit/test/contract/model-config-provider.js";
+import { modelConfigProviderContract } from "erix-agent/contract-tests";
 
 const CREDS_PATH = join(homedir(), ".config/mcp/creds/touwaka-test-db.json");
 

--- a/tests/llm-kit-adapters/transcript-store-meta.test.mjs
+++ b/tests/llm-kit-adapters/transcript-store-meta.test.mjs
@@ -1,5 +1,6 @@
 import { test, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
@@ -39,6 +40,15 @@ if (creds) {
   });
 
   await db.connect();
+  await db.sequelize.query(`
+    CREATE TABLE IF NOT EXISTS llm_kit_run_state (
+      run_id VARCHAR(128) NOT NULL,
+      state VARCHAR(32) NULL,
+      checkpoint JSON NULL,
+      updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (run_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  `);
   const setupStore = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
   Transcript = db.sequelize.models[MODEL_NAME];
   await setupStore.sync({ force: true });
@@ -145,5 +155,27 @@ if (!creds) {
 
     const limited = await store.findByTopic("topic-target", { limit: 2 });
     assert.deepEqual(limited.map((item) => item.messages[0].content[0].text), ["a1", "a3"]);
+  });
+
+  test("checkpoint 保存、追加覆盖并可读回，run state 写入不抛错", async () => {
+    const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
+    const runId = `run-checkpoint-${randomUUID()}`;
+    const checkpoint = {
+      round: 2,
+      messages: [{ role: "assistant", content: "first" }],
+    };
+    const replacement = {
+      round: 3,
+      messages: [{ role: "assistant", content: "replacement" }],
+    };
+
+    assert.equal(await store.loadLatestCheckpoint(runId), undefined);
+    await store.markRunState(runId, "running");
+    await store.saveCheckpoint(runId, checkpoint);
+    assert.deepEqual(await store.loadLatestCheckpoint(runId), checkpoint);
+
+    await store.appendCheckpoint(runId, replacement);
+    assert.deepEqual(await store.loadLatestCheckpoint(runId), replacement);
+    assert.equal(await store.loadLatestCheckpoint(`run-missing-${randomUUID()}`), undefined);
   });
 }

--- a/tests/llm-kit-adapters/transcript-store.contract.test.mjs
+++ b/tests/llm-kit-adapters/transcript-store.contract.test.mjs
@@ -1,5 +1,5 @@
 /**
- * touwaka TranscriptStore 适配器 × erix-llm-kit 契约测试（真实 MariaDB）
+ * touwaka TranscriptStore 适配器 × erix-agent 契约测试（真实 MariaDB）
  *
  * 在测试库（llm_kit_test）内用适配器定义的 Sequelize 模型建出
  * llm_kit_transcripts 表，逐测试清空后跑库的 transcriptStoreContract 全部断言。
@@ -24,9 +24,7 @@ for (const m of ["info", "warn", "error", "debug"]) {
 import Database from "../../lib/db.js";
 import { createTouwakaTranscriptStore } from "../../lib/llm-kit-adapters/transcript-store.js";
 
-// TODO: @erix/llm-kit 发布到 Gitea npm registry 后改为包导入：
-//   import { transcriptStoreContract } from "@erix/llm-kit/contract-tests";
-import { transcriptStoreContract } from "../../../erix-llm-kit/test/contract/transcript-store.js";
+import { transcriptStoreContract } from "erix-agent/contract-tests";
 
 const CREDS_PATH = join(homedir(), ".config/mcp/creds/touwaka-test-db.json");
 


### PR DESCRIPTION
## 变更

erix-agent@0.2.0 集成适配（阶段 1）：契约测试消费已发布包 + TranscriptStore run state/checkpoint 契约实现。

### A. 依赖与包导入固化
- `package.json` 新增 `erix-agent@^0.2.0`（零依赖 ESM 引擎库，已发布 npm）
- 2 个契约测试从相对路径引兄弟仓库 checkout（`../../../erix-llm-kit/test/contract/*.js`）改为消费发布包的 `erix-agent/contract-tests`
- `lib/llm-kit-adapters/README.md` 更新导入说明（去掉过时的 `@erix/llm-kit` / Gitea registry 描述）

### B. TranscriptStore checkpoint 契约
- `scripts/upgrade-database.js` 新增幂等迁移：建 `llm_kit_run_state` 表（run_id PK / state / checkpoint JSON / updated_at），归入统一升级脚本
- `lib/llm-kit-adapters/transcript-store.js` 实现 `markRunState / saveCheckpoint / appendCheckpoint / loadLatestCheckpoint`（原子 upsert，state 与 checkpoint 列互不覆盖；缺表给出明确迁移提示）
- `transcript-store-meta.test.mjs` 扩展 checkpoint 保存/覆盖/读取 + run_id 隔离测试（erix contract 套件不覆盖 checkpoint，自测补齐）

## 验证
- `node --test tests/llm-kit-adapters/*.test.mjs`：21/21 通过（真实 MariaDB，llm_kit_test 测试库）
- `npm run lint` 通过
- 无相对路径残留；`models/`、`llm_kit_transcripts` 表结构未动

## 关联
- erix-agent 侧：ErixWong/erix-agent issue #1（引擎升级承载 touwaka，里程碑 0.2.0 已发布）
- 本地任务留痕：docs/tasks/active/task-260902-llm-kit-v020-integration/（不入库）
