### PR TITLE
fix: llm_kit_transcripts 建表迁移补充

### DIFF
--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -3963,6 +3963,38 @@ const MIGRATIONS = [
     }
   },
 
+  // ==================== erix-agent TranscriptStore transcripts ====================
+  {
+    name: 'llm_kit_transcripts table create',
+    check: async (conn) => await hasTable(conn, 'llm_kit_transcripts'),
+    migrate: async (conn) => {
+      await conn.execute(`
+        CREATE TABLE IF NOT EXISTS llm_kit_transcripts (
+          run_id VARCHAR(128) NOT NULL,
+          round INT NOT NULL,
+          ts VARCHAR(32) NOT NULL,
+          folded TINYINT(1) NOT NULL DEFAULT 0,
+          messages JSON NOT NULL,
+          folded_payload JSON NULL,
+          topic_id VARCHAR(64) NULL,
+          user_id VARCHAR(64) NULL,
+          expert_id VARCHAR(64) NULL,
+          model_name VARCHAR(128) NULL,
+          provider_name VARCHAR(128) NULL,
+          \`usage\` JSON NULL,
+          latency_ms INT NULL,
+          error_info JSON NULL,
+          is_deleted TINYINT(1) NOT NULL DEFAULT 0,
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          PRIMARY KEY (run_id, round),
+          KEY idx_llm_kit_transcripts_topic_id (topic_id),
+          KEY idx_llm_kit_transcripts_user_id (user_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+      `);
+      console.log('  ✓ Created llm_kit_transcripts table');
+    }
+  },
+
 ];
 
 /**


### PR DESCRIPTION
## 变更
`scripts/upgrade-database.js` 补 llm_kit_transcripts 建表迁移（幂等，hasTable check）——PR #1108 只加了 llm_kit_run_state，transcripts 表建表遗漏；e2e（runErix 真实对话）暴露生产库缺表导致 TranscriptStore 写入失败。

## 验证
- 表 DDL 与 lib/llm-kit-adapters/transcript-store.js 模型一致（usage 列反引号处理保留字）；生产库已手动建表（e2e 用），迁移幂等可安全重跑
- node --check 通过；e2e 全链路已跑通（runErix + transcripts 写入正常）