### PR TITLE
feat: message-converter 对齐 canonical v0.2——reasoning 原生块 + 兼容读取

### DIFF
--- a/lib/llm-kit-adapters/message-converter.js
+++ b/lib/llm-kit-adapters/message-converter.js
@@ -73,9 +73,8 @@ function auxiliaryBlocksForRow(row) {
   const blocks = [];
   if (isNonEmpty(row?.reasoning_content)) {
     blocks.push({
-      type: "raw",
-      protocol: "touwaka",
-      payload: { kind: "reasoning", text: asText(row.reasoning_content) },
+      type: "reasoning",
+      text: asText(row.reasoning_content),
     });
   }
   if (isNonEmpty(row?.inner_voice)) {
@@ -252,7 +251,9 @@ function recordBaseFields(record, role) {
 }
 
 function appendRawFields(row, block) {
-  if (block?.protocol === "touwaka" && block.payload?.kind === "reasoning") {
+  if (block?.type === "reasoning") {
+    row.reasoning_content = asText(block.text);
+  } else if (block?.protocol === "touwaka" && block.payload?.kind === "reasoning") {
     row.reasoning_content = asText(block.payload.text);
   } else if (block?.protocol === "touwaka" && block.payload?.kind === "inner_voice") {
     row.inner_voice = asText(block.payload.text);

--- a/tests/llm-kit-adapters/message-converter.test.mjs
+++ b/tests/llm-kit-adapters/message-converter.test.mjs
@@ -129,7 +129,7 @@ test("reasoning、inner_voice、usage 和业务元数据进入同一轮", () => 
   });
   assert.deepEqual(records[0].messages[0].content, [
     { type: "text", text: "回答" },
-    { type: "raw", protocol: "touwaka", payload: { kind: "reasoning", text: "先思考" } },
+    { type: "reasoning", text: "先思考" },
     { type: "raw", protocol: "touwaka", payload: { kind: "inner_voice", text: "保持谨慎" } },
   ]);
 
@@ -141,6 +141,25 @@ test("reasoning、inner_voice、usage 和业务元数据进入同一轮", () => 
     created_at: "2026-08-29T00:02:01.000Z",
   }]);
   assert.equal(Object.hasOwn(incompleteUsage.records[0].meta, "usage"), false);
+});
+
+test("兼容读取旧 reasoning raw 包装", () => {
+  const restored = canonicalToLegacyMessages([{
+    round: 1,
+    messages: [{
+      role: "assistant",
+      content: [
+        { type: "text", text: "回答" },
+        {
+          type: "raw",
+          protocol: "touwaka",
+          payload: { kind: "reasoning", text: "历史思考" },
+        },
+      ],
+    }],
+  }]);
+
+  assert.equal(restored[0].reasoning_content, "历史思考");
 });
 
 test("孤儿 tool 行归入 round 0", () => {


### PR DESCRIPTION
## 变更

message-converter 对齐 erix-agent canonical v0.2（阶段 2）：reasoning 改为原生块。

- `lib/llm-kit-adapters/message-converter.js`
  - 出向：`reasoning_content` 列不再包装为 `raw{protocol:'touwaka', kind:'reasoning'}`，直接输出 canonical 原生 `{ type: "reasoning", text }` 块（与 erix-agent v0.2 块模型一致）
  - 入向：原生 `reasoning` 块写回 `row.reasoning_content`；**保留**对历史 `raw{protocol:'touwaka', payload:{kind:'reasoning'}}` 格式的兼容读取（存量数据）
  - `inner_voice`（touwaka 业务特有，erix 无对应概念）维持原 raw 包装不变
- `tests/llm-kit-adapters/message-converter.test.mjs`：更新 reasoning 出向断言为原生块；新增旧 raw 包装兼容读取用例

## 验证
- `node --test tests/llm-kit-adapters/message-converter.test.mjs`：6/6 通过（纯单元，无 DB）
- `npm run lint` 通过

## 关联
- 承接 erix-agent issue #1（touwaka 消费方侧适配器对齐，阶段 2）；阶段 1 = PR #1108（依赖固化 + TranscriptStore checkpoint）
- 本地任务留痕：docs/tasks/active/task-260902-llm-kit-v020-integration/（不入库）
