### PR TITLE
feat: erix runToolLoop 装配层（L3-M2）——tool executor + completion/retry/context + store 接线

### DIFF
--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -23,7 +23,7 @@ const MAX_CONSECUTIVE_NO_TOOL_ROUNDS = 3; // 连续无工具调用且无完成�
 // R16-3: 补充"阶段3完成"“最终报告”等实际结束语——锚点清洗 agent 收尾时输出
 // "## 阶段3完成！"（外部引用定位回写完毕），此前不在信号内被误判为过渡文本，
 // 连续两轮追加 assistant 消息导致消息列表末尾相邻 assistant，provider 400 报错。
-const COMPLETION_SIGNALS = [
+export const COMPLETION_SIGNALS = [
   '任务完成',
   '已完成全部',
   '全部完成',

--- a/lib/llm-kit-adapters/loop-bridge.js
+++ b/lib/llm-kit-adapters/loop-bridge.js
@@ -1,0 +1,295 @@
+import { COMPLETION_SIGNALS } from "../agent/agent-loop.js";
+import { createTouwakaTranscriptStore } from "./transcript-store.js";
+
+export const TOUWAKA_COMPLETION_SIGNALS = COMPLETION_SIGNALS;
+
+const STRUCTURED_RESULT_FIELDS = [
+  "data",
+  "success",
+  "error",
+  "duration",
+  "toolMessageId",
+  "atomic_steps",
+  "toolName",
+  "metadata",
+  "content",
+];
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorText(error) {
+  return String(error?.message ?? error);
+}
+
+function isTouwakaToolResult(value) {
+  return isRecord(value) && STRUCTURED_RESULT_FIELDS.some((key) => hasOwn(value, key));
+}
+
+function resultMetadata(value) {
+  if (!isRecord(value)) return {};
+
+  const metadata = isRecord(value.metadata) ? { ...value.metadata } : {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (!["data", "content", "success", "metadata"].includes(key)) {
+      metadata[key] = entry;
+    }
+  }
+  return metadata;
+}
+
+function normalizeToolResult(value) {
+  if (value instanceof Error) {
+    const message = errorText(value);
+    return {
+      success: false,
+      data: message,
+      content: message,
+    };
+  }
+
+  if (!isTouwakaToolResult(value)) return value;
+
+  const hasData = hasOwn(value, "data");
+  const hasError = hasOwn(value, "error");
+  const data = hasData
+    ? value.data
+    : hasError
+      ? value.error
+      : value.content;
+  const normalized = {
+    success: value.success ?? !hasError,
+    data,
+  };
+
+  for (const key of ["duration", "toolMessageId"]) {
+    if (hasOwn(value, key)) normalized[key] = value[key];
+  }
+
+  const metadata = resultMetadata(value);
+  for (const [key, entry] of Object.entries(metadata)) {
+    if (!hasOwn(normalized, key)) normalized[key] = entry;
+  }
+  if (isRecord(value.metadata)) normalized.metadata = { ...value.metadata };
+
+  return normalized;
+}
+
+async function forwardToolResult(onToolResult, options, result) {
+  if (typeof onToolResult !== "function") return result;
+
+  const hookResult = onToolResult.length <= 1
+    ? await onToolResult(result, options)
+    : await onToolResult(
+      options.name,
+      result?.data ?? result,
+      resultMetadata(result),
+    );
+  return hookResult === undefined ? result : normalizeToolResult(hookResult);
+}
+
+/**
+ * Adapt either supported touwaka single-tool executor form to erix's
+ * structured executeTool contract.
+ *
+ * A one-argument erix wrapper is intentional: erix uses function.length to
+ * decide whether it should pass structured options or positional arguments.
+ *
+ * @param {{
+ *   executeTool: Function,
+ *   onToolResult?: Function,
+ * }} options
+ * @returns {Function}
+ */
+export function createErixToolExecutor({ executeTool, onToolResult } = {}) {
+  if (typeof executeTool !== "function") {
+    throw new TypeError("[llm-kit-adapters] executeTool is required");
+  }
+  if (onToolResult !== undefined && typeof onToolResult !== "function") {
+    throw new TypeError("[llm-kit-adapters] onToolResult must be a function");
+  }
+
+  const useStructuredExecutor = executeTool.length <= 1;
+
+  return async function erixExecuteTool(options) {
+    const executionOptions = options ?? {};
+    let result;
+    try {
+      result = useStructuredExecutor
+        ? await executeTool(executionOptions)
+        : await executeTool(executionOptions.name, executionOptions.input);
+    } catch (error) {
+      if (executionOptions.signal?.aborted) throw error;
+      result = error instanceof Error ? error : new Error(errorText(error));
+    }
+
+    return forwardToolResult(
+      onToolResult,
+      executionOptions,
+      normalizeToolResult(result),
+    );
+  };
+}
+
+function modelMetadataFor(modelConfig) {
+  if (!isRecord(modelConfig)) return undefined;
+
+  const metadata = {};
+  const contextWindowTokens = modelConfig.contextWindowTokens
+    ?? modelConfig.context_window_tokens
+    ?? modelConfig.max_tokens;
+  const maxOutputTokens = modelConfig.maxOutputTokens
+    ?? modelConfig.max_output_tokens;
+  if (contextWindowTokens !== undefined) {
+    metadata.contextWindowTokens = contextWindowTokens;
+  }
+  if (maxOutputTokens !== undefined) metadata.maxOutputTokens = maxOutputTokens;
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function buildRetryOptions(retry) {
+  if (retry === false) return false;
+  return {
+    attempts: 2,
+    backoffBaseMs: 1500,
+    backoffMaxMs: 10000,
+    ...(isRecord(retry) ? retry : {}),
+  };
+}
+
+function buildStallDetection(stallDetection) {
+  if (stallDetection === false) return false;
+  return {
+    window: 4,
+    ...(isRecord(stallDetection) ? stallDetection : {}),
+  };
+}
+
+/**
+ * Build the complete erix runToolLoop option envelope without binding the
+ * loop to touwaka's database or request runtime.
+ *
+ * @param {{
+ *   provider: object,
+ *   executeTool: Function,
+ *   store?: object,
+ *   runId?: string,
+ *   maxRounds?: number,
+ *   signals?: string[],
+ *   modelConfig?: object,
+ *   context?: object,
+ *   retry?: object|false,
+ *   stallDetection?: object|false,
+ *   toolContext?: object,
+ *   requestMeta?: object,
+ *   onEvent?: Function,
+ *   stream?: boolean,
+ *   [key:string]: any,
+ * }} options
+ * @returns {object}
+ */
+export function buildErixRunOptions({
+  provider,
+  executeTool,
+  store,
+  runId,
+  maxRounds,
+  signals,
+  modelConfig,
+  context,
+  retry,
+  stallDetection,
+  toolContext,
+  requestMeta,
+  onEvent,
+  stream,
+  ...passthrough
+} = {}) {
+  const derivedModelMetadata = modelMetadataFor(modelConfig);
+  const suppliedModelMetadata = isRecord(passthrough.modelMetadata)
+    ? passthrough.modelMetadata
+    : {};
+  const modelMetadata = Object.keys({
+    ...derivedModelMetadata,
+    ...suppliedModelMetadata,
+  }).length > 0
+    ? { ...derivedModelMetadata, ...suppliedModelMetadata }
+    : undefined;
+
+  return {
+    ...(isRecord(requestMeta) ? requestMeta : {}),
+    ...passthrough,
+    provider,
+    executeTool: createErixToolExecutor({ executeTool }),
+    ...(store === undefined ? {} : { store }),
+    ...(runId === undefined ? {} : { runId }),
+    maxRounds: maxRounds === undefined ? 8 : maxRounds,
+    completion: {
+      signals: signals ?? TOUWAKA_COMPLETION_SIGNALS,
+      maxNoToolRounds: 3,
+    },
+    retry: buildRetryOptions(retry),
+    stallDetection: buildStallDetection(stallDetection),
+    ...(modelConfig === undefined ? {} : { modelConfig }),
+    ...(modelMetadata === undefined ? {} : { modelMetadata }),
+    ...(context === undefined ? {} : { context }),
+    ...(toolContext === undefined ? {} : { toolContext }),
+    ...(onEvent === undefined ? {} : { onEvent }),
+    ...(stream === undefined ? {} : { stream }),
+  };
+}
+
+function adaptRoundRecord(record) {
+  const source = record ?? {};
+  return {
+    round: source.round,
+    ts: source.ts,
+    messages: source.messages,
+    ...(source.folded === undefined ? {} : { folded: source.folded }),
+    ...(source.foldedPayload === undefined ? {} : { foldedPayload: source.foldedPayload }),
+    ...(source.meta === undefined ? {} : { meta: source.meta }),
+  };
+}
+
+/**
+ * Adapt touwaka's MariaDB transcript store to the store methods consumed by
+ * erix runToolLoop. Checkpoint objects are passed through unchanged.
+ *
+ * @param {{db: object, tableName?: string}} options
+ * @returns {{
+ *   appendRound: Function,
+ *   saveCheckpoint: Function,
+ *   appendCheckpoint: Function,
+ *   loadLatestCheckpoint: Function,
+ *   markRunState: Function,
+ * }}
+ */
+export function createErixStore({ db, tableName } = {}) {
+  const transcriptStore = createTouwakaTranscriptStore({
+    db,
+    ...(tableName === undefined ? {} : { tableName }),
+  });
+
+  return {
+    async appendRound(runId, record) {
+      return transcriptStore.appendRound(runId, adaptRoundRecord(record));
+    },
+    async saveCheckpoint(runId, checkpoint) {
+      return transcriptStore.saveCheckpoint(runId, checkpoint);
+    },
+    async appendCheckpoint(runId, checkpoint) {
+      return transcriptStore.appendCheckpoint(runId, checkpoint);
+    },
+    async loadLatestCheckpoint(runId) {
+      return transcriptStore.loadLatestCheckpoint(runId);
+    },
+    async markRunState(runId, state) {
+      return transcriptStore.markRunState(runId, state);
+    },
+  };
+}

--- a/tests/llm-kit-adapters/loop-bridge.test.mjs
+++ b/tests/llm-kit-adapters/loop-bridge.test.mjs
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runToolLoop } from "erix-agent";
+import {
+  TOUWAKA_COMPLETION_SIGNALS,
+  buildErixRunOptions,
+  createErixToolExecutor,
+} from "../../lib/llm-kit-adapters/loop-bridge.js";
+
+function textResponse(text, stopReason = "end_turn") {
+  return {
+    content: [{ type: "text", text }],
+    stopReason,
+    usage: { input_tokens: 10, output_tokens: 4 },
+  };
+}
+
+function toolResponse(input = { text: "hi" }) {
+  return {
+    content: [{
+      type: "tool_use",
+      id: "t1",
+      name: "echo",
+      input,
+    }],
+    stopReason: "tool_use",
+    usage: { input_tokens: 12, output_tokens: 5 },
+  };
+}
+
+function createFakeProvider(responses) {
+  const calls = [];
+  return {
+    calls,
+    provider: {
+      async chatStream(request) {
+        const index = calls.length;
+        calls.push(request);
+        const response = responses[Math.min(index, responses.length - 1)];
+        for (const block of response.content ?? []) {
+          if (block?.type === "text") request.onDelta?.(block.text);
+          if (block?.type === "reasoning") {
+            request.onReasoningDelta?.(block.text, { source: "fake" });
+          }
+        }
+        request.onUsage?.(response.usage);
+        return response;
+      },
+    },
+  };
+}
+
+function createRecordingStore() {
+  const calls = {
+    appendRound: [],
+    saveCheckpoint: [],
+    markRunState: [],
+  };
+  return {
+    calls,
+    store: {
+      async appendRound(...args) {
+        calls.appendRound.push(args);
+      },
+      async saveCheckpoint(...args) {
+        calls.saveCheckpoint.push(args);
+      },
+      async markRunState(...args) {
+        calls.markRunState.push(args);
+      },
+    },
+  };
+}
+
+async function runWith(options) {
+  return runToolLoop(options);
+}
+
+test("builds an erix loop with structured tool execution and canonical results", async () => {
+  const provider = createFakeProvider([
+    toolResponse(),
+    textResponse("done"),
+  ]);
+  const toolCalls = [];
+  const store = createRecordingStore();
+  const events = [];
+  const executeTool = async ({ id, name, input, context, signal }) => {
+    toolCalls.push({ id, name, input, context, signal });
+    return {
+      success: true,
+      data: "echo: hi",
+      duration: 12,
+      toolMessageId: "tool-message-1",
+      atomic_steps: ["echo"],
+      toolName: "echo",
+    };
+  };
+
+  const options = buildErixRunOptions({
+    ...provider,
+    executeTool,
+    store: store.store,
+    runId: "run-bridge-1",
+    initialUserMessage: "say hi",
+    stream: true,
+    toolContext: { trace_id: "trace-1" },
+    modelConfig: { max_tokens: 32768, max_output_tokens: 4096 },
+    requestMeta: { user_id: "user-1", expert_id: "expert-1" },
+    signals: ["done"],
+    onEvent: (event) => events.push(event),
+  });
+
+  assert.equal(options.executeTool.length, 1);
+  assert.deepEqual(options.modelMetadata, {
+    contextWindowTokens: 32768,
+    maxOutputTokens: 4096,
+  });
+  assert.deepEqual(options.retry, {
+    attempts: 2,
+    backoffBaseMs: 1500,
+    backoffMaxMs: 10000,
+  });
+  assert.deepEqual(options.stallDetection, { window: 4 });
+  assert.deepEqual(options.user_id, "user-1");
+  assert.deepEqual(options.expert_id, "expert-1");
+
+  const result = await runWith(options);
+  const toolResultMessage = result.messages.find((message) => (
+    message.role === "user"
+    && message.content.some((block) => block.type === "tool_result")
+  ));
+  const [toolResult] = toolResultMessage.content;
+
+  assert.equal(provider.calls.length, 2);
+  assert.deepEqual(toolCalls[0], {
+    id: "t1",
+    name: "echo",
+    input: { text: "hi" },
+    context: { trace_id: "trace-1", round: 1 },
+    signal: toolCalls[0].signal,
+  });
+  assert.ok(toolCalls[0].signal);
+  assert.equal(result.rounds, 2);
+  assert.equal(result.finalText, "done");
+  assert.equal(toolResult.content, "echo: hi");
+  assert.equal(toolResult.success, true);
+  assert.deepEqual(toolResult.atomic_steps, ["echo"]);
+  assert.equal(toolResult.toolMessageId, "tool-message-1");
+  assert.equal(events.at(-1).type, "round_end");
+  assert.equal(events.at(-1).stopReason, "end_turn");
+
+  assert.ok(store.calls.appendRound.length > 0);
+  assert.ok(store.calls.saveCheckpoint.length > 0);
+  assert.ok(store.calls.markRunState.length > 0);
+  for (const args of [
+    ...store.calls.appendRound,
+    ...store.calls.saveCheckpoint,
+    ...store.calls.markRunState,
+  ]) {
+    assert.equal(args[0], "run-bridge-1");
+  }
+});
+
+test("completion signals stop immediately, while missing signals use the no-tool limit", async () => {
+  const completionProvider = createFakeProvider([
+    toolResponse(),
+    textResponse(`工作${TOUWAKA_COMPLETION_SIGNALS[0]}`),
+    textResponse("should not be called"),
+  ]);
+  const completionResult = await runWith(buildErixRunOptions({
+    ...completionProvider,
+    executeTool: async () => "ok",
+    initialUserMessage: "start",
+    stream: true,
+    runId: "run-completion",
+  }));
+
+  assert.equal(completionProvider.calls.length, 2);
+  assert.equal(completionResult.finalText, `工作${TOUWAKA_COMPLETION_SIGNALS[0]}`);
+
+  const noSignalProvider = createFakeProvider([
+    toolResponse(),
+    textResponse("progress 1"),
+    textResponse("progress 2"),
+    textResponse("progress 3"),
+    textResponse("should not be called"),
+  ]);
+  const noSignalResult = await runWith(buildErixRunOptions({
+    ...noSignalProvider,
+    executeTool: async () => "ok",
+    initialUserMessage: "start",
+    stream: true,
+    runId: "run-no-signal",
+  }));
+
+  assert.equal(noSignalProvider.calls.length, 4);
+  assert.equal(noSignalResult.rounds, 4);
+  assert.equal(noSignalResult.finalText, "progress 3");
+});
+
+test("failed tool execution becomes an error tool_result without breaking the loop", async () => {
+  const provider = createFakeProvider([
+    toolResponse(),
+    textResponse("任务完成"),
+  ]);
+  const result = await runWith(buildErixRunOptions({
+    ...provider,
+    executeTool: async () => {
+      throw new Error("tool exploded");
+    },
+    initialUserMessage: "start",
+    stream: true,
+    runId: "run-tool-error",
+  }));
+
+  const toolResult = result.messages
+    .flatMap((message) => message.content ?? [])
+    .find((block) => block.type === "tool_result");
+  assert.equal(provider.calls.length, 2);
+  assert.equal(result.finalText, "任务完成");
+  assert.equal(toolResult.success, false);
+  assert.equal(toolResult.is_error, true);
+  assert.equal(toolResult.content, "tool exploded");
+});
+
+test("supports the positional executor and forwards the result hook", async () => {
+  const calls = [];
+  const hookCalls = [];
+  const positionalExecutor = async (name, input) => {
+    calls.push([name, input]);
+    return { success: true, data: "positional", atomic_steps: ["step-1"] };
+  };
+  const executor = createErixToolExecutor({
+    executeTool: positionalExecutor,
+    onToolResult: async (result) => {
+      hookCalls.push(result);
+    },
+  });
+
+  const result = await executor({
+    id: "t-positional",
+    name: "echo",
+    input: { value: 1 },
+    context: { round: 2 },
+    signal: new AbortController().signal,
+  });
+
+  assert.equal(executor.length, 1);
+  assert.deepEqual(calls, [["echo", { value: 1 }]]);
+  assert.equal(hookCalls.length, 1);
+  assert.equal(result.success, true);
+  assert.equal(result.data, "positional");
+  assert.deepEqual(result.atomic_steps, ["step-1"]);
+});


### PR DESCRIPTION
## 变更

L3-M2：erix runToolLoop 装配层（AgentLoop → runToolLoop 迁移第二阶段）。

- 新增 `lib/llm-kit-adapters/loop-bridge.js`（295 行）：
  - `TOUWAKA_COMPLETION_SIGNALS`（import 复用 agent-loop 导出，避免漂移）
  - `createErixToolExecutor()`：结构化 executor 适配（length 判断与 erix 一致）；touwaka toolResult 归一（success/data/duration/toolMessageId/atomic_steps/toolName/error）；Error → success:false
  - `buildErixRunOptions()`：completion.signals=TOUWAKA_COMPLETION_SIGNALS + maxNoToolRounds 3、retry 默认 2/1500/10000、maxRounds 8、stallDetection {window:4}、modelMetadata 从 modelConfig 派生、事件/上下文透传
  - `createErixStore()`：erix store 契约（appendRound record 映射 round/ts/messages/folded/foldedPayload/meta；checkpoint/markRunState 原样透传）
- `lib/agent/agent-loop.js`：仅 1 行 `const COMPLETION_SIGNALS` → `export const`（无行为变化）
- 新增 `tests/llm-kit-adapters/loop-bridge.test.mjs`（255 行纯 mock）：4/4 覆盖工具轮次+结构化 context/completion 信号即停/失败 is_error/store 接线（appendRound/saveCheckpoint/markRunState）

## 验证
- `node --test tests/llm-kit-adapters/*.test.mjs`：32/32 全绿（M2 4 + 既有 28）；lint/node --check 过
- reviewer 审计：**通过**（契约与 erix-agent@0.2.0 实际实现 loop.js 逐项核对：length 启发式/toolResultData/normalizeExecutionResult/appendRound record 形状）；chat-service/lib/chat 零改动

## Backlog（reviewer 建议，非阻塞；resume 支持时立项）
1. 【中】createErixStore 缺 load() 透传——resume:true 会失败（当前迁移不启用 resume，M3 不依赖）
2. 【中低】adaptRoundRecord 丢弃 erix record 的 foldedRoundRange 等 6 字段（影响 resume 折叠编号连续性）
3. 【低】completion 配置不可禁用/覆盖（与 retry/stallDetection 语义不一致）
4. 【低】adaptRoundRecord 无直接单测
5. 【低】executor length 启发式边界（带默认参数位置式误判；与 erix 固有行为一致）

## 关联
- 承接 erix-agent issue #1（L3-M2）；M1（provider-adapter）+ M2 已合/待合 master
- 本地任务留痕：docs/tasks/active/（不入库）
