### PR TITLE
feat: AgentLoop.runErix——erix runToolLoop 承载专家循环（L3-M3a 平行实现）

### DIFF
--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -13,6 +13,8 @@ import { addTokenUsage } from '../token-usage-accumulator.js';
 import { createRoundStateSnapshot, restoreRoundStateSnapshot } from '../chat/round-state-snapshot.js';
 import { getSystemSettingService } from '../../server/services/system-setting.service.js';
 import { compactHistory } from './history-compactor.js';
+import { canonicalToOpenAIMessages, runToolLoop } from 'erix-agent';
+import { createTouwakaProvider } from '../llm-kit-adapters/provider-adapter.js';
 
 const DEFAULT_STREAM_RECOVERY_MAX_ATTEMPTS = 2;
 const DEFAULT_STREAM_RECOVERY_BASE_DELAY_MS = 1500;
@@ -449,6 +451,622 @@ export class AgentLoop {
     logger.info(`[AgentLoop] 本轮 LLM 调用次数: ${llmCallsCount}, 专家: ${expert_id}, 策略: ${expertService.expertConfig?.expert?.context_strategy || 'full'}`);
 
     return { fullContent, fullReasoningContent, tokenUsage, allToolCalls, finalMessages: messages, llmCallsCount };
+  }
+
+  async runErix(expertService, {
+    modelConfig,
+    thinkingConfig,
+    tools = [],
+    currentMessages = [],
+    llmPayload = {},
+    user_id,
+    expert_id,
+    taskContext,
+    topic_id,
+    task_id,
+    session,
+    request_id,
+    onDelta,
+    shouldStop,
+    runtimeState = null,
+    agent_invocation_context = null,
+  }) {
+    const {
+      buildErixRunOptions,
+      createErixStore,
+      TOUWAKA_COMPLETION_SIGNALS,
+    } = await import('../llm-kit-adapters/loop-bridge.js');
+    const configuredMaxRounds = expertService.expertConfig?.expert?.max_tool_rounds;
+    const maxRounds = configuredMaxRounds || (
+      typeof this.db?.getModel === 'function'
+        ? await getSystemSettingService(this.db).getMaxToolRounds()
+        : 20
+    );
+    const maxRecoveryAttempts = resolvePositiveIntegerEnv(
+      'CHAT_STREAM_RECOVERY_MAX_ATTEMPTS',
+      DEFAULT_STREAM_RECOVERY_MAX_ATTEMPTS,
+    );
+    const recoveryBaseDelayMs = resolvePositiveIntegerEnv(
+      'CHAT_STREAM_RECOVERY_BASE_DELAY_MS',
+      DEFAULT_STREAM_RECOVERY_BASE_DELAY_MS,
+    );
+    const recoveryMaxDelayMs = resolvePositiveIntegerEnv(
+      'CHAT_STREAM_RECOVERY_MAX_DELAY_MS',
+      DEFAULT_STREAM_RECOVERY_MAX_DELAY_MS,
+    );
+    const compactBudgetTokens = Math.max(
+      1,
+      resolvePositiveIntegerEnv('CHAT_COMPACT_BUDGET_TOKENS', 80000),
+    );
+    const compactKeepRounds = Math.max(
+      0,
+      resolvePositiveIntegerEnv('CHAT_COMPACT_KEEP_ROUNDS', 6),
+    );
+    const llmParams = expertService.llmClient.getExpertLLMParams();
+    const abortController = new AbortController();
+
+    llmPayload.model = modelConfig.model_name;
+    llmPayload.temperature = llmParams.temperature;
+    llmPayload.top_p = llmParams.top_p;
+    llmPayload.frequency_penalty = llmParams.frequency_penalty;
+    llmPayload.presence_penalty = llmParams.presence_penalty;
+    llmPayload.max_tokens = modelConfig.max_output_tokens || 32768;
+    llmPayload._debug ??= {};
+    if (tools.length > 0) llmPayload.tools = tools;
+
+    const assertNotStopped = () => {
+      if (!shouldStop?.()) return;
+      const error = new Error('Request aborted by user');
+      if (!abortController.signal.aborted) abortController.abort(error);
+      throw error;
+    };
+
+    const parseToolInput = (value) => {
+      if (value !== null && typeof value === 'object') return value;
+      try {
+        return JSON.parse(value === undefined ? '{}' : String(value));
+      } catch {
+        return {
+          _truncatedArguments: value,
+          _raw: value,
+        };
+      }
+    };
+
+    const canonicalContentBlock = (block) => {
+      if (!block || typeof block !== 'object') {
+        return { type: 'raw', protocol: 'openai', payload: block };
+      }
+      if (block.type === 'text') {
+        return { type: 'text', text: String(block.text ?? '') };
+      }
+      if (block.type === 'reasoning' || block.type === 'thinking') {
+        return { type: 'reasoning', text: String(block.text ?? block.thinking ?? '') };
+      }
+      if (block.type === 'image') return { ...block };
+      if (block.type === 'image_url') {
+        const imageUrl = block.image_url && typeof block.image_url === 'object'
+          ? block.image_url
+          : {};
+        return {
+          type: 'image',
+          ...(imageUrl.url === undefined ? {} : { url: imageUrl.url }),
+          ...(imageUrl.detail === undefined ? {} : { detail: imageUrl.detail }),
+        };
+      }
+      if (block.type === 'tool_use' || block.type === 'tool_result') {
+        return { ...block };
+      }
+      return { type: 'raw', protocol: 'openai', payload: block };
+    };
+
+    const canonicalMessage = (message) => {
+      if (message?.role === 'tool') {
+        return {
+          role: 'user',
+          content: [{
+            type: 'tool_result',
+            tool_use_id: message.tool_call_id,
+            content: typeof message.content === 'string'
+              ? message.content
+              : JSON.stringify(message.content ?? ''),
+            ...(message.is_error === undefined ? {} : { is_error: Boolean(message.is_error) }),
+          }],
+        };
+      }
+
+      if (message?.content && Array.isArray(message.content)
+        && message.content.some(block => (
+          block?.type === 'tool_use'
+          || block?.type === 'tool_result'
+          || block?.type === 'image'
+        ))) {
+        return {
+          ...message,
+          content: message.content.map(canonicalContentBlock),
+        };
+      }
+
+      const content = Array.isArray(message?.content)
+        ? message.content.map(canonicalContentBlock)
+        : message?.content;
+      const blocks = Array.isArray(content)
+        ? [...content]
+        : content === undefined || content === null
+          ? []
+          : [{ type: 'text', text: String(content) }];
+
+      if (message?.role === 'assistant') {
+        for (const toolCall of message.tool_calls ?? []) {
+          blocks.push({
+            type: 'tool_use',
+            id: toolCall?.id,
+            name: toolCall?.function?.name ?? toolCall?.name,
+            input: parseToolInput(toolCall?.function?.arguments ?? toolCall?.arguments),
+          });
+        }
+        if (typeof message.reasoning_content === 'string') {
+          blocks.push({ type: 'reasoning', text: message.reasoning_content });
+        }
+      }
+
+      return {
+        role: message?.role,
+        content: Array.isArray(message?.content) || message?.content === null
+          || message?.content === undefined
+          || message?.role === 'assistant' && (message.tool_calls?.length || message.reasoning_content)
+          ? blocks
+          : content,
+        ...(message?._synthetic ? { _synthetic: true } : {}),
+      };
+    };
+
+    const canonicalizeMessages = (messages) => {
+      const result = [];
+      for (const message of messages) {
+        const converted = canonicalMessage(message);
+        const previous = result.at(-1);
+        const convertedToolResults = converted.role === 'user'
+          && Array.isArray(converted.content)
+          && converted.content.length > 0
+          && converted.content.every(block => block?.type === 'tool_result');
+        const previousToolResults = previous?.role === 'user'
+          && Array.isArray(previous.content)
+          && previous.content.length > 0
+          && previous.content.every(block => block?.type === 'tool_result');
+        if (convertedToolResults && previousToolResults) {
+          previous.content.push(...converted.content);
+        } else {
+          result.push(converted);
+        }
+      }
+      return result;
+    };
+
+    const canonicalMessages = canonicalizeMessages(currentMessages);
+
+    const canonicalTools = tools
+      .map(tool => {
+        const functionTool = tool?.function;
+        return {
+          name: functionTool?.name ?? tool?.name,
+          ...(functionTool?.description ?? tool?.description
+            ? { description: functionTool?.description ?? tool?.description }
+            : {}),
+          inputSchema: functionTool?.parameters ?? tool?.inputSchema ?? {},
+        };
+      })
+      .filter(tool => tool.name);
+
+    const toOpenAIToolCall = ({ id, name, input }) => ({
+      id,
+      type: 'function',
+      function: {
+        name,
+        arguments: JSON.stringify(input ?? {}),
+      },
+    });
+
+    const toLegacyToolResult = (result, executionOptions) => ({
+      ...(result && typeof result === 'object' ? result : {}),
+      toolCallId: result?.toolCallId ?? executionOptions.id,
+      toolName: result?.toolName ?? executionOptions.name,
+      duration: result?.duration ?? 0,
+    });
+
+    const formatToolResultForLLM = (result) => {
+      const formatted = expertService.toolManager?.formatToolResultsForLLM?.([result]);
+      const first = Array.isArray(formatted) ? formatted[0] : formatted;
+      const content = first?.content ?? first;
+      if (typeof content === 'string') return content;
+      const serialized = JSON.stringify(content ?? result.data);
+      return serialized === undefined ? String(content ?? result.data) : serialized;
+    };
+
+    const pendingToolResults = [];
+    const allToolCalls = [];
+    const toolRounds = new Set();
+    let fullContent = '';
+    let fullReasoningContent = '';
+    let tokenUsage = null;
+    let sawUsage = false;
+    let currentRound = 0;
+    let latestCanonicalMessages = canonicalMessages;
+    let preparedToolRound = null;
+    let preparedToolResults = [];
+    let preparedRequestMessages = null;
+    let preparedRequestRound = null;
+
+    const savePayload = (messages, compaction = null) => {
+      const openAIMessages = canonicalToOpenAIMessages(undefined, messages);
+      llmPayload.messages = openAIMessages;
+      llmPayload._debug.context_messages_count = openAIMessages.length;
+      if (compaction) {
+        llmPayload._debug.compacted_rounds = compaction.foldedRounds;
+        llmPayload._debug.tokens_before_compact = compaction.tokensBefore;
+        llmPayload._debug.tokens_after_compact = compaction.tokensAfter;
+      }
+      llmPayload.cached_at = new Date().toISOString();
+      this.save_llm_payload(user_id, expert_id, llmPayload);
+    };
+
+    const executeSingleTool = async (executionOptions) => {
+      assertNotStopped();
+      const toolCall = toOpenAIToolCall(executionOptions);
+      onDelta?.({
+        type: 'tool_call',
+        toolCalls: presentToolCalls([toolCall], expertService.toolManager),
+      });
+
+      const startedAt = Date.now();
+      let callbackResult = null;
+      let result;
+      try {
+        const results = await expertService.handleToolCalls(
+          [toolCall],
+          user_id,
+          session?.accessToken,
+          taskContext,
+          topic_id,
+          async toolResult => {
+            callbackResult = toolResult;
+            if (toolCall.context) toolResult.context = toolCall.context;
+          },
+          session,
+          agent_invocation_context,
+        );
+        result = results?.[0] ?? callbackResult;
+      } catch (error) {
+        if (executionOptions.signal?.aborted || abortController.signal.aborted) throw error;
+        result = {
+          success: false,
+          data: error?.message ?? String(error),
+          error: error?.message ?? String(error),
+        };
+      }
+
+      const toolResult = toLegacyToolResult(result, executionOptions);
+      if (toolResult.duration === 0) toolResult.duration = Date.now() - startedAt;
+      pendingToolResults.push(toolResult);
+      toolRounds.add(executionOptions.context?.round ?? currentRound);
+      allToolCalls.push({
+        ...toolCall,
+        result: {
+          success: toolResult.success,
+          data: toolResult.data,
+          error: toolResult.error,
+        },
+        duration: toolResult.duration || 0,
+        tool_message_id: toolResult.toolMessageId || null,
+        ...(toolResult.atomic_steps ? { atomic_steps: toolResult.atomic_steps } : {}),
+        timestamp: new Date().toISOString(),
+      });
+      onDelta?.({ type: 'tool_result', result: toolResult });
+
+      return {
+        ...toolResult,
+        data: formatToolResultForLLM(toolResult),
+      };
+    };
+
+    const openAIMessageToCanonical = (message) => {
+      if (message?.role === 'tool') {
+        return {
+          role: 'user',
+          content: [{
+            type: 'tool_result',
+            tool_use_id: message.tool_call_id,
+            content: String(message.content ?? ''),
+          }],
+        };
+      }
+      return canonicalMessage(message);
+    };
+
+    const prepareProviderRequest = async request => {
+      assertNotStopped();
+
+      if (preparedRequestMessages === request.messages && preparedRequestRound === currentRound) {
+        latestCanonicalMessages = request.messages;
+        return;
+      }
+
+      if (currentRound > 1) {
+        const shadowMessages = request.messages.flatMap(message => (
+          canonicalToOpenAIMessages(undefined, [message]).map(converted => (
+            message?._synthetic ? { ...converted, _synthetic: true } : converted
+          ))
+        ));
+        const strippedMessages = LLMClient.stripHistoricalImages(shadowMessages);
+        const strippedCanonicalMessages = canonicalizeMessages(strippedMessages);
+        request.messages.splice(
+          0,
+          request.messages.length,
+          ...strippedCanonicalMessages,
+        );
+      }
+
+      if (preparedToolRound !== currentRound) {
+        preparedToolRound = currentRound;
+        preparedToolResults = pendingToolResults.splice(0, pendingToolResults.length);
+      }
+      const roundToolResults = preparedToolResults;
+      if (roundToolResults.length === 0) {
+        latestCanonicalMessages = request.messages;
+        preparedRequestMessages = request.messages;
+        preparedRequestRound = currentRound;
+        return;
+      }
+
+      const consumption = typeof expertService._consumeDocRetrievalResult === 'function'
+        ? await expertService._consumeDocRetrievalResult(roundToolResults, {
+          caller: 'AgentLoop.runErix',
+          extra: { round: currentRound },
+        })
+        : null;
+      if (consumption?.found && consumption.evidenceInjection) {
+        request.messages.unshift({
+          role: 'system',
+          content: consumption.evidenceInjection,
+        });
+      }
+
+      const shadowMessages = canonicalToOpenAIMessages(undefined, request.messages);
+      const shadowLength = shadowMessages.length;
+      LLMClient.injectImageUserMessages(shadowMessages, modelConfig, roundToolResults);
+      for (const message of shadowMessages.slice(shadowLength)) {
+        request.messages.push(openAIMessageToCanonical(message));
+      }
+      latestCanonicalMessages = request.messages;
+      preparedRequestMessages = request.messages;
+      preparedRequestRound = currentRound;
+    };
+
+    const thinkingFields = {
+      thinking: thinkingConfig?.thinking,
+      reasoning: thinkingConfig?.reasoning,
+      reasoning_effort: thinkingConfig?.reasoning_effort,
+      enable_thinking: thinkingConfig?.enable_thinking,
+      chat_template_kwargs: thinkingConfig?.chat_template_kwargs,
+    };
+    const baseProvider = createTouwakaProvider({
+      llmClient: expertService.llmClient,
+      resolveModel: async () => modelConfig,
+      defaultUserId: user_id,
+      defaultRequestId: request_id,
+    });
+
+    const invokeProvider = async (method, request) => {
+      await prepareProviderRequest(request);
+      const enrichedRequest = { ...request, ...thinkingFields };
+      if (runtimeState) runtimeState.has_active_transport = true;
+      try {
+        return await baseProvider[method](enrichedRequest);
+      } catch (error) {
+        if (
+          error
+          && typeof error === 'object'
+          && error.message !== 'Request aborted by user'
+          && isRetryableError(error)
+        ) {
+          error.retryable = true;
+        }
+        throw error;
+      } finally {
+        if (runtimeState) runtimeState.has_active_transport = false;
+      }
+    };
+
+    const provider = {
+      chatStream: request => invokeProvider('chatStream', request),
+    };
+    if (typeof baseProvider.chat === 'function') {
+      provider.chat = request => invokeProvider('chat', request);
+    }
+
+    const onErixEvent = (event) => {
+      if (event.type === 'round_start') {
+        currentRound = event.round;
+        if (runtimeState) {
+          runtimeState.round = event.round;
+          runtimeState.round_snapshot_ref = {
+            round: event.round,
+            taken_at: new Date().toISOString(),
+          };
+        }
+      } else if (event.type === 'attempt') {
+        if (runtimeState) runtimeState.has_active_transport = true;
+      } else if (event.type === 'recovering') {
+        if (runtimeState) {
+          runtimeState.has_active_transport = false;
+          runtimeState.recovery_attempt = event.attempt;
+        }
+        onDelta?.({
+          type: 'recovering',
+          request_id,
+          round: event.round,
+          attempt: event.attempt,
+          max_attempts: maxRecoveryAttempts,
+          content: fullContent,
+          reasoning_content: fullReasoningContent,
+        });
+      } else if (event.type === 'recovered') {
+        onDelta?.({
+          type: 'recovered',
+          request_id,
+          round: event.round,
+          attempt: event.attempt,
+        });
+      } else if (event.type === 'round_end') {
+        if (runtimeState) runtimeState.has_active_transport = false;
+        savePayload(latestCanonicalMessages);
+        if (toolRounds.has(event.round)) {
+          const executedRounds = event.round;
+          const threshold = executedRounds / maxRounds;
+          if (executedRounds >= maxRounds) {
+            const summary = this.generate_tool_call_summary(allToolCalls);
+            onDelta?.({
+              type: 'tool_limit_reached',
+              totalRounds: maxRounds,
+              executedRounds,
+              summary,
+              message: `已达到最大工具调用次数（${executedRounds}轮），AI 正在生成总结`,
+            });
+          } else if (threshold >= 0.8) {
+            onDelta?.({
+              type: 'tool_limit_warning',
+              currentRound: executedRounds,
+              maxRounds,
+              remainingRounds: maxRounds - executedRounds,
+              message: `已调用 ${executedRounds}/${maxRounds} 轮（${Math.round(threshold * 100)}%），即将达到上限`,
+            });
+          }
+        }
+      }
+    };
+
+    const context = {
+      budgetTokens: compactBudgetTokens,
+      keepRounds: compactKeepRounds,
+      stripHistoricalImages: true,
+      onAfterFold: ({
+        messages,
+        foldedRounds,
+        tokensBefore,
+        tokensAfter,
+      }) => {
+        if (!foldedRounds) return;
+        latestCanonicalMessages = messages;
+        onDelta?.({
+          type: 'history_compacted',
+          foldedRounds,
+          tokensBefore,
+          tokensAfter,
+          round: currentRound,
+          content: `已自动压缩早期工具执行记录（${foldedRounds} 轮），以控制上下文长度。`,
+        });
+        savePayload(latestCanonicalMessages, {
+          foldedRounds,
+          tokensBefore,
+          tokensAfter,
+        });
+      },
+    };
+
+    assertNotStopped();
+    const erixRunOptions = buildErixRunOptions({
+      provider,
+      executeTool: executeSingleTool,
+      store: this.db?.sequelize && typeof this.db.sequelize.define === 'function'
+        ? createErixStore({ db: this.db })
+        : undefined,
+      runId: request_id,
+      maxRounds,
+      signals: TOUWAKA_COMPLETION_SIGNALS,
+      modelConfig,
+      context,
+      stallDetection: false,
+      retry: {
+        attempts: maxRecoveryAttempts,
+        backoffBaseMs: recoveryBaseDelayMs,
+        backoffMaxMs: recoveryMaxDelayMs,
+      },
+      toolContext: {
+        user_id,
+        expert_id,
+        taskContext,
+        topic_id,
+        task_id,
+        session,
+        request_id,
+        agent_invocation_context,
+      },
+      requestMeta: {
+        user_id,
+        expert_id,
+        request_id,
+      },
+      initialMessages: canonicalMessages,
+      tools: canonicalTools,
+      maxTokens: llmPayload.max_tokens,
+      temperature: llmPayload.temperature,
+      topP: llmPayload.top_p,
+      stream: true,
+      signal: abortController.signal,
+      onDelta: delta => {
+        fullContent += delta;
+        onDelta?.({ type: 'delta', content: delta });
+      },
+      onReasoningDelta: reasoningDelta => {
+        fullReasoningContent += reasoningDelta;
+        onDelta?.({ type: 'reasoning_delta', content: reasoningDelta });
+      },
+      onToolCall: () => {},
+      onUsage: usage => {
+        if (!usage) return;
+        sawUsage = true;
+        tokenUsage = addTokenUsage(tokenUsage, {
+          prompt_tokens: usage.prompt_tokens ?? usage.input_tokens,
+          completion_tokens: usage.completion_tokens ?? usage.output_tokens,
+          total_tokens: usage.total_tokens
+            ?? (Number(usage.prompt_tokens ?? usage.input_tokens ?? 0)
+              + Number(usage.completion_tokens ?? usage.output_tokens ?? 0)),
+        });
+      },
+      onEvent: onErixEvent,
+    });
+    erixRunOptions.completion.maxNoToolRounds = MAX_CONSECUTIVE_NO_TOOL_ROUNDS + 1;
+    const loopResult = await runToolLoop(erixRunOptions);
+
+    latestCanonicalMessages = loopResult.messages;
+    const finalMessages = canonicalToOpenAIMessages(undefined, latestCanonicalMessages);
+    if (!fullContent && loopResult.finalText) fullContent = loopResult.finalText;
+    if (!fullReasoningContent) {
+      fullReasoningContent = latestCanonicalMessages
+        .flatMap(message => Array.isArray(message.content) ? message.content : [])
+        .filter(block => block?.type === 'reasoning')
+        .map(block => block.text)
+        .join('');
+    }
+    if (!tokenUsage && sawUsage) {
+      tokenUsage = {
+        prompt_tokens: loopResult.usage.input_tokens || 0,
+        completion_tokens: loopResult.usage.output_tokens || 0,
+        total_tokens: (loopResult.usage.input_tokens || 0) + (loopResult.usage.output_tokens || 0),
+      };
+    }
+    if (!fullContent || fullContent.trim() === '') {
+      fullContent = '我已处理您的请求，但没有生成具体的回复内容。';
+    }
+
+    return {
+      fullContent,
+      fullReasoningContent,
+      tokenUsage,
+      allToolCalls,
+      finalMessages,
+      llmCallsCount: loopResult.rounds,
+    };
   }
 }
 

