### PR TITLE
feat: erix Provider 适配层（L3-M1）——桥接 LLMClient 到 erix provider 契约

### DIFF
--- a/lib/llm-kit-adapters/README.md
+++ b/lib/llm-kit-adapters/README.md
@@ -10,6 +10,7 @@ erix-llm-kit 的"驱动模型"：接口在库，DB 适配器在项目侧（ADR-0
 | `model-config-provider.js` | ModelConfigProvider | `ai_models` + `providers` 表（经 lib/db.js） |
 | `transcript-store.js` | TranscriptStore | `llm_kit_transcripts` 表（可通过 `tableName` 指定其他表，适配器内 Sequelize 模型） |
 | `message-converter.js` | OpenAI ↔ canonical 双向转换 | 纯函数，无 DB 依赖 |
+| `provider-adapter.js` | erix Provider (`chatStream`/`chat`) | `LLMClient.callStream`/`call`，纯桥接 |
 
 ## 测试
 

--- a/lib/llm-kit-adapters/provider-adapter.js
+++ b/lib/llm-kit-adapters/provider-adapter.js
@@ -1,0 +1,508 @@
+import {
+  canonicalToOpenAIMessages,
+  canonicalToolsToOpenAI,
+} from "erix-agent";
+
+const PASSTHROUGH_FIELDS = [
+  ["thinking", "thinking"],
+  ["reasoning", "reasoning"],
+  ["reasoning_effort", "reasoning_effort"],
+  ["enable_thinking", "enable_thinking"],
+  ["chat_template_kwargs", "chat_template_kwargs"],
+  ["frequency_penalty", "frequency_penalty", "frequencyPenalty"],
+  ["presence_penalty", "presence_penalty", "presencePenalty"],
+  ["response_format", "response_format", "responseFormat"],
+  ["max_tokens", "max_tokens", "maxTokens", "max_output_tokens"],
+  ["temperature", "temperature"],
+  ["top_p", "top_p", "topP"],
+];
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function firstDefined(source, keys) {
+  for (const key of keys) {
+    if (hasOwn(source, key) && source[key] !== undefined) return source[key];
+  }
+  return undefined;
+}
+
+function setIfDefined(target, key, value) {
+  if (value !== undefined) target[key] = value;
+}
+
+function normalizeUsage(usage) {
+  if (usage === null || typeof usage !== "object" || Array.isArray(usage)) {
+    return undefined;
+  }
+
+  const normalized = {};
+  setIfDefined(normalized, "input_tokens", firstDefined(usage, [
+    "input_tokens",
+    "prompt_tokens",
+  ]));
+  setIfDefined(normalized, "output_tokens", firstDefined(usage, [
+    "output_tokens",
+    "completion_tokens",
+  ]));
+  return Object.keys(normalized).length === 0 ? undefined : normalized;
+}
+
+function normalizeStopReason(reason, fallback) {
+  if (reason == null) return fallback;
+  return {
+    stop: "end_turn",
+    tool_calls: "tool_use",
+    tool_use: "tool_use",
+    length: "max_tokens",
+  }[reason] ?? reason;
+}
+
+function parseToolArguments(rawArguments) {
+  const value = rawArguments === undefined ? "{}" : rawArguments;
+  if (value !== null && typeof value === "object") return value;
+
+  try {
+    return JSON.parse(String(value));
+  } catch {
+    return {
+      _truncatedArguments: value,
+      _raw: value,
+    };
+  }
+}
+
+function asToolCallEntries(value, state) {
+  if (Array.isArray(value)) {
+    return value.map((item, index) => ({ item, fallbackIndex: index }));
+  }
+
+  const existingIndexes = Object.keys(state.slots).map(Number);
+  const fallbackIndex = existingIndexes.length === 1 ? existingIndexes[0] : 0;
+  return [{ item: value, fallbackIndex }];
+}
+
+function toolCallParts(item) {
+  if (item === null || typeof item !== "object" || Array.isArray(item)) {
+    return undefined;
+  }
+
+  const functionPart = item.function;
+  const functionObject = functionPart !== null
+    && typeof functionPart === "object"
+    && !Array.isArray(functionPart)
+    ? functionPart
+    : undefined;
+  const name = item.name ?? functionObject?.name;
+
+  let argumentsValue;
+  let hasArguments = false;
+  for (const source of [item, functionObject]) {
+    if (!source) continue;
+    for (const key of ["argumentsDelta", "arguments"]) {
+      if (hasOwn(source, key) && source[key] !== undefined) {
+        argumentsValue = source[key];
+        hasArguments = true;
+        break;
+      }
+    }
+    if (hasArguments) break;
+  }
+  if (!hasArguments && hasOwn(item, "input")) {
+    argumentsValue = JSON.stringify(item.input ?? {});
+    hasArguments = true;
+  }
+
+  return {
+    index: item.index,
+    id: item.id,
+    name,
+    argumentsValue,
+    hasArguments,
+  };
+}
+
+function appendToolCallFragments(value, state, request) {
+  for (const { item, fallbackIndex } of asToolCallEntries(value, state)) {
+    const parts = toolCallParts(item);
+    if (!parts) continue;
+
+    const requestedIndex = Number(parts.index);
+    const index = Number.isInteger(requestedIndex) && requestedIndex >= 0
+      ? requestedIndex
+      : fallbackIndex;
+    const slot = state.slots[index] ?? {
+      id: undefined,
+      name: undefined,
+      arguments: "",
+    };
+    state.slots[index] = slot;
+
+    if (parts.id !== undefined) slot.id = parts.id;
+    if (parts.name !== undefined) slot.name = String(parts.name);
+    if (parts.hasArguments) {
+      const fragment = parts.argumentsValue !== null
+        && typeof parts.argumentsValue === "object"
+        ? JSON.stringify(parts.argumentsValue)
+        : String(parts.argumentsValue);
+      slot.arguments += fragment;
+    }
+
+    const emitted = {
+      index,
+      ...(slot.id === undefined ? {} : { id: slot.id }),
+      ...(parts.name === undefined ? {} : { name: String(parts.name) }),
+      ...(parts.hasArguments
+        ? {
+          argumentsDelta: parts.argumentsValue !== null
+            && typeof parts.argumentsValue === "object"
+            ? JSON.stringify(parts.argumentsValue)
+            : String(parts.argumentsValue),
+        }
+        : {}),
+    };
+    request.onToolCall?.(emitted);
+    request.onEvent?.({ type: "tool_call", ...emitted });
+  }
+}
+
+function completedToolUseBlocks(state) {
+  return Object.keys(state.slots)
+    .map(Number)
+    .sort((left, right) => left - right)
+    .map((index) => state.slots[index])
+    .filter(Boolean)
+    .map((slot) => ({
+      type: "tool_use",
+      id: slot.id,
+      name: slot.name,
+      input: parseToolArguments(slot.arguments),
+    }));
+}
+
+function responseMessage(response) {
+  const choice = response?.choices?.[0];
+  return choice?.message ?? response;
+}
+
+function responseToolCalls(response) {
+  const message = responseMessage(response);
+  return Array.isArray(message?.tool_calls)
+    ? message.tool_calls
+    : Array.isArray(response?.toolCalls)
+      ? response.toolCalls
+      : [];
+}
+
+function responseContent(response) {
+  const message = responseMessage(response);
+  return message?.content ?? response?.content;
+}
+
+function toChatResponse(response, fallbackStopReason) {
+  const message = responseMessage(response);
+  const toolCalls = responseToolCalls(response);
+  const content = [];
+  const reasoning = message?.reasoningContent ?? message?.reasoning_content;
+
+  if (Array.isArray(message?.content)) {
+    content.push(...message.content);
+  } else {
+    if (typeof reasoning === "string" && reasoning.length > 0) {
+      content.push({ type: "reasoning", text: reasoning });
+    }
+    const text = responseContent(response);
+    if (typeof text === "string" && text.length > 0) {
+      content.push({ type: "text", text });
+    }
+  }
+
+  for (const toolCall of toolCalls) {
+    const parts = toolCallParts(toolCall);
+    if (!parts) continue;
+    content.push({
+      type: "tool_use",
+      id: parts.id,
+      name: parts.name,
+      input: parseToolArguments(parts.argumentsValue),
+    });
+  }
+
+  const rawStopReason = message?.stopReason
+    ?? message?.stop_reason
+    ?? response?.stopReason
+    ?? response?.stop_reason
+    ?? message?.finishReason
+    ?? message?.finish_reason
+    ?? response?.finishReason
+    ?? response?.finish_reason;
+  const stopReason = normalizeStopReason(
+    rawStopReason,
+    content.some((block) => block?.type === "tool_use")
+      ? "tool_use"
+      : fallbackStopReason,
+  );
+  const normalized = { content, stopReason };
+  const usage = normalizeUsage(response?.usage);
+  if (usage !== undefined) normalized.usage = usage;
+  return normalized;
+}
+
+function abortReason(signal) {
+  if (signal?.reason instanceof Error) return signal.reason;
+  const error = new Error(
+    signal?.reason === undefined ? "The operation was aborted" : String(signal.reason),
+  );
+  error.name = "AbortError";
+  return error;
+}
+
+function abortClientRequest(llmClient, { user_id, request_id }) {
+  if (request_id !== undefined && typeof llmClient.abortRequest === "function") {
+    llmClient.abortRequest(request_id);
+    return;
+  }
+  if (user_id !== undefined && typeof llmClient.abortUserRequest === "function") {
+    llmClient.abortUserRequest(user_id);
+  }
+}
+
+async function invokeWithAbort(
+  operation,
+  llmClient,
+  requestMeta,
+  onAbort,
+) {
+  const { signal } = requestMeta;
+  if (!signal) return operation();
+  if (signal.aborted) {
+    onAbort?.();
+    abortClientRequest(llmClient, requestMeta);
+    throw abortReason(signal);
+  }
+
+  let rejectAbort;
+  const abortPromise = new Promise((_, reject) => {
+    rejectAbort = reject;
+  });
+  const abort = () => {
+    onAbort?.();
+    abortClientRequest(llmClient, requestMeta);
+    rejectAbort(abortReason(signal));
+  };
+  signal.addEventListener("abort", abort, { once: true });
+
+  const operationPromise = Promise.resolve().then(() => {
+    if (signal.aborted) throw abortReason(signal);
+    return operation();
+  });
+  try {
+    return await Promise.race([operationPromise, abortPromise]);
+  } finally {
+    signal.removeEventListener?.("abort", abort);
+  }
+}
+
+function resolveRequestMeta(request, opts, {
+  defaultUserId,
+  defaultRequestId,
+}) {
+  const user_id = request.user_id
+    ?? opts.user_id
+    ?? defaultUserId
+    ?? "anonymous";
+  const request_id = request.request_id
+    ?? opts.request_id
+    ?? defaultRequestId;
+  const signal = request.signal ?? opts.signal;
+  return {
+    user_id,
+    ...(request_id === undefined ? {} : { request_id }),
+    ...(signal === undefined ? {} : { signal }),
+  };
+}
+
+function buildCallOptions(request, requestMeta) {
+  const options = {
+    tools: canonicalToolsToOpenAI(request.tools),
+    user_id: requestMeta.user_id,
+  };
+
+  if (requestMeta.request_id !== undefined) {
+    options.request_id = requestMeta.request_id;
+  }
+  if (requestMeta.signal !== undefined) options.signal = requestMeta.signal;
+
+  for (const [target, ...sourceKeys] of PASSTHROUGH_FIELDS) {
+    setIfDefined(options, target, firstDefined(request, sourceKeys));
+  }
+
+  for (const [key, callback] of [
+    ["onDelta", request.onDelta],
+    ["onReasoningDelta", request.onReasoningDelta],
+    ["onToolCall", request.onToolCall],
+    ["onUsage", request.onUsage],
+  ]) {
+    if (typeof callback === "function") options[key] = callback;
+  }
+  return options;
+}
+
+function streamResponse(response, state, reportedUsage) {
+  const content = [];
+  if (state.reasoning.length > 0) {
+    content.push({ type: "reasoning", text: state.reasoning });
+  }
+  if (state.text.length > 0) content.push({ type: "text", text: state.text });
+  content.push(...completedToolUseBlocks(state));
+
+  const returnedUsage = normalizeUsage(response?.usage);
+  const usage = reportedUsage ?? returnedUsage;
+  const normalized = {
+    content,
+    stopReason: normalizeStopReason(
+      response?.stopReason ?? response?.stop_reason ?? response?.finishReason,
+      Object.keys(state.slots).length > 0 ? "tool_use" : "end_turn",
+    ),
+  };
+  if (usage !== undefined) normalized.usage = usage;
+  return normalized;
+}
+
+/**
+ * Bridge erix-agent's provider contract to Touwaka's LLMClient.
+ *
+ * `resolveModel` receives the original canonical request and
+ * `{user_id, request_id, signal}` metadata. The returned model config is
+ * passed unchanged to `llmClient.callStream`/`call`.
+ *
+ * @param {{
+ *   llmClient: object,
+ *   resolveModel: (request: object, requestMeta: object) => Promise<object>,
+ *   defaultUserId?: string,
+ *   defaultRequestId?: string,
+ * }} options
+ * @returns {{chat?: Function, chatStream: Function}}
+ */
+export function createTouwakaProvider({
+  llmClient,
+  resolveModel,
+  defaultUserId,
+  defaultRequestId,
+} = {}) {
+  if (!llmClient || typeof llmClient.callStream !== "function") {
+    throw new TypeError("[llm-kit-adapters] llmClient.callStream is required");
+  }
+  if (typeof resolveModel !== "function") {
+    throw new TypeError("[llm-kit-adapters] resolveModel is required");
+  }
+
+  async function chatStream(request = {}, opts = {}) {
+    const requestMeta = resolveRequestMeta(request, opts, {
+      defaultUserId,
+      defaultRequestId,
+    });
+    const modelConfig = await resolveModel(request, requestMeta);
+
+    const state = {
+      active: true,
+      text: "",
+      reasoning: "",
+      slots: {},
+    };
+    let reportedUsage;
+    const callOptions = buildCallOptions(request, requestMeta);
+    callOptions.onDelta = (delta) => {
+      if (!state.active) return;
+      if (typeof delta === "string") state.text += delta;
+      request.onDelta?.(delta);
+      request.onEvent?.({ type: "delta", delta });
+    };
+    callOptions.onReasoningDelta = (delta, metadata) => {
+      if (!state.active) return;
+      if (typeof delta === "string") state.reasoning += delta;
+      request.onReasoningDelta?.(delta, metadata);
+      request.onEvent?.({
+        type: "reasoning_delta",
+        delta,
+        ...(metadata === undefined ? {} : { metadata }),
+      });
+    };
+    callOptions.onToolCall = (toolCall) => {
+      if (!state.active) return;
+      appendToolCallFragments(toolCall, state, request);
+    };
+    callOptions.onUsage = (usage) => {
+      if (!state.active) return;
+      reportedUsage = usage;
+      request.onUsage?.(usage);
+      request.onEvent?.({ type: "usage", usage });
+    };
+
+    let response;
+    try {
+      response = await invokeWithAbort(
+        () => llmClient.callStream(modelConfig, canonicalToOpenAIMessages(
+          request.system,
+          request.messages,
+        ), callOptions),
+        llmClient,
+        requestMeta,
+        () => {
+          state.active = false;
+        },
+      );
+    } finally {
+      state.active = false;
+    }
+
+    if (state.slots && Object.keys(state.slots).length === 0) {
+      const returnedToolCalls = responseToolCalls(response);
+      if (returnedToolCalls.length > 0) {
+        appendToolCallFragments(returnedToolCalls, state, request);
+      }
+    }
+    if (reportedUsage === undefined && response?.usage !== undefined) {
+      reportedUsage = response.usage;
+      request.onUsage?.(reportedUsage);
+      request.onEvent?.({ type: "usage", usage: reportedUsage });
+    }
+    return streamResponse(response, state, normalizeUsage(reportedUsage));
+  }
+
+  const provider = { chatStream };
+  if (typeof llmClient.call === "function") {
+    provider.chat = async (request = {}, opts = {}) => {
+      const requestMeta = resolveRequestMeta(request, opts, {
+        defaultUserId,
+        defaultRequestId,
+      });
+      const modelConfig = await resolveModel(request, requestMeta);
+      const callOptions = buildCallOptions(request, requestMeta);
+      delete callOptions.onDelta;
+      delete callOptions.onReasoningDelta;
+      delete callOptions.onToolCall;
+      delete callOptions.onUsage;
+      const response = await invokeWithAbort(
+        () => llmClient.call(modelConfig, canonicalToOpenAIMessages(
+          request.system,
+          request.messages,
+        ), callOptions),
+        llmClient,
+        requestMeta,
+      );
+      return toChatResponse(
+        response,
+        responseToolCalls(response).length > 0 ? "tool_use" : "end_turn",
+      );
+    };
+  } else {
+    provider.chat = async () => {
+      // M1 only guarantees the streaming path; non-stream orchestration remains
+      // unavailable until the later AgentLoop integration phase.
+      throw new Error("[llm-kit-adapters] chat is not implemented in M1; use chatStream");
+    };
+  }
+  return provider;
+}

