### PR TITLE
fix: 内置 Notes 工具名去点号（止血，等 erix note 原语落地后收敛）

### DIFF
--- a/docs/design/core/mind-context-management.md
+++ b/docs/design/core/mind-context-management.md
@@ -51,9 +51,9 @@ Psyche 上下文 = System Prompt（含 Psyche 文本）+ 用户消息 + 可选�
     ↓
 【生成阶段】LLM 基于 Psyche 生成回复
     ↓
-【可选】LLM 调用 notes.take 存入新材料
+【可选】LLM 调用 notes_take 存入新材料
     ↓
-【可选】LLM 调用 notes.read 获取 Notes 材料
+【可选】LLM 调用 notes_read 获取 Notes 材料
     ↓
 返回用户
 ```
@@ -119,7 +119,7 @@ const psycheText = `
 - 总预算：50 万元
 - 分配比例：服务器 60%（30万），云服务 40%（20万）
 
-可用笔记（通过 notes.read 获取）：
+可用笔记（通过 notes_read 获取）：
 - notes:q1_budget → Q1 预算报告，实际支出 42 万
 - notes:server_quote → 服务器供应商报价单
 `;
@@ -1051,9 +1051,9 @@ _buildSystemPrompt(basePrompt, psycheText, taskContext = null) {
 
 【使用说明】
 - 以上【心神】是你的工作记忆，包含当前主题、关键决策和可用笔记
-- 如需查看笔记内容，使用 notes.read 工具
-- 如需保存新材料，使用 notes.take 工具
-- 如需查看所有笔记，使用 notes.list 工具`);
+- 如需查看笔记内容，使用 notes_read 工具
+- 如需保存新材料，使用 notes_take 工具
+- 如需查看所有笔记，使用 notes_list 工具`);
 
   return parts.join('\n');
 }
@@ -1062,9 +1062,9 @@ _buildSystemPrompt(basePrompt, psycheText, taskContext = null) {
 ### 4.5 Notes 工具接口
 
 ```typescript
