### PR TITLE
feat: erix judge 接入反思模型（reflective，fallback 主模型）

### DIFF
--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -908,6 +908,24 @@ export class AgentLoop {
       defaultUserId: user_id,
       defaultRequestId: request_id,
     });
+    const judgeProvider = createTouwakaProvider({
+      llmClient: expertService.llmClient,
+      resolveModel: async () => {
+        if (typeof expertService.llmClient?.getModelForMind !== 'function') {
+          return modelConfig;
+        }
+        try {
+          return await expertService.llmClient.getModelForMind('reflective');
+        } catch (error) {
+          logger.warn('[AgentLoop] 反思模型配置不可用，judge 回退主模型:', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return modelConfig;
+        }
+      },
+      defaultUserId: user_id,
+      defaultRequestId: request_id,
+    });
 
     const invokeProvider = async (method, request) => {
       await prepareProviderRequest(request);
@@ -1109,6 +1127,12 @@ export class AgentLoop {
       temperature: llmPayload.temperature,
       topP: llmPayload.top_p,
       wrapup: false, // erix 0.3.3+：关闭 WRAPUP_INSTRUCTION 注入，touwaka 是对话宿主（erix-agent #32）
+      // judge 走反思模型（erix-agent #32 配套）；显式对齐默认触发语义，避免传对象后短任务误触发
+      reflection: {
+        enabled: maxRounds >= 16,
+        roundJudge: true,
+        judge: { provider: judgeProvider },
+      },
       stream: true,
       signal: abortController.signal,
       onDelta: delta => {

--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -910,19 +910,27 @@ export class AgentLoop {
     });
     const judgeProvider = createTouwakaProvider({
       llmClient: expertService.llmClient,
-      resolveModel: async () => {
-        if (typeof expertService.llmClient?.getModelForMind !== 'function') {
-          return modelConfig;
-        }
-        try {
-          return await expertService.llmClient.getModelForMind('reflective');
-        } catch (error) {
-          logger.warn('[AgentLoop] 反思模型配置不可用，judge 回退主模型:', {
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return modelConfig;
-        }
-      },
+      resolveModel: (() => {
+        let reflectiveModelPromise;
+        return async () => {
+          if (!reflectiveModelPromise) {
+            reflectiveModelPromise = (async () => {
+              if (typeof expertService.llmClient?.getModelForMind !== 'function') {
+                return modelConfig;
+              }
+              try {
+                return await expertService.llmClient.getModelForMind('reflective');
+              } catch (error) {
+                logger.warn('[AgentLoop] 反思模型配置不可用，judge 回退主模型:', {
+                  error: error instanceof Error ? error.message : String(error),
+                });
+                return modelConfig;
+              }
+            })();
+          }
+          return reflectiveModelPromise;
+        };
+      })(),
       defaultUserId: user_id,
       defaultRequestId: request_id,
     });
@@ -1127,9 +1135,9 @@ export class AgentLoop {
       temperature: llmPayload.temperature,
       topP: llmPayload.top_p,
       wrapup: false, // erix 0.3.3+：关闭 WRAPUP_INSTRUCTION 注入，touwaka 是对话宿主（erix-agent #32）
-      // judge 走反思模型（erix-agent #32 配套）；显式对齐默认触发语义，避免传对象后短任务误触发
+      // erix 只在未显式传 reflection 时读取该 env；宿主显式传入时需自行对齐运维开关
       reflection: {
-        enabled: maxRounds >= 16,
+        enabled: maxRounds >= 16 && process.env.ERIX_NO_REFLECTION?.trim() !== '1',
         roundJudge: true,
         judge: { provider: judgeProvider },
       },
@@ -1170,11 +1178,23 @@ export class AgentLoop {
         .map(block => block.text)
         .join('');
     }
-    if (!tokenUsage && sawUsage) {
+    const loopUsage = loopResult?.usage;
+    const hasLoopUsage = loopUsage && (
+      Number(loopUsage.input_tokens) > 0 || Number(loopUsage.output_tokens) > 0
+    );
+    if (hasLoopUsage) {
+      // loopResult.usage 是 erix 全量（主循环 + judge，trackLatest:false 已并入），权威来源
       tokenUsage = {
-        prompt_tokens: loopResult.usage.input_tokens || 0,
-        completion_tokens: loopResult.usage.output_tokens || 0,
-        total_tokens: (loopResult.usage.input_tokens || 0) + (loopResult.usage.output_tokens || 0),
+        prompt_tokens: Number(loopUsage.input_tokens) || 0,
+        completion_tokens: Number(loopUsage.output_tokens) || 0,
+        total_tokens: (Number(loopUsage.input_tokens) || 0) + (Number(loopUsage.output_tokens) || 0),
+      };
+    } else if (!tokenUsage && sawUsage) {
+      // 保留原兜底（mock/usage 结构不匹配时）
+      tokenUsage = {
+        prompt_tokens: loopResult.usage?.input_tokens || 0,
+        completion_tokens: loopResult.usage?.output_tokens || 0,
+        total_tokens: (loopResult.usage?.input_tokens || 0) + (loopResult.usage?.output_tokens || 0),
       };
     }
     if (!fullContent || fullContent.trim() === '') {

--- a/tests/agent/agent-loop-erix.test.mjs
+++ b/tests/agent/agent-loop-erix.test.mjs
@@ -192,6 +192,7 @@ function createScriptedExpertService({
       async callStream(_modelConfig, _messages, options) {
         const script = scripts[streamCalls] || scripts.at(-1) || {};
         streamCalls += 1;
+        if (script.usage) options.onUsage(script.usage);
         if (script.reasoning) options.onReasoningDelta(script.reasoning);
         if (script.content) options.onDelta(script.content);
         if (script.toolCalls) options.onToolCall(script.toolCalls);
@@ -234,6 +235,44 @@ function createScriptedExpertService({
     },
   };
 
+  return expertService;
+}
+
+function createJudgeCapableExpertService({
+  maxToolRounds = 20,
+  reflectiveModel = { model_name: 'reflective-model' },
+} = {}) {
+  const expertService = createScriptedExpertService({
+    maxToolRounds,
+    scripts: [{
+      content: '任务完成 Final answer',
+      usage: {
+        input_tokens: 11,
+        output_tokens: 5,
+      },
+    }],
+  });
+  const resolvedMinds = [];
+  const judgeCalls = [];
+  expertService.llmClient.getModelForMind = async mindType => {
+    resolvedMinds.push(mindType);
+    return reflectiveModel;
+  };
+  expertService.llmClient.call = async (modelConfig, messages) => {
+    judgeCalls.push({ modelConfig, messages });
+    return {
+      content: [{
+        type: 'text',
+        text: '{"done":true,"confidence":0.95,"reason":"任务已完成","evidence":"已返回最终结果"}',
+      }],
+      usage: {
+        input_tokens: 7,
+        output_tokens: 3,
+      },
+    };
+  };
+  expertService.getResolvedMinds = () => resolvedMinds;
+  expertService.getJudgeCalls = () => judgeCalls;
   return expertService;
 }
 
@@ -557,6 +596,55 @@ test('runErix emits history_compacted with the compaction shape', async () => {
   assert.ok(compactedEvent.foldedRounds > 0);
   assert.ok(compactedEvent.tokensBefore > compactedEvent.tokensAfter);
   assert.match(compactedEvent.content, /自动压缩/);
+});
+
+test('runErix judge falls back to the primary model when reflective config is unavailable', async () => {
+  const input = createInput();
+  const expertService = createJudgeCapableExpertService();
+  delete expertService.llmClient.getModelForMind;
+
+  const result = await withEnv('ERIX_NO_REFLECTION', undefined, () => (
+    createLoop().runErix(expertService, {
+      ...input,
+      onDelta: () => {},
+    })
+  ));
+
+  assert.equal(expertService.getJudgeCalls().length, 1);
+  assert.equal(expertService.getJudgeCalls()[0].modelConfig, input.modelConfig);
+  assert.deepEqual(result.tokenUsage, {
+    prompt_tokens: 18,
+    completion_tokens: 8,
+    total_tokens: 26,
+  });
+});
+
+test('runErix uses the reflective model for long-task judge calls', async () => {
+  const reflectiveModel = { model_name: 'marked-reflective-model' };
+  const expertService = createJudgeCapableExpertService({ reflectiveModel });
+
+  await withEnv('ERIX_NO_REFLECTION', undefined, () => (
+    createLoop().runErix(expertService, createInput({
+      onDelta: () => {},
+    }))
+  ));
+
+  assert.deepEqual(expertService.getResolvedMinds(), ['reflective']);
+  assert.equal(expertService.getJudgeCalls().length, 1);
+  assert.equal(expertService.getJudgeCalls()[0].modelConfig, reflectiveModel);
+});
+
+test('runErix disables long-task judge calls when ERIX_NO_REFLECTION is enabled', async () => {
+  const expertService = createJudgeCapableExpertService();
+
+  await withEnv('ERIX_NO_REFLECTION', '1', () => (
+    createLoop().runErix(expertService, createInput({
+      onDelta: () => {},
+    }))
+  ));
+
+  assert.deepEqual(expertService.getResolvedMinds(), []);
+  assert.deepEqual(expertService.getJudgeCalls(), []);
 });
 
 test('run routes to runErix by default and to the legacy loop with ERIX_LOOP=0', async () => {

--- a/tests/agent/agent-loop-erix.test.mjs
+++ b/tests/agent/agent-loop-erix.test.mjs
@@ -266,8 +266,8 @@ function createJudgeCapableExpertService({
         text: '{"done":true,"confidence":0.95,"reason":"任务已完成","evidence":"已返回最终结果"}',
       }],
       usage: {
-        input_tokens: 7,
-        output_tokens: 3,
+        prompt_tokens: 7,
+        completion_tokens: 3,
       },
     };
   };
@@ -604,10 +604,12 @@ test('runErix judge falls back to the primary model when reflective config is un
   delete expertService.llmClient.getModelForMind;
 
   const result = await withEnv('ERIX_NO_REFLECTION', undefined, () => (
-    createLoop().runErix(expertService, {
-      ...input,
-      onDelta: () => {},
-    })
+    withEnv('ERIX_NO_ROUND_JUDGE', undefined, () => (
+      createLoop().runErix(expertService, {
+        ...input,
+        onDelta: () => {},
+      })
+    ))
   ));
 
   assert.equal(expertService.getJudgeCalls().length, 1);
@@ -624,9 +626,11 @@ test('runErix uses the reflective model for long-task judge calls', async () => 
   const expertService = createJudgeCapableExpertService({ reflectiveModel });
 
   await withEnv('ERIX_NO_REFLECTION', undefined, () => (
-    createLoop().runErix(expertService, createInput({
-      onDelta: () => {},
-    }))
+    withEnv('ERIX_NO_ROUND_JUDGE', undefined, () => (
+      createLoop().runErix(expertService, createInput({
+        onDelta: () => {},
+      }))
+    ))
   ));
 
   assert.deepEqual(expertService.getResolvedMinds(), ['reflective']);
@@ -638,9 +642,11 @@ test('runErix disables long-task judge calls when ERIX_NO_REFLECTION is enabled'
   const expertService = createJudgeCapableExpertService();
 
   await withEnv('ERIX_NO_REFLECTION', '1', () => (
-    createLoop().runErix(expertService, createInput({
-      onDelta: () => {},
-    }))
+    withEnv('ERIX_NO_ROUND_JUDGE', undefined, () => (
+      createLoop().runErix(expertService, createInput({
+        onDelta: () => {},
+      }))
+    ))
   ));
 
   assert.deepEqual(expertService.getResolvedMinds(), []);


### PR DESCRIPTION
## 目标

erix runToolLoop 的 **judge LLM 调用改走反思模型**（reflective），而非与主对话共用 expressive 模型。

## 背景

- touwaka 是双脑架构：expressive（对话表达）+ reflective（内部判断，低温度/更便宜/专用于判断，与 Inner Voice/Psyche 同模型）
- erix 0.3.x judge（round judge/拦截审计/wrapup 归一化）默认用主 provider = expressive——长任务 judge 调用挤占对话模型配额/成本
- judge 语义（任务完成度/方向审计）与反思模型定位（内部判断）天然吻合

## 改动（lib/agent/agent-loop.js，+24 行）

1. 新增 `judgeProvider`：`createTouwakaProvider({ resolveModel: () => getModelForMind('reflective') })`，反思模型缺失/解析失败时 **fallback 主模型**（不崩、judge 仍可用），并记 warning
2. `buildErixRunOptions` 传 `reflection: { enabled: maxRounds >= 16, roundJudge: true, judge: { provider: judgeProvider } }`
   - **关键**：erix 一旦传 reflection 对象就强制启用（不再看 maxRounds）——必须显式 `enabled: maxRounds >= 16` 复刻默认触发语义，避免短任务（<16 轮）误触发 judge（行为变化）
   - 主循环仍用原 expressive provider，不动

## 验证

- node --check 通过
- agent-loop-erix 10/10（mock maxRounds=5 → judge 不触发，行为不变）
- llm-kit-adapters 34/34
- lint 通过

## 现状专家反思模型配置（真机查证）

| 专家 | expressive | reflective |
|---|---|---|
| 小美 | openai/gpt-5.6-luna | tencent/hy3（轻量独立）|
| 机器之心 | qwen3.6:35b | qwen3.6:35b（同）|
| 标准引用清洗专家 | openai/gpt-5.6-luna | nvidia/free（免费）|

合并后需真机长任务（≥16 轮）验证：judge 落库 record_json + 日志确认走反思模型。