--- a/tests/llm-kit-adapters/provider-adapter.test.mjs
+++ b/tests/llm-kit-adapters/provider-adapter.test.mjs
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTouwakaProvider } from "../../lib/llm-kit-adapters/provider-adapter.js";
+
+function createMockClient(sequence = []) {
+  const calls = [];
+  const llmClient = {
+    calls,
+    async callStream(model, messages, options) {
+      calls.push({ model, messages, options });
+      for (const step of sequence) {
+        await Promise.resolve();
+        if (step.type === "delta") options.onDelta?.(step.value);
+        if (step.type === "reasoning") options.onReasoningDelta?.(step.value);
+        if (step.type === "tool_call") options.onToolCall?.(step.value);
+        if (step.type === "usage") options.onUsage?.(step.value);
+      }
+    },
+  };
+  return llmClient;
+}
+
+function resolveModelFactory(calls, model = { model_name: "mock-model" }) {
+  return async (request, requestMeta) => {
+    calls.push({ request, requestMeta });
+    return model;
+  };
+}
+
+test("canonical messages use erix OpenAI conversion and keep reasoning out of content", async () => {
+  const resolved = [];
+  const llmClient = createMockClient();
+  const provider = createTouwakaProvider({
+    llmClient,
+    resolveModel: resolveModelFactory(resolved),
+  });
+
+  await provider.chatStream({
+    system: "You are helpful.",
+    messages: [
+      { role: "user", content: [{ type: "text", text: "inspect" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "private reasoning" },
+          { type: "text", text: "I will inspect." },
+          {
+            type: "raw",
+            protocol: "vendor",
+            payload: { trace_id: "trace-1" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: "call-1",
+          content: "result",
+        }],
+      },
+    ],
+  });
+
+  const [call] = llmClient.calls;
+  assert.deepEqual(call.messages, [
+    { role: "system", content: "You are helpful." },
+    { role: "user", content: "inspect" },
+    {
+      role: "assistant",
+      content: "I will inspect.",
+      reasoning_content: "private reasoning",
+      raw_blocks: [{
+        type: "raw",
+        protocol: "vendor",
+        payload: { trace_id: "trace-1" },
+      }],
+    },
+    { role: "tool", tool_call_id: "call-1", content: "result" },
+  ]);
+  assert.equal(call.messages[2].content.includes("private reasoning"), false);
+  assert.deepEqual(resolved[0].requestMeta, { user_id: "anonymous" });
+});
+
+test("canonical tools are converted to OpenAI function tools", async () => {
+  const llmClient = createMockClient();
+  const provider = createTouwakaProvider({
+    llmClient,
+    resolveModel: resolveModelFactory([]),
+  });
+
+  await provider.chatStream({
+    messages: [],
+    tools: [{
+      name: "lookup",
+      description: "Find a value.",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    }],
+  });
+
+  assert.deepEqual(llmClient.calls[0].options.tools, [{
+    type: "function",
+    function: {
+      name: "lookup",
+      description: "Find a value.",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+      },
+    },
+  }]);
+});
+
+test("stream callbacks and events preserve delta, reasoning, tool fragments, and usage order", async () => {
+  const events = [];
+  const callbacks = [];
+  const llmClient = createMockClient([
+    { type: "delta", value: "hello " },
+    { type: "reasoning", value: "think " },
+    {
+      type: "tool_call",
+      value: {
+        index: 0,
+        id: "call-1",
+        function: { name: "lookup", arguments: '{"query":' },
+      },
+    },
+    {
+      type: "tool_call",
+      value: {
+        index: 0,
+        function: { arguments: '"touwaka"}' },
+      },
+    },
+    { type: "usage", value: { prompt_tokens: 8, completion_tokens: 5 } },
+  ]);
+  const provider = createTouwakaProvider({
+    llmClient,
+    resolveModel: resolveModelFactory([]),
+  });
+
+  const response = await provider.chatStream({
+    messages: [],
+    onDelta: (value) => callbacks.push(["delta", value]),
+    onReasoningDelta: (value) => callbacks.push(["reasoning", value]),
+    onToolCall: (value) => callbacks.push(["tool_call", value]),
+    onUsage: (value) => callbacks.push(["usage", value]),
+    onEvent: (event) => events.push(event),
+  });
+
+  assert.deepEqual(events.map((event) => event.type), [
+    "delta",
+    "reasoning_delta",
+    "tool_call",
+    "tool_call",
+    "usage",
+  ]);
+  assert.deepEqual(callbacks, [
+    ["delta", "hello "],
+    ["reasoning", "think "],
+    ["tool_call", {
+      index: 0,
+      id: "call-1",
+      name: "lookup",
+      argumentsDelta: '{"query":',
+    }],
+    ["tool_call", {
+      index: 0,
+      id: "call-1",
+      argumentsDelta: '"touwaka"}',
+    }],
+    ["usage", { prompt_tokens: 8, completion_tokens: 5 }],
+  ]);
+  assert.deepEqual(response, {
+    content: [
+      { type: "reasoning", text: "think " },
+      { type: "text", text: "hello " },
+      {
+        type: "tool_use",
+        id: "call-1",
+        name: "lookup",
+        input: { query: "touwaka" },
+      },
+    ],
+    stopReason: "tool_use",
+    usage: { input_tokens: 8, output_tokens: 5 },
+  });
+});
+
+test("request generation parameters and model resolution reach callStream", async () => {
+  const resolved = [];
+  const model = {
+    model_name: "resolved-model",
+    provider_name: "mock-provider",
+    max_output_tokens: 2048,
+    model_type: "text",
+  };
+  const llmClient = createMockClient();
+  const provider = createTouwakaProvider({
+    llmClient,
+    resolveModel: resolveModelFactory(resolved, model),
+    defaultUserId: "user-1",
+    defaultRequestId: "request-1",
+  });
+
+  await provider.chatStream({
+    messages: [],
+    temperature: 0.25,
+    topP: 0.4,
+    maxTokens: 321,
+    thinking: { type: "enabled" },
+  });
+
+  assert.equal(resolved.length, 1);
+  assert.deepEqual(resolved[0].requestMeta, {
+    user_id: "user-1",
+    request_id: "request-1",
+  });
+  assert.equal(llmClient.calls[0].model, model);
+  assert.equal(llmClient.calls[0].options.temperature, 0.25);
+  assert.equal(llmClient.calls[0].options.top_p, 0.4);
+  assert.equal(llmClient.calls[0].options.max_tokens, 321);
+  assert.deepEqual(llmClient.calls[0].options.thinking, { type: "enabled" });
+  assert.equal(llmClient.calls[0].options.user_id, "user-1");
+  assert.equal(llmClient.calls[0].options.request_id, "request-1");
+});
+
+test("chat bridges the existing non-streaming LLMClient.call when available", async () => {
+  const llmClient = createMockClient();
+  llmClient.call = async (model, messages, options) => {
+    llmClient.chatCall = { model, messages, options };
+    return {
+      content: "done",
+      toolCalls: [{
+        id: "call-1",
+        function: { name: "finish", arguments: "{}" },
+      }],
+      usage: { prompt_tokens: 2, completion_tokens: 3 },
+    };
+  };
+  const provider = createTouwakaProvider({
+    llmClient,
+    resolveModel: resolveModelFactory([]),
+  });
+
+  const response = await provider.chat({
+    messages: [{ role: "user", content: "start" }],
+  });
+
+  assert.deepEqual(response, {
+    content: [
+      { type: "text", text: "done" },
+      { type: "tool_use", id: "call-1", name: "finish", input: {} },
+    ],
+    stopReason: "tool_use",
+    usage: { input_tokens: 2, output_tokens: 3 },
+  });
+  assert.equal(llmClient.chatCall.messages[0].content, "start");
+});
+
+test("request.signal aborts the client request by request_id", async () => {
+  const controller = new AbortController();
+  const abortCalls = [];
+  const llmClient = {
+    callStream() {
+      return new Promise(() => {});
+    },
+    abortRequest(requestId) {
+      abortCalls.push(requestId);
+    },
+  };
+  const provider = createTouwakaProvider({
+    llmClient,
+    resolveModel: resolveModelFactory([]),
+    defaultUserId: "user-1",
+    defaultRequestId: "request-1",
+  });
+  const pending = provider.chatStream({
+    messages: [],
+    signal: controller.signal,
+  });
+  const reason = new Error("cancelled");
+  controller.abort(reason);
+
+  await assert.rejects(pending, (error) => error === reason);
+  assert.deepEqual(abortCalls, ["request-1"]);
+});
+