--- a/tests/agent/agent-loop-erix.test.mjs
+++ b/tests/agent/agent-loop-erix.test.mjs
@@ -1,0 +1,341 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { AgentLoop } from '../../lib/agent/agent-loop.js';
+import logger from '../../lib/logger.js';
+
+logger.logFile = '/tmp/touwaka-agent-loop-erix-test.log';
+
+function createLoop(overrides = {}) {
+  return new AgentLoop({
+    db: {},
+    execute_tools: async () => {
+      throw new Error('execute_tools should not be called');
+    },
+    save_llm_payload: () => {},
+    generate_tool_call_summary: () => 'summary',
+    ...overrides,
+  });
+}
+
+function createInput(overrides = {}) {
+  return {
+    modelConfig: {
+      model_name: 'test-model',
+      max_output_tokens: 2048,
+    },
+    thinkingConfig: {
+      thinking: false,
+      reasoning: null,
+      reasoning_effort: null,
+      enable_thinking: false,
+      chat_template_kwargs: null,
+    },
+    tools: [{
+      type: 'function',
+      function: {
+        name: 'echo',
+        description: 'Echo input',
+        parameters: { type: 'object' },
+      },
+    }],
+    currentMessages: [{ role: 'user', content: 'hello' }],
+    llmPayload: { _debug: {} },
+    user_id: 'user_1',
+    expert_id: 'expert_1',
+    taskContext: { workspace_mode: 'test' },
+    topic_id: 'topic_1',
+    task_id: 'task_1',
+    session: { accessToken: 'token' },
+    request_id: 'request_1',
+    ...overrides,
+  };
+}
+
+function createFakeExpertService({ noTool = false, result = null } = {}) {
+  let streamCalls = 0;
+  const secondRoundMessages = [];
+  const toolCall = {
+    id: 'call_1',
+    type: 'function',
+    function: {
+      name: 'echo',
+      arguments: '{"value":42}',
+    },
+  };
+  const toolResult = result || {
+    success: true,
+    data: { value: 42 },
+    duration: 12,
+    toolCallId: 'call_1',
+    toolMessageId: 'tool_msg_1',
+    toolName: 'echo',
+  };
+
+  const expertService = {
+    expertConfig: {
+      expert: {
+        max_tool_rounds: 5,
+        context_strategy: 'full',
+      },
+    },
+    llmClient: {
+      getExpertLLMParams() {
+        return {
+          temperature: 0.7,
+          top_p: 1,
+          frequency_penalty: 0,
+          presence_penalty: 0,
+        };
+      },
+      async callStream(_modelConfig, messages, options) {
+        streamCalls += 1;
+        if (streamCalls === 2) secondRoundMessages.push(...messages);
+        options.onUsage({
+          prompt_tokens: 2,
+          completion_tokens: 3,
+          total_tokens: 5,
+        });
+        if (noTool || streamCalls > 1) {
+          options.onDelta('任务完成 Final answer');
+          return;
+        }
+        options.onDelta('Need tool');
+        options.onReasoningDelta('Thinking');
+        options.onToolCall([toolCall]);
+      },
+    },
+    toolManager: {
+      formatToolDisplay(toolId) {
+        return `Tool: ${toolId}`;
+      },
+      formatToolResultsForLLM(results) {
+        return results.map(item => ({
+          role: 'tool',
+          tool_call_id: item.toolCallId,
+          content: JSON.stringify({
+            success: item.success,
+            data: item.data,
+            error: item.error,
+          }),
+        }));
+      },
+    },
+    async handleToolCalls(_toolCalls, _userId, _accessToken, _taskContext, _topicId, onToolComplete) {
+      await onToolComplete?.(toolResult);
+      return [toolResult];
+    },
+    _consumeDocRetrievalResult() {
+      return { found: false };
+    },
+    getStreamCalls() {
+      return streamCalls;
+    },
+    getSecondRoundMessages() {
+      return secondRoundMessages;
+    },
+  };
+
+  return expertService;
+}
+
+test('runErix returns the established result shape after a tool round', async () => {
+  const savedPayloads = [];
+  const events = [];
+  const loop = createLoop({
+    save_llm_payload: (_userId, _expertId, payload) => {
+      savedPayloads.push(structuredClone(payload));
+    },
+  });
+
+  const result = await loop.runErix(createFakeExpertService(), createInput({
+    onDelta: event => events.push(event),
+  }));
+
+  assert.equal(result.fullContent, 'Need tool任务完成 Final answer');
+  assert.equal(result.fullReasoningContent, 'Thinking');
+  assert.deepEqual(result.tokenUsage, {
+    prompt_tokens: 4,
+    completion_tokens: 6,
+    total_tokens: 10,
+  });
+  assert.equal(result.allToolCalls.length, 1);
+  assert.equal(result.allToolCalls[0].result.data.value, 42);
+  assert.equal(result.allToolCalls[0].tool_message_id, 'tool_msg_1');
+  assert.ok(result.finalMessages.length > 0);
+  assert.equal(result.llmCallsCount, 2);
+  assert.equal(savedPayloads.length, 2);
+  assert.deepEqual(events.map(event => event.type), [
+    'delta',
+    'reasoning_delta',
+    'tool_call',
+    'tool_result',
+    'delta',
+  ]);
+  assert.equal(events[2].toolCalls[0].displayName, 'Tool: echo');
+});
+
+test('runErix completion signals finish a no-tool request in one round', async () => {
+  const expertService = createFakeExpertService({ noTool: true });
+  const result = await createLoop().runErix(expertService, createInput({
+    tools: [],
+  }));
+
+  assert.equal(expertService.getStreamCalls(), 1);
+  assert.equal(result.fullContent, '任务完成 Final answer');
+  assert.deepEqual(result.allToolCalls, []);
+  assert.equal(result.llmCallsCount, 1);
+});
+
+test('runErix maps evidence and multimodal tool results before the next provider request', async () => {
+  const evidenceExpert = createFakeExpertService();
+  evidenceExpert._consumeDocRetrievalResult = () => ({
+    found: true,
+    evidenceInjection: 'DOCUMENT EVIDENCE',
+    docRetrievalResults: [{ tool_name: 'echo' }],
+  });
+  const evidenceResult = await createLoop().runErix(evidenceExpert, createInput());
+  assert.equal(evidenceResult.fullContent, 'Need tool任务完成 Final answer');
+  assert.equal(evidenceExpert.getSecondRoundMessages()[0].role, 'system');
+  assert.equal(evidenceExpert.getSecondRoundMessages()[0].content, 'DOCUMENT EVIDENCE');
+
+  const imageExpert = createFakeExpertService({
+    result: {
+      success: true,
+      data: {
+        dataUrl: 'data:image/png;base64,aGVsbG8=',
+        filename: 'demo.png',
+      },
+      duration: 1,
+      toolCallId: 'call_1',
+      toolName: 'echo',
+    },
+  });
+  await createLoop().runErix(imageExpert, createInput({
+    modelConfig: {
+      model_name: 'vision-model',
+      model_type: 'multimodal',
+      max_output_tokens: 2048,
+    },
+  }));
+  const syntheticMessage = imageExpert.getSecondRoundMessages().at(-1);
+  assert.equal(syntheticMessage.role, 'user');
+  assert.equal(syntheticMessage.content[0].type, 'text');
+  assert.equal(syntheticMessage.content[1].type, 'image_url');
+  assert.equal(
+    syntheticMessage.content[1].image_url.url,
+    'data:image/png;base64,aGVsbG8=',
+  );
+});
+
+test('runErix rejects an already stopped request using the run error', async () => {
+  await assert.rejects(
+    () => createLoop().runErix(createFakeExpertService(), createInput({
+      shouldStop: () => true,
+    })),
+    /Request aborted by user/,
+  );
+});
+
+test('runErix maps a retryable provider failure to recovering and recovered SSE events', async () => {
+  const previousBaseDelay = process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS;
+  const previousMaxDelay = process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS;
+  process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS = '0';
+  process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS = '0';
+
+  try {
+    const expertService = createFakeExpertService({ noTool: true });
+    let calls = 0;
+    expertService.llmClient.callStream = async (_modelConfig, _messages, options) => {
+      calls += 1;
+      if (calls === 1) {
+        const error = new Error('socket hang up');
+        error.code = 'ECONNRESET';
+        throw error;
+      }
+      options.onDelta('Recovered');
+    };
+
+    const events = [];
+    const result = await createLoop().runErix(expertService, createInput({
+      tools: [],
+      onDelta: event => events.push(event),
+    }));
+
+    assert.equal(calls, 2);
+    assert.equal(result.fullContent, 'Recovered');
+    assert.deepEqual(events.map(event => event.type), [
+      'recovering',
+      'recovered',
+      'delta',
+    ]);
+    assert.equal(events[0].max_attempts, 2);
+  } finally {
+    if (previousBaseDelay === undefined) {
+      delete process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS;
+    } else {
+      process.env.CHAT_STREAM_RECOVERY_BASE_DELAY_MS = previousBaseDelay;
+    }
+    if (previousMaxDelay === undefined) {
+      delete process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS;
+    } else {
+      process.env.CHAT_STREAM_RECOVERY_MAX_DELAY_MS = previousMaxDelay;
+    }
+  }
+});
+
+test('run and runErix preserve key behavior for the same mock input', async () => {
+  const oldEvents = [];
+  const oldExpert = createFakeExpertService();
+  const oldLoop = createLoop({
+    db: {
+      getModel() {
+        return {};
+      },
+    },
+    execute_tools: async (_expertService, input) => {
+      const result = {
+        success: true,
+        data: { value: 42 },
+        duration: 12,
+        toolCallId: 'call_1',
+        toolMessageId: 'tool_msg_1',
+        toolName: 'echo',
+      };
+      input.onDelta?.({ type: 'tool_result', result });
+      return [result];
+    },
+  });
+  const oldResult = await oldLoop.run(oldExpert, createInput({
+    onDelta: event => oldEvents.push(event),
+  }));
+
+  const erixEvents = [];
+  const erixResult = await createLoop().runErix(
+    createFakeExpertService(),
+    createInput({ onDelta: event => erixEvents.push(event) }),
+  );
+
+  assert.equal(erixResult.fullContent, oldResult.fullContent);
+  assert.equal(erixResult.fullReasoningContent, oldResult.fullReasoningContent);
+  assert.deepEqual(erixResult.tokenUsage, oldResult.tokenUsage);
+  assert.equal(erixResult.llmCallsCount, oldResult.llmCallsCount);
+  assert.deepEqual(
+    erixResult.allToolCalls.map(call => ({
+      id: call.id,
+      name: call.function.name,
+      data: call.result.data,
+      duration: call.duration,
+      tool_message_id: call.tool_message_id,
+    })),
+    oldResult.allToolCalls.map(call => ({
+      id: call.id,
+      name: call.function.name,
+      data: call.result.data,
+      duration: call.duration,
+      tool_message_id: call.tool_message_id,
+    })),
+  );
+  assert.deepEqual(erixEvents.map(event => event.type), oldEvents.map(event => event.type));
+  assert.ok(erixResult.finalMessages.length > 0);
+});


