### PR TITLE
chore: 部署基础镜像 Node 20→22 升级（对齐 erix-agent engines>=22）

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 ## 🚀 快速开始
 
 ### 环境要求
-- Node.js 20+
+- Node.js 22+（对齐 erix-agent 引擎要求；Node 20 亦兼容运行）
 - MariaDB 11.x (支持原生向量类型)
 - (可选) Python 3.10+ - 用于 Python 技能支持
 
@@ -131,7 +131,7 @@ npm run dev:frontend # 前端 :5173
 
 ### 推荐方案：使用预构建镜像（快速部署）
 
-我们推荐使用 `nikolaik/python-nodejs:python3.12-nodejs20-bullseye` 镜像，它已经预装了 Python 3.12 和 Node.js 20，无需本地构建。
+我们推荐使用 `nikolaik/python-nodejs:python3.12-nodejs22-bookworm` 镜像，它已经预装了 Python 3.12 和 Node.js 22，无需本地构建。
 
 ```bash
 # 1. 创建部署目录

--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -7,7 +7,7 @@
 
 services:
   app:
-    image: nikolaik/python-nodejs:python3.12-nodejs20-bullseye
+    image: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     container_name: touwaka-mate
     restart: unless-stopped
     ports:

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -14,7 +14,7 @@
 
 services:
   app:
-    image: nikolaik/python-nodejs:python3.12-nodejs20-bullseye
+    image: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     container_name: touwaka-mate
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: nikolaik/python-nodejs:python3.12-nodejs20-bullseye
+    image: nikolaik/python-nodejs:python3.12-nodejs22-bookworm
     container_name: touwaka-mate
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## 变更

部署运行时 Node 20 → 22 升级（erix-agent engines >=22 对齐，L3 AgentLoop 替换前置）。

- 4 个 compose 部署配置 base 镜像：`nikolaik/python-nodejs:python3.12-nodejs20-bullseye` → `nikolaik/python-nodejs:python3.12-nodejs22-bookworm`
  - `docker-compose.yml` / `docker-compose.standalone.yml` / `docker-compose.nas.yml`（已入库）；`docker-compose.local.yml`（本地未跟踪文件，本机同样已改）
  - bullseye → bookworm 随镜像上游演进（nikolaik 官方 nodejs22 组合基于 bookworm，已从 GitHub versions.json / Docker Hub 确认存在）
- `README.md`：环境要求 Node.js 20+ → 22+；推荐镜像说明同步

## 说明
- touwaka 业务代码无 Node 22 不兼容语法（await using 等核查为误匹配）；本地开发机 node 22.23 已长期运行
- python 保持 3.12 不变，仅 Node 主版本与 Debian 层升级

## 验证
- 4 个 compose YAML 解析有效；无 nodejs20 引用残留
- 部署侧（NAS/standalone）需在目标环境重新 `docker compose pull && up -d` 生效并回归

## 关联
- 承接 erix-agent issue #1（touwaka 消费方侧，Node 22 为 AgentLoop 引擎替换前置）
- 本地任务留痕：docs/tasks/active/task-260902-llm-kit-v020-integration/（不入库）