### PR DESCRIPTION
## 变更

L3-M1：erix Provider 适配层（AgentLoop → runToolLoop 迁移第一阶段）。

- 新增 `lib/llm-kit-adapters/provider-adapter.js`（508 行）：`createTouwakaProvider({llmClient, resolveModel})` → erix provider 形状 `{chat?, chatStream}`
  - canonical 消息/tools → OpenAI 兼容格式（复用 `erix-agent` 的 `canonicalToOpenAIMessages`/`canonicalToolsToOpenAI`：reasoning → reasoning_content、raw → raw_blocks、tool_result → role:"tool"）
  - `chatStream` 桥接 `llmClient.callStream`：delta/reasoning/tool-call（分片累积 + 完整数组兼容）/usage 事件转发 + erix LoopEvent；返回 canonical ChatResponse（content Block[]/stopReason/usage 归一 input|output_tokens）
  - 参数透传 11 项（thinking/reasoning/reasoning_effort/enable_thinking/chat_template_kwargs/frequency_penalty/presence_penalty/response_format/max_tokens/temperature/top_p）
  - `request.signal` → touwaka abort 机制（abortRequest/abortUserRequest），预先中止单次处理
  - 非流式 `chat`：llmClient.call 存在则桥接，缺失抛明确 M1 错误
- 新增 `tests/llm-kit-adapters/provider-adapter.test.mjs`（292 行纯 mock）：6/6 覆盖转换/事件顺序/分片拼接/ChatResponse/参数透传/中止
- `lib/llm-kit-adapters/README.md` 适配器清单登记

## 验证
- `node --test tests/llm-kit-adapters/*.test.mjs`：27/27 全绿（provider-adapter 6 + 既有 21）
- `npm run lint`、`node --check` 通过
- reviewer 审计：**通过**（契约符合性对照 erix-agent@0.2.0 实际导出逐项一致；运行路径零改动、无新增依赖）
- 红线：lib/agent/*、lib/chat-service.js、lib/llm-client.js 零改动；未接入 AgentLoop（M2/M3 范畴）

## Backlog（reviewer minor 建议，M2 处理）
1. 测试补 onToolCall 完整数组模式用例 + chat 缺失 M1 错误断言
2. base-llm callStream 透出 finishReason（使 stopReason 区分 max_tokens 截断）

## 关联
- 承接 erix-agent issue #1（L3 里程碑 M1）；依赖 PR #1108（erix-agent 依赖基线）
- 本地任务留痕：docs/tasks/active/task-260902-llm-kit-v020-integration/（不入库）