### PR DESCRIPTION
## 变更

L3-M3a：AgentLoop.runErix——erix runToolLoop 承载专家循环（平行实现，**未切流量**，旧 run 与 chat-service 零改动）。

- `lib/agent/agent-loop.js` 新增 `runErix(expertService, options)`（+618 行，旧 run 0 行改动）：
  - 经 M1 provider-adapter + M2 loop-bridge 接入 `erix-agent.runToolLoop`（动态 import 规避 ESM 循环依赖）
  - 消息转换：OpenAI 格式 ↔ canonical（tool→tool_result、assistant tool_calls→tool_use、image_url→image、reasoning_content→reasoning、连续 tool_result 合并满足 erix 配对校验）；出参 finalMessages 转回 OpenAI 审计格式
  - 完成信号：TOUWAKA_COMPLETION_SIGNALS + maxNoToolRounds = MAX_CONSECUTIVE_NO_TOOL_ROUNDS+1（=4，精确复刻旧 run 第 4 次连续无工具轮终止）
  - 证据注入（_consumeDocRetrievalResult）/多模态（injectImageUserMessages/stripHistoricalImages 影子转换）经 provider 请求包装层闭包实现，_synthetic 标记全程保留，重试不双重注入
  - SSE 映射：recovering/recovered/history_compacted(onAfterFold)/tool_limit_warning/reached(round_end 阈值)/tool_call(presentToolCalls)/tool_result
  - shouldStop → AbortController；retry 对齐 CHAT_STREAM_RECOVERY_*（attempts 2/退避公式与旧一致）；context budgetTokens 80000/keepRounds 6（CHAT_COMPACT_* 可调）
  - 出参：{fullContent, fullReasoningContent, tokenUsage, allToolCalls(含 result/duration/atomic_steps/timestamp), finalMessages, llmCallsCount}
