### PR TITLE
fix: tool context 契约——仅透传 string（erix 结构化 context 对象不再崩前端）

### DIFF
--- a/frontend/src/composables/useToolDataParser.ts
+++ b/frontend/src/composables/useToolDataParser.ts
@@ -83,7 +83,7 @@ const getToolData = (message: ChatMessage): NormalizedToolData => {
     name: toolData?.name || toolData?.tool_name || 'unknown_tool',
     success: toolData?.success ?? true,
     duration: toolData?.duration ?? null,
-    context: toolData?.context ?? null,
+    context: typeof toolData?.context === 'string' ? toolData.context : null,
     timestamp: toolData?.timestamp ?? null,
     arguments: toolData?.arguments ?? null,
   }
@@ -201,6 +201,7 @@ const buildToolContextIndex = (allMessages: ChatMessage[]): ToolContextIndex => 
 
     if (msg.role !== 'tool' || !msg.request_id) return
 
+    // getToolData filters legacy/structured object contexts to keep display data string-only.
     const context = getToolData(msg).context?.trim()
     if (!context) return
 

--- a/frontend/src/composables/useToolDataParser.ts
+++ b/frontend/src/composables/useToolDataParser.ts
@@ -12,7 +12,7 @@ export interface ToolCallData {
   arguments?: Record<string, unknown>
   result?: unknown
   result_preview?: string
-  context?: string
+  context?: string | null
   /** round03：原子工具执行轨迹（仅 document_retrieval skill） */
   atomic_steps?: string[]
 }