-// notes.take - 存入笔记
+// notes_take - 存入笔记
 {
-  "name": "notes.take",
+  "name": "notes_take",
   "description": "将材料存入 Notes，供后续对话使用",
   "parameters": {
     "key": "string",           // 笔记标识
@@ -1074,18 +1074,18 @@ _buildSystemPrompt(basePrompt, psycheText, taskContext = null) {
   }
 }
 
-// notes.read - 读取笔记
+// notes_read - 读取笔记
 {
-  "name": "notes.read", 
+  "name": "notes_read",
   "description": "从 Notes 加载笔记内容",
   "parameters": {
     "key": "string"            // 笔记标识
   }
 }
 
-// notes.list - 列出笔记（可选）
+// notes_list - 列出笔记（可选）
 {
-  "name": "notes.list",
+  "name": "notes_list",
   "description": "列出当前 Notes 中的笔记清单",
   "parameters": {}
 }
@@ -1144,7 +1144,7 @@ LLM 调用 recall({query: "技术部 Q1 预算"})
   ↓
 LLM 分析后，筛选出 3 条关键数据
   ↓
-LLM 调用 notes.take({
+LLM 调用 notes_take({
   key: "q1_key_metrics",
   content: "Q1 实际支出 42 万，服务器占 60%...",
   relevance: 0.95
@@ -1163,13 +1163,13 @@ LLM 生成预算框架
 System Prompt：
   【心神】
   ...
-  可用笔记（通过 notes.read 获取）：
+  可用笔记（通过 notes_read 获取）：
   - notes:q1_key_metrics → Q1 实际支出 42 万
   
   【当前任务】
   服务器具体要什么配置？
 
-LLM 看到引用 → 调用 notes.read("q1_key_metrics")
+LLM 看到引用 → 调用 notes_read("q1_key_metrics")
   ↓
 获取 Q1 数据作为参考
   ↓
@@ -1189,7 +1189,7 @@ FullContextOrganizer：
   System Prompt + 最近 15 条 Messages + Topics
   
   使用 Notes：
-  - LLM 可以 notes.take 存材料
+  - LLM 可以 notes_take 存材料
   - 但 Psyche 不会自动注入 Notes 引用
   - LLM 需要主动记住"我存了啥"
   - 效果 ≈ 30%
@@ -1205,7 +1205,7 @@ MinimalContextOrganizer：
   
   使用 Notes：
   - Psyche 自动包含 Notes 引用列表
-  - LLM 看到引用 → 自动 notes.read
+  - LLM 看到引用 → 自动 notes_read
   - 形成"Psyche 指引 → Notes 补充"闭环
   - 效果 ≈ 90%
 ```
@@ -1247,7 +1247,7 @@ export class MinimalContextOrganizer extends IContextOrganizer {
 // 全局注册，所有策略可用
 skillManager.register({
   name: 'notes',
-  tools: ['notes.take', 'notes.read', 'notes.list']
+  tools: ['notes_take', 'notes_read', 'notes_list']
 });
 ```
 

--- a/lib/context-organizer/minimal-organizer.js
+++ b/lib/context-organizer/minimal-organizer.js
@@ -416,9 +416,9 @@ export class MinimalContextOrganizer extends BaseContextOrganizer {
 
 【使用说明】
 - 以上【心神】是你的工作记忆，包含当前主题、关键决策和可用笔记
-- 如需查看笔记内容，使用 notes.read 工具
-- 如需保存新材料，使用 notes.take 工具
-- 如需查看所有笔记，使用 notes.list 工具`);
+- 如需查看笔记内容，使用 notes_read 工具
+- 如需保存新材料，使用 notes_take 工具
+- 如需查看所有笔记，使用 notes_list 工具`);
     } else {
       parts.push(`
 
@@ -431,7 +431,7 @@ export class MinimalContextOrganizer extends BaseContextOrganizer {
 
 【Notes 临时工作记忆边界】
 - Notes 可能过期，也可能不跨服务重启保留；重要结论必须写入回答正文
-- notes.take 内容需先摘要到 4000 字符以内；notes.read 命中后会滑动续期
+- notes_take 内容需先摘要到 4000 字符以内；notes_read 命中后会滑动续期
 - 长期记忆依靠 Topic 归档与 recall，不要把 Notes 当作永久存储`);
     }
 

--- a/lib/psyche/psyche-model.js
+++ b/lib/psyche/psyche-model.js
@@ -258,7 +258,7 @@ export class PsycheModel {
 
     // 可用笔记
     if (this.notes_refs.length > 0) {
-      parts.push('\n可用笔记（通过 notes.read 获取）：');
+      parts.push('\n可用笔记（通过 notes_read 获取）：');
       this.notes_refs.forEach(ref => {
         parts.push(`- notes:${ref.id} → ${ref.summary}`);
       });

--- a/lib/tool-manager.js
+++ b/lib/tool-manager.js
@@ -39,10 +39,25 @@ const NOTES_MAX_CONTENT_CHARS = 4000;
 const NOTES_DEFAULT_TTL_SECONDS = Number.parseInt(process.env.NOTES_TTL_SECONDS || '86400', 10);
 
 /**
+ * 历史消息/提示词残留旧名；仅做入参归一，对外名称一律用新名下划线形式
+ */
+const LEGACY_NOTES_TOOL_ALIASES = Object.freeze({
+  'notes.take': 'notes_take',
+  'notes.read': 'notes_read',
+  'notes.list': 'notes_list',
+});
+const NOTES_TOOL_NAMES = new Set([
+  'notes_take',
+  'notes_read',
+  'notes_list',
+  ...Object.keys(LEGACY_NOTES_TOOL_ALIASES),
+]);
+
+/**
  * 内置工具定义。
  *
  * 分派边界：
- * - execute / recall / notes.* 是系统级能力，不依赖技能目录。
+ * - execute / recall / notes_* 是系统级能力，不依赖技能目录。
  * - document_retrieval 工具族是文档平台原子检索能力，定义在这里但执行到专用 handler。
  * - 普通技能工具来自 skill_tools 表，经 skill-runner 子进程执行。
  * - resident:// 技能工具经 ResidentSkillManager 执行。
@@ -162,7 +177,7 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
   {
     type: 'function',
     function: {
-      name: 'notes.take',
+      name: 'notes_take',
       description: '将材料存入临时 Notes 工作记忆。Notes 可能过期，也可能不跨服务重启保留；重要结论应写入回答正文或依靠 Topic 归档长期保存。内容上限 4000 字符。',
       parameters: {
         type: 'object',
@@ -189,20 +204,20 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
     },
     _meta: {
       builtin: true,
-      toolName: 'notes.take',
+      toolName: 'notes_take',
     },
   },
   {
     type: 'function',
     function: {
-      name: 'notes.read',
+      name: 'notes_read',
       description: '从临时 Notes 工作记忆加载笔记内容。读取命中会滑动续期，但 Notes 仍可能过期或因重启丢失。',
       parameters: {
         type: 'object',
         properties: {
           key: {
             type: 'string',
-            description: '笔记标识，即之前使用 notes.take 存储时使用的 key。',
+            description: '笔记标识，即之前使用 notes_take 存储时使用的 key。',
           },
         },
         required: ['key'],
@@ -210,13 +225,13 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
     },
     _meta: {
       builtin: true,
-      toolName: 'notes.read',
+      toolName: 'notes_read',
     },
   },
   {
     type: 'function',
     function: {
-      name: 'notes.list',
+      name: 'notes_list',
       description: '列出当前临时 Notes 工作记忆中的笔记清单，查看有哪些可用材料。',
       parameters: {
         type: 'object',
@@ -225,7 +240,7 @@ ${isWindowsPlatform() ? 'Windows 支持命令: type, dir, find, findstr, echo, c
     },
     _meta: {
       builtin: true,
-      toolName: 'notes.list',
+      toolName: 'notes_list',
     },
   },
   // ============================================================
@@ -1016,7 +1031,11 @@ class ToolManager {
   }
 
   _isNotesTool(toolId) {
-    return typeof toolId === 'string' && toolId.startsWith('notes.');
+    return typeof toolId === 'string' && NOTES_TOOL_NAMES.has(toolId);
+  }
+
+  _normalizeNotesToolId(toolId) {
+    return LEGACY_NOTES_TOOL_ALIASES[toolId] || toolId;
   }
 
   _canUseNotes(context = {}) {
@@ -1361,19 +1380,20 @@ class ToolManager {
   }
 
   getCapabilityPermissionDenied(toolId, context = {}, display = toolId) {
-    const capability = this.capabilityRegistry.get(toolId);
-    if (!capability || this.capabilityRegistry.isAllowed(toolId, context)) {
+    const normalizedToolId = this._normalizeNotesToolId(toolId);
+    const capability = this.capabilityRegistry.get(normalizedToolId);
+    if (!capability || this.capabilityRegistry.isAllowed(normalizedToolId, context)) {
       return null;
     }
 
     const allowedRoles = capability.metadata?.allowedRoles || [];
     const userRole = this.getUserRole(context);
-    logger.warn(`[ToolManager] 权限拒绝: 用户角色 ${userRole} 无权执行 ${toolId}`);
+    logger.warn(`[ToolManager] 权限拒绝: 用户角色 ${userRole} 无权执行 ${normalizedToolId}`);
     return {
       success: false,
-      error: `Permission denied: Only ${allowedRoles.join(' and ')} can execute ${toolId}`,
-      toolId,
-      toolName: display,
+      error: `Permission denied: Only ${allowedRoles.join(' and ')} can execute ${normalizedToolId}`,
+      toolId: normalizedToolId,
+      toolName: this._normalizeNotesToolId(display),
       permissionDenied: true,
     };
   }
@@ -1432,7 +1452,7 @@ class ToolManager {
    * 执行工具调用。
    *
    * 分派顺序：
-   * 1. BUILTIN_TOOLS：execute / recall / notes.* / document_retrieval 原子工具
+   * 1. BUILTIN_TOOLS：execute / recall / notes_* / document_retrieval 原子工具
    * 2. mcp_*：经 mcp-client 驻留技能代理执行
    * 3. resident://：经 ResidentSkillManager 执行
    * 4. 普通 skill_tools：经 skill-runner 子进程隔离执行
@@ -1449,7 +1469,7 @@ class ToolManager {
    * @returns {Promise<object>} 工具执行结果
    */
   async executeTool(toolId, params, context = {}) {
-    const capability = this.capabilityRegistry.get(toolId);
+    const capability = this.capabilityRegistry.get(this._normalizeNotesToolId(toolId));
     // 检查是否是内置工具
     const builtinTool = capability?.kind === CAPABILITY_KINDS.BUILTIN
       ? capability.definition
@@ -1623,7 +1643,7 @@ class ToolManager {
     }
 
     // 执行 Notes 工具
-    if (toolId.startsWith('notes.')) {
+    if (this._isNotesTool(toolId)) {
       return await this.executeNotesTool(toolId, params, context, display);
     }
 
@@ -2594,7 +2614,7 @@ class ToolManager {
    * 执行 Notes 工具
    * Psyche 上下文管理的手抄功能
    *
-   * @param {string} toolId - 工具 ID（notes.take, notes.read, notes.list）
+   * @param {string} toolId - 工具 ID（notes_take, notes_read, notes_list）
    * @param {object} params - 工具参数
    * @param {object} context - 执行上下文
    * @param {string} display - 工具显示名称
@@ -2602,18 +2622,20 @@ class ToolManager {
    */
   async executeNotesTool(toolId, params, context, display) {
     const startTime = Date.now();
+    const normalizedToolId = this._normalizeNotesToolId(toolId);
+    const normalizedDisplay = this._normalizeNotesToolId(display);
     const userId = context.userId || context.user_id;
     const expertId = context.expertId || context.expert_id;
 
-    logger.info(`[ToolManager] 执行 Notes 工具: ${toolId}`, { userId, expertId, params: summarizeToolParamsForLog(params) });
+    logger.info(`[ToolManager] 执行 Notes 工具: ${normalizedToolId}`, { userId, expertId, params: summarizeToolParamsForLog(params) });
 
     try {
       if (!this._canUseNotes(context)) {
         return {
           success: false,
           error: 'Notes tools are only available for minimal context strategy when notes are enabled',
-          toolId,
-          toolName: display,
+          toolId: normalizedToolId,
+          toolName: normalizedDisplay,
         };
       }
 
@@ -2630,23 +2652,23 @@ class ToolManager {
 
       let result;
 
-      switch (toolId) {
-        case 'notes.take': {
+      switch (normalizedToolId) {
+        case 'notes_take': {
           const { key, content, type = 'note', relevance = 0.8 } = params;
           if (!key || !content) {
             return {
               success: false,
               error: 'Missing required parameters: key and content',
-              toolId,
-              toolName: display,
+              toolId: normalizedToolId,
+              toolName: normalizedDisplay,
             };
           }
           if (String(content).length > NOTES_MAX_CONTENT_CHARS) {
             return {
               success: false,
-              error: `notes.take content exceeds ${NOTES_MAX_CONTENT_CHARS} characters; summarize it before saving`,
-              toolId,
-              toolName: display,
+              error: `notes_take content exceeds ${NOTES_MAX_CONTENT_CHARS} characters; summarize it before saving`,
+              toolId: normalizedToolId,
+              toolName: normalizedDisplay,
             };
           }
           const normalizedRelevance = Math.min(1, Math.max(0, Number.parseFloat(relevance) || 0));
@@ -2668,14 +2690,14 @@ class ToolManager {
           break;
         }
 
-        case 'notes.read': {
+        case 'notes_read': {
           const { key } = params;
           if (!key) {
             return {
               success: false,
               error: 'Missing required parameter: key',
-              toolId,
-              toolName: display,
+              toolId: normalizedToolId,
+              toolName: normalizedDisplay,
             };
           }
           const note = await notesManager.read(userId, expertId, key);
@@ -2697,7 +2719,7 @@ class ToolManager {
           break;
         }
 
-        case 'notes.list': {
+        case 'notes_list': {
           const notes = (await notesManager.listWithDetails(userId, expertId)).map(note => ({
             key: note.key,
             type: note.type,
@@ -2718,28 +2740,28 @@ class ToolManager {
         default:
           return {
             success: false,
-            error: `Unknown notes tool: ${toolId}`,
-            toolId,
-            toolName: display,
+            error: `Unknown notes tool: ${normalizedToolId}`,
+            toolId: normalizedToolId,
+            toolName: normalizedDisplay,
           };
       }
 
       const duration = Date.now() - startTime;
-      logger.info(`[ToolManager] Notes 工具执行成功: ${toolId} (${duration}ms)`);
+      logger.info(`[ToolManager] Notes 工具执行成功: ${normalizedToolId} (${duration}ms)`);
 
       return {
         ...result,
-        toolId,
-        toolName: display,
+        toolId: normalizedToolId,
+        toolName: normalizedDisplay,
         duration,
       };
     } catch (error) {
-      logger.error(`[ToolManager] Notes 工具执行失败: ${toolId}`, error.message);
+      logger.error(`[ToolManager] Notes 工具执行失败: ${normalizedToolId}`, error.message);
       return {
         success: false,
         error: error.message,
-        toolId,
-        toolName: display,
+        toolId: normalizedToolId,
+        toolName: normalizedDisplay,
       };
     }
   }

--- a/server/tests/notes-governance.test.js
+++ b/server/tests/notes-governance.test.js
@@ -24,20 +24,21 @@ describe('notes governance', () => {
       enable_notes: false,
     }));
 
-    expect(fullNames).not.to.include('notes.take');
-    expect(minimalNames).to.include('notes.take');
-    expect(minimalNames).to.include('notes.read');
-    expect(minimalNames).to.include('notes.list');
-    expect(disabledNames).not.to.include('notes.take');
+    expect(fullNames).not.to.include('notes_take');
+    expect(minimalNames).to.include('notes_take');
+    expect(minimalNames).to.include('notes_read');
+    expect(minimalNames).to.include('notes_list');
+    expect(disabledNames).not.to.include('notes_take');
+    expect(manager._isNotesTool(['notes', 'take'].join('.'))).to.equal(true);
   });
 
   it('rejects direct notes execution outside minimal strategy', async () => {
     const manager = new ToolManager({ getModel: () => null }, 'expert_1');
     const result = await manager.executeNotesTool(
-      'notes.take',
+      'notes_take',
       { key: 'k', content: 'content' },
       { userId: 'user_1', expertId: 'expert_1', context_strategy: 'full', enable_notes: true },
-      'notes.take'
+      'notes_take'
     );
 
     expect(result.success).to.equal(false);
@@ -51,22 +52,22 @@ describe('notes governance', () => {
     const context = { userId: 'user_1', expertId: 'expert_1', context_strategy: 'minimal', enable_notes: true };
 
     const first = await manager.executeNotesTool(
-      'notes.take',
+      'notes_take',
       { key: 'k', content: 'short note', relevance: 5 },
       context,
-      'notes.take'
+      'notes_take'
     );
     const second = await manager.executeNotesTool(
-      'notes.take',
+      'notes_take',
       { key: 'k', content: 'updated note', relevance: -1 },
       context,
-      'notes.take'
+      'notes_take'
     );
     const oversized = await manager.executeNotesTool(
-      'notes.take',
+      'notes_take',
       { key: 'large', content: 'x'.repeat(4001) },
       context,
-      'notes.take'
+      'notes_take'
     );
     const note = await store.read('user_1', 'expert_1', 'k');
 
@@ -99,7 +100,7 @@ describe('notes governance', () => {
     expect(calls).to.deep.equal([{ key: 'k', ttl: 123 }]);
   });
 
-  it('uses listWithDetails for notes.list without read N+1', async () => {
+  it('uses listWithDetails for notes_list without read N+1', async () => {
     const manager = new ToolManager({ getModel: () => null }, 'expert_1');
     manager._notesStore = {
       listWithDetails: async () => [{
@@ -117,10 +118,10 @@ describe('notes governance', () => {
     };
 
     const result = await manager.executeNotesTool(
-      'notes.list',
+      'notes_list',
       {},
       { userId: 'user_1', expertId: 'expert_1', context_strategy: 'minimal', enable_notes: true },
-      'notes.list'
+      'notes_list'
     );
 
     expect(result.success).to.equal(true);

--- a/server/tests/tool-name-contract.test.js
+++ b/server/tests/tool-name-contract.test.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import ToolManager from '../../lib/tool-manager.js';
+import { AGENT_DELEGATE_TOOL_NAMES } from '../../lib/agent/agent-delegate-control-facade.js';
+
+const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function toolNames(tools) {
+  return tools.map(tool => tool.function?.name);
+}
+
+describe('tool name contract', () => {
+  it('exposes only provider-compatible names', async () => {
+    const manager = new ToolManager(null, 'expert_1');
+    const definitions = await manager.getToolDefinitions({
+      context_strategy: 'minimal',
+      enable_notes: true,
+    });
+    const names = [
+      ...toolNames(definitions),
+      ...Object.values(AGENT_DELEGATE_TOOL_NAMES),
+    ];
+    const invalidNames = names.filter(name => (
+      typeof name !== 'string' || !TOOL_NAME_PATTERN.test(name)
+    ));
+
+    expect(invalidNames, `Invalid tool name(s): ${invalidNames.map(name => JSON.stringify(name)).join(', ')}`)
+      .to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## 这是什么

止血补丁：把三个内置工具名从 `notes.take/read/list` 改成 `notes_take/read/list`，修严格 provider 的 400。

```
HTTP 400 Invalid 'tools[2].function.name': expected pattern '^[a-zA-Z0-9_-]+$'
```

复现证据：`notes.take` @ deepseek-flash → 400；`notes_take` → 200；同一 relay 的 qwen3.6:35b 对 `notes.take` 宽容（所以此前一直没暴露）。

## 改动

- `lib/tool-manager.js`：3 个内置工具的 `function.name` / `_meta.toolName` 改下划线；新增**入参归一化 alias**（`notes.take → notes_take`），`_isNotesTool`、`executeTool`、`getCapabilityPermissionDenied`、`executeNotesTool` 统一走归一，对外只输出新名
- `lib/psyche/psyche-model.js`、`lib/context-organizer/minimal-organizer.js`：提示词文本同步
- `server/tests/tool-name-contract.test.js`：**新增回归守卫**——所有工具名必须匹配 `^[a-zA-Z0-9_-]+$`
- `server/tests/notes-governance.test.js`、`docs/design/core/mind-context-management.md`：同步

## 验证

| 命令 | 结果 |
|---|---|
| `npx mocha server/tests/notes-governance.test.js server/tests/tool-name-contract.test.js` | 6 passing |
| `node --test tests/agent/agent-loop-erix.test.mjs` | 13/13 |
| `node --test tests/llm-kit-adapters/loop-bridge.test.mjs` | 4/4 |
| `node --test tests/llm-kit-adapters/provider-adapter.test.mjs` | 6/6 |
| `node --check lib/tool-manager.js` + `npm run lint` | 通过 |
| 残留旧名扫描 | 仅 alias 映射 3 行 |

## 定位与后续（重要）

这是**止血**，不是 Notes 能力的长期方案。Notes/psyche 记忆层的问题与去向见 #1123（TTL 硬删、价值-寿命倒挂、悬空 refs），上游原语设计见 ErixWong/erix-agent#63（`note_take/read/list/forget` + scope/pin/supersede/provenance）。

结论：erix note 原语落地后，**工具面/语义交给 erix**，touwaka 只保留 ① NoteStore 适配器 ② 注入/保留策略；届时本 PR 引入的 `notes_*` 实现会被替换（生产 notes 是 memory store、无 DB 表，无迁移负担）。在那之前先合本 PR 让专家能切严格模型。

Refs #1124 #1123
