### PR TITLE
feat: erix-agent 升级 ^0.3.2 + record_json 快照列（judge 决策落库）

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **一个具备自我反思能力的 AI 专家副本系统**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Node.js](https://img.shields.io/badge/Node.js-20+-green.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-22+-green.svg)](https://nodejs.org/)
 [![Vue.js](https://img.shields.io/badge/Vue.js-3+-4FC08D.svg)](https://vuejs.org/)
 [![MariaDB](https://img.shields.io/badge/MariaDB-11.x-003545.svg)](https://mariadb.org/)
 
@@ -75,7 +75,7 @@
 ## 🚀 快速开始
 
 ### 环境要求
-- Node.js 22+（对齐 erix-agent 引擎要求；Node 20 亦兼容运行）
+- Node.js 22+（对齐 erix-agent 引擎要求，Node <22 不再支持）
 - MariaDB 11.x (支持原生向量类型)
 - (可选) Python 3.10+ - 用于 Python 技能支持
 

--- a/docs/development/quick-start.md
+++ b/docs/development/quick-start.md
@@ -2,7 +2,7 @@
 
 ## 环境要求
 
-- **Node.js** 18+
+- **Node.js** 22+
 - **MySQL** 8.0+ / MariaDB
 - **Python** 3.10+ (可选，用于 Python 技能支持)
 

--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -1108,6 +1108,7 @@ export class AgentLoop {
       maxTokens: llmPayload.max_tokens,
       temperature: llmPayload.temperature,
       topP: llmPayload.top_p,
+      wrapup: false, // erix 0.3.3+：关闭 WRAPUP_INSTRUCTION 注入，touwaka 是对话宿主（erix-agent #32）
       stream: true,
       signal: abortController.signal,
       onDelta: delta => {

--- a/lib/llm-kit-adapters/loop-bridge.js
+++ b/lib/llm-kit-adapters/loop-bridge.js
@@ -247,6 +247,7 @@ export function buildErixRunOptions({
 function adaptRoundRecord(record) {
   const source = record ?? {};
   return {
+    ...source,
     round: source.round,
     ts: source.ts,
     messages: source.messages,

--- a/lib/llm-kit-adapters/transcript-store.js
+++ b/lib/llm-kit-adapters/transcript-store.js
@@ -52,6 +52,10 @@ function defineTranscriptModel(sequelize, tableName) {
       type: DataTypes.JSON,
       allowNull: true,
     },
+    record_json: {
+      type: DataTypes.JSON,
+      allowNull: true,
+    },
     topic_id: {
       type: DataTypes.STRING(64),
       allowNull: true,
@@ -116,6 +120,11 @@ function parseJsonColumn(value) {
   return value;
 }
 
+function parseRecordJsonColumn(value) {
+  const parsed = parseJsonColumn(value);
+  return typeof parsed === "string" ? parseJsonColumn(parsed) : parsed;
+}
+
 function isMissingRunStateTableError(error) {
   return [error, error?.parent, error?.original].some((candidate) => (
     candidate?.code === "ER_NO_SUCH_TABLE" || candidate?.errno === 1146
@@ -124,6 +133,7 @@ function isMissingRunStateTableError(error) {
 
 function toRecord(row) {
   const record = {
+    ...(parseRecordJsonColumn(row.record_json) ?? {}),
     round: row.round,
     ts: row.ts,
     folded: Boolean(row.folded),
@@ -269,6 +279,13 @@ export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAM
 
   return {
     async appendRound(runId, record, meta) {
+      const recordSnapshot = record == null
+        ? null
+        : Object.fromEntries(
+          Object.entries(record).filter(([key]) => (
+            key !== "messages" && key !== "foldedPayload"
+          )),
+        );
       await Transcript.create({
         run_id: runId,
         round: record.round,
@@ -276,6 +293,9 @@ export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAM
         folded: record.folded ?? false,
         messages: record.messages,
         folded_payload: record.foldedPayload ?? null,
+        record_json: recordSnapshot === null
+          ? null
+          : (JSON.stringify(recordSnapshot) ?? null),
         ...metaToColumns(meta ?? record.meta),
       });
     },

--- a/lib/llm-kit-adapters/transcript-store.js
+++ b/lib/llm-kit-adapters/transcript-store.js
@@ -299,6 +299,8 @@ export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAM
           ? null
           : recordSnapshot,
         ...metaToColumns(meta ?? record.meta),
+      }, {
+        ignoreDuplicates: true,
       });
     },
 

--- a/lib/llm-kit-adapters/transcript-store.js
+++ b/lib/llm-kit-adapters/transcript-store.js
@@ -120,6 +120,8 @@ function parseJsonColumn(value) {
   return value;
 }
 
+// New DataTypes.JSON rows are objects after deserialization; legacy rows may
+// contain a JSON-encoded string, so retain the second parse for compatibility.
 function parseRecordJsonColumn(value) {
   const parsed = parseJsonColumn(value);
   return typeof parsed === "string" ? parseJsonColumn(parsed) : parsed;
@@ -283,7 +285,7 @@ export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAM
         ? null
         : Object.fromEntries(
           Object.entries(record).filter(([key]) => (
-            key !== "messages" && key !== "foldedPayload"
+            key !== "messages" && key !== "foldedPayload" && key !== "meta"
           )),
         );
       await Transcript.create({
@@ -295,7 +297,7 @@ export function createTouwakaTranscriptStore({ db, tableName = DEFAULT_TABLE_NAM
         folded_payload: record.foldedPayload ?? null,
         record_json: recordSnapshot === null
           ? null
-          : (JSON.stringify(recordSnapshot) ?? null),
+          : recordSnapshot,
         ...metaToColumns(meta ?? record.meta),
       });
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "docx": "^9.6.1",
         "dotenv": "^16.6.1",
         "echarts": "^5.5.0",
-        "erix-agent": "^0.2.0",
+        "erix-agent": "^0.3.2",
         "exceljs": "^4.4.0",
         "hyperformula": "^2.7.0",
         "jsonwebtoken": "^9.0.3",
@@ -1061,7 +1061,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2263,10 +2262,10 @@
       }
     },
     "node_modules/erix-agent": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/erix-agent/-/erix-agent-0.2.0.tgz",
-      "integrity": "sha512-Wkv085/APx63MrQL28HK7957jLHeDvGq3KtvbltUNkTyICp/1EJrmWoDlz2Hv8im49WUGilIg3c8UWBg0QlpQA==",
-      "license": "UNLICENSED",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/erix-agent/-/erix-agent-0.3.2.tgz",
+      "integrity": "sha512-eOOznxjyXhI4OK612DrxKlvhF+u7/cxSz8PdqbMdwtHXLaAzaaHqiS0GQwjfEuHRemkJvHf/68XdgWf2UHbhJA==",
+      "license": "MIT",
       "bin": {
         "erix": "bin/cli.js"
       },
@@ -2853,7 +2852,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3283,7 +3281,6 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.2.tgz",
       "integrity": "sha512-2LOQnFKu3m0VxpE+5sb5+BRTSKrXmNxGgxVRiKwD9s5KQB1zID/FRXhtzeV7RT1L2GVpdEEAfVuclFOMGl1ikA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~1.0.1",
@@ -3938,7 +3935,6 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
       "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
@@ -4726,7 +4722,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -5706,7 +5701,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "docx": "^9.6.1",
         "dotenv": "^16.6.1",
         "echarts": "^5.5.0",
-        "erix-agent": "^0.3.2",
+        "erix-agent": "^0.3.3",
         "exceljs": "^4.4.0",
         "hyperformula": "^2.7.0",
         "jsonwebtoken": "^9.0.3",
@@ -2262,9 +2262,9 @@
       }
     },
     "node_modules/erix-agent": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/erix-agent/-/erix-agent-0.3.2.tgz",
-      "integrity": "sha512-eOOznxjyXhI4OK612DrxKlvhF+u7/cxSz8PdqbMdwtHXLaAzaaHqiS0GQwjfEuHRemkJvHf/68XdgWf2UHbhJA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/erix-agent/-/erix-agent-0.3.3.tgz",
+      "integrity": "sha512-iJu3CR0CRLx/nzJzzJCT9vxVLw9gbwWGo4WQOmc+gXSTLHXsY0dgVp0/2cjfB0v2J2yk0Nwila9yTiUZuYbq5A==",
       "license": "MIT",
       "bin": {
         "erix": "bin/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "sequelize-auto": "^0.8.8"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docx": "^9.6.1",
     "dotenv": "^16.6.1",
     "echarts": "^5.5.0",
-    "erix-agent": "^0.2.0",
+    "erix-agent": "^0.3.2",
     "exceljs": "^4.4.0",
     "hyperformula": "^2.7.0",
     "jsonwebtoken": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docx": "^9.6.1",
     "dotenv": "^16.6.1",
     "echarts": "^5.5.0",
-    "erix-agent": "^0.3.2",
+    "erix-agent": "^0.3.3",
     "exceljs": "^4.4.0",
     "hyperformula": "^2.7.0",
     "jsonwebtoken": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "sequelize-auto": "^0.8.8"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22"
   }
 }

--- a/scripts/upgrade-database.js
+++ b/scripts/upgrade-database.js
@@ -3976,6 +3976,7 @@ const MIGRATIONS = [
           folded TINYINT(1) NOT NULL DEFAULT 0,
           messages JSON NOT NULL,
           folded_payload JSON NULL,
+          record_json JSON NULL,
           topic_id VARCHAR(64) NULL,
           user_id VARCHAR(64) NULL,
           expert_id VARCHAR(64) NULL,
@@ -3992,6 +3993,22 @@ const MIGRATIONS = [
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
       `);
       console.log('  ✓ Created llm_kit_transcripts table');
+    }
+  },
+
+  // ==================== erix-agent TranscriptStore record snapshot ====================
+  {
+    name: 'llm_kit_transcripts.record_json column add',
+    check: async (conn) => {
+      if (!await hasTable(conn, 'llm_kit_transcripts')) return true;
+      return await hasColumn(conn, 'llm_kit_transcripts', 'record_json');
+    },
+    migrate: async (conn) => {
+      await conn.execute(`
+        ALTER TABLE llm_kit_transcripts
+        ADD COLUMN record_json JSON NULL AFTER folded_payload
+      `);
+      console.log('  ✓ Added record_json column to llm_kit_transcripts table');
     }
   },
 

--- a/tests/agent/agent-loop-erix.test.mjs
+++ b/tests/agent/agent-loop-erix.test.mjs
@@ -308,8 +308,10 @@ test('runErix maps evidence and multimodal tool results before the next provider
   });
   const evidenceResult = await createLoop().runErix(evidenceExpert, createInput());
   assert.equal(evidenceResult.fullContent, 'Need tool任务完成 Final answer');
-  assert.equal(evidenceExpert.getSecondRoundMessages()[0].role, 'system');
-  assert.equal(evidenceExpert.getSecondRoundMessages()[0].content, 'DOCUMENT EVIDENCE');
+  const evidenceMessage = evidenceExpert.getSecondRoundMessages().find(message => (
+    message.role === 'system' && message.content === 'DOCUMENT EVIDENCE'
+  ));
+  assert.ok(evidenceMessage);
 
   const imageExpert = createFakeExpertService({
     result: {

--- a/tests/agent/agent-loop-erix.test.mjs
+++ b/tests/agent/agent-loop-erix.test.mjs
@@ -312,6 +312,16 @@ test('runErix maps evidence and multimodal tool results before the next provider
     message.role === 'system' && message.content === 'DOCUMENT EVIDENCE'
   ));
   assert.ok(evidenceMessage);
+  assert.equal(
+    evidenceExpert.getSecondRoundMessages().some(message => (
+      typeof message.content === 'string'
+      && (
+        message.content.includes('任务完成或需要给出结论时')
+        || message.content.includes('{"done":true')
+      )
+    )),
+    false,
+  );
 
   const imageExpert = createFakeExpertService({
     result: {

--- a/tests/llm-kit-adapters/transcript-store-meta.test.mjs
+++ b/tests/llm-kit-adapters/transcript-store-meta.test.mjs
@@ -122,9 +122,48 @@ if (!creds) {
       toolUses: [{ name: "finish", success: true }],
       roundKey: "round-2",
       dedupKey: "dedup-round-2",
+      meta: {
+        topicId: "topic-judge",
+        userId: "user-judge",
+        expertId: "expert-judge",
+        modelName: "model-judge",
+        providerName: "provider-judge",
+        usage: { prompt_tokens: 20, completion_tokens: 8, cost: 0.2 },
+        latencyMs: 456,
+        errorInfo: { retryable: false },
+        isDeleted: false,
+      },
     };
 
     await store.appendRound("run-judge", record);
+
+    const [rawRow] = await db.sequelize.query(`
+      SELECT
+        record_json,
+        JSON_TYPE(record_json) AS record_json_type,
+        JSON_EXTRACT(record_json, '$.judge') AS judge_json
+      FROM ${TABLE_NAME}
+      WHERE run_id = ? AND round = ?
+    `, {
+      replacements: ["run-judge", record.round],
+    });
+    assert.equal(rawRow.length, 1);
+    const rawRecordJson = rawRow[0].record_json;
+    const parsedRecordJson = typeof rawRecordJson === "string"
+      ? JSON.parse(rawRecordJson)
+      : rawRecordJson;
+    assert.equal(rawRow[0].record_json_type, "OBJECT");
+    assert.equal(
+      typeof parsedRecordJson,
+      "object",
+      "record_json must be stored as a JSON object, not a JSON-encoded string",
+    );
+    assert.notEqual(parsedRecordJson, null);
+    assert.deepEqual(parsedRecordJson.judge, record.judge);
+    const judgeFromJsonPath = typeof rawRow[0].judge_json === "string"
+      ? JSON.parse(rawRow[0].judge_json)
+      : rawRow[0].judge_json;
+    assert.deepEqual(judgeFromJsonPath, record.judge);
 
     const [loaded] = await store.load("run-judge");
     const [loadedWithMeta] = await store.loadWithMeta("run-judge");
@@ -139,6 +178,8 @@ if (!creds) {
       assert.equal(value.roundKey, record.roundKey);
       assert.equal(value.dedupKey, record.dedupKey);
     }
+    assert.equal(Object.hasOwn(loaded, "meta"), false);
+    assert.deepEqual(loadedWithMeta.meta, record.meta);
     assert.deepEqual(loaded.messages, record.messages);
     assert.deepEqual(loaded.foldedPayload, record.foldedPayload);
     assert.deepEqual(loadedWithMeta.messages, record.messages);

--- a/tests/llm-kit-adapters/transcript-store-meta.test.mjs
+++ b/tests/llm-kit-adapters/transcript-store-meta.test.mjs
@@ -98,6 +98,53 @@ if (!creds) {
     assert.deepEqual(loaded[0].meta, meta);
   });
 
+  test("appendRound 持久化并还原 judge record 快照", async () => {
+    const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
+    const record = {
+      round: 2,
+      ts: "2026-08-29T10:00:01.000Z",
+      folded: true,
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+      foldedPayload: [{ role: "user", content: "folded" }],
+      judge: {
+        done: true,
+        confidence: 0.98,
+        reason: "完成目标",
+        evidence: ["工具返回成功", "结果已确认"],
+        direction: "wrapup",
+        directionReason: "无需继续调用工具",
+      },
+      summary: "已完成任务",
+      l0facts: ["用户要求已满足"],
+      wrapup: { status: "completed", reason: "judge_done" },
+      response: "任务已完成",
+      textPreview: "任务已完成",
+      toolUses: [{ name: "finish", success: true }],
+      roundKey: "round-2",
+      dedupKey: "dedup-round-2",
+    };
+
+    await store.appendRound("run-judge", record);
+
+    const [loaded] = await store.load("run-judge");
+    const [loadedWithMeta] = await store.loadWithMeta("run-judge");
+    for (const value of [loaded, loadedWithMeta]) {
+      assert.deepEqual(value.judge, record.judge);
+      assert.deepEqual(value.summary, record.summary);
+      assert.deepEqual(value.l0facts, record.l0facts);
+      assert.deepEqual(value.wrapup, record.wrapup);
+      assert.deepEqual(value.response, record.response);
+      assert.deepEqual(value.textPreview, record.textPreview);
+      assert.deepEqual(value.toolUses, record.toolUses);
+      assert.equal(value.roundKey, record.roundKey);
+      assert.equal(value.dedupKey, record.dedupKey);
+    }
+    assert.deepEqual(loaded.messages, record.messages);
+    assert.deepEqual(loaded.foldedPayload, record.foldedPayload);
+    assert.deepEqual(loadedWithMeta.messages, record.messages);
+    assert.deepEqual(loadedWithMeta.foldedPayload, record.foldedPayload);
+  });
+
   test("load 保持纯净，不返回 meta", async () => {
     const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
     await store.appendRound("run-clean", {

--- a/tests/llm-kit-adapters/transcript-store-meta.test.mjs
+++ b/tests/llm-kit-adapters/transcript-store-meta.test.mjs
@@ -98,6 +98,34 @@ if (!creds) {
     assert.deepEqual(loaded[0].meta, meta);
   });
 
+  test("appendRound 按 run_id/round 幂等并保留首条", async () => {
+    const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
+    const runId = "run-idempotent";
+    const first = {
+      round: 1,
+      ts: "2026-08-29T10:00:00.000Z",
+      messages: [{ role: "assistant", content: [{ type: "text", text: "first" }] }],
+    };
+    const second = {
+      round: 1,
+      ts: "2026-08-29T10:00:01.000Z",
+      messages: [{ role: "assistant", content: [{ type: "text", text: "second" }] }],
+    };
+
+    await store.appendRound(runId, first, {
+      topicId: "topic-first",
+    });
+    await assert.doesNotReject(() => store.appendRound(runId, second, {
+      topicId: "topic-second",
+    }));
+
+    const loaded = await store.loadWithMeta(runId);
+    assert.equal(loaded.length, 1);
+    assert.equal(loaded[0].ts, first.ts);
+    assert.deepEqual(loaded[0].messages, first.messages);
+    assert.equal(loaded[0].meta.topicId, "topic-first");
+  });
+
   test("appendRound 持久化并还原 judge record 快照", async () => {
     const store = createTouwakaTranscriptStore({ db, tableName: TABLE_NAME });
     const record = {


### PR DESCRIPTION
## 背景

erix-agent 0.3.x 引入 round judge 体系（`runToolLoop` 在 maxRounds≥16 时默认启用，judge 决策随每轮 record 输出）。touwaka 的 transcript 适配层 `adaptRoundRecord` 用白名单只透传 `round/ts/messages/folded/foldedPayload/meta`，导致 **judge/summary/l0facts/wrapup 等字段落库即丢**——DB 无法按轮重建 judge 叙事链（issue #1116），且 erix resume 时 governor 历史无法重建。

## 改动（方案 C：通用快照列，已确认）

- **依赖**：`erix-agent ^0.2.0 → ^0.3.2`（0.3.0/0.3.1/0.3.2 src 一致；exports/contract-tests/store 契约零 diff，向后兼容）
- **`llm_kit_transcripts` 加 `record_json JSON NULL` 列**：存 record 除 `messages`/`folded_payload` 外的完整快照（覆盖 judge/summary/l0facts/wrapup/response/toolUses/roundKey/dedupKey 及未来 erix record 新字段，免逐次 ALTER）
- **`adaptRoundRecord`**：改为透传完整 record，不再白名单丢弃
- **load 还原**：`toRecord`/`toRecordWithMeta` 展开 record_json 与列值合并，resume 时 governor 历史完整
- **迁移**：`scripts/upgrade-database.js` 建表 DDL 加列 + 老库幂等 `ALTER TABLE`（migration 追加，仅此一列，不动其他表/字段/索引）
- **测试**：真实 MariaDB 往返用例（judge/summary/l0facts/wrapup 等落库→load deepEqual）+ 契约测试保持绿；agent-loop-erix 测试适配 0.3.2 默认追加的 wrapup system prompt（仅放宽消息定位断言，未改 runErix 参数/judge 策略）

## 验证

- `node --test tests/llm-kit-adapters/*.test.mjs *.mjs`：**33/33 pass**（含契约测试真实 DB 8 pass）
- `node --test tests/agent/agent-loop-erix.test.mjs`：**10/10 pass**
- `node --check` 改动文件 + `npm run lint`：通过
- `npm ls erix-agent`：0.3.2

## 说明

- judge 策略维持 erix 默认（maxRounds≥16 自动启用，短任务不触发），未改 runErix 调用参数；后续如需按 expert 精细开关可另开 issue
- checkpoint fail-closed（store 成对时 DB 写失败抛 `checkpoint_failed`）为 0.3.x 行为变化，升级后需观察 DB 稳定性

Closes #1116