- `tests/agent/agent-loop-erix.test.mjs`（341 行纯 mock 6 用例）：工具轮/完成信号/证据+图片注入/中止/恢复事件/新旧等价对照（deepEqual）

## 验证
- agent-loop-erix 6/6、test-agent-loop（旧 run）1/1、llm-kit-adapters 32/32 全绿（logs/ 权限环境问题，测试在可写 cwd 跑）
- reviewer 深度审计：**通过**（旧 run 0 删除行；maxNoToolRounds=4 轨迹验证；重试快照/证据重注入引用机制逐行核对）

## Backlog（非阻塞，M3b 切流量前处理）
1. 【必修】runErix 补观测日志（旧 run 的每轮/token/工具名/P0 调用次数日志）
2. recovering/recovered SSE attempt 编号与旧 run 差 1（erix 1-based）
3. 【产品确认】erix 内建行为差异：续轮注入"（请继续完成任务）"、失忆检测续轮、max_tokens 自动续写、checkpoint store DB 写入、压缩格式（erix context 折叠 vs 旧 compactHistory system 摘要）
4. 补测试：maxNoToolRounds 边界/tool_limit/history_compacted
5. 截断历史（tool_calls 无配对 tool）→ erix validateMessages 抛错防御

## 关联
- 承接 erix-agent issue #1（L3-M3a）；M3b（切流量 + 开关 + 日志）待派
- 本地任务留痕：docs/tasks/active/（不入库）
