### PR TITLE
chore: erix-agent 升级 ^0.3.5（体检修复批次适配）

### DIFF
--- a/lib/agent/agent-loop.js
+++ b/lib/agent/agent-loop.js
@@ -1163,6 +1163,17 @@ export class AgentLoop {
               + Number(usage.completion_tokens ?? usage.output_tokens ?? 0)),
         });
       },
+      // erix-agent 0.3.5：观察者异常不再中断循环，改由宿主记录而非 erix 内部 console.error
+      onObserverError: error => {
+        logger.warn('[AgentLoop] erix 观察者回调异常', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+      onPersistenceError: error => {
+        logger.warn('[AgentLoop] erix transcript 持久化失败', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
       onEvent: onErixEvent,
     });
     erixRunOptions.completion.maxNoToolRounds = maxNoToolRounds;

--- a/lib/llm-kit-adapters/README.md
+++ b/lib/llm-kit-adapters/README.md
@@ -12,9 +12,16 @@ erix-llm-kit 的"驱动模型"：接口在库，DB 适配器在项目侧（ADR-0
 | `message-converter.js` | OpenAI ↔ canonical 双向转换 | 纯函数，无 DB 依赖 |
 | `provider-adapter.js` | erix Provider (`chatStream`/`chat`) | `LLMClient.callStream`/`call`，纯桥接 |
 
+## 与 erix-agent 0.3.5 的行为变化（touwaka 侧知悉项）
+
+- checkpoint 执行后写失败由静默改为 fail-closed（抛出 `KitError` `checkpoint_failed`），该次请求会显式失败。由于 `request_id` 每请求新生成，且本项目没有复用 `runId` 的 resume 场景，无需按 tool id 做幂等保护。
+- observer 回调异常改走 `onObserverError`，不再掀掉整轮循环；`runErix` 已接线到 `logger.warn`。
+- 流式 `onDelta` 时机不变。本项目显式传入 `retry.attempts >= 1`，仍在尝试成功后批量 flush；仅 `CHAT_STREAM_RECOVERY_MAX_ATTEMPTS=0` 时才会启用 0.3.5 的实时透传路径。
+- 其余 0.3.5 变化（file store `runId` 哈希、`ERIX_*` env 校验、`providerOptions` 保护、内置 provider 的 SSE 解析）本项目不适用。
+
 ## 测试
 
-契约测试消费已发布的 `erix-agent@0.2.0` 包，通过
+契约测试消费已发布的 `erix-agent@0.3.5` 包，通过
 `erix-agent/contract-tests` 导入接口兼容断言：
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "docx": "^9.6.1",
         "dotenv": "^16.6.1",
         "echarts": "^5.5.0",
-        "erix-agent": "^0.3.4",
+        "erix-agent": "^0.3.5",
         "exceljs": "^4.4.0",
         "hyperformula": "^2.7.0",
         "jsonwebtoken": "^9.0.3",
@@ -2262,9 +2262,9 @@
       }
     },
     "node_modules/erix-agent": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/erix-agent/-/erix-agent-0.3.4.tgz",
-      "integrity": "sha512-f0bRPc6z2ATPFwTrPuurx4HK1W1kRPNh2fKO27STpP0lMj9E25NhdBx1D25yoRInGUR4zZZCC8DLSNlxT0hQFQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/erix-agent/-/erix-agent-0.3.5.tgz",
+      "integrity": "sha512-/USxXvUbhkpbX5iwbq/6NBmZbh/mWqc42go1poMN3uz1Kx3uv+P6PDxl05+5tQKjT/asdFs4N2WiPDnBq6T2YQ==",
       "license": "MIT",
       "bin": {
         "erix": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "docx": "^9.6.1",
     "dotenv": "^16.6.1",
     "echarts": "^5.5.0",
-    "erix-agent": "^0.3.4",
+    "erix-agent": "^0.3.5",
     "exceljs": "^4.4.0",
     "hyperformula": "^2.7.0",
     "jsonwebtoken": "^9.0.3",


### PR DESCRIPTION
## 变更

`erix-agent` `^0.3.4` → `^0.3.5`（全项目体检修复批次，erix #37~#45 / PR #47~#56）。

- `package.json` / `package-lock.json`：版本与 integrity 同步（sha512 已核对 npm registry）
- `lib/agent/agent-loop.js`：`runErix` 接线 `onObserverError` / `onPersistenceError` → `logger.warn`
  （0.3.5 起 observer 回调异常不再掀掉整轮循环，改由宿主记录，不再只落 erix 内部 `console.error`）
- `lib/llm-kit-adapters/README.md`：新增 0.3.5 行为变化知悉项；契约测试版本口径 `0.2.0` → `0.3.5`

## 适配结论（6 条宿主迁移注意逐条核对）

| 注意项 | touwaka 命中 | 处置 |
|---|---|---|
| ① 流式 onDelta 实时化（retry=0） | 否（显式传 `retry.attempts>=1`，仍批量 flush） | 文档知悉；`CHAT_STREAM_RECOVERY_MAX_ATTEMPTS=0` 时得益 |
| ② checkpoint 执行后写失败 fail-closed | 是 | 本项目无复用 runId 的 resume（`request_id` 每请求新生成），无需 tool id 幂等保护；记录为行为变化 |
| ③ file store runId 哈希 | 不适用（DB store） | — |
| ④ token 系数 fail-fast | 不适用（不传系数） | — |
| ⑤ l0 `exitOk` 空结果轮次 | 间接（judge 内部） | 无动作 |
| ⑥ observer 异常走 `onObserverError` | 是 | 已接线 `logger.warn` |

`exports`（`.` / `./tools` / `./contract-tests`）零变化；包内 `test/contract` 零 diff（store / provider 契约稳定）。

## 验证

- `node --test`：loop-bridge 4、provider-adapter 6、message-converter 6、
  transcript-store.contract 8（真实 MariaDB，未 skip）、transcript-store-meta 6、
  model-config-provider.contract 4、agent-loop-erix 13 —— 合计 **47 pass / 0 fail**
- `node --check lib/agent/agent-loop.js`、`npm run lint` 通过
- `onObserverError` 实测：`onDelta` 抛错后循环继续（`rounds=1`，正常返回 finalText），错误上报到宿主回调
- `npm ls` / lockfile integrity 与 `npm view erix-agent@0.3.5 dist.integrity` 一致

## 风险与待办

- 极罕见的 transcript 写抖动在 0.3.5 下由「静默继续」变为「该次请求显式失败」（换记录不丢，可重试）
- 真机抽验一次专家对话（judge 落库 + 对话形态）由 Eric 执行
- 不涉及 DB 字段 / API 契约 / 前端改动；未改 `models/`

Closes #1121
Refs #1096