@@ -95,7 +95,10 @@ const getToolData = (message: ChatMessage): NormalizedToolData => {
 const parseToolCallsToArray = (message: ChatMessage): ToolCallData[] => {
   const toolCalls = parseToolCallsRaw(message)
   if (!toolCalls) return []
-  return Array.isArray(toolCalls) ? toolCalls : [toolCalls]
+  return (Array.isArray(toolCalls) ? toolCalls : [toolCalls]).map(call => ({
+    ...call,
+    context: typeof call?.context === 'string' ? call.context : null,
+  }))
 }
 
 const formatToolCallTime = (toolCall: ToolCallData): string => {

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -54,6 +54,7 @@ import logger from './logger.js';
 import { resolveThinkingRequestConfig } from './llm-thinking-config.js';
 import { buildToolCallSnapshot } from './tool-call-snapshot-builder.js';
 import { buildStreamTurnContext, buildToolContext } from './chat/turn-context-builder.js';
+import { normalizeToolContext } from './tool-context.js';
 import AgentRuntime from './agent/agent-runtime.js';
 import AgentLoop from './agent/agent-loop.js';
 import AgentDefinitionResolver, { AGENT_SOURCE_TYPES } from './agent/agent-definition-resolver.js';
@@ -445,9 +446,9 @@ class ChatService {
         logger.info(`[ChatService] 工具执行完成: ${toolResult.toolName}, 成功: ${toolResult.success}`);
         const originalCall = collectedToolCalls.find(c => c.id === toolResult.toolCallId);
         // tool context 契约：仅透传字符串（erix 结构化 executeTool 的 context 是执行对象，非展示语义——对象存库会崩前端）
-        if (typeof originalCall?.context === 'string') {
-          toolResult.context = originalCall.context;
-        }
+        toolResult.context = normalizeToolContext(
+          typeof originalCall?.context === 'string' ? originalCall.context : toolResult.context
+        );
         await this.saveToolMessage(topic_id, user_id, toolResult, expert_id, task_id, request_id);
         onDelta?.({ type: 'tool_result', result: toolResult });
       },
@@ -787,9 +788,9 @@ class ChatService {
               // 关联 context（从原始 toolCall 中获取）
               const originalCall = llmResponse.toolCalls.find(c => c.id === toolResult.toolCallId);
               // tool context 契约：仅透传字符串（erix 结构化 executeTool 的 context 是执行对象，非展示语义——对象存库会崩前端）
-              if (typeof originalCall?.context === 'string') {
-                toolResult.context = originalCall.context;
-              }
+              toolResult.context = normalizeToolContext(
+                typeof originalCall?.context === 'string' ? originalCall.context : toolResult.context
+              );
               // 保存工具消息到数据库
               await this.saveToolMessage(topic_id, user_id, toolResult, expert_id, task_id, request_id);
             },
@@ -1151,6 +1152,9 @@ class ChatService {
     const resultLength = fullResult.length;
     const isSuccess = toolResult.success;
 
+    // 持久化与 SSE 共用同一个 string|null 边界值。
+    toolResult.context = normalizeToolContext(toolResult.context);
+
     // 构建 tool_calls 字段内容
     const toolCallsData = {
       tool_call_id: toolResult.toolCallId,
@@ -1159,7 +1163,7 @@ class ChatService {
       success: isSuccess,
       duration: toolResult.duration || 0,
       timestamp: new Date().toISOString(),
-      context: toolResult.context || null,
+      context: toolResult.context,
       result_length: resultLength,
       // 图片标记（用于上下文加载时识别）
       has_image: hasBase64Image || false,

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -444,7 +444,8 @@ class ChatService {
       async (toolResult) => {
         logger.info(`[ChatService] 工具执行完成: ${toolResult.toolName}, 成功: ${toolResult.success}`);
         const originalCall = collectedToolCalls.find(c => c.id === toolResult.toolCallId);
-        if (originalCall?.context) {
+        // tool context 契约：仅透传字符串（erix 结构化 executeTool 的 context 是执行对象，非展示语义——对象存库会崩前端）
+        if (typeof originalCall?.context === 'string') {
           toolResult.context = originalCall.context;
         }
         await this.saveToolMessage(topic_id, user_id, toolResult, expert_id, task_id, request_id);
@@ -785,7 +786,8 @@ class ChatService {
               logger.info(`[ChatService.chat] 工具执行完成: ${toolResult.toolName}, 成功: ${toolResult.success}`);
               // 关联 context（从原始 toolCall 中获取）
               const originalCall = llmResponse.toolCalls.find(c => c.id === toolResult.toolCallId);
-              if (originalCall?.context) {
+              // tool context 契约：仅透传字符串（erix 结构化 executeTool 的 context 是执行对象，非展示语义——对象存库会崩前端）
+              if (typeof originalCall?.context === 'string') {
                 toolResult.context = originalCall.context;
               }
               // 保存工具消息到数据库

--- a/lib/chat-service.js
+++ b/lib/chat-service.js
@@ -802,6 +802,7 @@ class ChatService {
             const result = toolResults[index];
             return {
               ...call,
+              context: normalizeToolContext(call?.context),
               result: result ? {
                 success: result.success,
                 data: result.data,

--- a/lib/tool-context.js
+++ b/lib/tool-context.js
@@ -1,0 +1,3 @@
+export function normalizeToolContext(context) {
+  return typeof context === 'string' ? context : null;
+}

--- a/server/controllers/internal.controller.js
+++ b/server/controllers/internal.controller.js
@@ -13,6 +13,7 @@ import Utils from '../../lib/utils.js';
 import { verifyAgentDelegationIntegrity } from '../../lib/agent/agent-delegation-integrity.js';
 import { getPermissionService } from '../services/permission.service.js';
 import { ResidentCapabilityError } from '../../lib/resident-capability-executor.js';
+import { normalizeToolContext } from '../../lib/tool-context.js';
 
 class InternalController {
   /**
@@ -260,6 +261,9 @@ class InternalController {
 
         // 发送工具结果给前端
         for (const toolResult of toolResults) {
+          if (toolResult && typeof toolResult === 'object') {
+            toolResult.context = normalizeToolContext(toolResult.context);
+          }
           if (!userConnection.res.writableEnded) {
             userConnection.res.write(`event: tool_result\n`);
             userConnection.res.write(`data: ${JSON.stringify({ result: toolResult })}\n\n`);

--- a/tests/tool-context-contract.test.mjs
+++ b/tests/tool-context-contract.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeToolContext } from '../lib/tool-context.js';
+
+test('preserves string tool contexts', () => {
+  assert.equal(normalizeToolContext('display context'), 'display context');
+  assert.equal(normalizeToolContext(''), '');
+});
+
+test('normalizes non-string tool contexts to null', () => {
+  assert.equal(normalizeToolContext(null), null);
+  assert.equal(normalizeToolContext(undefined), null);
+  assert.equal(normalizeToolContext({ phase: 'execute' }), null);
+  assert.equal(normalizeToolContext(['context']), null);
+  assert.equal(normalizeToolContext(42), null);
+});


### PR DESCRIPTION
## 问题

erix 0.3.2+ runErix 结构化 executeTool 向宿主传递 `context: { ...baseToolContext, round }`（对象，含 user_id/expert_id/taskContext——供宿主执行使用）。touwaka 的回调把它误透传到 `toolResult.context` 并存入 DB，而前端 `useToolDataParser` 假设 context 是 string → `context?.trim()` TypeError → **整页渲染中断**（话题列表/历史全不可见，看似"数据丢失"）。

实证：E2E 产生 11 条对象 context 的 tool 消息（fs/* 工具），页面崩溃；历史数据（0.3.2 前 OpenAI 格式工具调用无 context）不受影响。

## 改动（2 文件 +6 行）

1. **lib/chat-service.js** 两处工具完成回调：`if (originalCall?.context)` → `if (typeof originalCall?.context === 'string')`——erix 结构化执行对象不再写入展示用 context（后端契约 toolResult.context = string|null）
2. **frontend/src/composables/useToolDataParser.ts** 运行时防御：getToolData 只接受 string context，对象/其他类型归一为 null——历史/未来脏数据不崩页

不改 agent-loop.js（context 对象给宿主是 erix 正确设计，agent-loop 用它取 round）。

## 验证
- 后端 node --check + llm-kit 34/34 + agent-loop 13/13 + lint
- 前端 vue-tsc type-check 通过
- 已修复线上 11 条脏数据（对象 context → 摘要 string），页面恢复

## 关联
- E2E 验证（erix 0.3.4 judge 修复）暴露的回归；历史消息未丢失（澄清：坏数据崩渲染而非数据被删）
